### PR TITLE
add client id to build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}
+            VITE_API_HOST=
 
       - name: Trigger deployment
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,14 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+# Accept build arguments for environment variables
+ARG VITE_DISCORD_CLIENT_ID
+ARG VITE_API_HOST
+
+# Set environment variables for the build
+ENV VITE_DISCORD_CLIENT_ID=$VITE_DISCORD_CLIENT_ID
+ENV VITE_API_HOST=$VITE_API_HOST
+
 # Build the application
 RUN npm run build
 


### PR DESCRIPTION
This pull request introduces changes to support passing environment-specific build arguments to the Docker build process and setting them as environment variables within the Docker image. The changes primarily affect the `.github/workflows/docker.yml` and `Dockerfile` files.

### Docker build enhancements:

* [`.github/workflows/docker.yml`](diffhunk://#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94R76-R78): Added `build-args` to the Docker build step to pass `VITE_DISCORD_CLIENT_ID` and `VITE_API_HOST` as build arguments using GitHub secrets.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R18-R25): Introduced `ARG` directives to accept `VITE_DISCORD_CLIENT_ID` and `VITE_API_HOST` as build arguments and set them as environment variables (`ENV`) during the image build process.