### PR TITLE
fix: Discord auth UI rerendering and debug panel toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ type AppView = 'character-list' | 'character-creation';
 
 function App() {
   const [currentView, setCurrentView] = useState<AppView>('character-list');
+  const [showDebugPanel, setShowDebugPanel] = useState(false);
   const discord = useDiscord();
 
   // In production, require Discord auth. In dev, allow test player
@@ -94,8 +95,28 @@ function App() {
           </CharacterDraftProvider>
         )}
 
-        {/* Discord debug panel - always show for debugging */}
-        <DiscordDebugPanel />
+        {/* Debug panel toggle button */}
+        <div className="fixed bottom-4 right-4 z-50">
+          <button
+            onClick={() => setShowDebugPanel(!showDebugPanel)}
+            className="bg-gray-800 hover:bg-gray-700 text-white p-2 rounded-full shadow-lg transition-all"
+            title={showDebugPanel ? 'Hide Debug Panel' : 'Show Debug Panel'}
+          >
+            {showDebugPanel ? '🔧✕' : '🔧'}
+          </button>
+        </div>
+
+        {/* Discord debug panel - show based on state */}
+        {showDebugPanel && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 20 }}
+            className="mt-8"
+          >
+            <DiscordDebugPanel />
+          </motion.div>
+        )}
       </motion.div>
     </div>
   );

--- a/src/discord/DiscordProvider.tsx
+++ b/src/discord/DiscordProvider.tsx
@@ -20,7 +20,7 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
   const [sdk, setSdk] = useState<DiscordSDK | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [user /*, setUser*/] = useState<DiscordUser | null>(null);
+  const [user, setUser] = useState<DiscordUser | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [participants, setParticipants] = useState<DiscordParticipant[]>([]);
 
@@ -113,8 +113,17 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
         setIsAuthenticated(true);
         setError(null);
 
-        // The SDK should now have access to user info
-        // TODO: Set user info from auth response if available
+        // Extract user info from auth response
+        if (auth.user) {
+          setUser({
+            id: auth.user.id,
+            username: auth.user.username,
+            discriminator: auth.user.discriminator,
+            avatar: auth.user.avatar || undefined,
+            global_name: auth.user.global_name || undefined,
+          });
+          console.log('👤 User authenticated:', auth.user.username);
+        }
 
         // Fetch initial participants
         await handleRefreshParticipants(sdkToUse);


### PR DESCRIPTION
## Summary
- Fixed authentication state not updating in UI after successful Discord login
- Added toggleable debug panel with smooth animations
- Extracted user info from Discord auth response

## Problem
After successful Discord authentication, the UI would remain on "Not authenticated" even though the authentication completed successfully. This was due to the user state not being properly set from the auth response.

## Solution
1. Uncommented `setUser` function and properly extract user data from Discord auth response
2. Set user state with id, username, discriminator, avatar, and global_name
3. Added a floating toggle button (bottom-right) to show/hide the debug panel
4. Added smooth motion animations for debug panel visibility

## Test Plan
- [x] Authenticate with Discord in the activity
- [x] Verify UI updates to show authenticated state
- [x] Verify user info displays correctly in debug panel
- [x] Test debug panel toggle button functionality
- [x] Verify animations work smoothly

Fixes #36

🤖 Generated with [Claude Code](https://claude.ai/code)