### PR TITLE
feat: Update Discord auth endpoint to /auth/discord/token

### DIFF
--- a/src/discord/DiscordProvider.tsx
+++ b/src/discord/DiscordProvider.tsx
@@ -75,8 +75,8 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
           window.location.hostname.includes('discordsays.com');
         const apiBase = import.meta.env.VITE_API_HOST || '';
         const apiUrl = isDiscordActivity
-          ? '/.proxy/api/discord/token'
-          : `${apiBase}/api/discord/token`;
+          ? '/.proxy/auth/discord/token'
+          : `${apiBase}/auth/discord/token`;
 
         console.log('🔐 Calling API:', apiUrl);
 


### PR DESCRIPTION
## Summary
Updates the Discord authentication endpoint from `/api/discord/token` to `/auth/discord/token` to prevent routing conflicts with gRPC service paths.

## Problem
- Discord proxy prefix mapping for `/api` was conflicting with gRPC service paths like `/api.v1alpha1.DiceService`
- This caused 405 Method Not Allowed errors when calling the dice service through Discord Activity
- The `/api` prefix created ambiguity between REST endpoints and gRPC service names

## Solution
- Move Discord auth endpoint from `/api/discord/token` to `/auth/discord/token`
- Clear separation between authentication endpoints and API routes
- Works with both Discord Activity proxy (`/.proxy/auth/discord/token`) and direct access

## Changes
- **DiscordProvider.tsx**: Update both Discord Activity and direct API URLs to use `/auth/discord/token`

## Testing
- All CI checks pass (format, lint, typecheck, build)
- Requires companion PR in rpg-deployment for nginx routing

## Related
- Companion PR: KirkDiggler/rpg-deployment#44
- Fixes 405 errors when calling dice service through Discord Activity
- Part of effort to cleanly separate auth routes from API routes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>