### PR TITLE
fix: Remove dead monsters from hex grid (#358)

### DIFF
--- a/src/hooks/useDungeonMap.test.ts
+++ b/src/hooks/useDungeonMap.test.ts
@@ -613,6 +613,132 @@ describe('updateEntitiesFromRoom', () => {
     expect(newState.entities.get('char-1')?.position?.x).toBe(2);
   });
 
+  it('removes dead monsters when API removes them from room entities', () => {
+    let state = createEmptyState();
+
+    // Room starts with a character and a monster
+    const room = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 0,
+          y: 0,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+        'mob-1': {
+          entityId: 'mob-1',
+          x: 2,
+          y: -2,
+          z: 0,
+          type: EntityType.MONSTER,
+        },
+      },
+    });
+    state = mergeRoom(state, room, []);
+    expect(state.entities.size).toBe(2);
+
+    // Monster killed: API sends updated room without the dead monster
+    const updatedRoom = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 1,
+          y: -1,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = updateEntitiesFromRoom(state, updatedRoom);
+
+    // Monster should be removed, only character remains
+    expect(state.entities.size).toBe(1);
+    expect(state.entities.has('char-1')).toBe(true);
+    expect(state.entities.has('mob-1')).toBe(false);
+  });
+
+  it('does not remove entities from other rooms when updating one room', () => {
+    let state = createEmptyState();
+
+    // Room 1 has a monster
+    const room1 = createRoom({
+      id: 'room-1',
+      width: 3,
+      height: 2,
+      entities: {
+        'mob-1': {
+          entityId: 'mob-1',
+          x: 1,
+          y: -1,
+          z: 0,
+          type: EntityType.MONSTER,
+        },
+      },
+    });
+    state = mergeRoom(state, room1, []);
+
+    // Room 2 has a character and another monster
+    const room2 = createRoom({
+      id: 'room-2',
+      width: 2,
+      height: 2,
+      originX: 4,
+      originZ: 0,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 4,
+          y: -4,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+        'mob-2': {
+          entityId: 'mob-2',
+          x: 5,
+          y: -5,
+          z: 0,
+          type: EntityType.MONSTER,
+        },
+      },
+    });
+    state = mergeRoom(state, room2, []);
+    expect(state.entities.size).toBe(3);
+
+    // Kill mob-2 in room 2 — room 1's mob-1 should NOT be affected
+    const updatedRoom2 = createRoom({
+      id: 'room-2',
+      width: 2,
+      height: 2,
+      originX: 4,
+      originZ: 0,
+      entities: {
+        'char-1': {
+          entityId: 'char-1',
+          x: 4,
+          y: -4,
+          z: 0,
+          type: EntityType.CHARACTER,
+        },
+      },
+    });
+    state = updateEntitiesFromRoom(state, updatedRoom2);
+
+    // mob-1 from room 1 should still exist
+    expect(state.entities.has('mob-1')).toBe(true);
+    // mob-2 from room 2 should be removed
+    expect(state.entities.has('mob-2')).toBe(false);
+    // char-1 should still exist
+    expect(state.entities.has('char-1')).toBe(true);
+    expect(state.entities.size).toBe(2);
+  });
+
   it('updates stored room data', () => {
     let state = createEmptyState();
 

--- a/src/hooks/useDungeonMap.ts
+++ b/src/hooks/useDungeonMap.ts
@@ -162,6 +162,10 @@ export function mergeRoom(
 /**
  * Update entity positions in the dungeon map (e.g., after movement, monster turns).
  * This updates the accumulated entities map without changing room/floor data.
+ *
+ * Also removes entities that were in the previous version of this room but are
+ * no longer present (e.g., monsters that died and were removed by the API).
+ *
  * Exported for testing.
  */
 export function updateEntitiesFromRoom(
@@ -170,6 +174,19 @@ export function updateEntitiesFromRoom(
 ): DungeonMapState {
   const newEntities = new Map(state.entities);
 
+  // Remove entities that were in the previous version of this room but are
+  // no longer present (e.g., dead monsters removed by the API)
+  const previousRoom = state.rooms.get(room.id);
+  if (previousRoom?.entities) {
+    const updatedEntityIds = new Set(Object.keys(room.entities ?? {}));
+    for (const entityId of Object.keys(previousRoom.entities)) {
+      if (!updatedEntityIds.has(entityId)) {
+        newEntities.delete(entityId);
+      }
+    }
+  }
+
+  // Add/update entities from the new room data
   if (room.entities) {
     for (const [entityId, entity] of Object.entries(room.entities)) {
       newEntities.set(entityId, entity);


### PR DESCRIPTION
## Summary

- When a monster dies (HP <= 0), the API removes it from the room's entity map via `updatedRoom` in `AttackResolvedEvent`
- `updateEntitiesFromRoom` in `useDungeonMap.ts` only added/updated entities but never removed ones that disappeared from the room
- Dead monsters remained visible on the hex grid indefinitely because the accumulated `dungeonMap.entities` map was never pruned
- **Fix:** Compare the previous room's entity keys with the updated room's entity keys and delete any that were removed, scoped to the specific room so entities in other rooms are unaffected

## Test plan

- [x] New test: dead monsters removed when API removes them from room entities
- [x] New test: entities from other rooms are not affected when one room updates
- [x] All 24 existing tests still pass
- [x] `npm run ci-check` passes (format, lint, typecheck, build, tests)
- [ ] Manual: kill a monster in combat, verify it disappears from the board

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)