### PR TITLE
feat: Add Discord auth interceptor for gRPC calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ VITE_API_HOST=http://localhost:8080
 # Development Settings
 # Show Discord debug panel in production (optional)
 VITE_SHOW_DEBUG=false
+
+# Local development player ID (bypasses Discord auth)
+# Only used when running in development mode without Discord
+# VITE_DEV_PLAYER_ID=test-player-123

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,92 @@
+/**
+ * Auth store for gRPC authentication.
+ *
+ * This module bridges React context (Discord auth) with the module-level
+ * gRPC client. The interceptor reads from this store to add auth headers.
+ *
+ * Usage:
+ * - DiscordProvider calls setAuth() after Discord authentication
+ * - The auth interceptor calls getAuth() for each gRPC request
+ * - In local dev, VITE_DEV_PLAYER_ID provides a fallback player ID
+ */
+
+interface AuthState {
+  discordToken: string | null;
+  playerId: string | null;
+}
+
+let authState: AuthState = {
+  discordToken: null,
+  playerId: null,
+};
+
+/**
+ * Set the current auth state. Called by DiscordProvider after auth.
+ */
+export function setAuth(token: string | null, playerId: string | null): void {
+  authState = { discordToken: token, playerId };
+
+  if (import.meta.env.MODE === 'development') {
+    console.log('🔐 Auth state updated:', {
+      hasToken: !!token,
+      playerId: playerId || '(none)',
+    });
+  }
+}
+
+/**
+ * Get the current Discord token for API authentication.
+ * Returns null if not authenticated.
+ */
+export function getDiscordToken(): string | null {
+  return authState.discordToken;
+}
+
+/**
+ * Get the current player ID.
+ * Falls back to VITE_DEV_PLAYER_ID in development mode.
+ */
+export function getPlayerId(): string | null {
+  if (authState.playerId) {
+    return authState.playerId;
+  }
+
+  // Development fallback
+  if (import.meta.env.MODE === 'development') {
+    const devPlayerId = import.meta.env.VITE_DEV_PLAYER_ID;
+    if (devPlayerId) {
+      return devPlayerId;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if we have valid auth credentials.
+ * In production: requires Discord token
+ * In development: accepts either token or dev player ID
+ */
+export function isAuthenticated(): boolean {
+  if (authState.discordToken) {
+    return true;
+  }
+
+  // Development mode allows running without Discord
+  if (import.meta.env.MODE === 'development') {
+    return !!import.meta.env.VITE_DEV_PLAYER_ID;
+  }
+
+  return false;
+}
+
+/**
+ * Clear auth state. Called on logout or auth failure.
+ */
+export function clearAuth(): void {
+  authState = { discordToken: null, playerId: null };
+
+  if (import.meta.env.MODE === 'development') {
+    console.log('🔐 Auth state cleared');
+  }
+}

--- a/src/discord/DiscordProvider.tsx
+++ b/src/discord/DiscordProvider.tsx
@@ -1,5 +1,8 @@
 import type { DiscordSDK } from '@discord/embedded-app-sdk';
 import React, { useCallback, useEffect, useState } from 'react';
+
+import { clearAuth, setAuth } from '@/api/auth';
+
 import { DiscordContext } from './context';
 import {
   getEnvironmentInfo,
@@ -123,12 +126,17 @@ export function DiscordProvider({ children }: DiscordProviderProps) {
             global_name: auth.user.global_name || undefined,
           });
           console.log('👤 User authenticated:', auth.user.username);
+
+          // Update auth store for gRPC interceptor
+          setAuth(access_token, auth.user.id);
         }
 
         // Fetch initial participants
         await handleRefreshParticipants(sdkToUse);
       } catch (err) {
         console.error('🔴 Discord authentication failed:', err);
+        // Clear auth state on failure
+        clearAuth();
         // Store error for display
         let errorMessage = 'Unknown error';
         if (err instanceof Error) {


### PR DESCRIPTION
## Summary

Adds authentication to all gRPC requests to work with rpg-api's new Discord OAuth authentication (PR #286).

- **New `src/api/auth.ts`** - Auth store module that bridges React context with the module-level gRPC client
- **Auth interceptor** - Adds `authorization: Discord <token>` header to all requests
- **DiscordProvider integration** - Updates auth store after successful Discord authentication
- **Development mode** - Supports `Dev <player_id>` scheme via `VITE_DEV_PLAYER_ID` env var

### How it works

```
DiscordProvider (auth success)
       │
       │ setAuth(token, playerId)
       ▼
   Auth Store (module-level)
       │
       │ getDiscordToken() / getPlayerId()
       ▼
  Auth Interceptor
       │
       │ req.header.set('authorization', ...)
       ▼
   gRPC Request
```

### For local development

Set `VITE_DEV_PLAYER_ID=test-player-123` in `.env.local` to bypass Discord auth.
The server must also have `AUTH_DEV_MODE=true` set.

## Test plan

- [x] TypeScript compiles
- [x] ESLint passes
- [x] Build succeeds
- [ ] Manual test with Discord Activity
- [ ] Manual test with local dev mode

**Depends on:** KirkDiggler/rpg-api#286

🤖 Generated with [Claude Code](https://claude.com/claude-code)