### PR TITLE
fix: properly serialize Discord error objects for display

### DIFF
--- a/src/discord/DiscordDebugPanel.tsx
+++ b/src/discord/DiscordDebugPanel.tsx
@@ -45,9 +45,17 @@ export function DiscordDebugPanel() {
             <li>
               Error:{' '}
               {discord.error ? (
-                <span style={{ color: 'red', wordBreak: 'break-word' }}>
+                <pre
+                  style={{
+                    color: 'red',
+                    wordBreak: 'break-word',
+                    whiteSpace: 'pre-wrap',
+                    fontSize: '0.875rem',
+                    margin: 0,
+                  }}
+                >
                   {discord.error}
-                </span>
+                </pre>
               ) : (
                 'None'
               )}

--- a/src/discord/DiscordProvider.tsx
+++ b/src/discord/DiscordProvider.tsx
@@ -71,7 +71,15 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
       } catch (err) {
         console.error('🔴 Discord authentication failed:', err);
         // Store error for display
-        const errorMessage = err instanceof Error ? err.message : String(err);
+        let errorMessage = 'Unknown error';
+        if (err instanceof Error) {
+          errorMessage = err.message;
+        } else if (err && typeof err === 'object') {
+          // Handle Discord SDK error objects
+          errorMessage = JSON.stringify(err, null, 2);
+        } else {
+          errorMessage = String(err);
+        }
         setError(errorMessage);
         // Don't throw - let user see error and retry
       }


### PR DESCRIPTION
- Convert error objects to JSON for readable display
- Use pre tag to preserve formatting
- Handle different error types (Error, object, string)