### PR TITLE
Join character

### DIFF
--- a/src/components/lobby/JoinGameTab.tsx
+++ b/src/components/lobby/JoinGameTab.tsx
@@ -1,8 +1,14 @@
+import { formatCharacterSummary } from '@/utils/displayNames';
+import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { useState } from 'react';
 
 interface JoinGameTabProps {
+  characters: Character[];
+  selectedCharacterId: string | null;
+  onSelectCharacter: (characterId: string) => void;
   onJoinLobby: (code: string) => void;
   loading: boolean;
+  charactersLoading: boolean;
   error?: string | null;
 }
 
@@ -10,16 +16,25 @@ interface JoinGameTabProps {
  * JoinGameTab - Tab content for joining an existing lobby
  *
  * Shows:
+ * - Character selection list
  * - Join code input field
  * - Join button
  * - Error message if join fails
  */
-export function JoinGameTab({ onJoinLobby, loading, error }: JoinGameTabProps) {
+export function JoinGameTab({
+  characters,
+  selectedCharacterId,
+  onSelectCharacter,
+  onJoinLobby,
+  loading,
+  charactersLoading,
+  error,
+}: JoinGameTabProps) {
   const [code, setCode] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (code.trim()) {
+    if (code.trim() && selectedCharacterId) {
       onJoinLobby(code.trim().toUpperCase());
     }
   };
@@ -30,8 +45,53 @@ export function JoinGameTab({ onJoinLobby, loading, error }: JoinGameTabProps) {
     setCode(value);
   };
 
+  const canJoin = code.length === 6 && selectedCharacterId && !loading;
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Character Selection */}
+      <div>
+        <h3
+          className="text-sm font-medium mb-3"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          Select Your Character
+        </h3>
+
+        {charactersLoading ? (
+          <div
+            className="text-center p-4"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            Loading characters...
+          </div>
+        ) : characters.length === 0 ? (
+          <div
+            className="p-4 rounded border-2 border-dashed text-center"
+            style={{
+              borderColor: 'var(--border-primary)',
+              backgroundColor: 'var(--bg-secondary)',
+              color: 'var(--text-muted)',
+            }}
+          >
+            <p className="mb-2">No characters available</p>
+            <p className="text-sm">Create a character first to join a game</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-2 max-h-48 overflow-y-auto">
+            {characters.map((character) => (
+              <CharacterOption
+                key={character.id}
+                character={character}
+                isSelected={selectedCharacterId === character.id}
+                onSelect={() => onSelectCharacter(character.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Join Code Input */}
       <div>
         <label
           htmlFor="join-code"
@@ -53,7 +113,6 @@ export function JoinGameTab({ onJoinLobby, loading, error }: JoinGameTabProps) {
             color: 'var(--text-primary)',
           }}
           autoComplete="off"
-          autoFocus
         />
         <p
           className="mt-2 text-sm text-center"
@@ -78,19 +137,71 @@ export function JoinGameTab({ onJoinLobby, loading, error }: JoinGameTabProps) {
 
       <button
         type="submit"
-        disabled={loading || code.length < 6}
+        disabled={!canJoin}
         className="w-full px-6 py-4 rounded-lg font-bold text-lg transition-all disabled:opacity-50 hover:brightness-110 active:scale-[0.98]"
         style={{
-          backgroundColor: loading || code.length < 6 ? '#4b5563' : '#8b5cf6',
+          backgroundColor: canJoin ? '#8b5cf6' : '#4b5563',
           color: 'white',
-          boxShadow:
-            loading || code.length < 6
-              ? 'none'
-              : '0 4px 14px rgba(139, 92, 246, 0.4)',
+          boxShadow: canJoin ? '0 4px 14px rgba(139, 92, 246, 0.4)' : 'none',
         }}
       >
         {loading ? 'Joining...' : '🎮 Join Game'}
       </button>
     </form>
+  );
+}
+
+function CharacterOption({
+  character,
+  isSelected,
+  onSelect,
+}: {
+  character: Character;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex items-center gap-3 p-3 rounded-lg border text-left transition-colors w-full"
+      style={{
+        backgroundColor: isSelected
+          ? 'var(--accent-primary)'
+          : 'var(--bg-secondary)',
+        borderColor: isSelected
+          ? 'var(--accent-primary)'
+          : 'var(--border-primary)',
+        color: isSelected ? 'white' : 'var(--text-primary)',
+      }}
+    >
+      <div
+        className="w-5 h-5 rounded-full border-2 flex items-center justify-center"
+        style={{
+          borderColor: isSelected ? 'white' : 'var(--border-primary)',
+          backgroundColor: isSelected ? 'white' : 'transparent',
+        }}
+      >
+        {isSelected && (
+          <div
+            className="w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: 'var(--accent-primary)' }}
+          />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-semibold truncate">{character.name}</div>
+        <div className="text-sm truncate" style={{ opacity: 0.8 }}>
+          {formatCharacterSummary(
+            character.level,
+            character.race,
+            character.class
+          )}
+        </div>
+      </div>
+      <div className="text-sm" style={{ opacity: 0.7 }}>
+        HP: {character.currentHitPoints || 0}
+      </div>
+    </button>
   );
 }

--- a/src/components/lobby/LobbyScreen.tsx
+++ b/src/components/lobby/LobbyScreen.tsx
@@ -148,9 +148,11 @@ export function LobbyScreen({
 
   // Join an existing lobby
   const handleJoinLobby = async (code: string) => {
+    if (!selectedCharacterId) return;
+
     try {
-      // Join without a character initially - can select in waiting room
-      const response = await joinEncounter(code, []);
+      // Join with selected character
+      const response = await joinEncounter(code, [selectedCharacterId]);
 
       // Set encounter state from response
       setEncounterId(response.encounterId);
@@ -340,8 +342,12 @@ export function LobbyScreen({
               />
             ) : (
               <JoinGameTab
+                characters={availableCharacters}
+                selectedCharacterId={selectedCharacterId}
+                onSelectCharacter={setSelectedCharacterId}
                 onJoinLobby={handleJoinLobby}
                 loading={joinLoading}
+                charactersLoading={charactersLoading}
                 error={joinError?.message ?? null}
               />
             )}


### PR DESCRIPTION
This pull request adds character selection to the "Join Game" lobby flow, requiring users to pick a character before joining a game. The UI now displays a list of available characters, handles loading states, and ensures the join action is only enabled when both a valid code and character are selected. The backend join logic is updated to include the selected character when joining a lobby.

**Lobby join flow improvements:**

* Added a character selection list to `JoinGameTab`, displaying available characters, handling loading and empty states, and requiring selection before joining a game. [[1]](diffhunk://#diff-e3ccf54dd808cdfe20c2c86ede3d55a50d6f1e8218417f66e64978df06f54050R1-R37) [[2]](diffhunk://#diff-e3ccf54dd808cdfe20c2c86ede3d55a50d6f1e8218417f66e64978df06f54050R48-R94)
* Updated the join button in `JoinGameTab` to only enable joining when a character is selected and the code is valid; improved button styling to reflect enabled/disabled state.
* Modified the join logic in `LobbyScreen` to send the selected character's ID when joining a lobby, instead of joining without a character.

**Component and prop updates:**

* Updated `JoinGameTab` props and usage to accept and manage character data, selection state, and loading state from parent (`LobbyScreen`). [[1]](diffhunk://#diff-e3ccf54dd808cdfe20c2c86ede3d55a50d6f1e8218417f66e64978df06f54050R1-R37) [[2]](diffhunk://#diff-96e49d00ca20265ec17103a14316bffdecdbe9d2b945470524aa3cc770e73027R345-R350)