### PR TITLE
Fix spell selection saving and display improvements

### DIFF
--- a/src/character/creation/CharacterDraftContext.tsx
+++ b/src/character/creation/CharacterDraftContext.tsx
@@ -10,6 +10,7 @@ import {
   AbilityScoresSchema,
   ChoiceSelectionSchema,
   ChoiceSource,
+  ChoiceType,
   CreateDraftRequestSchema,
   UpdateAbilityScoresRequestSchema,
   UpdateClassRequestSchema,
@@ -107,6 +108,33 @@ function cleanSelectedKeys(selectedKeys: unknown[]): string[] {
     .filter((key) => typeof key === 'string' && !key.includes('"$typeName"'));
 }
 
+// Helper to determine choice type from choice ID
+function getChoiceType(choiceId: string): ChoiceType {
+  const lowerChoiceId = choiceId.toLowerCase();
+
+  if (lowerChoiceId.includes('spell') || lowerChoiceId.includes('cantrip')) {
+    return ChoiceType.SPELL;
+  } else if (lowerChoiceId.includes('skill')) {
+    return ChoiceType.SKILL;
+  } else if (lowerChoiceId.includes('equipment')) {
+    return ChoiceType.EQUIPMENT;
+  } else if (lowerChoiceId.includes('language')) {
+    return ChoiceType.LANGUAGE;
+  } else if (lowerChoiceId.includes('tool')) {
+    return ChoiceType.TOOL;
+  } else if (lowerChoiceId.includes('weapon')) {
+    return ChoiceType.WEAPON_PROFICIENCY;
+  } else if (lowerChoiceId.includes('armor')) {
+    return ChoiceType.ARMOR_PROFICIENCY;
+  } else if (lowerChoiceId.includes('feat')) {
+    return ChoiceType.FEAT;
+  } else if (lowerChoiceId.includes('ability')) {
+    return ChoiceType.ABILITY_SCORE;
+  }
+
+  return ChoiceType.UNSPECIFIED;
+}
+
 // Helper to convert our choice format to ChoiceSelection
 function createChoiceSelections(
   choices: Record<string, string[]>,
@@ -120,6 +148,7 @@ function createChoiceSelections(
         create(ChoiceSelectionSchema, {
           choiceId,
           source,
+          choiceType: getChoiceType(choiceId),
           selectedKeys,
         })
       );

--- a/src/character/creation/components/SpellInfoDisplay.tsx
+++ b/src/character/creation/components/SpellInfoDisplay.tsx
@@ -6,12 +6,14 @@ interface SpellInfoDisplayProps {
   spellcastingInfo: SpellcastingInfo;
   className?: string;
   onSelectSpells?: () => void;
+  selectedSpells?: string[];
 }
 
 export function SpellInfoDisplay({
   spellcastingInfo,
   className,
   onSelectSpells,
+  selectedSpells = [],
 }: SpellInfoDisplayProps) {
   const getAbilityDisplayName = (ability: string) => {
     const abilityMap: Record<string, string> = {
@@ -249,6 +251,115 @@ export function SpellInfoDisplay({
           </div>
         </div>
       )}
+
+      {/* Selected Spells */}
+      {selectedSpells.length > 0 &&
+        (() => {
+          // Common cantrip spell IDs
+          const cantripIds = [
+            'SPELL_ACID_SPLASH',
+            'SPELL_FIRE_BOLT',
+            'SPELL_POISON_SPRAY',
+            'SPELL_MAGE_HAND',
+            'SPELL_MINOR_ILLUSION',
+            'SPELL_PRESTIDIGITATION',
+            'SPELL_RAY_OF_FROST',
+            'SPELL_LIGHT',
+            'SPELL_MENDING',
+            'SPELL_MESSAGE',
+            'SPELL_SHOCKING_GRASP',
+            'SPELL_CHILL_TOUCH',
+            'SPELL_DANCING_LIGHTS',
+            'SPELL_TRUE_STRIKE',
+          ];
+
+          const cantrips = selectedSpells.filter((spell) =>
+            cantripIds.includes(spell)
+          );
+          const level1Spells = selectedSpells.filter(
+            (spell) => !cantripIds.includes(spell)
+          );
+
+          const formatSpellName = (spell: string) =>
+            spell
+              .replace('SPELL_', '')
+              .replace(/_/g, ' ')
+              .toLowerCase()
+              .split(' ')
+              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+              .join(' ');
+
+          return (
+            <div
+              className="p-3 rounded-lg border"
+              style={{
+                backgroundColor: 'var(--bg-secondary)',
+                borderColor: 'var(--border-primary)',
+              }}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <BookOpen
+                  className="w-4 h-4"
+                  style={{ color: 'var(--accent-primary)' }}
+                />
+                <span
+                  className="text-sm font-medium"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  Selected Spells
+                </span>
+              </div>
+              <div className="space-y-3">
+                {cantrips.length > 0 && (
+                  <div>
+                    <div
+                      className="text-xs font-medium mb-1"
+                      style={{
+                        color: 'var(--accent-primary)',
+                      }}
+                    >
+                      Cantrips
+                    </div>
+                    <div
+                      className="text-xs space-y-1"
+                      style={{
+                        color: 'var(--text-primary)',
+                        fontFamily: 'var(--font-body)',
+                      }}
+                    >
+                      {cantrips.map((spell) => (
+                        <div key={spell}>• {formatSpellName(spell)}</div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+                {level1Spells.length > 0 && (
+                  <div>
+                    <div
+                      className="text-xs font-medium mb-1"
+                      style={{
+                        color: 'var(--accent-primary)',
+                      }}
+                    >
+                      1st Level Spells
+                    </div>
+                    <div
+                      className="text-xs space-y-1"
+                      style={{
+                        color: 'var(--text-primary)',
+                        fontFamily: 'var(--font-body)',
+                      }}
+                    >
+                      {level1Spells.map((spell) => (
+                        <div key={spell}>• {formatSpellName(spell)}</div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })()}
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- Implemented proper spell selection saving to character draft
- Fixed spell display grouping and theme colors
- Corrected race traits to show only user choices

## Changes
- Save spell selections with proper choice keys (`wizard-cantrips`, `wizard-spells`)
- Group spell display by level (cantrips vs 1st level)
- Fix spell display color for dark themes (use `--text-primary` instead of `--text-secondary`)
- Set correct choiceType (7) for spell choices
- Fix race traits to show only user choices, not all proficiencies
- Restore spell selections from draft on component load
- Remove unused `formatProficiencies` and `getExtraLanguages` functions

## Related Issues
- See #113 for the background selection feature that still needs to be implemented

## Test Plan
1. Create a new character
2. Select a spellcasting class (e.g., Wizard)
3. Choose spells when prompted
4. Verify spells are saved and displayed correctly on the character sheet
5. Reload the page and verify spells are restored from the draft
6. Switch between light and dark themes to verify text is readable

🤖 Generated with [Claude Code](https://claude.ai/code)