### PR TITLE
Fix hover panel HP by handling ActionExecutedEvent in stream

### DIFF
--- a/src/api/useEncounterStream.ts
+++ b/src/api/useEncounterStream.ts
@@ -1,5 +1,6 @@
 import { create } from '@bufbuild/protobuf';
 import type {
+  ActionExecutedEvent,
   AttackResolvedEvent,
   CombatEndedEvent,
   CombatPausedEvent,
@@ -63,6 +64,7 @@ interface UseEncounterStreamOptions {
   // Combat action events (for BattleMap)
   onMovementCompleted?: (event: MovementCompletedEvent) => void;
   onAttackResolved?: (event: AttackResolvedEvent) => void;
+  onActionExecuted?: (event: ActionExecutedEvent) => void;
   onFeatureActivated?: (event: FeatureActivatedEvent) => void;
   onTurnEnded?: (event: TurnEndedEvent) => void;
   onMonsterTurnCompleted?: (event: MonsterTurnCompletedEvent) => void;
@@ -127,6 +129,9 @@ function dispatchEvent(
       break;
     case 'attackResolved':
       options.onAttackResolved?.(eventPayload.value);
+      break;
+    case 'actionExecuted':
+      options.onActionExecuted?.(eventPayload.value);
       break;
     case 'featureActivated':
       options.onFeatureActivated?.(eventPayload.value);

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -33,6 +33,7 @@ import {
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import {
   EncounterEndReason,
+  type ActionExecutedEvent,
   type AttackResolvedEvent,
   type AvailableAbility,
   type AvailableAction,
@@ -460,6 +461,41 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       availableCharacters,
       updateMapEntities,
     ]
+  );
+
+  // Multiplayer sync: Action executed (new action system) - sync monster HP for other players
+  const handleActionExecuted = useCallback(
+    (event: ActionExecutedEvent) => {
+      console.log('🎯 ActionExecuted event received:', event);
+
+      // Update monster HP when a strike hits a monster target
+      if (
+        event.result?.case === 'strikeResult' &&
+        event.result.value.hit &&
+        event.result.value.damage > 0
+      ) {
+        const strikeDamage = event.result.value.damage;
+        setMonsters((prev) =>
+          prev.map((m) =>
+            m.monsterId === event.targetId
+              ? {
+                  ...m,
+                  currentHitPoints: Math.max(
+                    0,
+                    m.currentHitPoints - strikeDamage
+                  ),
+                }
+              : m
+          )
+        );
+      }
+
+      // Update entity positions if room changed (e.g., entity defeated)
+      if (event.updatedRoom) {
+        updateMapEntities(event.updatedRoom);
+      }
+    },
+    [updateMapEntities]
   );
 
   // Multiplayer sync: Movement completed - sync entity positions and movement resources
@@ -920,6 +956,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     onTurnEnded: handleTurnEnded,
     onMonsterTurnCompleted: handleMonsterTurnCompleted,
     onAttackResolved: handleAttackResolved,
+    onActionExecuted: handleActionExecuted,
     onMovementCompleted: handleMovementCompleted,
     onFeatureActivated: handleFeatureActivated,
     // Player sync events
@@ -1467,6 +1504,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           console.log(
             `Damage: ${damage} ${damageType}${critical ? ' (CRITICAL!)' : ''}`
           );
+          // Monster HP is updated via the handleActionExecuted stream handler,
+          // which fires for both local and remote players' ExecuteAction calls.
         }
 
         // Add combat log entry - get display names for attacker and target


### PR DESCRIPTION
## Summary

- Fixes enemy hover panel always showing "Uninjured" regardless of damage dealt
- Root cause: stream dispatcher only handled legacy `AttackResolvedEvent` but the new action system emits `ActionExecutedEvent` — monster HP was never updated
- Added `ActionExecutedEvent` handling in stream dispatcher and LobbyView

## Changes

- `src/api/useEncounterStream.ts` — added `actionExecuted` dispatch case
- `src/components/LobbyView.tsx` — added `handleActionExecuted` to decrement monster HP on hit

## Test plan

- [ ] Attack a monster, hover over it → status changes from "Uninjured" to "Injured"/"Bloodied"
- [ ] Verify HP updates for both local player attacks and multiplayer sync

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)