### PR TITLE
fix: Convert issue template labels from strings to arrays

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Something isn't working right in the Discord activity
 title: '[BUG] '
-labels: 'bug', 'discord-activity'
+labels: [bug, discord-activity]
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest an idea for the Discord activity
 title: '[FEATURE] '
-labels: 'enhancement', 'discord-activity'
+labels: [enhancement, discord-activity]
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -2,7 +2,7 @@
 name: General Feedback
 about: Share your thoughts, questions, or general feedback about the game
 title: '[FEEDBACK] '
-labels: 'feedback', 'discord-activity'
+labels: [feedback, discord-activity]
 assignees: ''
 ---
 


### PR DESCRIPTION
GitHub requires labels to be arrays in YAML frontmatter for proper rendering in the issue template picker. This fixes templates not appearing in the 'New Issue' dropdown.

🤖 Generated with [Claude Code](https://claude.ai/code)