### PR TITLE
Add automatic deployment trigger after Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,3 +73,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Trigger deployment
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
+        with:
+          workflow: deploy.yml
+          repo: KirkDiggler/rpg-deployment
+          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          inputs: '{"source": "rpg-dnd5e-web", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary

- Add workflow dispatch trigger to rpg-deployment after successful Docker build
- Pass source repository and commit SHA for better deployment visibility
- Only triggers on main branch pushes to avoid unnecessary deployments

## Changes

- Added step to trigger rpg-deployment workflow after Docker image is built and pushed
- Configured to only run on main branch pushes
- Passes source repo name and commit SHA for deployment tracking
- Includes security best practices (pinned action version) and error handling

## Dependencies

- Requires `DEPLOYMENT_TOKEN` secret to be added to this repository
- Token needs `repo` permissions to trigger workflows in rpg-deployment

## Benefits

- Completes automated deployment pipeline alongside rpg-api
- Removes manual deployment steps for web app updates
- Provides clear visibility into what triggered each deployment

## Testing

After merging and adding the token:
1. Push to main branch
2. Watch Docker workflow complete
3. Observe automatic deployment trigger
4. Check deployment summary showing "Triggered by: rpg-dnd5e-web"

🤖 Generated with [Claude Code](https://claude.ai/code)