### PR TITLE
Fix Discord Activity API calls

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Local development settings
+VITE_DISCORD_CLIENT_ID=1064354130778411068
+VITE_API_HOST=http://localhost:80

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,7 +75,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}
-            VITE_API_HOST=
+            VITE_API_HOST=${{ secrets.VITE_API_HOST }}
 
       - name: Trigger deployment
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
- Fixes Discord Activity authentication by setting VITE_API_HOST during build
- Resolves the "Failed to fetch" error in issue KirkDiggler/rpg-deployment#31

## Problem
Discord Activities run on `discordsays.com` domain. Without `VITE_API_HOST` set during build, the frontend tries to call `/api/discord/token` on the Discord domain instead of `https://rpg-toolkit.app/api/discord/token`.

## Solution
- Use `VITE_API_HOST` from GitHub secrets during Docker build
- This ensures the frontend knows to call the backend at the correct domain

## Required Action
**Before merging**: Add the GitHub secret `VITE_API_HOST` with value `https://rpg-toolkit.app` to this repository.

## Test Plan
1. Add the secret to GitHub
2. Merge this PR to trigger a new build
3. Test Discord Activity authentication

🤖 Generated with [Claude Code](https://claude.ai/code)