### PR TITLE
fix: properly display Discord authentication errors

### DIFF
--- a/src/discord/DiscordDebugPanel.tsx
+++ b/src/discord/DiscordDebugPanel.tsx
@@ -42,7 +42,16 @@ export function DiscordDebugPanel() {
           <ul style={{ margin: 0, paddingLeft: '1.5rem' }}>
             <li>Is Discord: {discord.isDiscord ? '✅' : '❌'}</li>
             <li>SDK Ready: {discord.isReady ? '✅' : '❌'}</li>
-            <li>Error: {discord.error || 'None'}</li>
+            <li>
+              Error:{' '}
+              {discord.error ? (
+                <span style={{ color: 'red', wordBreak: 'break-word' }}>
+                  {discord.error}
+                </span>
+              ) : (
+                'None'
+              )}
+            </li>
             <li>Frame ID: {envInfo.frameId || 'None'}</li>
             <li>Instance ID: {envInfo.instanceId || 'None'}</li>
             <li>Channel ID: {envInfo.channelId || 'None'}</li>

--- a/src/discord/DiscordProvider.tsx
+++ b/src/discord/DiscordProvider.tsx
@@ -70,7 +70,10 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
         }
       } catch (err) {
         console.error('🔴 Discord authentication failed:', err);
-        throw err;
+        // Store error for display
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        setError(errorMessage);
+        // Don't throw - let user see error and retry
       }
     },
     [sdk, handleRefreshParticipants]
@@ -90,8 +93,11 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
         setSdk(discordSdk);
         setIsReady(true);
 
-        // Try to auto-authenticate if we have a token
-        await handleAuthenticate(discordSdk);
+        // Don't auto-authenticate - let user trigger it manually
+        // This helps us see any errors in the debug panel
+        console.log(
+          '🎮 Discord SDK ready - click authenticate button to login'
+        );
       } catch (err) {
         const errorMessage =
           err instanceof Error


### PR DESCRIPTION
- Don't throw errors in authenticate handler, store them for display
- Show errors in red text in debug panel
- Disable auto-authentication to better diagnose issues
- User must click authenticate button to see any errors