### PR TITLE
fix: Combat log shows correct AC for attack targets

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -364,7 +364,15 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           availableCharacters.find((c) => c.id === event.targetId)?.name ||
           formatEntityId(event.targetId);
 
-        const { hit, damage, damageType, critical, attackRoll } = event.result;
+        const {
+          hit,
+          damage,
+          damageType,
+          critical,
+          attackRoll,
+          attackTotal,
+          targetAc,
+        } = event.result;
 
         const logEntry: CombatLogEntry = {
           id: `attack-stream-${Date.now()}`,
@@ -394,6 +402,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
             : undefined,
           details: {
             attackRoll,
+            attackTotal,
+            targetAc,
             damage: hit ? damage : undefined,
             damageType: hit ? damageType : undefined,
             critical,
@@ -769,7 +779,15 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
             availableCharacters.find((c) => c.id === targetId)?.name ||
             formatEntityId(targetId);
 
-          const { hit, damage, damageType, critical, attackRoll } = result;
+          const {
+            hit,
+            damage,
+            damageType,
+            critical,
+            attackRoll,
+            attackTotal,
+            targetAc,
+          } = result;
 
           const logEntry: CombatLogEntry = {
             id: `attack-history-${event.eventId}`,
@@ -799,6 +817,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
               : undefined,
             details: {
               attackRoll,
+              attackTotal,
+              targetAc,
               damage: hit ? damage : undefined,
               damageType: hit ? damageType : undefined,
               critical,


### PR DESCRIPTION
## Problem
Combat log was showing incorrect AC when displaying attack results (e.g., showing AC 11 instead of 14 for a Barbarian with Unarmored Defense).

## Root Cause  
The attack log entries created in `handleAttackResolved` and `handleHistoricalEvents` were not extracting `targetAc` and `attackTotal` from the event result.

## Fix
Include `targetAc` and `attackTotal` in the `details` object when creating combat log entries.

## Debugging Lesson 🦺
We initially investigated the toolkit and API layers, but:
- ✅ Toolkit tests pass
- ✅ API returns correct AC in attack results
- ❌ **UI wasn't reading the correct field**

Verified each layer before diving deep → found the bug faster.

Fixes #326