### PR TITLE
feat: Improve theme aesthetics and set dark-fantasy as default

### DIFF
--- a/public/themes/arcane.css
+++ b/public/themes/arcane.css
@@ -1,71 +1,89 @@
 /* Mystical Arcane Theme - Magical, mysterious, spellcasting focus */
 :root {
   /* Background colors */
-  --bg-primary: #0f172a; /* Deep midnight blue */
-  --bg-secondary: #1e1b4b; /* Dark purple */
+  --bg-primary: #0c0a1f; /* Deep mystical void */
+  --bg-secondary: #1a1547; /* Dark arcane purple */
 
   /* Card and content backgrounds */
-  --card-bg: #4c1d95; /* Rich purple */
-  --section-bg: rgba(76, 29, 149, 0.9); /* Rich purple with transparency */
-  --stat-bg: #5b21b6; /* Medium purple */
-  --modal-bg: #4c1d95; /* Rich purple */
+  --card-bg: #312e81; /* Deep indigo */
+  --section-bg: rgba(49, 46, 129, 0.95); /* Deep indigo with transparency */
+  --stat-bg: #4338ca; /* Vibrant indigo */
+  --modal-bg: #312e81; /* Deep indigo */
 
   /* Text colors */
-  --text-primary: #e0f2fe; /* Pale blue */
-  --text-secondary: #1e1b4b; /* Dark purple */
-  --text-button: #e0f2fe; /* Pale blue */
-  --text-muted: #8b5cf6; /* Violet */
+  --text-primary: #e0e7ff; /* Pale lavender */
+  --text-secondary: #c7d2fe; /* Light lavender */
+  --text-button: #ffffff; /* Pure white */
+  --text-muted: #a5b4fc; /* Muted indigo */
   --text-subtle: #cbd5e1; /* Silver */
 
   /* Accent colors */
-  --accent-primary: #06b6d4; /* Bright cyan */
-  --accent-primary-hover: #0891b2; /* Darker cyan */
-  --accent-secondary: #5b21b6; /* Medium purple */
-  --accent-secondary-hover: #7c3aed; /* Lighter purple */
+  --accent-primary: #0ea5e9; /* Mystic cyan */
+  --accent-primary-hover: #0284c7; /* Deeper cyan */
+  --accent-secondary: #6366f1; /* Bright indigo */
+  --accent-secondary-hover: #818cf8; /* Lighter indigo */
 
   /* Border colors */
-  --border-primary: #e2e8f0; /* Silver */
-  --border-section: rgba(226, 232, 240, 0.3); /* Silver with transparency */
-  --border-dashed: rgba(226, 232, 240, 0.5); /* Silver with transparency */
+  --border-primary: #6366f1; /* Bright indigo borders */
+  --border-section: rgba(99, 102, 241, 0.4); /* Indigo with transparency */
+  --border-dashed: rgba(99, 102, 241, 0.6); /* Indigo with transparency */
 
   /* Background elements */
-  --inventory-bg: rgba(15, 23, 42, 0.3); /* Deep midnight with transparency */
-  --resource-bg: rgba(15, 23, 42, 0.4); /* Deep midnight with transparency */
-  --overlay-bg: rgba(15, 23, 42, 0.8); /* Deep midnight with transparency */
+  --inventory-bg: rgba(12, 10, 31, 0.5); /* Deep void with transparency */
+  --resource-bg: rgba(12, 10, 31, 0.6); /* Deep void with transparency */
+  --overlay-bg: rgba(12, 10, 31, 0.9); /* Deep void with transparency */
 
   /* Game element colors */
-  --health: #f43f5e; /* Rose */
-  --mana: #06b6d4; /* Cyan */
-  --stamina: #a855f7; /* Purple */
-  --experience: #8b5cf6; /* Violet */
+  --health: #ec4899; /* Mystic pink */
+  --mana: #0ea5e9; /* Mystic cyan */
+  --stamina: #8b5cf6; /* Mystic violet */
+  --experience: #f59e0b; /* Golden amber */
 
   /* Rarity colors */
-  --common: #94a3b8; /* Slate */
+  --common: #6b7280; /* Gray */
   --uncommon: #10b981; /* Emerald */
-  --rare: #06b6d4; /* Cyan */
+  --rare: #0ea5e9; /* Cyan */
   --epic: #8b5cf6; /* Violet */
-  --legendary: #a855f7; /* Purple */
+  --legendary: #fbbf24; /* Golden for legendary */
 
-  /* Shadows */
+  /* Shadows - Magical depth */
   --shadow-card:
-    0 10px 15px -3px rgba(30, 27, 75, 0.4), 0 4px 6px -2px rgba(30, 27, 75, 0.3);
+    0 0 0 1px rgba(99, 102, 241, 0.2), 0 10px 15px -3px rgba(12, 10, 31, 0.7),
+    0 4px 6px -2px rgba(12, 10, 31, 0.5),
+    inset 0 1px 0 0 rgba(99, 102, 241, 0.1);
   --shadow-card-hover:
-    0 20px 25px -5px rgba(30, 27, 75, 0.5),
-    0 10px 10px -5px rgba(30, 27, 75, 0.4);
+    0 0 0 1px rgba(14, 165, 233, 0.4), 0 20px 25px -5px rgba(12, 10, 31, 0.8),
+    0 10px 10px -5px rgba(12, 10, 31, 0.6),
+    inset 0 1px 0 0 rgba(14, 165, 233, 0.2);
   --shadow-button:
-    0 4px 6px -1px rgba(30, 27, 75, 0.3), 0 2px 4px -1px rgba(30, 27, 75, 0.2);
+    0 0 0 1px rgba(99, 102, 241, 0.2), 0 4px 6px -1px rgba(12, 10, 31, 0.5),
+    0 2px 4px -1px rgba(12, 10, 31, 0.3),
+    inset 0 1px 0 0 rgba(99, 102, 241, 0.1);
   --shadow-section:
-    0 4px 6px -1px rgba(30, 27, 75, 0.3), 0 2px 4px -1px rgba(30, 27, 75, 0.2);
-  --shadow-modal: 0 25px 50px -12px rgba(15, 23, 42, 0.5);
-  --text-shadow: 1px 1px 2px rgba(15, 23, 42, 0.5);
+    inset 0 2px 4px 0 rgba(12, 10, 31, 0.3),
+    0 4px 6px -1px rgba(12, 10, 31, 0.5), 0 0 0 1px rgba(99, 102, 241, 0.1);
+  --shadow-modal:
+    0 0 0 1px rgba(99, 102, 241, 0.3), 0 25px 50px -12px rgba(12, 10, 31, 0.8),
+    0 0 100px -20px rgba(99, 102, 241, 0.3);
+  --text-shadow: 2px 2px 4px rgba(12, 10, 31, 0.8);
 
-  /* Gradients */
-  --gradient-dice: linear-gradient(to bottom right, #06b6d4, #8b5cf6);
+  /* Gradients - Mystical energy */
+  --gradient-dice: linear-gradient(
+    135deg,
+    #0ea5e9 0%,
+    #6366f1 50%,
+    #8b5cf6 100%
+  );
 
   /* Glow effects with mystical energy */
-  --glow-common: 0 0 10px rgba(148, 163, 184, 0.5);
-  --glow-uncommon: 0 0 15px rgba(16, 185, 129, 0.6);
-  --glow-rare: 0 0 20px rgba(6, 182, 212, 0.7);
-  --glow-epic: 0 0 25px rgba(139, 92, 246, 0.8);
-  --glow-legendary: 0 0 30px rgba(168, 85, 247, 0.9);
+  --glow-common: 0 0 10px rgba(107, 114, 128, 0.5);
+  --glow-uncommon:
+    0 0 15px rgba(16, 185, 129, 0.6), 0 0 30px rgba(16, 185, 129, 0.2);
+  --glow-rare:
+    0 0 20px rgba(14, 165, 233, 0.7), 0 0 40px rgba(14, 165, 233, 0.3);
+  --glow-epic:
+    0 0 25px rgba(139, 92, 246, 0.8), 0 0 50px rgba(139, 92, 246, 0.4);
+  --glow-legendary:
+    0 0 30px rgba(251, 191, 36, 0.9), 0 0 60px rgba(251, 191, 36, 0.5),
+    0 0 90px rgba(251, 191, 36, 0.2);
 }

--- a/public/themes/dark-fantasy.css
+++ b/public/themes/dark-fantasy.css
@@ -1,70 +1,80 @@
 /* Modern Dark Fantasy Theme - Sleek, modern, serious fantasy */
 :root {
   /* Background colors */
-  --bg-primary: #1a1a1a; /* Deep charcoal */
-  --bg-secondary: #2a2a2a; /* Rich dark gray */
+  --bg-primary: #0a0a0a; /* Ultra deep black */
+  --bg-secondary: #141414; /* Rich charcoal */
 
   /* Card and content backgrounds */
-  --card-bg: #334155; /* Dark slate */
-  --section-bg: rgba(51, 65, 85, 0.9); /* Dark slate with transparency */
-  --stat-bg: #475569; /* Lighter slate */
-  --modal-bg: #334155; /* Dark slate */
+  --card-bg: #1e293b; /* Darker slate with better contrast */
+  --section-bg: rgba(30, 41, 59, 0.95); /* Darker slate with higher opacity */
+  --stat-bg: #334155; /* Dark slate */
+  --modal-bg: #1e293b; /* Darker slate */
 
   /* Text colors */
-  --text-primary: #f1f5f9; /* Light gray */
-  --text-secondary: #374151; /* Dark gray */
-  --text-button: #f1f5f9; /* Light gray */
-  --text-muted: #64748b; /* Medium gray */
-  --text-subtle: #94a3b8; /* Light medium gray */
+  --text-primary: #f8fafc; /* Brighter white for better readability */
+  --text-secondary: #e2e8f0; /* Light gray for secondary text */
+  --text-button: #ffffff; /* Pure white for buttons */
+  --text-muted: #94a3b8; /* Lighter muted text */
+  --text-subtle: #cbd5e1; /* Brighter subtle text */
 
   /* Accent colors */
   --accent-primary: #3b82f6; /* Electric blue */
-  --accent-primary-hover: #1d4ed8; /* Darker blue */
-  --accent-secondary: #475569; /* Lighter slate */
-  --accent-secondary-hover: #64748b; /* Medium gray */
+  --accent-primary-hover: #2563eb; /* Brighter hover blue */
+  --accent-secondary: #334155; /* Dark slate */
+  --accent-secondary-hover: #475569; /* Lighter slate hover */
 
   /* Border colors */
-  --border-primary: #94a3b8; /* Silver */
-  --border-section: rgba(148, 163, 184, 0.3); /* Silver with transparency */
-  --border-dashed: rgba(148, 163, 184, 0.5); /* Silver with transparency */
+  --border-primary: #475569; /* Darker borders for better integration */
+  --border-section: rgba(71, 85, 105, 0.5); /* Darker section borders */
+  --border-dashed: rgba(71, 85, 105, 0.6); /* Darker dashed borders */
 
   /* Background elements */
-  --inventory-bg: rgba(15, 23, 42, 0.3); /* Very dark with transparency */
-  --resource-bg: rgba(15, 23, 42, 0.4); /* Very dark with transparency */
-  --overlay-bg: rgba(15, 23, 42, 0.8); /* Very dark with transparency */
+  --inventory-bg: rgba(10, 10, 10, 0.5); /* Darker inventory background */
+  --resource-bg: rgba(10, 10, 10, 0.6); /* Darker resource background */
+  --overlay-bg: rgba(10, 10, 10, 0.9); /* Darker overlay */
 
   /* Game element colors */
-  --health: #ef4444; /* Bright red */
+  --health: #dc2626; /* Deeper red for better contrast */
   --mana: #3b82f6; /* Electric blue */
-  --stamina: #f59e0b; /* Gold */
-  --experience: #8b5cf6; /* Violet */
+  --stamina: #d97706; /* Deeper amber */
+  --experience: #9333ea; /* Richer purple */
 
   /* Rarity colors */
-  --common: #9ca3af; /* Gray */
-  --uncommon: #10b981; /* Emerald */
-  --rare: #3b82f6; /* Blue */
-  --epic: #8b5cf6; /* Violet */
-  --legendary: #f59e0b; /* Amber */
+  --common: #6b7280; /* Darker gray */
+  --uncommon: #059669; /* Deeper emerald */
+  --rare: #2563eb; /* Deeper blue */
+  --epic: #7c3aed; /* Richer violet */
+  --legendary: #dc2626; /* Red for legendary (more dramatic) */
 
-  /* Shadows */
+  /* Shadows - Enhanced for depth */
   --shadow-card:
-    0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+    0 0 0 1px rgba(71, 85, 105, 0.1), 0 10px 15px -3px rgba(0, 0, 0, 0.7),
+    0 4px 6px -2px rgba(0, 0, 0, 0.5);
   --shadow-card-hover:
-    0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 10px 10px -5px rgba(0, 0, 0, 0.4);
+    0 0 0 1px rgba(59, 130, 246, 0.3), 0 20px 25px -5px rgba(0, 0, 0, 0.8),
+    0 10px 10px -5px rgba(0, 0, 0, 0.6);
   --shadow-button:
-    0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+    0 0 0 1px rgba(71, 85, 105, 0.1), 0 4px 6px -1px rgba(0, 0, 0, 0.5),
+    0 2px 4px -1px rgba(0, 0, 0, 0.3);
   --shadow-section:
-    0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
-  --shadow-modal: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
-  --text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+    inset 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 4px 6px -1px rgba(0, 0, 0, 0.5);
+  --shadow-modal:
+    0 0 0 1px rgba(71, 85, 105, 0.2), 0 25px 50px -12px rgba(0, 0, 0, 0.8);
+  --text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
 
-  /* Gradients */
-  --gradient-dice: linear-gradient(to bottom right, #3b82f6, #1e40af);
+  /* Gradients - More dramatic */
+  --gradient-dice: linear-gradient(
+    135deg,
+    #3b82f6 0%,
+    #1e40af 50%,
+    #1e3a8a 100%
+  );
 
-  /* Glow effects */
-  --glow-common: 0 0 10px rgba(156, 163, 175, 0.5);
-  --glow-uncommon: 0 0 15px rgba(16, 185, 129, 0.6);
-  --glow-rare: 0 0 20px rgba(59, 130, 246, 0.7);
-  --glow-epic: 0 0 25px rgba(139, 92, 246, 0.8);
-  --glow-legendary: 0 0 30px rgba(245, 158, 11, 0.9);
+  /* Glow effects - Subtler and more refined */
+  --glow-common: 0 0 8px rgba(107, 114, 128, 0.4);
+  --glow-uncommon: 0 0 12px rgba(5, 150, 105, 0.5);
+  --glow-rare: 0 0 16px rgba(37, 99, 235, 0.6);
+  --glow-epic: 0 0 20px rgba(124, 58, 237, 0.7);
+  --glow-legendary:
+    0 0 24px rgba(220, 38, 38, 0.8), 0 0 36px rgba(220, 38, 38, 0.4);
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -9,22 +9,10 @@ export interface Theme {
 
 export const themes: Theme[] = [
   {
-    id: 'wood',
-    name: 'Board Game Wood',
-    description: 'Classic wood texture with parchment - warm and tactile',
-    preview: '#8B5A3C',
-  },
-  {
     id: 'dark-fantasy',
     name: 'Modern Dark Fantasy',
     description: 'Sleek modern design with electric blue accents',
     preview: '#3b82f6',
-  },
-  {
-    id: 'dungeon',
-    name: 'Dungeon Stone',
-    description: 'Underground atmosphere with torchlight warmth',
-    preview: '#ea580c',
   },
   {
     id: 'arcane',
@@ -32,10 +20,16 @@ export const themes: Theme[] = [
     description: 'Magical purple and cyan with mystical energy',
     preview: '#8b5cf6',
   },
+  {
+    id: 'dungeon',
+    name: 'Dungeon Stone',
+    description: 'Underground atmosphere with torchlight warmth',
+    preview: '#ea580c',
+  },
 ];
 
 const THEME_STORAGE_KEY = 'rpg-dnd5e-theme';
-const DEFAULT_THEME = 'arcane';
+const DEFAULT_THEME = 'dark-fantasy';
 
 export function useTheme() {
   const [currentTheme, setCurrentTheme] = useState<string>(DEFAULT_THEME);


### PR DESCRIPTION
## Summary
- Enhanced dark-fantasy theme with ultra-deep blacks and better contrast for a more immersive experience
- Improved arcane theme with deeper mystical colors and magical glow effects
- Changed default theme from arcane to dark-fantasy as requested

## Key Changes
- **Dark Fantasy Theme**: Darker backgrounds (#0a0a0a), better text contrast, red legendary items for drama
- **Arcane Theme**: Deep mystical void backgrounds, indigo/cyan color scheme, multi-layered magical glows
- **Removed Wood Theme**: Removed from available options as requested
- **Default Theme**: Changed from 'arcane' to 'dark-fantasy'

## Visual Improvements
- Enhanced shadows with subtle borders for depth
- Refined glow effects for rarity tiers
- Better text readability with brighter whites and improved contrast
- More dramatic gradients and visual effects

## Test Plan
- [ ] Theme selector shows only 3 themes (dark-fantasy, arcane, dungeon)
- [ ] Default theme loads as dark-fantasy on first visit
- [ ] Theme switching works correctly
- [ ] All UI elements are readable in both themes
- [ ] Visual effects (shadows, glows) render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)