### PR TITLE
fix: Weapon rendering on character models (#337)

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -1790,35 +1790,39 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
 
     console.log('[useEffect] Fetching full character data for:', idsToFetch);
 
-    idsToFetch.forEach(async (characterId) => {
-      try {
-        const { characterClient } = await import('@/api/client');
-        const { create } = await import('@bufbuild/protobuf');
-        const { GetCharacterRequestSchema } =
-          await import('@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb');
+    // Hoist dynamic imports before the loop to avoid re-importing on each iteration
+    const fetchCharacters = async () => {
+      const { characterClient } = await import('@/api/client');
+      const { create } = await import('@bufbuild/protobuf');
+      const { GetCharacterRequestSchema } =
+        await import('@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb');
 
-        const getCharRequest = create(GetCharacterRequestSchema, {
-          characterId,
-        });
-        const response = await characterClient.getCharacter(getCharRequest);
-
-        if (response.character) {
-          setFullCharactersMap((prev) => {
-            const newMap = new Map(prev);
-            newMap.set(
-              characterId,
-              mergeCharacterUpdate(prev.get(characterId), response.character!)
-            );
-            return newMap;
+      idsToFetch.forEach(async (characterId) => {
+        try {
+          const getCharRequest = create(GetCharacterRequestSchema, {
+            characterId,
           });
+          const response = await characterClient.getCharacter(getCharRequest);
+
+          if (response.character) {
+            setFullCharactersMap((prev) => {
+              const newMap = new Map(prev);
+              newMap.set(
+                characterId,
+                mergeCharacterUpdate(prev.get(characterId), response.character!)
+              );
+              return newMap;
+            });
+          }
+        } catch (error) {
+          console.error(
+            `Failed to fetch full character data for ${characterId}:`,
+            error
+          );
         }
-      } catch (error) {
-        console.error(
-          `Failed to fetch full character data for ${characterId}:`,
-          error
-        );
-      }
-    });
+      });
+    };
+    fetchCharacters();
   }, [encounterId, fullCharactersMap]);
 
   const getSelectedCharacters = (): Character[] => {


### PR DESCRIPTION
## Summary
- **Root cause**: Encounter stream event handlers (`handleCombatStarted`, `handleStateSync`, `handlePlayerJoined`) were using raw `map.set(id, char)` to update `fullCharactersMap`, overwriting previously-fetched full character data (including `equipmentSlots`) with partial stream data that omits equipment.
- **Fix 1**: All three handlers now use `mergeCharacterUpdate()` which preserves visual-critical fields (equipment, appearance, class, race) when the incoming data has default/empty values.
- **Fix 2**: The `getCharacter` fetch effect now covers **all party members** (not just local player's `selectedCharacterIds`), ensuring other players' weapon/shield attachments also render.
- **Fix 3**: The fetch effect uses a ref-based dedup set to avoid infinite re-fetch loops when `fullCharactersMap` updates trigger re-renders.

## Test plan
- [ ] Start an encounter with a character equipped with a weapon (e.g., shortsword, greataxe)
- [ ] Verify weapon model appears on the 3D character immediately after combat starts
- [ ] Take damage (trigger AttackResolved event) and verify weapon persists on the model
- [ ] In multiplayer: verify other players' characters also show their equipped weapons
- [ ] Reconnect mid-combat (triggers StateSync) and verify weapons still render
- [ ] Navigate through dungeon doors (new room) and verify weapons persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)