### PR TITLE
feat: Upgrade to rpg-api-protos v0.1.23 with choice system refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.15",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.23",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -247,14 +247,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -357,28 +357,28 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.6.1.tgz",
-      "integrity": "sha512-DaG6XlyKpz08bmHY5SGX2gfIllaqtDJ/KwVoxsmP22COOLYwDBe7yD3DZGwXem/Xq7QOc9cuR7R3MpAv5CFfDw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.6.2.tgz",
+      "integrity": "sha512-vLu7SRY84CV/Dd+NUdgtidn2hS5hSMUC1vDBY0VcviTdgRYkU43vIz3vIFbmx14cX1r+mM7WjzE5Fl1fGEM0RQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.2.tgz",
-      "integrity": "sha512-xZuylIUNvNlH52e/4eQsZvY4QZyDJRtEFEDnn/yBrv5Xi5ZZI/p8X+GAHH35ucVaBvv9u7OzHZo8+tEh1EFTxA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.3.tgz",
+      "integrity": "sha512-jAbVMHVtDCydGt2P20VpmLjbLtERqSV0RMSyQF3k2zhK8pzQ2QaCAcyVhufClqrOAFZUKL5BqVYtttaxvhmRgg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.2.tgz",
-      "integrity": "sha512-QANMFPiL2o66BdBEctg4TsQLe5ozsBLqcle3dCBp7BwGlNGTY6NnNnqmt+YRnpeMW88GgomJwWNMGCrRD9pRKA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.3.tgz",
+      "integrity": "sha512-w4LZ2Ci+NW/kcMoHnoczJgyGTmxuv/MQ+tTm2UNL40HimXKWYCAna/fV0AbHRnTiteiwEBpeSCaxF34MetzhAw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.2"
+        "@connectrpc/connect": "2.0.3"
       }
     },
     "node_modules/@discord/embedded-app-sdk": {
@@ -957,9 +957,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
-      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
+      "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -994,31 +994,31 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
-      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
-      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
-      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.5.tgz",
+      "integrity": "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.2"
+        "@floating-ui/dom": "^1.7.3"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1151,7 +1151,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#55f3934a9073fe085d8129a367d5e2c216ca21fa",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#977ac81f04be3bf0af5ed14e7c3adb0e57f14db2",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
@@ -1856,9 +1856,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
       "cpu": [
         "arm"
       ],
@@ -1870,9 +1870,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
       "cpu": [
         "arm64"
       ],
@@ -1884,9 +1884,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
+      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
       "cpu": [
         "arm64"
       ],
@@ -1898,9 +1898,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
       "cpu": [
         "x64"
       ],
@@ -1912,9 +1912,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
       "cpu": [
         "arm64"
       ],
@@ -1926,9 +1926,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
       "cpu": [
         "x64"
       ],
@@ -1940,9 +1940,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
       "cpu": [
         "arm"
       ],
@@ -1954,9 +1954,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
       "cpu": [
         "arm"
       ],
@@ -1968,9 +1968,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
       "cpu": [
         "arm64"
       ],
@@ -1982,9 +1982,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
       "cpu": [
         "arm64"
       ],
@@ -1996,9 +1996,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
       "cpu": [
         "loong64"
       ],
@@ -2009,10 +2009,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
       "cpu": [
         "ppc64"
       ],
@@ -2024,9 +2024,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
       "cpu": [
         "riscv64"
       ],
@@ -2052,9 +2052,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
       "cpu": [
         "s390x"
       ],
@@ -2066,9 +2066,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
       "cpu": [
         "x64"
       ],
@@ -2080,9 +2080,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
       "cpu": [
         "x64"
       ],
@@ -2094,9 +2094,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
       "cpu": [
         "arm64"
       ],
@@ -2108,9 +2108,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
       "cpu": [
         "ia32"
       ],
@@ -2122,9 +2122,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
       "cpu": [
         "x64"
       ],
@@ -2498,9 +2498,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
-      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2508,9 +2508,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2518,9 +2518,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
-      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3051,9 +3051,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {
@@ -3261,9 +3261,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.188",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.188.tgz",
-      "integrity": "sha512-pfEx5CBFAocOKNrc+i5fSvhDaI1Vr9R9aT5uX1IzM3hhdL6k649wfuUcdUd9EZnmbE1xdfA51CwqQ61CO3Xl3g==",
+      "version": "1.5.193",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.193.tgz",
+      "integrity": "sha512-eePuBZXM9OVCwfYUhd2OzESeNGnWmLyeu0XAEjf7xjijNjHFdeJSzuRUGN4ueT2tEYo5YqjHramKEFxz67p3XA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3367,9 +3367,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
-      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
+      "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3379,8 +3379,8 @@
         "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.31.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/js": "9.32.0",
+        "@eslint/plugin-kit": "^0.3.4",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3690,12 +3690,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.6.tgz",
-      "integrity": "sha512-dsJ389QImVE3lQvM8Mnk99/j8tiZDM/7706PCqvkQ8sSCnpmWxsgX+g0lj7r5OBVL0U36pIecCTBoIWcM2RuKw==",
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.23.6",
+        "motion-dom": "^12.23.12",
         "motion-utils": "^12.23.6",
         "tslib": "^2.4.0"
       },
@@ -3920,9 +3920,9 @@
       "license": "ISC"
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4554,9 +4554,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.6.tgz",
-      "integrity": "sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w==",
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.23.6"
@@ -4826,15 +4826,15 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
-      "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.2.0.tgz",
+      "integrity": "sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "prettier": ">=2.0",
         "typescript": ">=2.9",
-        "vue-tsc": "^2.1.0"
+        "vue-tsc": "^2.1.0 || 3"
       },
       "peerDependenciesMeta": {
         "vue-tsc": {
@@ -4874,24 +4874,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.1.1"
       }
     },
     "node_modules/react-refresh": {
@@ -5028,9 +5028,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
-      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
+      "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5044,26 +5044,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.1",
-        "@rollup/rollup-android-arm64": "4.45.1",
-        "@rollup/rollup-darwin-arm64": "4.45.1",
-        "@rollup/rollup-darwin-x64": "4.45.1",
-        "@rollup/rollup-freebsd-arm64": "4.45.1",
-        "@rollup/rollup-freebsd-x64": "4.45.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-        "@rollup/rollup-linux-arm64-musl": "4.45.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-musl": "4.45.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "@rollup/rollup-android-arm-eabi": "4.46.2",
+        "@rollup/rollup-android-arm64": "4.46.2",
+        "@rollup/rollup-darwin-arm64": "4.46.2",
+        "@rollup/rollup-darwin-x64": "4.46.2",
+        "@rollup/rollup-freebsd-arm64": "4.46.2",
+        "@rollup/rollup-freebsd-x64": "4.46.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.46.2",
+        "@rollup/rollup-linux-arm64-musl": "4.46.2",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.46.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-musl": "4.46.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.46.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.46.2",
+        "@rollup/rollup-win32-x64-msvc": "4.46.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -5540,15 +5540,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.5.tgz",
-      "integrity": "sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.6.tgz",
+      "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
-        "picomatch": "^4.0.2",
+        "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.40.0",
         "tinyglobby": "^0.2.14"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.15",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.23",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/character/creation/ClassSelectionModal.tsx
+++ b/src/character/creation/ClassSelectionModal.tsx
@@ -1,5 +1,5 @@
 import type { ClassInfo } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import { ChoiceType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import { ChoiceCategory } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useListClasses } from '../../api/hooks';
@@ -203,7 +203,7 @@ export function ClassSelectionModal({
     // Validate skill choices
     const skillChoices =
       currentClassData.choices?.filter(
-        (choice) => choice.choiceType === ChoiceType.SKILL
+        (choice) => choice.choiceType === ChoiceCategory.SKILLS
       ) || [];
 
     for (const choice of skillChoices) {
@@ -219,7 +219,7 @@ export function ClassSelectionModal({
     // Validate equipment choices
     const equipmentChoices =
       currentClassData.choices?.filter(
-        (choice) => choice.choiceType === ChoiceType.EQUIPMENT
+        (choice) => choice.choiceType === ChoiceCategory.EQUIPMENT
       ) || [];
 
     for (const choice of equipmentChoices) {
@@ -236,9 +236,9 @@ export function ClassSelectionModal({
     const proficiencyChoices =
       currentClassData.choices?.filter(
         (choice) =>
-          choice.choiceType === ChoiceType.TOOL ||
-          choice.choiceType === ChoiceType.WEAPON_PROFICIENCY ||
-          choice.choiceType === ChoiceType.ARMOR_PROFICIENCY
+          choice.choiceType === ChoiceCategory.TOOLS ||
+          choice.choiceType === ChoiceCategory.WEAPON_PROFICIENCIES ||
+          choice.choiceType === ChoiceCategory.ARMOR_PROFICIENCIES
       ) || [];
 
     for (const choice of proficiencyChoices) {
@@ -254,7 +254,7 @@ export function ClassSelectionModal({
     // Validate feat choices
     const featChoices =
       currentClassData.choices?.filter(
-        (choice) => choice.choiceType === ChoiceType.FEAT
+        (choice) => choice.choiceType === ChoiceCategory.FEATS
       ) || [];
 
     for (const choice of featChoices) {
@@ -626,7 +626,7 @@ export function ClassSelectionModal({
             {(() => {
               const skillChoices =
                 currentClassData.choices?.filter(
-                  (choice) => choice.choiceType === ChoiceType.SKILL
+                  (choice) => choice.choiceType === ChoiceCategory.SKILLS
                 ) || [];
 
               if (skillChoices.length === 0) return null;
@@ -759,7 +759,7 @@ export function ClassSelectionModal({
             {(() => {
               const equipmentChoices =
                 currentClassData.choices?.filter(
-                  (choice) => choice.choiceType === ChoiceType.EQUIPMENT
+                  (choice) => choice.choiceType === ChoiceCategory.EQUIPMENT
                 ) || [];
 
               if (equipmentChoices.length === 0) return null;
@@ -805,9 +805,9 @@ export function ClassSelectionModal({
               const proficiencyChoices =
                 currentClassData.choices?.filter(
                   (choice) =>
-                    choice.choiceType === ChoiceType.TOOL ||
-                    choice.choiceType === ChoiceType.WEAPON_PROFICIENCY ||
-                    choice.choiceType === ChoiceType.ARMOR_PROFICIENCY
+                    choice.choiceType === ChoiceCategory.TOOLS ||
+                    choice.choiceType === ChoiceCategory.WEAPON_PROFICIENCIES ||
+                    choice.choiceType === ChoiceCategory.ARMOR_PROFICIENCIES
                 ) || [];
 
               if (proficiencyChoices.length === 0) return null;
@@ -850,7 +850,7 @@ export function ClassSelectionModal({
             {(() => {
               const featChoices =
                 currentClassData.choices?.filter(
-                  (choice) => choice.choiceType === ChoiceType.FEAT
+                  (choice) => choice.choiceType === ChoiceCategory.FEATS
                 ) || [];
 
               if (featChoices.length === 0) return null;
@@ -894,14 +894,16 @@ export function ClassSelectionModal({
               const otherChoices =
                 currentClassData.choices?.filter(
                   (choice) =>
-                    choice.choiceType === ChoiceType.SPELL ||
-                    choice.choiceType === ChoiceType.LANGUAGE ||
-                    (choice.choiceType !== ChoiceType.SKILL &&
-                      choice.choiceType !== ChoiceType.EQUIPMENT &&
-                      choice.choiceType !== ChoiceType.TOOL &&
-                      choice.choiceType !== ChoiceType.WEAPON_PROFICIENCY &&
-                      choice.choiceType !== ChoiceType.ARMOR_PROFICIENCY &&
-                      choice.choiceType !== ChoiceType.FEAT)
+                    choice.choiceType === ChoiceCategory.SPELLS ||
+                    choice.choiceType === ChoiceCategory.LANGUAGES ||
+                    (choice.choiceType !== ChoiceCategory.SKILLS &&
+                      choice.choiceType !== ChoiceCategory.EQUIPMENT &&
+                      choice.choiceType !== ChoiceCategory.TOOLS &&
+                      choice.choiceType !==
+                        ChoiceCategory.WEAPON_PROFICIENCIES &&
+                      choice.choiceType !==
+                        ChoiceCategory.ARMOR_PROFICIENCIES &&
+                      choice.choiceType !== ChoiceCategory.FEATS)
                 ) || [];
 
               if (otherChoices.length === 0) return null;

--- a/src/character/creation/RaceSelectionModal.tsx
+++ b/src/character/creation/RaceSelectionModal.tsx
@@ -1,5 +1,5 @@
 import type { RaceInfo } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import { ChoiceType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import { ChoiceCategory } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { Language } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -218,7 +218,7 @@ export function RaceSelectionModal({
     // Validate language choices
     const languageChoices =
       currentRaceData.choices?.filter(
-        (choice) => choice.choiceType === ChoiceType.LANGUAGE
+        (choice) => choice.choiceType === ChoiceCategory.LANGUAGES
       ) || [];
 
     for (const choice of languageChoices) {
@@ -235,10 +235,10 @@ export function RaceSelectionModal({
     const proficiencyChoices =
       currentRaceData.choices?.filter(
         (choice) =>
-          choice.choiceType === ChoiceType.SKILL ||
-          choice.choiceType === ChoiceType.TOOL ||
-          choice.choiceType === ChoiceType.WEAPON_PROFICIENCY ||
-          choice.choiceType === ChoiceType.ARMOR_PROFICIENCY
+          choice.choiceType === ChoiceCategory.SKILLS ||
+          choice.choiceType === ChoiceCategory.TOOLS ||
+          choice.choiceType === ChoiceCategory.WEAPON_PROFICIENCIES ||
+          choice.choiceType === ChoiceCategory.ARMOR_PROFICIENCIES
       ) || [];
 
     for (const choice of proficiencyChoices) {
@@ -618,7 +618,7 @@ export function RaceSelectionModal({
             {(() => {
               const languageChoices =
                 currentRaceData.choices?.filter(
-                  (choice) => choice.choiceType === ChoiceType.LANGUAGE
+                  (choice) => choice.choiceType === ChoiceCategory.LANGUAGES
                 ) || [];
 
               if (languageChoices.length === 0) return null;
@@ -662,10 +662,10 @@ export function RaceSelectionModal({
               const proficiencyChoices =
                 currentRaceData.choices?.filter(
                   (choice) =>
-                    choice.choiceType === ChoiceType.SKILL ||
-                    choice.choiceType === ChoiceType.TOOL ||
-                    choice.choiceType === ChoiceType.WEAPON_PROFICIENCY ||
-                    choice.choiceType === ChoiceType.ARMOR_PROFICIENCY
+                    choice.choiceType === ChoiceCategory.SKILLS ||
+                    choice.choiceType === ChoiceCategory.TOOLS ||
+                    choice.choiceType === ChoiceCategory.WEAPON_PROFICIENCIES ||
+                    choice.choiceType === ChoiceCategory.ARMOR_PROFICIENCIES
                 ) || [];
 
               if (proficiencyChoices.length === 0) return null;

--- a/src/components/ChoiceRenderer.tsx
+++ b/src/components/ChoiceRenderer.tsx
@@ -1,5 +1,5 @@
 import type { Choice } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import { ChoiceType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import { ChoiceCategory } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { EquipmentChoice } from './choices/EquipmentChoice';
 import { GenericChoice } from './choices/GenericChoice';
 import { LanguageChoice } from './choices/LanguageChoice';
@@ -22,7 +22,7 @@ export function ChoiceRenderer({
   currentSelections,
 }: ChoiceRendererProps) {
   switch (choice.choiceType) {
-    case ChoiceType.SKILL:
+    case ChoiceCategory.SKILLS:
       return (
         <SkillChoice
           choice={choice}
@@ -31,7 +31,7 @@ export function ChoiceRenderer({
         />
       );
 
-    case ChoiceType.EQUIPMENT:
+    case ChoiceCategory.EQUIPMENT:
       return (
         <EquipmentChoice
           choice={choice}
@@ -40,7 +40,7 @@ export function ChoiceRenderer({
         />
       );
 
-    case ChoiceType.SPELL:
+    case ChoiceCategory.SPELLS:
       return (
         <SpellChoice
           choice={choice}
@@ -49,7 +49,7 @@ export function ChoiceRenderer({
         />
       );
 
-    case ChoiceType.LANGUAGE:
+    case ChoiceCategory.LANGUAGES:
       return (
         <LanguageChoice
           choice={choice}
@@ -58,9 +58,9 @@ export function ChoiceRenderer({
         />
       );
 
-    case ChoiceType.TOOL:
-    case ChoiceType.WEAPON_PROFICIENCY:
-    case ChoiceType.ARMOR_PROFICIENCY:
+    case ChoiceCategory.TOOLS:
+    case ChoiceCategory.WEAPON_PROFICIENCIES:
+    case ChoiceCategory.ARMOR_PROFICIENCIES:
       // These are proficiency types that can be handled generically for now
       return (
         <GenericChoice


### PR DESCRIPTION
## Summary
- Upgraded rpg-api-protos from v0.1.15 to v0.1.23
- Migrated choice system to support new proto structure
- Maintained backward compatibility with existing API calls

## Changes Made

### Proto Dependency Update
- Updated package.json to use rpg-api-protos v0.1.23
- Regenerated package-lock.json to ensure correct commit hash

### Choice System Migration
1. **Enum Updates**: `ChoiceType` → `ChoiceCategory`
   - Updated all imports and usage in ClassSelectionModal, RaceSelectionModal, and ChoiceRenderer
   - Updated enum values (e.g., `SKILL` → `SKILLS`, `LANGUAGE` → `LANGUAGES`)

2. **Type Updates**: `ChoiceSelection` → `ChoiceData` 
   - Added `extractSelectionsFromChoiceData()` helper to handle new oneof pattern
   - Updated draft loading logic to process ChoiceData from `draft.choices`
   - Maintained ChoiceSelection for update requests (API still expects this format)

3. **Oneof Pattern Support**
   - New type-safe selection pattern replaces google.protobuf.Any
   - Handles skills, languages, equipment, spells, cantrips, race, class, background
   - Properly converts enum values to strings for UI compatibility

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint checks pass
- ✅ Pre-commit hooks pass
- ⚠️ Build has pre-existing errors unrelated to this change

## Breaking Changes
The choice system has been refactored in the protos. While this PR maintains backward compatibility in the frontend, any code directly accessing choice data structures will need updates.

## Related
- Fixes #125
- Proto changes: KirkDiggler/rpg-api-protos commits 67eb198 and 3c710bf

🤖 Generated with [Claude Code](https://claude.ai/code)