### PR TITLE
fix: show Unarmed Strike instead of Unknown Weapon (#363)

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -1419,7 +1419,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
                 switch (sourceCase) {
                   case 'weapon':
                     // Use type-safe enum display for weapon name
-                    // Weapon.UNSPECIFIED means unarmed — use the resolved weaponName
+                    // If the backend leaves the weapon UNSPECIFIED, fall back to the resolved weaponName
                     sourceName =
                       value === Weapon.UNSPECIFIED
                         ? weaponName

--- a/src/components/combat-v2/panels/CombatHistorySidebar.tsx
+++ b/src/components/combat-v2/panels/CombatHistorySidebar.tsx
@@ -10,6 +10,7 @@ import type {
   DamageBreakdown,
   DamageComponent,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { Weapon } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { useEffect, useRef, useState } from 'react';
 import styles from '../styles/combat.module.css';
 
@@ -370,10 +371,14 @@ function getSourceDisplay(
     const { case: sourceCase, value } = component.sourceRef.source;
     switch (sourceCase) {
       case 'weapon': {
-        const display = getWeaponDisplay(value);
+        // If the backend leaves the weapon UNSPECIFIED, fall back to the resolved weaponName
+        const name =
+          value === Weapon.UNSPECIFIED
+            ? weaponName || 'Weapon'
+            : getWeaponDisplay(value).title;
         return {
           icon: '🔨',
-          name: display.title,
+          name,
           value: valueStr,
         };
       }


### PR DESCRIPTION
## Summary
- Detect `UNARMED_STRIKE` and `FLURRY_STRIKE` action IDs when resolving the weapon name in combat toasts/logs, displaying "Unarmed Strike" instead of falling back to empty equipment or generic "Weapon"
- When the damage breakdown `sourceRef` sends `Weapon.UNSPECIFIED`, use the already-resolved `weaponName` (which is "Unarmed Strike" for unarmed actions) instead of showing "Unknown Weapon" from the enum display map

## Test plan
- [ ] Start combat with a Monk character
- [ ] Use unarmed strike — verify toast shows "Unarmed Strike" not "Unknown Weapon"
- [ ] Use Flurry of Blows — verify each strike toast shows "Unarmed Strike"
- [ ] Use a regular weapon attack — verify it still shows the equipped weapon name
- [ ] Check combat log history entries show correct weapon names

🤖 Generated with [Claude Code](https://claude.com/claude-code)