### PR TITLE
fix: Filter dead monsters from hex grid rendering

### DIFF
--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -48,31 +48,56 @@ export function BattleMapPanel({
   onDoorClick,
   isDoorLoading,
 }: BattleMapPanelProps) {
-  // Build entities array from accumulated dungeonMap entities
-  const entities = useMemo(() => {
-    return Array.from(dungeonMap.entities.values()).map((entity) => {
-      let displayType: 'player' | 'monster' | 'obstacle';
-      if (entity.entityType === EntityType.CHARACTER) {
-        displayType = 'player';
-      } else if (entity.entityType === EntityType.MONSTER) {
-        displayType = 'monster';
-      } else {
-        displayType = 'obstacle';
+  // Build a set of dead monster IDs so we can exclude them from the grid
+  const deadMonsterIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (monsters) {
+      for (const m of monsters) {
+        if (m.currentHitPoints <= 0) {
+          ids.add(m.monsterId);
+        }
       }
-      return {
-        entityId: entity.entityId,
-        name:
-          allPartyCharacters.find((c) => c.id === entity.entityId)?.name ||
-          entity.entityId,
-        position: {
-          x: entity.position?.x || 0,
-          y: entity.position?.y || 0,
-          z: entity.position?.z || 0,
-        },
-        type: displayType,
-      };
-    });
-  }, [dungeonMap.entities, allPartyCharacters]);
+    }
+    return ids;
+  }, [monsters]);
+
+  // Build entities array from accumulated dungeonMap entities,
+  // filtering out monsters that have been killed (HP <= 0)
+  const entities = useMemo(() => {
+    return Array.from(dungeonMap.entities.values())
+      .filter((entity) => {
+        // Remove dead monsters from the grid
+        if (
+          entity.entityType === EntityType.MONSTER &&
+          deadMonsterIds.has(entity.entityId)
+        ) {
+          return false;
+        }
+        return true;
+      })
+      .map((entity) => {
+        let displayType: 'player' | 'monster' | 'obstacle';
+        if (entity.entityType === EntityType.CHARACTER) {
+          displayType = 'player';
+        } else if (entity.entityType === EntityType.MONSTER) {
+          displayType = 'monster';
+        } else {
+          displayType = 'obstacle';
+        }
+        return {
+          entityId: entity.entityId,
+          name:
+            allPartyCharacters.find((c) => c.id === entity.entityId)?.name ||
+            entity.entityId,
+          position: {
+            x: entity.position?.x || 0,
+            y: entity.position?.y || 0,
+            z: entity.position?.z || 0,
+          },
+          type: displayType,
+        };
+      });
+  }, [dungeonMap.entities, allPartyCharacters, deadMonsterIds]);
 
   // Convert doors map to array for HexGrid
   const doorsArray = useMemo(


### PR DESCRIPTION
## Summary
- Dead monsters (HP <= 0) now get filtered out of the hex grid entity list in `BattleMapPanel`
- PR #359's removal logic in `useDungeonMap.updateEntitiesFromRoom()` depends on the API excluding dead monsters from `updatedRoom`, but the API still includes them — so this fix works at the render layer instead
- Uses the existing `monsters` (MonsterCombatState[]) prop which already tracks currentHitPoints via the AttackResolved stream handler

## Root Cause
Two separate state systems drive monster rendering:
1. `dungeonMap.entities` — entity placements from room data (drives grid position)
2. `monsters` (MonsterCombatState[]) — combat HP state (updated by AttackResolved)

PR #359 tried to remove dead monsters by comparing room entity keys in `updateEntitiesFromRoom`, but the API's `updatedRoom` still includes the dead monster entity. The fix cross-references the `monsters` HP state when building the entity list for rendering.

## Test plan
- [ ] Attack a monster until HP reaches 0
- [ ] Verify monster disappears from the hex grid
- [ ] Verify player cannot target the dead monster's hex
- [ ] Verify other monsters remain on the grid
- [ ] Verify combat continues normally after monster death

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)