### PR TITLE
Fix AbortError and implement proper race/class lookup

### DIFF
--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -99,7 +99,7 @@ export function useGetCharacter(characterId: string) {
 
     fetchCharacter(controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchCharacter]);
 
   return { ...state, refetch: () => fetchCharacter() };
@@ -160,7 +160,7 @@ export function useListCharacters(
 
     fetchCharacters(undefined, controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchCharacters]);
 
   return {
@@ -219,7 +219,7 @@ export function useGetDraft(draftId: string) {
 
     fetchDraft(controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchDraft]);
 
   return { ...state, refetch: () => fetchDraft() };
@@ -279,7 +279,7 @@ export function useListDrafts(
 
     fetchDrafts(undefined, controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchDrafts]);
 
   return {
@@ -607,7 +607,7 @@ export function useListRaces(
 
     fetchRaces(undefined, controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchRaces]);
 
   return {
@@ -671,7 +671,7 @@ export function useListClasses(
 
     fetchClasses(undefined, controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchClasses]);
 
   return {
@@ -739,7 +739,7 @@ export function useListEquipmentByType(
 
     fetchEquipment(undefined, controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchEquipment]);
 
   return {
@@ -813,7 +813,7 @@ export function useListEquipmentByTypeConditional(
 
     fetchEquipment(undefined, controller.signal);
 
-    return () => controller.abort();
+    return () => controller.abort('Component unmounted');
   }, [fetchEquipment, enabled]);
 
   return {

--- a/src/utils/lookupUtils.ts
+++ b/src/utils/lookupUtils.ts
@@ -1,0 +1,91 @@
+import type {
+  ClassInfo,
+  RaceInfo,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import {
+  Class,
+  Race,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+
+/**
+ * Race lookup utilities for converting between enum IDs and full RaceInfo objects
+ */
+export const raceLookup = {
+  /**
+   * Find a RaceInfo by its enum value
+   */
+  findByEnum: (races: RaceInfo[], raceEnum: Race): RaceInfo | undefined => {
+    return races.find((race) => race.id === Race[raceEnum].toLowerCase());
+  },
+
+  /**
+   * Find a RaceInfo by its enum value, throwing if not found
+   */
+  findByEnumOrThrow: (races: RaceInfo[], raceEnum: Race): RaceInfo => {
+    const race = raceLookup.findByEnum(races, raceEnum);
+    if (!race) {
+      throw new Error(
+        `Race not found for enum: ${Race[raceEnum]} (${raceEnum})`
+      );
+    }
+    return race;
+  },
+};
+
+/**
+ * Class lookup utilities for converting between enum IDs and full ClassInfo objects
+ */
+export const classLookup = {
+  /**
+   * Find a ClassInfo by its enum value
+   */
+  findByEnum: (
+    classes: ClassInfo[],
+    classEnum: Class
+  ): ClassInfo | undefined => {
+    return classes.find((cls) => cls.id === Class[classEnum].toLowerCase());
+  },
+
+  /**
+   * Find a ClassInfo by its enum value, throwing if not found
+   */
+  findByEnumOrThrow: (classes: ClassInfo[], classEnum: Class): ClassInfo => {
+    const cls = classLookup.findByEnum(classes, classEnum);
+    if (!cls) {
+      throw new Error(
+        `Class not found for enum: ${Class[classEnum]} (${classEnum})`
+      );
+    }
+    return cls;
+  },
+};
+
+/**
+ * Get race name from enum, with fallback
+ */
+export function getRaceName(races: RaceInfo[], raceEnum: Race): string {
+  const race = raceLookup.findByEnum(races, raceEnum);
+  return race?.name || Race[raceEnum] || 'Unknown Race';
+}
+
+/**
+ * Get class name from enum, with fallback
+ */
+export function getClassName(classes: ClassInfo[], classEnum: Class): string {
+  const cls = classLookup.findByEnum(classes, classEnum);
+  return cls?.name || Class[classEnum] || 'Unknown Class';
+}
+
+/**
+ * Type guard for checking if race is loaded
+ */
+export function isRaceLoaded(race: RaceInfo | undefined): race is RaceInfo {
+  return race !== undefined;
+}
+
+/**
+ * Type guard for checking if class is loaded
+ */
+export function isClassLoaded(cls: ClassInfo | undefined): cls is ClassInfo {
+  return cls !== undefined;
+}


### PR DESCRIPTION
## Summary

This PR fixes two critical issues discovered during tech debt review:

1. **AbortError in console**: 'signal is aborted without reason' errors were appearing when components unmounted
2. **Incorrect assumptions about draft data**: The code assumed the API returns full RaceInfo/ClassInfo objects with drafts, but it actually only returns enum IDs

## Changes

### 🐛 Fixed AbortError
- Added reason to all controller.abort() calls throughout the hooks
- Now calls abort with 'Component unmounted' reason to prevent console errors
- Affects all API hooks that use AbortController for cleanup

### 🔧 Implemented Race/Class Lookup System
- Created lookupUtils.ts with utilities to find full objects from enum IDs
- Added raceLookup and classLookup helpers with type-safe lookups
- Includes fallback handling for missing data

### 📡 Updated CharacterDraftContext
- Added hooks to fetch available races and classes (useListRaces, useListClasses)
- Added useEffect hooks to look up full race/class info when draft loads
- Removed misleading comments claiming draft contains full objects
- Fixed loading logic to work with enum IDs from the API

### 🧹 Code Cleanup
- Removed incorrect code that tried to set race/class info from draft
- Updated comments to accurately reflect what the API returns
- Moved useEffect for proficiency calculation after helper function definitions

## Technical Details

The rpg-api returns drafts with only enum IDs:
- draft.raceId (Race enum)
- draft.classId (Class enum)

We now:
1. Fetch the full race/class lists on component mount
2. Use the lookup utilities to find the matching full objects
3. Store the full objects in context for use throughout the app

## Testing

- [x] No more AbortError messages in console
- [x] Race/class info properly loads when opening a draft
- [x] Proficiencies and languages calculate correctly
- [x] TypeScript builds without errors
- [x] All CI checks pass

## Related Issues

Part of the tech debt cleanup effort identified in our review.

Fixes console errors from #134 (double API call fix)