### PR TITLE
fix: Use Discord proxy for API calls in Activity

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,8 +3,11 @@ import { createClient } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { CharacterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 
-// Get API host from environment - default to current origin if not set
-const API_HOST = import.meta.env.VITE_API_HOST || window.location.origin;
+// Get API host from environment - handle Discord Activity proxy
+const isDiscordActivity = window.location.hostname.includes('discordsays.com');
+const API_HOST = isDiscordActivity
+  ? '/.proxy'
+  : import.meta.env.VITE_API_HOST || window.location.origin;
 
 // Logging interceptor for debugging
 const loggingInterceptor: Interceptor = (next) => async (req) => {
@@ -13,6 +16,7 @@ const loggingInterceptor: Interceptor = (next) => async (req) => {
 
   if (import.meta.env.MODE === 'development') {
     console.log(`🔵 Request: ${methodName}`, req.message);
+    console.log(`📡 API Host: ${API_HOST}`);
   }
 
   try {


### PR DESCRIPTION
## Summary
- Fixed "Failed to load characters" error in Discord Activity
- Added proxy detection for gRPC API calls

## Problem
After successful authentication in the Discord Activity, the app would show "Failed to load characters" because the gRPC API calls were not using the Discord proxy path.

## Solution  
- Detect when running in Discord Activity (discordsays.com domain)
- Use `/.proxy` prefix for API calls when in Discord Activity
- Add API host logging for debugging

## Test Plan
- [x] Deploy to Discord Activity
- [x] Authenticate with Discord
- [x] Verify characters load successfully
- [x] Check console logs show correct API host

🤖 Generated with [Claude Code](https://claude.ai/code)