### PR TITLE
fix: bonus strike target selection broken (#323)

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -1105,7 +1105,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         // This ensures bonus strikes (OFF_HAND_STRIKE, UNARMED_STRIKE) are used correctly
         // after a primary attack, instead of defaulting to STRIKE.
         const firstStrike = findFirstStrike(availableActions);
-        if (firstStrike) {
+        if (firstStrike !== undefined) {
           console.log(
             '🎯 Strike available:',
             ActionId[firstStrike],


### PR DESCRIPTION
## Summary
- Fixed bonus strike (Off-Hand Strike, Unarmed Strike, Martial Arts Bonus Strike) target selection not registering when clicking an enemy after a primary attack
- Three code paths in `LobbyView.tsx` defaulted to `ActionId.STRIKE` instead of using the actual available bonus strike action from `availableActions`
- All three now use `findFirstStrike(availableActions)` to pick the correct action ID and pass it explicitly, avoiding React state timing issues

## Root Cause
After a primary attack completes, the API returns updated `availableActions` containing the bonus strike (e.g., `OFF_HAND_STRIKE`). When clicking an enemy to target it, the code auto-executed `handleAttackAction` but:
1. `handleEntityClick` passed no `overrideActionId`, so it fell through to `ActionId.STRIKE`
2. `handleAttackComplete` (HexGrid path) used `setTimeout` with no action ID
3. `handleAttackAction` fallback chain skipped current `availableActions` state

The API would reject the `STRIKE` action (already used), causing the attack to silently fail and the "select a target" prompt to persist.

## Test plan
- [ ] Start combat as a character with two-weapon fighting (e.g., dual-wielding)
- [ ] Activate Attack, strike an enemy with primary weapon
- [ ] Verify Off-Hand Strike appears in available actions
- [ ] Click an enemy -- should auto-execute the Off-Hand Strike (not show "select a target")
- [ ] Repeat with a Monk character for Martial Arts Bonus Strike (unarmed strike after monk weapon attack)

Fixes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)