### PR TITLE
feat: Accumulate revealed rooms into dungeon map state

### DIFF
--- a/src/hooks/useDungeonMap.test.ts
+++ b/src/hooks/useDungeonMap.test.ts
@@ -1,0 +1,654 @@
+/**
+ * Tests for useDungeonMap state management logic
+ *
+ * Tests the pure functions that power dungeon map accumulation:
+ * mergeRoom, updateEntitiesFromRoom, generateFloorTiles, createEmptyState.
+ *
+ * These are the core of Phase 2 multi-room rendering (rpg-dnd5e-web #311).
+ */
+
+import { create } from '@bufbuild/protobuf';
+import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import {
+  PositionSchema,
+  WallSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import type {
+  DoorInfo,
+  EntityPlacement,
+  Room,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  DoorInfoSchema,
+  EntityPlacementSchema,
+  RoomSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  createEmptyState,
+  generateFloorTiles,
+  mergeRoom,
+  updateEntitiesFromRoom,
+} from './useDungeonMap';
+
+/** Helper to create a Room proto message */
+function createRoom(opts: {
+  id: string;
+  width: number;
+  height: number;
+  originX?: number;
+  originZ?: number;
+  entities?: Record<
+    string,
+    {
+      entityId: string;
+      x: number;
+      y: number;
+      z: number;
+      type: EntityType;
+    }
+  >;
+  walls?: Array<{
+    startX: number;
+    startY: number;
+    startZ: number;
+    endX: number;
+    endY: number;
+    endZ: number;
+  }>;
+}): Room {
+  const origin = create(PositionSchema, {
+    x: opts.originX ?? 0,
+    y: -(opts.originX ?? 0) - (opts.originZ ?? 0),
+    z: opts.originZ ?? 0,
+  });
+
+  const entities: Record<string, EntityPlacement> = {};
+  if (opts.entities) {
+    for (const [key, e] of Object.entries(opts.entities)) {
+      entities[key] = create(EntityPlacementSchema, {
+        entityId: e.entityId,
+        position: create(PositionSchema, { x: e.x, y: e.y, z: e.z }),
+        entityType: e.type,
+      });
+    }
+  }
+
+  const walls: Wall[] = (opts.walls ?? []).map((w) =>
+    create(WallSchema, {
+      start: create(PositionSchema, {
+        x: w.startX,
+        y: w.startY,
+        z: w.startZ,
+      }),
+      end: create(PositionSchema, { x: w.endX, y: w.endY, z: w.endZ }),
+    })
+  );
+
+  return create(RoomSchema, {
+    id: opts.id,
+    width: opts.width,
+    height: opts.height,
+    origin,
+    entities,
+    walls,
+  });
+}
+
+/** Helper to create a DoorInfo proto */
+function createDoor(
+  connectionId: string,
+  x: number,
+  y: number,
+  z: number,
+  isOpen = false
+): DoorInfo {
+  return create(DoorInfoSchema, {
+    connectionId,
+    position: create(PositionSchema, { x, y, z }),
+    isOpen,
+  });
+}
+
+describe('createEmptyState', () => {
+  it('returns empty dungeon map', () => {
+    const state = createEmptyState();
+
+    expect(state.floorTiles.size).toBe(0);
+    expect(state.walls).toHaveLength(0);
+    expect(state.entities.size).toBe(0);
+    expect(state.doors.size).toBe(0);
+    expect(state.revealedRoomIds.size).toBe(0);
+    expect(state.rooms.size).toBe(0);
+    expect(state.currentRoomId).toBeNull();
+  });
+});
+
+describe('generateFloorTiles', () => {
+  it('generates tiles at origin (0,0,0) for default room', () => {
+    const room = createRoom({ id: 'room-1', width: 3, height: 2 });
+    const tiles = generateFloorTiles(room);
+
+    expect(tiles).toHaveLength(6); // 3 × 2
+
+    // Check specific positions
+    const positions = tiles.map((t) => `${t.x},${t.y},${t.z}`);
+    expect(positions).toContain('0,0,0');
+    expect(positions).toContain('1,-1,0');
+    expect(positions).toContain('2,-2,0');
+    expect(positions).toContain('0,-1,1');
+    expect(positions).toContain('1,-2,1');
+    expect(positions).toContain('2,-3,1');
+  });
+
+  it('generates tiles at offset origin', () => {
+    const room = createRoom({
+      id: 'room-1',
+      width: 2,
+      height: 2,
+      originX: 10,
+      originZ: 5,
+    });
+    const tiles = generateFloorTiles(room);
+
+    expect(tiles).toHaveLength(4);
+
+    // All tiles should be offset
+    const positions = tiles.map((t) => `${t.x},${t.y},${t.z}`);
+    expect(positions).toContain('10,-15,5');
+    expect(positions).toContain('11,-16,5');
+    expect(positions).toContain('10,-16,6');
+    expect(positions).toContain('11,-17,6');
+
+    // Should NOT include origin (0,0,0)
+    expect(positions).not.toContain('0,0,0');
+  });
+
+  it('maintains cube coordinate invariant (x + y + z = 0)', () => {
+    const room = createRoom({
+      id: 'room-1',
+      width: 5,
+      height: 7,
+      originX: 3,
+      originZ: 4,
+    });
+    const tiles = generateFloorTiles(room);
+
+    for (const tile of tiles) {
+      expect(tile.x + tile.y + tile.z).toBe(0);
+    }
+  });
+
+  it('generates correct count for various sizes', () => {
+    expect(
+      generateFloorTiles(createRoom({ id: 'r', width: 1, height: 1 }))
+    ).toHaveLength(1);
+    expect(
+      generateFloorTiles(createRoom({ id: 'r', width: 10, height: 10 }))
+    ).toHaveLength(100);
+    expect(
+      generateFloorTiles(createRoom({ id: 'r', width: 20, height: 15 }))
+    ).toHaveLength(300);
+  });
+
+  it('tags all tiles with their room ID', () => {
+    const room = createRoom({ id: 'my-room', width: 3, height: 3 });
+    const tiles = generateFloorTiles(room);
+
+    for (const tile of tiles) {
+      expect(tile.roomId).toBe('my-room');
+    }
+  });
+});
+
+describe('mergeRoom', () => {
+  describe('first room', () => {
+    it('adds floor tiles to empty state', () => {
+      const state = createEmptyState();
+      const room = createRoom({ id: 'room-1', width: 3, height: 2 });
+
+      const result = mergeRoom(state, room, []);
+
+      expect(result.floorTiles.size).toBe(6);
+      expect(result.floorTiles.has('0,0,0')).toBe(true);
+      expect(result.floorTiles.has('2,-3,1')).toBe(true);
+    });
+
+    it('sets current room and tracks revealed rooms', () => {
+      const state = createEmptyState();
+      const room = createRoom({ id: 'room-1', width: 3, height: 2 });
+
+      const result = mergeRoom(state, room, []);
+
+      expect(result.currentRoomId).toBe('room-1');
+      expect(result.revealedRoomIds.has('room-1')).toBe(true);
+      expect(result.rooms.get('room-1')).toBe(room);
+    });
+
+    it('adds doors', () => {
+      const state = createEmptyState();
+      const room = createRoom({ id: 'room-1', width: 3, height: 2 });
+      const doors = [
+        createDoor('conn-a', 2, -2, 0),
+        createDoor('conn-b', 0, -1, 1),
+      ];
+
+      const result = mergeRoom(state, room, doors);
+
+      expect(result.doors.size).toBe(2);
+      expect(result.doors.has('conn-a')).toBe(true);
+      expect(result.doors.has('conn-b')).toBe(true);
+    });
+
+    it('adds entities', () => {
+      const state = createEmptyState();
+      const room = createRoom({
+        id: 'room-1',
+        width: 3,
+        height: 2,
+        entities: {
+          'char-1': {
+            entityId: 'char-1',
+            x: 0,
+            y: 0,
+            z: 0,
+            type: EntityType.CHARACTER,
+          },
+          'mob-1': {
+            entityId: 'mob-1',
+            x: 2,
+            y: -2,
+            z: 0,
+            type: EntityType.MONSTER,
+          },
+        },
+      });
+
+      const result = mergeRoom(state, room, []);
+
+      expect(result.entities.size).toBe(2);
+      expect(result.entities.has('char-1')).toBe(true);
+      expect(result.entities.has('mob-1')).toBe(true);
+    });
+
+    it('adds walls', () => {
+      const state = createEmptyState();
+      const room = createRoom({
+        id: 'room-1',
+        width: 3,
+        height: 2,
+        walls: [
+          {
+            startX: 0,
+            startY: 0,
+            startZ: 0,
+            endX: 2,
+            endY: -2,
+            endZ: 0,
+          },
+        ],
+      });
+
+      const result = mergeRoom(state, room, []);
+
+      expect(result.walls).toHaveLength(1);
+    });
+  });
+
+  describe('second room with offset', () => {
+    it('accumulates floor tiles from both rooms', () => {
+      let state = createEmptyState();
+
+      const room1 = createRoom({ id: 'room-1', width: 3, height: 2 });
+      state = mergeRoom(state, room1, []);
+
+      const room2 = createRoom({
+        id: 'room-2',
+        width: 2,
+        height: 2,
+        originX: 4,
+        originZ: 0,
+      });
+      state = mergeRoom(state, room2, []);
+
+      // 6 + 4 = 10 tiles
+      expect(state.floorTiles.size).toBe(10);
+
+      // Room 1 tiles
+      expect(state.floorTiles.has('0,0,0')).toBe(true);
+      // Room 2 tiles
+      expect(state.floorTiles.has('4,-4,0')).toBe(true);
+      expect(state.floorTiles.has('5,-5,0')).toBe(true);
+    });
+
+    it('updates current room to newest', () => {
+      let state = createEmptyState();
+
+      state = mergeRoom(
+        state,
+        createRoom({ id: 'room-1', width: 3, height: 2 }),
+        []
+      );
+      state = mergeRoom(
+        state,
+        createRoom({
+          id: 'room-2',
+          width: 2,
+          height: 2,
+          originX: 4,
+          originZ: 0,
+        }),
+        []
+      );
+
+      expect(state.currentRoomId).toBe('room-2');
+      expect(state.revealedRoomIds.size).toBe(2);
+    });
+
+    it('accumulates walls from both rooms', () => {
+      let state = createEmptyState();
+
+      const room1 = createRoom({
+        id: 'room-1',
+        width: 3,
+        height: 2,
+        walls: [
+          { startX: 0, startY: 0, startZ: 0, endX: 2, endY: -2, endZ: 0 },
+        ],
+      });
+      state = mergeRoom(state, room1, []);
+
+      const room2 = createRoom({
+        id: 'room-2',
+        width: 2,
+        height: 2,
+        originX: 4,
+        originZ: 0,
+        walls: [
+          { startX: 4, startY: -4, startZ: 0, endX: 5, endY: -5, endZ: 0 },
+        ],
+      });
+      state = mergeRoom(state, room2, []);
+
+      expect(state.walls).toHaveLength(2);
+    });
+
+    it('accumulates doors from both rooms', () => {
+      let state = createEmptyState();
+
+      state = mergeRoom(
+        state,
+        createRoom({ id: 'room-1', width: 3, height: 2 }),
+        [createDoor('conn-a', 2, -2, 0)]
+      );
+      state = mergeRoom(
+        state,
+        createRoom({
+          id: 'room-2',
+          width: 2,
+          height: 2,
+          originX: 4,
+          originZ: 0,
+        }),
+        [createDoor('conn-b', 5, -5, 0)]
+      );
+
+      expect(state.doors.size).toBe(2);
+    });
+
+    it('merges entities across rooms (character moves, old monsters remain)', () => {
+      let state = createEmptyState();
+
+      const room1 = createRoom({
+        id: 'room-1',
+        width: 3,
+        height: 2,
+        entities: {
+          'char-1': {
+            entityId: 'char-1',
+            x: 1,
+            y: -1,
+            z: 0,
+            type: EntityType.CHARACTER,
+          },
+          'mob-1': {
+            entityId: 'mob-1',
+            x: 2,
+            y: -2,
+            z: 0,
+            type: EntityType.MONSTER,
+          },
+        },
+      });
+      state = mergeRoom(state, room1, []);
+
+      const room2 = createRoom({
+        id: 'room-2',
+        width: 2,
+        height: 2,
+        originX: 4,
+        originZ: 0,
+        entities: {
+          // Character moved to room 2
+          'char-1': {
+            entityId: 'char-1',
+            x: 4,
+            y: -4,
+            z: 0,
+            type: EntityType.CHARACTER,
+          },
+          'mob-2': {
+            entityId: 'mob-2',
+            x: 5,
+            y: -5,
+            z: 0,
+            type: EntityType.MONSTER,
+          },
+        },
+      });
+      state = mergeRoom(state, room2, []);
+
+      // 3 unique entities
+      expect(state.entities.size).toBe(3);
+      // char-1 updated to new position
+      expect(state.entities.get('char-1')?.position?.x).toBe(4);
+      // mob-1 still exists from room 1
+      expect(state.entities.has('mob-1')).toBe(true);
+      // mob-2 from room 2
+      expect(state.entities.has('mob-2')).toBe(true);
+    });
+  });
+
+  describe('re-adding same room (state sync / update)', () => {
+    it('does not duplicate floor tiles', () => {
+      let state = createEmptyState();
+
+      const room = createRoom({ id: 'room-1', width: 3, height: 2 });
+      state = mergeRoom(state, room, []);
+      state = mergeRoom(state, room, []);
+
+      // Still 6, not 12
+      expect(state.floorTiles.size).toBe(6);
+    });
+
+    it('updates entity positions', () => {
+      let state = createEmptyState();
+
+      const room1 = createRoom({
+        id: 'room-1',
+        width: 3,
+        height: 2,
+        entities: {
+          'char-1': {
+            entityId: 'char-1',
+            x: 0,
+            y: 0,
+            z: 0,
+            type: EntityType.CHARACTER,
+          },
+        },
+      });
+      state = mergeRoom(state, room1, []);
+
+      // Same room, character moved
+      const room1Updated = createRoom({
+        id: 'room-1',
+        width: 3,
+        height: 2,
+        entities: {
+          'char-1': {
+            entityId: 'char-1',
+            x: 1,
+            y: -1,
+            z: 0,
+            type: EntityType.CHARACTER,
+          },
+        },
+      });
+      state = mergeRoom(state, room1Updated, []);
+
+      expect(state.entities.get('char-1')?.position?.x).toBe(1);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate input state', () => {
+      const state = createEmptyState();
+      const room = createRoom({ id: 'room-1', width: 3, height: 2 });
+
+      const newState = mergeRoom(state, room, []);
+
+      // Original state unchanged
+      expect(state.floorTiles.size).toBe(0);
+      expect(state.revealedRoomIds.size).toBe(0);
+      expect(state.currentRoomId).toBeNull();
+
+      // New state has data
+      expect(newState.floorTiles.size).toBe(6);
+    });
+  });
+});
+
+describe('updateEntitiesFromRoom', () => {
+  it('updates entity positions without changing floor tiles', () => {
+    let state = createEmptyState();
+
+    const room = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 0,
+          y: 0,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = mergeRoom(state, room, []);
+
+    const updatedRoom = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 2,
+          y: -2,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = updateEntitiesFromRoom(state, updatedRoom);
+
+    // Floor tiles unchanged
+    expect(state.floorTiles.size).toBe(6);
+    // Entity position updated
+    expect(state.entities.get('char-1')?.position?.x).toBe(2);
+  });
+
+  it('does not mutate input state', () => {
+    let state = createEmptyState();
+
+    const room = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 0,
+          y: 0,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = mergeRoom(state, room, []);
+
+    const updatedRoom = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 2,
+          y: -2,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    const newState = updateEntitiesFromRoom(state, updatedRoom);
+
+    // Original state entities unchanged
+    expect(state.entities.get('char-1')?.position?.x).toBe(0);
+    // New state updated
+    expect(newState.entities.get('char-1')?.position?.x).toBe(2);
+  });
+
+  it('updates stored room data', () => {
+    let state = createEmptyState();
+
+    const room = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 0,
+          y: 0,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = mergeRoom(state, room, []);
+
+    const updatedRoom = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 2,
+          y: -2,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = updateEntitiesFromRoom(state, updatedRoom);
+
+    // Stored room should be the updated one
+    expect(state.rooms.get('room-1')).toBe(updatedRoom);
+  });
+});

--- a/src/hooks/useDungeonMap.ts
+++ b/src/hooks/useDungeonMap.ts
@@ -1,0 +1,262 @@
+/**
+ * useDungeonMap - Accumulates revealed rooms into a single dungeon map state
+ *
+ * Instead of replacing room state on each reveal, this hook maintains
+ * an accumulated view of all explored rooms in the dungeon.
+ *
+ * Each room uses its `origin` field (dungeon-absolute coordinates) to
+ * position floor tiles, walls, entities, and doors in a unified coordinate system.
+ *
+ * Phase 2 of multi-room rendering (rpg-dnd5e-web #311).
+ * Rendering changes come in Phase 3 (#312).
+ */
+
+import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import type {
+  DoorInfo,
+  EntityPlacement,
+  Room,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { useCallback, useState } from 'react';
+
+/** A floor tile in dungeon-absolute coordinates */
+export interface AbsoluteFloorTile {
+  x: number;
+  y: number;
+  z: number;
+  roomId: string;
+}
+
+/** Accumulated dungeon map state across all revealed rooms */
+export interface DungeonMapState {
+  /** All floor tile positions (dungeon-absolute coordinates) keyed by "x,y,z" */
+  floorTiles: Map<string, AbsoluteFloorTile>;
+
+  /** All walls across revealed rooms (already in absolute coords from API) */
+  walls: Wall[];
+
+  /** All entities across all rooms, keyed by entity ID */
+  entities: Map<string, EntityPlacement>;
+
+  /** All doors across all rooms, keyed by connection ID */
+  doors: Map<string, DoorInfo>;
+
+  /** Set of revealed room IDs */
+  revealedRoomIds: Set<string>;
+
+  /** Room data indexed by room ID (for local coordinate lookups) */
+  rooms: Map<string, Room>;
+
+  /** The currently active room ID (where combat/player is) */
+  currentRoomId: string | null;
+}
+
+/** Create coordinate key for map lookups */
+function coordKey(x: number, y: number, z: number): string {
+  return `${x},${y},${z}`;
+}
+
+/** Create an empty dungeon map state. Exported for testing. */
+export function createEmptyState(): DungeonMapState {
+  return {
+    floorTiles: new Map(),
+    walls: [],
+    entities: new Map(),
+    doors: new Map(),
+    revealedRoomIds: new Set(),
+    rooms: new Map(),
+    currentRoomId: null,
+  };
+}
+
+/**
+ * Generate floor tile positions for a room using its origin.
+ * Room origin is in dungeon-absolute cube coordinates.
+ * Floor tiles span from origin to origin + (width, height).
+ * Exported for testing.
+ */
+export function generateFloorTiles(room: Room): AbsoluteFloorTile[] {
+  const tiles: AbsoluteFloorTile[] = [];
+  const originX = room.origin?.x ?? 0;
+  const originZ = room.origin?.z ?? 0;
+
+  for (let z = 0; z < room.height; z++) {
+    for (let x = 0; x < room.width; x++) {
+      const absX = originX + x;
+      const absZ = originZ + z;
+      const absY = -absX - absZ; // Cube coordinate constraint: x + y + z = 0
+      tiles.push({
+        x: absX,
+        y: absY,
+        z: absZ,
+        roomId: room.id,
+      });
+    }
+  }
+  return tiles;
+}
+
+/**
+ * Merge a room into existing dungeon map state.
+ * Handles both first room (combat started) and subsequent rooms (room revealed).
+ * Exported for testing.
+ */
+export function mergeRoom(
+  state: DungeonMapState,
+  room: Room,
+  doors: DoorInfo[]
+): DungeonMapState {
+  // If room already revealed, update entities/doors but don't duplicate tiles
+  const isUpdate = state.revealedRoomIds.has(room.id);
+
+  // Clone state for immutable update
+  const newFloorTiles = new Map(state.floorTiles);
+  // On update, keep existing walls (walls don't carry roomId so we can't filter).
+  // On new room, spread to clone the array for immutability.
+  const newWalls = [...state.walls];
+  const newEntities = new Map(state.entities);
+  const newDoors = new Map(state.doors);
+  const newRevealedRoomIds = new Set(state.revealedRoomIds);
+  const newRooms = new Map(state.rooms);
+
+  // Add floor tiles (only for new rooms)
+  if (!isUpdate) {
+    const tiles = generateFloorTiles(room);
+    for (const tile of tiles) {
+      newFloorTiles.set(coordKey(tile.x, tile.y, tile.z), tile);
+    }
+  }
+
+  // Add walls (already in absolute coordinates from API Phase 1)
+  if (!isUpdate && room.walls) {
+    newWalls.push(...room.walls);
+  }
+
+  // Merge entities (keyed by ID — handles movement between rooms)
+  if (room.entities) {
+    for (const [entityId, entity] of Object.entries(room.entities)) {
+      newEntities.set(entityId, entity);
+    }
+  }
+
+  // Merge doors (keyed by connection ID)
+  for (const door of doors) {
+    newDoors.set(door.connectionId, door);
+  }
+
+  // Track room
+  newRevealedRoomIds.add(room.id);
+  newRooms.set(room.id, room);
+
+  return {
+    floorTiles: newFloorTiles,
+    walls: newWalls,
+    entities: newEntities,
+    doors: newDoors,
+    revealedRoomIds: newRevealedRoomIds,
+    rooms: newRooms,
+    currentRoomId: room.id,
+  };
+}
+
+/**
+ * Update entity positions in the dungeon map (e.g., after movement, monster turns).
+ * This updates the accumulated entities map without changing room/floor data.
+ * Exported for testing.
+ */
+export function updateEntitiesFromRoom(
+  state: DungeonMapState,
+  room: Room
+): DungeonMapState {
+  const newEntities = new Map(state.entities);
+
+  if (room.entities) {
+    for (const [entityId, entity] of Object.entries(room.entities)) {
+      newEntities.set(entityId, entity);
+    }
+  }
+
+  // Also update the stored room data
+  const newRooms = new Map(state.rooms);
+  newRooms.set(room.id, room);
+
+  return {
+    ...state,
+    entities: newEntities,
+    rooms: newRooms,
+  };
+}
+
+export interface UseDungeonMapResult {
+  /** The accumulated dungeon map state */
+  dungeonMap: DungeonMapState;
+
+  /** The currently active room (for backward compat with existing rendering) */
+  currentRoom: Room | null;
+
+  /**
+   * Add/merge a room into the dungeon map.
+   * Call on CombatStarted and RoomRevealed events.
+   */
+  addRoom: (room: Room, doors: DoorInfo[]) => void;
+
+  /**
+   * Update entity positions from an updated room.
+   * Call on TurnEnded, MonsterTurnCompleted, MovementCompleted, AttackResolved.
+   */
+  updateEntities: (room: Room) => void;
+
+  /**
+   * Update doors state (e.g., when a door is opened).
+   */
+  updateDoors: (doors: DoorInfo[]) => void;
+
+  /**
+   * Reset the dungeon map (e.g., new encounter).
+   */
+  reset: () => void;
+}
+
+/**
+ * Hook to manage accumulated dungeon map state across room reveals.
+ */
+export function useDungeonMap(): UseDungeonMapResult {
+  const [dungeonMap, setDungeonMap] =
+    useState<DungeonMapState>(createEmptyState);
+
+  const addRoom = useCallback((room: Room, doors: DoorInfo[]) => {
+    setDungeonMap((prev) => mergeRoom(prev, room, doors));
+  }, []);
+
+  const updateEntities = useCallback((room: Room) => {
+    setDungeonMap((prev) => updateEntitiesFromRoom(prev, room));
+  }, []);
+
+  const updateDoors = useCallback((doors: DoorInfo[]) => {
+    setDungeonMap((prev) => {
+      const newDoors = new Map(prev.doors);
+      for (const door of doors) {
+        newDoors.set(door.connectionId, door);
+      }
+      return { ...prev, doors: newDoors };
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setDungeonMap(createEmptyState());
+  }, []);
+
+  // Derive current room from state
+  const currentRoom = dungeonMap.currentRoomId
+    ? (dungeonMap.rooms.get(dungeonMap.currentRoomId) ?? null)
+    : null;
+
+  return {
+    dungeonMap,
+    currentRoom,
+    addRoom,
+    updateEntities,
+    updateDoors,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2 of multi-room rendering ([tracking issue: rpg-api#426](https://github.com/KirkDiggler/rpg-api/issues/426)). Closes #311.

Replaces the single `room` state with an accumulated dungeon map that tracks all revealed rooms across a dungeon encounter.

## Changes

### New: `useDungeonMap` hook (`src/hooks/useDungeonMap.ts`)
- Pure function state management for dungeon map accumulation
- `mergeRoom()` — adds new room with floor tiles at absolute positions using `Room.origin`
- `updateEntitiesFromRoom()` — updates entity positions without changing floor/wall data
- `generateFloorTiles()` — generates floor tiles with cube coordinate invariant (`x + y + z = 0`)
- Immutable state updates throughout
- Tracks: floor tiles, walls, entities (by ID), doors (by connection ID), revealed room IDs, current room

### Updated: `LobbyView.tsx`
- Removed standalone `room` / `setRoom` state
- `CombatStarted` / `RoomRevealed` / `StateSync` → `addRoom(room, doors)`
- `TurnEnded` / `MonsterTurn` / `AttackResolved` / `Movement` → `updateEntities(room)`
- `resetDungeonState` → `resetDungeonMap()`
- `currentRoom` derived from hook (backward compat with `BattleMapPanel`)
- All `useCallback` dependency arrays updated

### Tests: 22 new tests (`src/hooks/useDungeonMap.test.ts`)
- Floor tile generation with offset origins
- Cube coordinate invariant verification
- Room accumulation (multiple rooms at different origins)
- Entity merging across rooms (character moves, monsters stay)
- Same-room re-add (no duplicate tiles)
- State immutability
- Reset behavior

## Backward Compatibility

This is a **state-only** change. Rendering still uses the current room (`BattleMapPanel` receives `room` prop as before). The accumulated `dungeonMap` state is wired up and ready for Phase 3 (render with absolute positions, #312).

## Depends On

- ✅ rpg-api#427 (merged) — API sends `Room.origin` and absolute wall coordinates

## Next

- Phase 3: Render dungeon map using `Room.origin` for floor tile positioning (#312)
- Phase 4: Camera follows player through multi-room dungeon (#313)  
- Phase 5: Room switching UI (#310)