### PR TITLE
feat: Implement cube coordinate system for hex grid

### DIFF
--- a/src/api/encounterHooks.ts
+++ b/src/api/encounterHooks.ts
@@ -1,3 +1,4 @@
+import type { CubeCoord } from '@/utils/hexUtils';
 import { create } from '@bufbuild/protobuf';
 import { PositionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import type {
@@ -68,19 +69,16 @@ export function useMoveCharacter() {
   });
 
   const moveCharacter = useCallback(
-    async (
-      encounterId: string,
-      entityId: string,
-      path: Array<{ x: number; y: number }>
-    ) => {
+    async (encounterId: string, entityId: string, path: CubeCoord[]) => {
       setState({ data: null, loading: true, error: null });
 
       try {
+        // Send cube coordinates to the server (x, y, z where x + y + z = 0)
         const request = create(MoveCharacterRequestSchema, {
           encounterId,
           entityId,
           path: path.map((pos) =>
-            create(PositionSchema, { x: pos.x, y: pos.y, z: 0 })
+            create(PositionSchema, { x: pos.x, y: pos.y, z: pos.z })
           ),
         });
 

--- a/src/components/EncounterDemo.tsx
+++ b/src/components/EncounterDemo.tsx
@@ -14,7 +14,12 @@ import {
   getSpellDisplay,
   getWeaponDisplay,
 } from '@/utils/enumDisplays';
-import { findHexPath, hexDistance } from '@/utils/hexUtils';
+import {
+  cubeKey,
+  findHexPath,
+  hexDistance,
+  type CubeCoord,
+} from '@/utils/hexUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type {
   CombatState,
@@ -70,9 +75,7 @@ export function EncounterDemo() {
     string | null
   >(null);
   const [movementMode, setMovementMode] = useState(false);
-  const [movementPath, setMovementPath] = useState<
-    Array<{ x: number; y: number }>
-  >([]);
+  const [movementPath, setMovementPath] = useState<CubeCoord[]>([]);
   const [combatLog, setCombatLog] = useState<CombatLogEntry[]>([]);
 
   // Damage number state
@@ -138,13 +141,16 @@ export function EncounterDemo() {
       clickedEntity.entityType.toLowerCase() === 'monster'
     ) {
       // Check if adjacent (within 1 hex for melee)
+      // Server provides cube coordinates in position.x, position.y, position.z
       const currentEntity = room?.entities[currentTurnEntityId];
       if (currentEntity?.position && clickedEntity.position) {
         const distance = hexDistance(
           currentEntity.position.x,
           currentEntity.position.y,
+          currentEntity.position.z,
           clickedEntity.position.x,
-          clickedEntity.position.y
+          clickedEntity.position.y,
+          clickedEntity.position.z
         );
 
         // Set as attack target (can be adjacent or not - button will handle enabling)
@@ -162,18 +168,18 @@ export function EncounterDemo() {
     setHoveredEntity(entityId);
   };
 
-  const handleCellClick = async (x: number, y: number) => {
+  const handleCellClick = async (clickedCube: CubeCoord) => {
     if (movementMode && selectedEntity && encounterId) {
       const entityPos = room?.entities[selectedEntity]?.position;
       if (!entityPos) return;
 
-      // Get the last position in the path, or entity's current position
-      const lastPos =
+      // Get the last position in the path, or entity's current position (as cube coords)
+      const lastPos: CubeCoord =
         movementPath.length > 0
           ? movementPath[movementPath.length - 1]
-          : { x: entityPos.x, y: entityPos.y };
+          : { x: entityPos.x, y: entityPos.y, z: entityPos.z };
 
-      // Get occupied positions (excluding the target)
+      // Get occupied positions (excluding the target) using cube keys
       const occupiedPositions = new Set<string>();
       if (room?.entities) {
         Object.values(room.entities).forEach((entity) => {
@@ -182,13 +188,19 @@ export function EncounterDemo() {
             entity.blocksMovement &&
             entity.entityId !== selectedEntity
           ) {
-            occupiedPositions.add(`${entity.position.x},${entity.position.y}`);
+            occupiedPositions.add(
+              cubeKey({
+                x: entity.position.x,
+                y: entity.position.y,
+                z: entity.position.z,
+              })
+            );
           }
         });
       }
 
       // Find path from last position to clicked hex
-      const newSegment = findHexPath(lastPos, { x, y }, occupiedPositions);
+      const newSegment = findHexPath(lastPos, clickedCube, occupiedPositions);
 
       // Validate total movement cost
       const pathCost = (movementPath.length + newSegment.length) * 5; // 5ft per hex
@@ -206,7 +218,7 @@ export function EncounterDemo() {
   };
 
   // Double-click: move directly to target hex in one action
-  const handleCellDoubleClick = async (x: number, y: number) => {
+  const handleCellDoubleClick = async (clickedCube: CubeCoord) => {
     // Need a selected entity and encounter
     const currentTurnEntityId = combatState?.currentTurn?.entityId;
     if (!currentTurnEntityId || !encounterId) return;
@@ -214,7 +226,7 @@ export function EncounterDemo() {
     const entityPos = room?.entities[currentTurnEntityId]?.position;
     if (!entityPos) return;
 
-    // Get occupied positions (excluding the current turn entity)
+    // Get occupied positions (excluding the current turn entity) using cube keys
     const occupiedPositions = new Set<string>();
     if (room?.entities) {
       Object.values(room.entities).forEach((entity) => {
@@ -223,15 +235,26 @@ export function EncounterDemo() {
           entity.blocksMovement &&
           entity.entityId !== currentTurnEntityId
         ) {
-          occupiedPositions.add(`${entity.position.x},${entity.position.y}`);
+          occupiedPositions.add(
+            cubeKey({
+              x: entity.position.x,
+              y: entity.position.y,
+              z: entity.position.z,
+            })
+          );
         }
       });
     }
 
     // Find path from entity position to clicked hex (ignore any existing path for double-click)
+    const entityCube: CubeCoord = {
+      x: entityPos.x,
+      y: entityPos.y,
+      z: entityPos.z,
+    };
     const pathToTarget = findHexPath(
-      { x: entityPos.x, y: entityPos.y },
-      { x, y },
+      entityCube,
+      clickedCube,
       occupiedPositions
     );
 

--- a/src/components/combat-v2/panels/ActionPanel.tsx
+++ b/src/components/combat-v2/panels/ActionPanel.tsx
@@ -1,5 +1,5 @@
 import { useEndTurn } from '@/api/encounterHooks';
-import { hexDistance } from '@/utils/hexUtils';
+import { hexDistance, type CubeCoord } from '@/utils/hexUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type {
   CombatState,
@@ -21,7 +21,7 @@ export interface ActionPanelProps {
   onActivateFeature?: (featureId: string) => void;
   onCombatStateUpdate?: (combatState: CombatState) => void;
   movementMode?: boolean;
-  movementPath?: Array<{ x: number; y: number }>;
+  movementPath?: CubeCoord[];
   onExecuteMove?: () => void;
   onCancelMove?: () => void;
   /** Enable debug mode with bright colors for visibility testing */
@@ -110,6 +110,7 @@ export function ActionPanel({
   };
 
   // Check if attack target is adjacent (for melee attacks)
+  // Server provides cube coordinates in position.x, position.y, position.z
   const isTargetAdjacent = (() => {
     if (!attackTarget || !room || !currentTurn.entityId) return false;
 
@@ -121,8 +122,10 @@ export function ActionPanel({
     const distance = hexDistance(
       currentEntity.position.x,
       currentEntity.position.y,
+      currentEntity.position.z,
       targetEntity.position.x,
-      targetEntity.position.y
+      targetEntity.position.y,
+      targetEntity.position.z
     );
 
     return distance === 1;

--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -1,5 +1,6 @@
 import type { DamageNumber } from '@/types/combat';
 import { formatCharacterSummary } from '@/utils/displayNames';
+import type { CubeCoord } from '@/utils/hexUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type { Room } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { useState } from 'react';
@@ -17,12 +18,12 @@ interface BattleMapPanelProps {
   attackTarget?: string | null;
   movementMode?: boolean;
   movementRange?: number;
-  movementPath?: Array<{ x: number; y: number }>;
+  movementPath?: CubeCoord[];
   damageNumbers?: DamageNumber[];
   onEntityClick: (entityId: string) => void;
   onEntityHover: (entityId: string | null) => void;
-  onCellClick: (x: number, y: number) => void;
-  onCellDoubleClick?: (x: number, y: number) => void;
+  onCellClick: (coord: CubeCoord) => void;
+  onCellDoubleClick?: (coord: CubeCoord) => void;
 }
 
 export function BattleMapPanel({

--- a/src/utils/hexUtils.ts
+++ b/src/utils/hexUtils.ts
@@ -1,76 +1,111 @@
 // Hex grid utility functions for pathfinding and distance calculations
+// Uses cube coordinates (x, y, z where x + y + z = 0)
 
-// Calculate hex distance (using offset coordinates with proper conversion)
+// Cube coordinate type for clarity
+export interface CubeCoord {
+  x: number;
+  y: number;
+  z: number;
+}
+
+// Offset coordinate type (for grid cell iteration and pixel conversion)
+export interface OffsetCoord {
+  col: number;
+  row: number;
+}
+
+// Convert cube coordinates to offset coordinates (pointy-top, odd-r)
+// odd-r: odd rows are shifted right
+export function cubeToOffset(cube: CubeCoord): OffsetCoord {
+  const col = cube.x + (cube.z - (cube.z & 1)) / 2;
+  const row = cube.z;
+  return { col, row };
+}
+
+// Convert offset coordinates to cube coordinates (pointy-top, odd-r)
+// odd-r: odd rows are shifted right
+export function offsetToCube(offset: OffsetCoord): CubeCoord {
+  const x = offset.col - (offset.row - (offset.row & 1)) / 2;
+  const z = offset.row;
+  const y = -x - z;
+  return { x, y, z };
+}
+
+// Calculate hex distance using cube coordinates directly
+// Server provides cube coordinates, so no conversion needed
 export function hexDistance(
   x1: number,
   y1: number,
+  z1: number,
   x2: number,
-  y2: number
+  y2: number,
+  z2: number
 ): number {
-  // Convert offset to cube coordinates for accurate distance
-  // For odd-r offset coordinates (pointy-top hexes)
-  const cubeX1 = x1;
-  const cubeZ1 = y1 - (x1 - (x1 & 1)) / 2;
-  const cubeY1 = -cubeX1 - cubeZ1;
-
-  const cubeX2 = x2;
-  const cubeZ2 = y2 - (x2 - (x2 & 1)) / 2;
-  const cubeY2 = -cubeX2 - cubeZ2;
-
-  // Manhattan distance in cube coordinates divided by 2
-  return Math.max(
-    Math.abs(cubeX1 - cubeX2),
-    Math.abs(cubeY1 - cubeY2),
-    Math.abs(cubeZ1 - cubeZ2)
-  );
+  // In cube coordinates, distance is the max of absolute differences
+  return Math.max(Math.abs(x1 - x2), Math.abs(y1 - y2), Math.abs(z1 - z2));
 }
 
-// Get 6 adjacent hexes (pointy-top orientation, odd-r offset)
-function getHexNeighbors(
-  x: number,
-  y: number
-): Array<{ x: number; y: number }> {
-  // Pointy-top hex neighbors (odd-r offset coordinates)
-  const parity = y & 1; // 0 for even rows, 1 for odd rows
-
-  return [
-    { x: x + 1, y: y }, // East
-    { x: x - 1, y: y }, // West
-    { x: x + parity, y: y - 1 }, // NorthEast
-    { x: x + parity - 1, y: y - 1 }, // NorthWest
-    { x: x + parity, y: y + 1 }, // SouthEast
-    { x: x + parity - 1, y: y + 1 }, // SouthWest
+// Get 6 adjacent hexes using cube coordinates
+// In cube coords, neighbors are simple: add direction vectors that sum to 0
+function getHexNeighbors(coord: CubeCoord): CubeCoord[] {
+  // Six directions in cube coordinates (each sums to 0)
+  const directions: CubeCoord[] = [
+    { x: 1, y: -1, z: 0 }, // East
+    { x: 1, y: 0, z: -1 }, // Southeast
+    { x: 0, y: 1, z: -1 }, // Southwest
+    { x: -1, y: 1, z: 0 }, // West
+    { x: -1, y: 0, z: 1 }, // Northwest
+    { x: 0, y: -1, z: 1 }, // Northeast
   ];
+
+  return directions.map((dir) => ({
+    x: coord.x + dir.x,
+    y: coord.y + dir.y,
+    z: coord.z + dir.z,
+  }));
+}
+
+// Helper to create a string key from cube coordinates for Set lookups
+export function cubeKey(coord: CubeCoord): string {
+  return `${coord.x},${coord.y},${coord.z}`;
 }
 
 // Find a path between two hexes using a greedy pathfinding approach.
 // Note: This method does not guarantee the shortest (optimal) path, especially when obstacles are present.
+// Uses cube coordinates (x, y, z where x + y + z = 0)
 export function findHexPath(
-  from: { x: number; y: number },
-  to: { x: number; y: number },
+  from: CubeCoord,
+  to: CubeCoord,
   occupiedPositions: Set<string>
-): Array<{ x: number; y: number }> {
+): CubeCoord[] {
   // If already adjacent or same, return direct path
-  const dist = hexDistance(from.x, from.y, to.x, to.y);
+  const dist = hexDistance(from.x, from.y, from.z, to.x, to.y, to.z);
   if (dist <= 1) return [to];
 
   // Simple straight-line pathing (greedy approach)
-  const path: Array<{ x: number; y: number }> = [];
-  let current = { ...from };
+  const path: CubeCoord[] = [];
+  let current: CubeCoord = { ...from };
 
-  while (hexDistance(current.x, current.y, to.x, to.y) > 0) {
+  while (hexDistance(current.x, current.y, current.z, to.x, to.y, to.z) > 0) {
     // Get all 6 neighbors
-    const neighbors = getHexNeighbors(current.x, current.y);
+    const neighbors = getHexNeighbors(current);
 
     // Find neighbor closest to target that isn't occupied
-    let best: { x: number; y: number } | null = null;
+    let best: CubeCoord | null = null;
     let bestDist = Infinity;
 
     for (const neighbor of neighbors) {
-      const key = `${neighbor.x},${neighbor.y}`;
+      const key = cubeKey(neighbor);
       if (occupiedPositions.has(key)) continue; // Skip occupied cells
 
-      const dist = hexDistance(neighbor.x, neighbor.y, to.x, to.y);
+      const dist = hexDistance(
+        neighbor.x,
+        neighbor.y,
+        neighbor.z,
+        to.x,
+        to.y,
+        to.z
+      );
       if (best === null || dist < bestDist) {
         best = neighbor;
         bestDist = dist;


### PR DESCRIPTION
## Summary
- Use server-provided cube coordinates (x, y, z where x + y + z = 0) instead of client-side coordinate conversion
- Fix hex selection alignment by using consistent odd-r offset system for pointy-top hexes
- Send actual cube coordinates (including z) in movement requests to server

## Changes
- **hexUtils.ts**: Added CubeCoord/OffsetCoord types, cubeToOffset/offsetToCube conversions, updated hexDistance signature
- **HexGrid.tsx**: Updated pixel conversion to use odd-r offset, changed callbacks to pass CubeCoord
- **VoxelGrid.tsx**: Same coordinate system updates for 3D rendering
- **encounterHooks.ts**: Accept CubeCoord[] and send proper z values in movement requests
- **EncounterDemo.tsx**: Updated movement path handling to use CubeCoord[]
- **BattleMapPanel.tsx**: Updated prop types to use CubeCoord

## Test plan
- [x] Verified hex selection is accurate (cursor position matches highlighted hex)
- [x] Tested movement path calculation uses cube coordinates
- [x] Confirmed movement requests send cube coordinates to server
- [x] CI checks pass

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)