### PR TITLE
Fix nginx configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,11 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy built application
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Create nginx user and directories with proper permissions
-RUN mkdir -p /var/cache/nginx /var/log/nginx /var/run && \
-    chown -R nginx:nginx /var/cache/nginx /var/log/nginx /var/run && \
-    chmod -R 755 /var/cache/nginx /var/log/nginx /var/run && \
-    touch /var/run/nginx.pid && \
-    chown nginx:nginx /var/run/nginx.pid
+# Create directories with proper permissions for non-root nginx
+RUN mkdir -p /var/cache/nginx /var/log/nginx /tmp && \
+    chown -R nginx:nginx /var/cache/nginx /var/log/nginx /usr/share/nginx/html && \
+    chmod -R 755 /var/cache/nginx /var/log/nginx && \
+    chmod 1777 /tmp
 
 # Add health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \

--- a/nginx.main.conf
+++ b/nginx.main.conf
@@ -1,0 +1,26 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
This pull request includes changes to improve the configuration and security of the Nginx setup in the Dockerized environment. The updates focus on enabling a non-root Nginx user, setting appropriate permissions, and introducing a new main configuration file for Nginx.

### Nginx Configuration Updates:

* **Non-root Nginx setup in `Dockerfile`:** Updated the directory creation and permission settings to support running Nginx as a non-root user. This includes adding `/tmp` with `1777` permissions and ensuring ownership and permissions are correctly set for necessary directories (`/var/cache/nginx`, `/var/log/nginx`, `/usr/share/nginx/html`). (`[DockerfileL41-R45](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L41-R45)`)

* **New main configuration file (`nginx.main.conf`):** Added a default Nginx configuration file with key settings, such as `worker_processes auto`, a custom `error_log` path, and a `pid` file in `/tmp`. It also includes HTTP settings like `log_format`, `access_log`, and optimizations (e.g., `sendfile`, `keepalive_timeout`). (`[nginx.main.confR1-R26](diffhunk://#diff-21c783388c983e43a5f52a9c3d5bab21bac5a8142e242d3a47ffbe67833c8fbdR1-R26)`)