### PR TITLE
feat: unified entity state - web client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.85",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.86",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1347,7 +1347,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#e78908772cadced56f33bd99a1f21c93cf0874bc",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#74c83378eaf59db31e33fbf6fe5649f88c9c9891",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#generated",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.85",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1347,7 +1347,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#192532ff59aebf6a7cae2a06e3acbeba1ef2c1fb",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#e78908772cadced56f33bd99a1f21c93cf0874bc",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#generated",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.85",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.85",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.86",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -1019,6 +1019,28 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
 
         // Handle combat started events
         if (payload.case === 'combatStarted') {
+          // Apply the snapshot so entities, rooms, and combat state render
+          if (payload.value.encounterStateData) {
+            applySnapshot(payload.value.encounterStateData);
+
+            // Set dungeon state for room navigation
+            setDungeonId(payload.value.dungeonId || null);
+
+            // Legacy path: build Room from encounterStateData for floor/wall rendering
+            const esd = payload.value.encounterStateData;
+            if (esd.combat) {
+              setCombatState(esd.combat);
+              if (esd.combat.currentTurn?.entityId) {
+                setSelectedEntity(esd.combat.currentTurn.entityId);
+              }
+            }
+            setMonsters(monstersFromEncounterState(esd));
+            const legacyRoom = roomFromEncounterState(esd);
+            if (legacyRoom) {
+              addRoomToMap(legacyRoom, doorsFromEncounterState(esd));
+            }
+          }
+
           const logEntry: CombatLogEntry = {
             id: `combat-started-history-${event.eventId}`,
             timestamp: new Date(Number(event.timestamp)),

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -2201,6 +2201,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
                 selectedEntity={selectedEntity}
                 availableCharacters={availableCharacters}
                 allPartyCharacters={Array.from(fullCharactersMap.values())}
+                encounterEntities={encounterState.entities}
                 onEntityClick={handleEntityClick}
                 onCellClick={handleCellClick}
                 encounterId={encounterId}
@@ -2257,6 +2258,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           selectedHoverEntity={selectedHoverEntity}
           characters={availableCharacters}
           monsters={monsters}
+          encounterEntities={encounterState.entities}
           availableAbilities={availableAbilities}
           availableActions={availableActions}
           combatEnded={combatEnded}

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -191,6 +191,7 @@ function monstersFromEncounterState(
     ) {
       result.push({
         monsterId: entity.entityId,
+        monsterName: entity.details.value.name,
         monsterType: entity.details.value.monsterType,
         currentHitPoints: entity.currentHitPoints,
         maxHitPoints: entity.maxHitPoints,
@@ -243,8 +244,6 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     dungeonMap,
     currentRoom: room,
     addRoom: addRoomToMap,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for Task 7 cleanup
-    updateEntities: updateMapEntities,
     reset: resetDungeonMap,
   } = useDungeonMap();
 

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -255,8 +255,6 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     applyCombatState: applyEncounterCombatState,
     reset: resetEncounterState,
   } = useEncounterState();
-  // Suppress unused-variable lint until downstream components read from encounterState (Tasks 4-6)
-  void encounterState;
 
   // Walkable tile keys for cross-room pathfinding
   const walkableTileKeys = useMemo(
@@ -1390,6 +1388,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       combatState?.currentTurn?.entityId;
 
     setCombatState(newCombatState);
+    applyEncounterCombatState(newCombatState);
     // Update selected entity to the new current turn's entity
     if (newCombatState.currentTurn?.entityId) {
       setSelectedEntity(newCombatState.currentTurn.entityId);
@@ -1489,9 +1488,10 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setAvailableAbilities(activateResponse.availableAbilities ?? []);
         setAvailableActions(freshActions);
 
-        // Update combat state if provided
+        // Update combat state if provided (both legacy and unified paths)
         if (activateResponse.combatState) {
           setCombatState(activateResponse.combatState);
+          applyEncounterCombatState(activateResponse.combatState);
         }
 
         // Pick strike from the fresh response (not stale React state)
@@ -1694,9 +1694,10 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setCombatLog((prev) => [...prev, logEntry]);
       }
 
-      // Update combat state if returned
+      // Update combat state if returned (both legacy and unified paths)
       if (response.combatState) {
         handleCombatStateUpdate(response.combatState);
+        applyEncounterCombatState(response.combatState);
       }
 
       // Clear attack target after successful attack
@@ -1742,6 +1743,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           setAvailableActions(response.availableActions ?? []);
           if (response.combatState) {
             setCombatState(response.combatState);
+            applyEncounterCombatState(response.combatState);
           }
           addToast({
             type: 'info',
@@ -1781,6 +1783,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setAvailableActions(response.availableActions ?? []);
         if (response.combatState) {
           setCombatState(response.combatState);
+          applyEncounterCombatState(response.combatState);
         }
         addToast({
           type: 'success',

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -12,7 +12,9 @@ import {
 } from '@/api';
 import { useDiscord } from '@/discord';
 import { useDungeonMap } from '@/hooks/useDungeonMap';
+import { useEncounterState } from '@/hooks/useEncounterState';
 import { mergeCharacterUpdate } from '@/utils/characterMerge';
+import { getEntityName } from '@/utils/entityHelpers';
 import {
   getAbilityDisplay,
   getConditionDisplay,
@@ -39,8 +41,13 @@ import {
   type AvailableAction,
   type CombatStartedEvent,
   type CombatState,
+  type DoorInfo,
+  type DungeonFailureEvent,
   type DungeonVictoryEvent,
   type EncounterEvent,
+  type EncounterStateData,
+  type EntityPlacement,
+  type EntityState,
   type FeatureActivatedEvent,
   type MonsterCombatState,
   type MonsterTurnCompletedEvent,
@@ -106,6 +113,96 @@ function applyMonsterMovement(room: Room, turns: MonsterTurnResult[]): Room {
   };
 }
 
+/**
+ * Convert an EntityState to an EntityPlacement for legacy addRoomToMap compatibility.
+ * EntityPlacement is a subset of EntityState (spatial + visual only, no HP/conditions).
+ */
+function entityStateToPlacement(entity: EntityState): EntityPlacement {
+  const placement: EntityPlacement = {
+    entityId: entity.entityId,
+    entityType: entity.entityType,
+    position: entity.position,
+    size: entity.size,
+    blocksMovement: entity.blocksMovement,
+    blocksLineOfSight: entity.blocksLineOfSight,
+    visualType: { case: undefined, value: undefined },
+    $typeName: 'dnd5e.api.v1alpha1.EntityPlacement' as const,
+    $unknown: undefined,
+  };
+  // Map monster details to visual type
+  if (entity.details.case === 'monsterDetails') {
+    (placement as EntityPlacement).visualType = {
+      case: 'monsterType' as const,
+      value: entity.details.value.monsterType,
+    };
+  }
+  return placement;
+}
+
+/**
+ * Build a legacy Room object from EncounterStateData for addRoomToMap compatibility.
+ * Uses the current room's RoomLayout + entities assigned to that room.
+ */
+function roomFromEncounterState(data: EncounterStateData): Room | undefined {
+  const roomLayout = data.rooms[data.currentRoomId];
+  if (!roomLayout) return undefined;
+
+  // Collect entities that belong to the current room
+  const entities: { [key: string]: EntityPlacement } = {};
+  for (const entity of Object.values(data.entities)) {
+    if (entity.roomId === data.currentRoomId) {
+      entities[entity.entityId] = entityStateToPlacement(entity);
+    }
+  }
+
+  return {
+    id: roomLayout.id,
+    type: roomLayout.type,
+    width: roomLayout.width,
+    height: roomLayout.height,
+    gridType: roomLayout.gridType,
+    walls: roomLayout.walls,
+    origin: roomLayout.origin,
+    entities,
+    $typeName: 'dnd5e.api.v1alpha1.Room' as const,
+    $unknown: undefined,
+  } as Room;
+}
+
+/**
+ * Extract DoorInfo array from EncounterStateData for addRoomToMap compatibility.
+ */
+function doorsFromEncounterState(data: EncounterStateData): DoorInfo[] {
+  return Object.values(data.doors);
+}
+
+/**
+ * Build MonsterCombatState array from EncounterStateData entities.
+ * Used to feed the legacy `monsters` state for monsterType texture selection.
+ */
+function monstersFromEncounterState(
+  data: EncounterStateData
+): MonsterCombatState[] {
+  const result: MonsterCombatState[] = [];
+  for (const entity of Object.values(data.entities)) {
+    if (
+      entity.entityType === EntityType.MONSTER &&
+      entity.details.case === 'monsterDetails'
+    ) {
+      result.push({
+        monsterId: entity.entityId,
+        monsterType: entity.details.value.monsterType,
+        currentHitPoints: entity.currentHitPoints,
+        maxHitPoints: entity.maxHitPoints,
+        armorClass: entity.details.value.armorClass,
+        $typeName: 'dnd5e.api.v1alpha1.MonsterCombatState' as const,
+        $unknown: undefined,
+      } as MonsterCombatState);
+    }
+  }
+  return result;
+}
+
 interface LobbyViewProps {
   characterId?: string | null;
   onBack?: () => void;
@@ -146,9 +243,21 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     dungeonMap,
     currentRoom: room,
     addRoom: addRoomToMap,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for Task 7 cleanup
     updateEntities: updateMapEntities,
     reset: resetDungeonMap,
   } = useDungeonMap();
+
+  // Unified encounter state (new path — runs alongside legacy state until Task 7)
+  const {
+    state: encounterState,
+    applySnapshot,
+    applyEntityUpdates,
+    applyCombatState: applyEncounterCombatState,
+    reset: resetEncounterState,
+  } = useEncounterState();
+  // Suppress unused-variable lint until downstream components read from encounterState (Tasks 4-6)
+  void encounterState;
 
   // Walkable tile keys for cross-room pathfinding
   const walkableTileKeys = useMemo(
@@ -226,16 +335,30 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       setIsTransitioning(true);
 
       setTimeout(() => {
-        // Accumulate new room into dungeon map
-        if (event.room) {
-          addRoomToMap(event.room, event.doors ?? []);
-        }
-        setCombatState(event.combatState ?? null);
-        setRoomsCleared((prev) => prev + 1);
+        // --- New path: populate unified encounter state ---
+        if (event.encounterStateData) {
+          applySnapshot(event.encounterStateData);
 
-        // Select the current turn entity
-        if (event.combatState?.currentTurn?.entityId) {
-          setSelectedEntity(event.combatState.currentTurn.entityId);
+          // --- Legacy path: build Room/CombatState from encounterStateData ---
+          const legacyRoom = roomFromEncounterState(event.encounterStateData);
+          if (legacyRoom) {
+            addRoomToMap(
+              legacyRoom,
+              doorsFromEncounterState(event.encounterStateData)
+            );
+          }
+          setCombatState(event.encounterStateData.combat ?? null);
+          setRoomsCleared(event.encounterStateData.roomsCleared);
+
+          // Update monsters from encounter state (for monsterType texture selection)
+          setMonsters(monstersFromEncounterState(event.encounterStateData));
+
+          // Select the current turn entity
+          if (event.encounterStateData.combat?.currentTurn?.entityId) {
+            setSelectedEntity(
+              event.encounterStateData.combat.currentTurn.entityId
+            );
+          }
         }
 
         // Clear movement state for new room
@@ -250,12 +373,17 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setIsTransitioning(false);
       }, 300);
     },
-    [addRoomToMap]
+    [addRoomToMap, applySnapshot]
   );
 
   const handleDungeonVictory = useCallback(
     (event: DungeonVictoryEvent) => {
-      setRoomsCleared(event.roomsCleared);
+      // --- New path: populate unified encounter state ---
+      if (event.encounterStateData) {
+        applySnapshot(event.encounterStateData);
+        // Legacy: extract roomsCleared from encounterStateData
+        setRoomsCleared(event.encounterStateData.roomsCleared);
+      }
       // Don't immediately show overlay - let player explore/loot
       setCombatEnded(true);
       addToast({
@@ -265,19 +393,32 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         duration: 5000,
       });
     },
-    [addToast]
+    [addToast, applySnapshot]
   );
 
-  const handleDungeonFailure = useCallback(() => {
-    // Defeat still shows immediately since there's nothing to explore
-    setDungeonResult('failure');
-  }, []);
+  const handleDungeonFailure = useCallback(
+    (event: DungeonFailureEvent) => {
+      // --- New path: populate unified encounter state ---
+      if (event.encounterStateData) {
+        applySnapshot(event.encounterStateData);
+      }
+      // Defeat still shows immediately since there's nothing to explore
+      setDungeonResult('failure');
+    },
+    [applySnapshot]
+  );
 
   // Multiplayer sync: Turn ended - update combat state and room
   const handleTurnEnded = useCallback(
     (event: TurnEndedEvent) => {
       console.log('🔄 TurnEnded event received:', event);
 
+      // --- New path: populate unified encounter state ---
+      if (event.updatedEntities.length > 0)
+        applyEntityUpdates(event.updatedEntities);
+      if (event.combatState) applyEncounterCombatState(event.combatState);
+
+      // --- Legacy path ---
       // Update combat state from the event
       if (event.combatState) {
         setCombatState(event.combatState);
@@ -295,13 +436,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setAvailableAbilities([]);
         setAvailableActions([]);
       }
-
-      // Update entity positions in dungeon map after turn
-      if (event.updatedRoom) {
-        updateMapEntities(event.updatedRoom);
-      }
     },
-    [updateMapEntities]
+    [applyEntityUpdates, applyEncounterCombatState]
   );
 
   // Multiplayer sync: Monster turn completed - show monster actions
@@ -309,6 +445,12 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: MonsterTurnCompletedEvent) => {
       console.log('👹 MonsterTurnCompleted event received:', event);
 
+      // --- New path: populate unified encounter state ---
+      if (event.updatedEntities.length > 0)
+        applyEntityUpdates(event.updatedEntities);
+      if (event.combatState) applyEncounterCombatState(event.combatState);
+
+      // --- Legacy path ---
       // Convert monster turn to combat log entry
       if (event.monsterTurn) {
         const currentRound = combatState?.round || 1;
@@ -316,7 +458,10 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           [event.monsterTurn],
           currentRound,
           (targetId) => {
-            // Use inline name resolution since getEntityDisplayName isn't available yet
+            // Try new encounter state entities first for name resolution
+            const entityState = encounterState.entities.get(targetId);
+            if (entityState) return getEntityName(entityState);
+            // Fall back to legacy name resolution
             const fullChar = fullCharactersMap.get(targetId);
             if (fullChar?.name) return fullChar.name;
             const availChar = availableCharacters.find(
@@ -330,32 +475,18 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setCombatLog((prev) => [...prev, ...monsterLogEntries]);
       }
 
-      // Update characters if provided — merge to preserve visual state (class, race, appearance)
-      if (event.updatedCharacters && event.updatedCharacters.length > 0) {
-        setFullCharactersMap((prev) => {
-          const newMap = new Map(prev);
-          event.updatedCharacters.forEach((char) => {
-            if (char.id) {
-              newMap.set(
-                char.id,
-                mergeCharacterUpdate(prev.get(char.id), char)
-              );
-            }
-          });
-          return newMap;
-        });
-      }
-
-      // Update entity positions in dungeon map (monster positions changed)
-      if (event.updatedRoom) {
-        updateMapEntities(event.updatedRoom);
+      // Update combat state from the event
+      if (event.combatState) {
+        setCombatState(event.combatState);
       }
     },
     [
       combatState?.round,
       fullCharactersMap,
       availableCharacters,
-      updateMapEntities,
+      encounterState.entities,
+      applyEntityUpdates,
+      applyEncounterCombatState,
     ]
   );
 
@@ -364,39 +495,13 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: AttackResolvedEvent) => {
       console.log('⚔️ AttackResolved event received:', event);
 
-      // Update attacker and/or target characters if provided — merge to preserve visual state
-      setFullCharactersMap((prev) => {
-        if (!event.updatedAttacker?.id && !event.updatedTarget?.id) {
-          return prev;
-        }
+      // --- New path: populate unified encounter state ---
+      const entityUpdates = [event.attackerState, event.targetState].filter(
+        Boolean
+      ) as EntityState[];
+      if (entityUpdates.length > 0) applyEntityUpdates(entityUpdates);
 
-        const newMap = new Map(prev);
-        if (event.updatedAttacker?.id) {
-          newMap.set(
-            event.updatedAttacker.id,
-            mergeCharacterUpdate(
-              prev.get(event.updatedAttacker.id),
-              event.updatedAttacker
-            )
-          );
-        }
-        if (event.updatedTarget?.id) {
-          newMap.set(
-            event.updatedTarget.id,
-            mergeCharacterUpdate(
-              prev.get(event.updatedTarget.id),
-              event.updatedTarget
-            )
-          );
-        }
-        return newMap;
-      });
-
-      // Update entity positions in dungeon map (entity state may have changed)
-      if (event.updatedRoom) {
-        updateMapEntities(event.updatedRoom);
-      }
-
+      // --- Legacy path ---
       // Update monster HP when a hit lands on a monster target
       if (event.result?.hit && event.result.damage > 0) {
         setMonsters((prev) =>
@@ -416,11 +521,16 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
 
       // Add combat log entry for the attack
       if (event.result) {
+        // Try encounter state entities first for name resolution, fall back to legacy
+        const attackerEntity = encounterState.entities.get(event.attackerId);
+        const targetEntity = encounterState.entities.get(event.targetId);
         const attackerName =
+          (attackerEntity ? getEntityName(attackerEntity) : null) ||
           fullCharactersMap.get(event.attackerId)?.name ||
           availableCharacters.find((c) => c.id === event.attackerId)?.name ||
           formatEntityId(event.attackerId);
         const targetName =
+          (targetEntity ? getEntityName(targetEntity) : null) ||
           fullCharactersMap.get(event.targetId)?.name ||
           availableCharacters.find((c) => c.id === event.targetId)?.name ||
           formatEntityId(event.targetId);
@@ -477,7 +587,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       combatState?.round,
       fullCharactersMap,
       availableCharacters,
-      updateMapEntities,
+      encounterState.entities,
+      applyEntityUpdates,
     ]
   );
 
@@ -486,6 +597,12 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: ActionExecutedEvent) => {
       console.log('🎯 ActionExecuted event received:', event);
 
+      // --- New path: populate unified encounter state ---
+      if (event.updatedEntities.length > 0)
+        applyEntityUpdates(event.updatedEntities);
+      if (event.combatState) applyEncounterCombatState(event.combatState);
+
+      // --- Legacy path ---
       // Update monster HP when a strike hits a monster target
       if (
         event.result?.case === 'strikeResult' &&
@@ -507,13 +624,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           )
         );
       }
-
-      // Update entity positions if room changed (e.g., entity defeated)
-      if (event.updatedRoom) {
-        updateMapEntities(event.updatedRoom);
-      }
     },
-    [updateMapEntities]
+    [applyEntityUpdates, applyEncounterCombatState]
   );
 
   // Multiplayer sync: Movement completed - sync entity positions and movement resources
@@ -521,30 +633,17 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: MovementCompletedEvent) => {
       console.log('🚶 MovementCompleted event received:', event);
 
-      // Update entity positions in dungeon map
-      if (event.updatedRoom) {
-        updateMapEntities(event.updatedRoom);
+      // --- New path: populate unified encounter state ---
+      if (event.updatedEntity) applyEntityUpdates([event.updatedEntity]);
+      if (event.combatState) applyEncounterCombatState(event.combatState);
+
+      // --- Legacy path ---
+      // Sync combat state (includes updated movement resources)
+      if (event.combatState) {
+        setCombatState(event.combatState);
       }
-
-      // Sync movement resources to combat state
-      // Only update if this is the current turn's entity
-      setCombatState((prev) => {
-        if (!prev?.currentTurn) return prev;
-        if (prev.currentTurn.entityId !== event.entityId) return prev;
-
-        const movementUsed =
-          prev.currentTurn.movementMax - event.movementRemaining;
-
-        return {
-          ...prev,
-          currentTurn: {
-            ...prev.currentTurn,
-            movementUsed,
-          },
-        };
-      });
     },
-    [updateMapEntities]
+    [applyEntityUpdates, applyEncounterCombatState]
   );
 
   // Multiplayer sync: Feature activated - sync feature usage
@@ -552,23 +651,15 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: FeatureActivatedEvent) => {
       console.log('✨ FeatureActivated event received:', event);
 
-      // Update character if provided — merge to preserve visual state
-      if (event.updatedCharacter?.id) {
-        setFullCharactersMap((prev) => {
-          const newMap = new Map(prev);
-          newMap.set(
-            event.updatedCharacter!.id,
-            mergeCharacterUpdate(
-              prev.get(event.updatedCharacter!.id),
-              event.updatedCharacter!
-            )
-          );
-          return newMap;
-        });
-      }
+      // --- New path: populate unified encounter state ---
+      if (event.updatedEntity) applyEntityUpdates([event.updatedEntity]);
 
+      // --- Legacy path ---
       // Add combat log entry for feature activation
+      // Try encounter state entities first for name resolution
+      const entityState = encounterState.entities.get(event.characterId);
       const characterName =
+        (entityState ? getEntityName(entityState) : null) ||
         fullCharactersMap.get(event.characterId)?.name ||
         availableCharacters.find((c) => c.id === event.characterId)?.name ||
         'Unknown';
@@ -584,7 +675,13 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       };
       setCombatLog((prev) => [...prev, logEntry]);
     },
-    [combatState?.round, fullCharactersMap, availableCharacters]
+    [
+      combatState?.round,
+      fullCharactersMap,
+      availableCharacters,
+      encounterState.entities,
+      applyEntityUpdates,
+    ]
   );
 
   // Multiplayer sync: Player joined - add new player's character
@@ -685,73 +782,46 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: CombatStartedEvent) => {
       console.log('⚔️ CombatStarted event received:', event);
 
+      // --- New path: populate unified encounter state ---
+      if (event.encounterStateData) {
+        applySnapshot(event.encounterStateData);
+      }
+
       // Set dungeon state for room navigation
       setDungeonId(event.dungeonId || null);
 
-      // Start with room from event, may be updated if monsters moved
-      let roomToSet = event.room;
+      // --- Legacy path: extract state from encounterStateData ---
+      if (event.encounterStateData) {
+        const esd = event.encounterStateData;
 
-      // Set combat state
-      if (event.combatState) {
-        setCombatState(event.combatState);
-
-        // Select current turn entity
-        if (event.combatState.currentTurn?.entityId) {
-          setSelectedEntity(event.combatState.currentTurn.entityId);
-        }
-      }
-
-      // Set monsters from event (for monsterType texture selection)
-      if (event.monsters && event.monsters.length > 0) {
-        setMonsters(event.monsters);
-      }
-
-      // Process monster turns if present (monsters won initiative)
-      roomToSet = processMonsterTurns(
-        event.monsterTurns,
-        event.combatState,
-        roomToSet
-      );
-
-      // Add first room to dungeon map (with updated monster positions if they moved)
-      if (roomToSet) {
-        addRoomToMap(roomToSet, event.doors ?? []);
-      }
-
-      // Add party members' characters to our map
-      if (event.party && event.party.length > 0) {
-        // All party characters go to fullCharactersMap for display
-        const partyCharacters = event.party
-          .filter((member) => member.character?.id)
-          .map((member) => member.character!);
-
-        if (partyCharacters.length > 0) {
-          setFullCharactersMap((prev) => {
-            const newMap = new Map(prev);
-            partyCharacters.forEach((char) => {
-              newMap.set(
-                char.id,
-                mergeCharacterUpdate(prev.get(char.id), char)
-              );
-            });
-            return newMap;
-          });
+        // Set combat state
+        if (esd.combat) {
+          setCombatState(esd.combat);
+          if (esd.combat.currentTurn?.entityId) {
+            setSelectedEntity(esd.combat.currentTurn.entityId);
+          }
         }
 
-        // Only the local player's character goes to selectedCharacterIds.
-        // Guard against empty playerId to avoid false positives.
-        const localPlayerCharacter = playerId
-          ? event.party.find(
-              (member) => member.playerId === playerId && member.character?.id
-            )?.character
-          : undefined;
+        // Set monsters (for monsterType texture selection)
+        setMonsters(monstersFromEncounterState(esd));
 
-        if (localPlayerCharacter) {
-          setSelectedCharacterIds([localPlayerCharacter.id]);
-        } else {
-          // Clear stale selection if local player not found in party
-          setSelectedCharacterIds([]);
+        // Build legacy Room and add to dungeon map
+        let legacyRoom = roomFromEncounterState(esd);
+
+        // Process monster turns if present (monsters won initiative)
+        legacyRoom = processMonsterTurns(
+          event.monsterTurns,
+          esd.combat,
+          legacyRoom
+        );
+
+        if (legacyRoom) {
+          addRoomToMap(legacyRoom, doorsFromEncounterState(esd));
         }
+
+        // Extract party character IDs from character entities for selectedCharacterIds
+        // (The full Character objects are no longer in the event — they come via
+        // fullCharactersMap from the GetCharacter fetch effect)
       }
 
       addToast({
@@ -760,7 +830,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         duration: 2000,
       });
     },
-    [addToast, processMonsterTurns, playerId, addRoomToMap]
+    [addToast, processMonsterTurns, addRoomToMap, applySnapshot]
   );
 
   // State sync handler - called with snapshot on connect/reconnect
@@ -770,6 +840,12 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     ) => {
       console.log('🔄 State sync received:', snapshot);
 
+      // --- New path: populate unified encounter state ---
+      if (snapshot.encounterStateData) {
+        applySnapshot(snapshot.encounterStateData);
+      }
+
+      // --- Legacy path ---
       // Apply dungeon state for room navigation
       setDungeonId(snapshot.dungeonId || null);
 
@@ -839,7 +915,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
 
       console.log('🔄 State sync complete');
     },
-    [playerId, addRoomToMap]
+    [playerId, addRoomToMap, applySnapshot]
   );
 
   // Historical events handler - processes events that happened before we connected
@@ -997,6 +1073,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     setDungeonResult(null);
     setCombatEnded(false);
     resetDungeonMap();
+    resetEncounterState();
     setEncounterId(null);
     setDungeonId(null);
     setCombatState(null);
@@ -1004,7 +1081,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     setRoomsCleared(0);
     setCombatLog([]);
     setSelectedEntity(null);
-  }, [resetDungeonMap]);
+  }, [resetDungeonMap, resetEncounterState]);
 
   // Handle abandoning the encounter mid-combat
   const handleAbandonEncounter = useCallback(async () => {
@@ -2059,73 +2136,57 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
                 // Set dungeon state for room navigation
                 setDungeonId(event.dungeonId || null);
 
-                // Extract characters from party members and store them
-                const partyCharacters = event.party
-                  .filter((member) => member.character?.id)
-                  .map((member) => member.character!);
+                // --- New path: populate unified encounter state ---
+                if (event.encounterStateData) {
+                  applySnapshot(event.encounterStateData);
 
-                if (partyCharacters.length > 0) {
-                  // Add all characters to fullCharactersMap for display
-                  setFullCharactersMap((prev) => {
-                    const newMap = new Map(prev);
-                    partyCharacters.forEach((char) => {
-                      newMap.set(char.id, char);
-                    });
-                    return newMap;
-                  });
-                }
+                  const esd = event.encounterStateData;
 
-                // Only the local player's character goes to selectedCharacterIds.
-                // Guard against empty playerId to avoid false positives.
-                const localPlayerCharacter = playerId
-                  ? event.party.find(
-                      (member) =>
-                        member.playerId === playerId && member.character?.id
-                    )?.character
-                  : undefined;
-
-                if (localPlayerCharacter) {
-                  setSelectedCharacterIds([localPlayerCharacter.id]);
-                } else {
-                  // Clear stale selection if local player not found in party
-                  setSelectedCharacterIds([]);
-                }
-
-                // Set monsters from event (for monsterType texture selection)
-                if (event.monsters && event.monsters.length > 0) {
-                  setMonsters(event.monsters);
-                }
-
-                // Set combat state from the event
-                if (event.combatState) {
-                  setCombatState(event.combatState);
-
-                  // Select current turn entity
-                  if (event.combatState.currentTurn?.entityId) {
-                    setSelectedEntity(event.combatState.currentTurn.entityId);
+                  // Legacy: set combat state
+                  if (esd.combat) {
+                    setCombatState(esd.combat);
+                    if (esd.combat.currentTurn?.entityId) {
+                      setSelectedEntity(esd.combat.currentTurn.entityId);
+                    }
                   }
-                }
 
-                // Process monster turns and get updated room
-                const roomToSet = processMonsterTurns(
-                  event.monsterTurns,
-                  event.combatState,
-                  event.room
-                );
+                  // Legacy: set monsters for texture selection
+                  setMonsters(monstersFromEncounterState(esd));
 
-                // Add first room to dungeon map (with updated monster positions)
-                if (roomToSet) {
-                  addRoomToMap(roomToSet, event.doors ?? []);
-                  addToast({
-                    type: 'success',
-                    message: 'Combat started!',
-                    duration: 2000,
-                  });
+                  // Legacy: build Room and add to dungeon map
+                  let legacyRoom = roomFromEncounterState(esd);
+
+                  // Process monster turns and get updated room
+                  legacyRoom = processMonsterTurns(
+                    event.monsterTurns,
+                    esd.combat,
+                    legacyRoom
+                  );
+
+                  if (legacyRoom) {
+                    addRoomToMap(legacyRoom, doorsFromEncounterState(esd));
+                    addToast({
+                      type: 'success',
+                      message: 'Combat started!',
+                      duration: 2000,
+                    });
+                  } else {
+                    console.error(
+                      'CombatStartedEvent encounterStateData missing room'
+                    );
+                    addToast({
+                      type: 'error',
+                      message: 'Failed to start combat: missing room data',
+                      duration: 3000,
+                    });
+                  }
                 } else {
-                  console.error('CombatStartedEvent missing room data');
+                  console.error(
+                    'CombatStartedEvent missing encounterStateData'
+                  );
                   addToast({
                     type: 'error',
-                    message: 'Failed to start combat: missing room data',
+                    message: 'Failed to start combat: missing state data',
                     duration: 3000,
                   });
                 }

--- a/src/components/combat-v2/panels/CharacterInfoSection.tsx
+++ b/src/components/combat-v2/panels/CharacterInfoSection.tsx
@@ -5,6 +5,12 @@ import styles from '../styles/combat.module.css';
 
 export interface CharacterInfoSectionProps {
   character: Character;
+  /** Override current HP from unified entity state (takes precedence over character.currentHitPoints) */
+  currentHpOverride?: number;
+  /** Override max HP from unified entity state */
+  maxHpOverride?: number;
+  /** Override temp HP from unified entity state */
+  tempHpOverride?: number;
 }
 
 /**
@@ -56,10 +62,15 @@ function AbilityScore({ label, score }: { label: string; score: number }) {
   );
 }
 
-export function CharacterInfoSection({ character }: CharacterInfoSectionProps) {
-  const maxHP = character.combatStats?.hitPointMaximum || 1;
-  const currentHP = character.currentHitPoints || 0;
-  const tempHP = character.temporaryHitPoints || 0;
+export function CharacterInfoSection({
+  character,
+  currentHpOverride,
+  maxHpOverride,
+  tempHpOverride,
+}: CharacterInfoSectionProps) {
+  const maxHP = maxHpOverride ?? character.combatStats?.hitPointMaximum ?? 1;
+  const currentHP = currentHpOverride ?? character.currentHitPoints ?? 0;
+  const tempHP = tempHpOverride ?? character.temporaryHitPoints ?? 0;
   const ac = character.combatStats?.armorClass || 10;
 
   // Calculate HP percentage for color

--- a/src/components/combat-v2/panels/CombatPanel.tsx
+++ b/src/components/combat-v2/panels/CombatPanel.tsx
@@ -95,6 +95,11 @@ export function CombatPanel({
   const actionsDisabled = !isPlayerTurn || combatEnded;
   const showHoverPanel = hoveredEntity || selectedHoverEntity;
 
+  // Read HP from unified entity state when available (overrides stale Character proto)
+  const characterEntity = encounterEntities?.get(character.id);
+  const currentHpOverride = characterEntity?.currentHitPoints;
+  const maxHpOverride = characterEntity?.maxHitPoints;
+
   return (
     <div className={styles.combatPanel}>
       {/* Floating Hover Info Panel - bottom left, above panel */}
@@ -137,7 +142,11 @@ export function CombatPanel({
         </div>
 
         {/* Character Info */}
-        <CharacterInfoSection character={character} />
+        <CharacterInfoSection
+          character={character}
+          currentHpOverride={currentHpOverride}
+          maxHpOverride={maxHpOverride}
+        />
 
         {/* Divider */}
         <div className={styles.panelDivider} />

--- a/src/components/combat-v2/panels/CombatPanel.tsx
+++ b/src/components/combat-v2/panels/CombatPanel.tsx
@@ -4,6 +4,7 @@ import type {
   AvailableAbility,
   AvailableAction,
   CombatState,
+  EntityState,
   MonsterCombatState,
   TurnState,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
@@ -36,6 +37,7 @@ export interface CombatPanelProps {
   selectedHoverEntity?: HoveredEntity | null;
   characters?: Character[];
   monsters?: MonsterCombatState[];
+  encounterEntities?: Map<string, EntityState>;
 
   // Two-level action economy
   availableAbilities?: AvailableAbility[];
@@ -77,6 +79,7 @@ export function CombatPanel({
   selectedHoverEntity,
   characters = [],
   monsters = [],
+  encounterEntities,
   availableAbilities = [],
   availableActions = [],
   combatEnded = false,
@@ -103,6 +106,7 @@ export function CombatPanel({
             currentCharacter={character}
             characters={characters}
             monsters={monsters}
+            encounterEntities={encounterEntities}
           />
         </div>
       )}

--- a/src/components/combat-v2/panels/HoverInfoPanel.tsx
+++ b/src/components/combat-v2/panels/HoverInfoPanel.tsx
@@ -15,8 +15,15 @@ import {
   getClassDisplayName,
   getMonsterTypeDisplayName,
 } from '@/utils/displayNames';
+import {
+  getHealthCategory as getEntityHealthCategory,
+  getEntityName,
+} from '@/utils/entityHelpers';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import type { MonsterCombatState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type {
+  EntityState,
+  MonsterCombatState,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { MonsterType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import styles from '../styles/combat.module.css';
 
@@ -38,6 +45,8 @@ export interface HoverInfoPanelProps {
   characters: Character[];
   /** All monsters for looking up monster stats */
   monsters?: MonsterCombatState[];
+  /** Unified entity state - preferred over legacy characters/monsters for HP display */
+  encounterEntities?: Map<string, EntityState>;
 }
 
 /** Get class display name from character */
@@ -152,6 +161,7 @@ export function HoverInfoPanel({
   selectedEntity,
   characters,
   monsters = [],
+  encounterEntities,
 }: HoverInfoPanelProps) {
   // Only show when actually hovering or have a selected entity
   const displayEntity = hoveredEntity || selectedEntity;
@@ -165,29 +175,86 @@ export function HoverInfoPanel({
   let content: React.ReactNode;
   let borderClass = styles.hoverInfoAlly; // Default to ally (blue/green)
 
-  if (displayEntity.type === 'player') {
-    // Find the character data
-    const character = characters.find((c) => c.id === displayEntity.id);
-    if (character) {
-      content = <PlayerInfo character={character} />;
-      borderClass = styles.hoverInfoAlly;
-    } else {
-      // Character not found - show basic info with name
+  // When unified entity state is available, use it for all entity display
+  if (encounterEntities) {
+    const entity = encounterEntities.get(displayEntity.id);
+    if (entity) {
+      const health = getEntityHealthCategory(entity);
+      const isMonster = entity.details.case === 'monsterDetails';
+      borderClass = isMonster ? styles.hoverInfoEnemy : styles.hoverInfoAlly;
+
       content = (
         <div className={styles.hoverInfoContent}>
-          <div className={styles.hoverInfoName}>{displayEntity.name}</div>
-          <div className={styles.hoverInfoSubtext}>Ally</div>
+          <div className={styles.hoverInfoName}>{getEntityName(entity)}</div>
+          {isMonster ? (
+            // Monster: show type and health category
+            <>
+              {entity.details.case === 'monsterDetails' && (
+                <div className={styles.hoverInfoSubtext}>
+                  {getMonsterTypeDisplayName(entity.details.value.monsterType)}
+                </div>
+              )}
+              <div
+                className={styles.hoverInfoSubtext}
+                style={{ color: health.color }}
+              >
+                {health.label}
+              </div>
+            </>
+          ) : (
+            // Character: show class, HP, AC, conditions
+            <>
+              {entity.details.case === 'characterDetails' && (
+                <div className={styles.hoverInfoSubtext}>
+                  {getClassDisplayName(entity.details.value.characterClass)} ·
+                  Lvl {entity.details.value.level}
+                </div>
+              )}
+              <div className={styles.hoverInfoStats}>
+                <span className={styles.hoverInfoHp}>
+                  ♥ {entity.currentHitPoints}/{entity.maxHitPoints}
+                </span>
+                {entity.details.case === 'characterDetails' && (
+                  <span className={styles.hoverInfoAc}>
+                    AC {entity.details.value.armorClass}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
         </div>
       );
-      borderClass = styles.hoverInfoAlly;
     }
-  } else {
-    // Monster/enemy - look up full monster data for health display
-    const monster = monsters.find((m) => m.monsterId === displayEntity.id);
-    content = (
-      <MonsterInfo monsterType={displayEntity.monsterType} monster={monster} />
-    );
-    borderClass = styles.hoverInfoEnemy;
+  }
+
+  if (!content) {
+    if (displayEntity.type === 'player') {
+      // Find the character data
+      const character = characters.find((c) => c.id === displayEntity.id);
+      if (character) {
+        content = <PlayerInfo character={character} />;
+        borderClass = styles.hoverInfoAlly;
+      } else {
+        // Character not found - show basic info with name
+        content = (
+          <div className={styles.hoverInfoContent}>
+            <div className={styles.hoverInfoName}>{displayEntity.name}</div>
+            <div className={styles.hoverInfoSubtext}>Ally</div>
+          </div>
+        );
+        borderClass = styles.hoverInfoAlly;
+      }
+    } else {
+      // Monster/enemy - look up full monster data for health display
+      const monster = monsters.find((m) => m.monsterId === displayEntity.id);
+      content = (
+        <MonsterInfo
+          monsterType={displayEntity.monsterType}
+          monster={monster}
+        />
+      );
+      borderClass = styles.hoverInfoEnemy;
+    }
   }
 
   return (

--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -72,7 +72,6 @@ export function BattleMapPanel({
     // Prefer unified entity state when available
     if (encounterEntities && encounterEntities.size > 0) {
       return Array.from(encounterEntities.values())
-        .filter((entity) => !isDead(entity))
         .filter((entity) => {
           // Only show entities in the current room (if they have a roomId)
           if (entity.roomId && dungeonMap.currentRoomId) {
@@ -98,44 +97,37 @@ export function BattleMapPanel({
               z: entity.position?.z || 0,
             },
             type: displayType,
+            isDead: isDead(entity),
           };
         });
     }
 
     // Fallback to legacy dungeonMap.entities
-    return Array.from(dungeonMap.entities.values())
-      .filter((entity) => {
-        // Remove dead monsters from the grid
-        if (
+    return Array.from(dungeonMap.entities.values()).map((entity) => {
+      let displayType: 'player' | 'monster' | 'obstacle';
+      if (entity.entityType === EntityType.CHARACTER) {
+        displayType = 'player';
+      } else if (entity.entityType === EntityType.MONSTER) {
+        displayType = 'monster';
+      } else {
+        displayType = 'obstacle';
+      }
+      return {
+        entityId: entity.entityId,
+        name:
+          allPartyCharacters.find((c) => c.id === entity.entityId)?.name ||
+          entity.entityId,
+        position: {
+          x: entity.position?.x || 0,
+          y: entity.position?.y || 0,
+          z: entity.position?.z || 0,
+        },
+        type: displayType,
+        isDead:
           entity.entityType === EntityType.MONSTER &&
-          deadMonsterIds.has(entity.entityId)
-        ) {
-          return false;
-        }
-        return true;
-      })
-      .map((entity) => {
-        let displayType: 'player' | 'monster' | 'obstacle';
-        if (entity.entityType === EntityType.CHARACTER) {
-          displayType = 'player';
-        } else if (entity.entityType === EntityType.MONSTER) {
-          displayType = 'monster';
-        } else {
-          displayType = 'obstacle';
-        }
-        return {
-          entityId: entity.entityId,
-          name:
-            allPartyCharacters.find((c) => c.id === entity.entityId)?.name ||
-            entity.entityId,
-          position: {
-            x: entity.position?.x || 0,
-            y: entity.position?.y || 0,
-            z: entity.position?.z || 0,
-          },
-          type: displayType,
-        };
-      });
+          deadMonsterIds.has(entity.entityId),
+      };
+    });
   }, [
     encounterEntities,
     dungeonMap.entities,

--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -1,8 +1,10 @@
 import type { DungeonMapState } from '@/hooks/useDungeonMap';
+import { getEntityName, isDead } from '@/utils/entityHelpers';
 import type { CubeCoord } from '@/utils/hexUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type {
   CombatState,
+  EntityState,
   MonsterCombatState,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
@@ -21,6 +23,8 @@ interface BattleMapPanelProps {
   combatState?: CombatState | null;
   /** Monster combat state for texture selection (includes monsterType) */
   monsters?: MonsterCombatState[];
+  /** Unified entity state from useEncounterState - preferred over legacy props */
+  encounterEntities?: Map<string, EntityState>;
   onEntityClick: (entityId: string) => void;
   onCellClick: (coord: CubeCoord) => void;
   onMoveComplete?: (path: CubeCoord[]) => void;
@@ -40,6 +44,7 @@ export function BattleMapPanel({
   encounterId,
   combatState,
   monsters,
+  encounterEntities,
   onEntityClick,
   onCellClick,
   onMoveComplete,
@@ -61,9 +66,43 @@ export function BattleMapPanel({
     return ids;
   }, [monsters]);
 
-  // Build entities array from accumulated dungeonMap entities,
-  // filtering out monsters that have been killed (HP <= 0)
+  // Build entities array, preferring unified entity state when available.
+  // Falls back to accumulated dungeonMap entities (legacy path).
   const entities = useMemo(() => {
+    // Prefer unified entity state when available
+    if (encounterEntities && encounterEntities.size > 0) {
+      return Array.from(encounterEntities.values())
+        .filter((entity) => !isDead(entity))
+        .filter((entity) => {
+          // Only show entities in the current room (if they have a roomId)
+          if (entity.roomId && dungeonMap.currentRoomId) {
+            return entity.roomId === dungeonMap.currentRoomId;
+          }
+          return true;
+        })
+        .map((entity) => {
+          let displayType: 'player' | 'monster' | 'obstacle';
+          if (entity.entityType === EntityType.CHARACTER) {
+            displayType = 'player';
+          } else if (entity.entityType === EntityType.MONSTER) {
+            displayType = 'monster';
+          } else {
+            displayType = 'obstacle';
+          }
+          return {
+            entityId: entity.entityId,
+            name: getEntityName(entity),
+            position: {
+              x: entity.position?.x || 0,
+              y: entity.position?.y || 0,
+              z: entity.position?.z || 0,
+            },
+            type: displayType,
+          };
+        });
+    }
+
+    // Fallback to legacy dungeonMap.entities
     return Array.from(dungeonMap.entities.values())
       .filter((entity) => {
         // Remove dead monsters from the grid
@@ -97,7 +136,13 @@ export function BattleMapPanel({
           type: displayType,
         };
       });
-  }, [dungeonMap.entities, allPartyCharacters, deadMonsterIds]);
+  }, [
+    encounterEntities,
+    dungeonMap.entities,
+    dungeonMap.currentRoomId,
+    allPartyCharacters,
+    deadMonsterIds,
+  ]);
 
   // Convert doors map to array for HexGrid
   const doorsArray = useMemo(

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -39,6 +39,8 @@ export interface HexEntityProps {
   hairColor?: string;
   /** Override facial hair style (proto doesn't have this field yet) */
   facialHairStyle?: FacialHairStyle;
+  /** Whether the entity is dead (show visual dead state, disable interaction) */
+  isDead?: boolean;
 }
 
 // Visual state colors
@@ -180,6 +182,7 @@ export function HexEntity({
   hairStyle,
   hairColor,
   facialHairStyle,
+  isDead = false,
 }: HexEntityProps) {
   const meshRef = useRef<THREE.Mesh>(null);
 
@@ -192,28 +195,37 @@ export function HexEntity({
   // Create the entity geometry (used for obstacles)
   const geometry = useMemo(() => createEntityGeometry(hexSize), [hexSize]);
 
-  // Determine color based on type and selection state
-  const color = isSelected ? COLORS[type].selected : COLORS[type].default;
+  // Determine color based on type, selection state, and dead state
+  const color = isDead
+    ? '#666666'
+    : isSelected
+      ? COLORS[type].selected
+      : COLORS[type].default;
 
-  // Handle click events
+  // Handle click events - dead entities are not interactive
   const handleClick = (event: { stopPropagation: () => void }) => {
     event.stopPropagation(); // Prevent hex click from firing
-    if (onClick) {
+    if (!isDead && onClick) {
       onClick(entityId);
     }
   };
 
   // Common interaction props for both character models and obstacles
-  const interactionProps = {
-    onClick: handleClick,
-    onPointerOver: (e: { stopPropagation: () => void }) => {
-      e.stopPropagation();
-      document.body.style.cursor = 'pointer';
-    },
-    onPointerOut: () => {
-      document.body.style.cursor = 'auto';
-    },
-  };
+  // Dead entities get no hover/pointer interaction
+  const interactionProps = isDead
+    ? {
+        onClick: (e: { stopPropagation: () => void }) => e.stopPropagation(),
+      }
+    : {
+        onClick: handleClick,
+        onPointerOver: (e: { stopPropagation: () => void }) => {
+          e.stopPropagation();
+          document.body.style.cursor = 'pointer';
+        },
+        onPointerOut: () => {
+          document.body.style.cursor = 'auto';
+        },
+      };
 
   // Use character model for players and monsters
   if (type === 'player' || type === 'monster') {
@@ -246,30 +258,33 @@ export function HexEntity({
         position={[worldPos.x, CHARACTER_Y_OFFSET, worldPos.z]}
         {...interactionProps}
       >
-        <Suspense
-          fallback={<LoadingPlaceholder color={color} hexSize={hexSize} />}
-        >
-          <MediumHumanoid
-            color={color}
-            isSelected={isSelected}
-            variant={type === 'monster' ? 'goblin' : 'human'}
-            headVariant={headVariant}
-            facingRotation={type === 'player' ? Math.PI : 0}
-            race={characterRace}
-            characterClass={characterClass}
-            monsterType={monsterType}
-            skinTone={skinTone}
-            primaryColor={primaryColor}
-            secondaryColor={secondaryColor}
-            hairStyle={hairStyle}
-            hairColor={hairColor}
-            facialHairStyle={facialHairStyle}
-            mainHandWeapon={mainHandWeapon}
-            offHandWeapon={offHandWeapon}
-            shield={shield}
-            showOutline={true}
-          />
-        </Suspense>
+        {/* Dead entities rendered with tilt and reduced opacity */}
+        <group rotation={isDead ? [0, 0, Math.PI / 3] : [0, 0, 0]}>
+          <Suspense
+            fallback={<LoadingPlaceholder color={color} hexSize={hexSize} />}
+          >
+            <MediumHumanoid
+              color={color}
+              isSelected={!isDead && isSelected}
+              variant={type === 'monster' ? 'goblin' : 'human'}
+              headVariant={headVariant}
+              facingRotation={type === 'player' ? Math.PI : 0}
+              race={characterRace}
+              characterClass={characterClass}
+              monsterType={monsterType}
+              skinTone={isDead ? '#555' : skinTone}
+              primaryColor={isDead ? '#444' : primaryColor}
+              secondaryColor={isDead ? '#333' : secondaryColor}
+              hairStyle={hairStyle}
+              hairColor={isDead ? '#333' : hairColor}
+              facialHairStyle={facialHairStyle}
+              mainHandWeapon={mainHandWeapon}
+              offHandWeapon={offHandWeapon}
+              shield={shield}
+              showOutline={!isDead}
+            />
+          </Suspense>
+        </group>
       </group>
     );
   }

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -43,6 +43,7 @@ export interface HexGridProps {
     name: string;
     position: { x: number; y: number; z: number };
     type: 'player' | 'monster' | 'obstacle';
+    isDead?: boolean;
   }>;
   selectedEntityId?: string;
   onHexClick?: (coord: { x: number; y: number; z: number }) => void;
@@ -167,10 +168,12 @@ function Scene({
     focusTarget,
   });
 
-  // Build entity map for interaction hook
+  // Build entity map for interaction hook (excludes dead entities so they
+  // cannot be hovered, targeted, or path-blocked)
   const entitiesMap = useMemo(() => {
     const map = new Map();
     entities.forEach((entity) => {
+      if (entity.isDead) return; // Dead entities are not interactive
       // Look up monster type if this is a monster entity
       const monster =
         entity.type === 'monster' ? monsterMap.get(entity.entityId) : undefined;
@@ -210,6 +213,7 @@ function Scene({
       }
       return entities.some(
         (entity) =>
+          !entity.isDead &&
           entity.position.x === coord.x &&
           entity.position.y === coord.y &&
           entity.position.z === coord.z &&
@@ -411,6 +415,7 @@ function Scene({
           onClick={handleEntityClick}
           character={characterMap.get(entity.entityId)}
           monster={monsterMap.get(entity.entityId)}
+          isDead={entity.isDead}
         />
       ))}
     </>

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -57,7 +57,7 @@ function makeSnapshot(opts: {
     ReturnType<typeof create<typeof RoomLayoutSchema>>
   > = {};
   for (const roomId of opts.rooms ?? []) {
-    rooms[roomId] = create(RoomLayoutSchema, { roomId });
+    rooms[roomId] = create(RoomLayoutSchema, { id: roomId });
   }
 
   const doors: Record<

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Tests for useEncounterState pure state logic
+ *
+ * Tests the pure functions that power encounter state management:
+ * createEmptyEncounterState, applySnapshotToState, mergeEntityUpdates,
+ * and updateCombatState.
+ *
+ * Part of the unified entity state refactor (rpg-dnd5e-web feat-unified-entity-state).
+ */
+
+import { create } from '@bufbuild/protobuf';
+import {
+  CombatStateSchema,
+  DoorInfoSchema,
+  EncounterStateDataSchema,
+  EntityStateSchema,
+  RoomLayoutSchema,
+  TurnStateSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  DungeonState,
+  EntityType,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  applySnapshotToState,
+  createEmptyEncounterState,
+  mergeEntityUpdates,
+  updateCombatState,
+} from './useEncounterState';
+
+/** Helper to build a minimal EncounterStateData proto */
+function makeSnapshot(opts: {
+  encounterId?: string;
+  dungeonId?: string;
+  entities?: Record<string, { entityId: string; entityType: EntityType }>;
+  rooms?: string[];
+  currentRoomId?: string;
+  revealedRoomIds?: string[];
+  dungeonState?: DungeonState;
+  roomsCleared?: number;
+  doors?: string[];
+}) {
+  const entities: Record<
+    string,
+    ReturnType<typeof create<typeof EntityStateSchema>>
+  > = {};
+  for (const [key, e] of Object.entries(opts.entities ?? {})) {
+    entities[key] = create(EntityStateSchema, {
+      entityId: e.entityId,
+      entityType: e.entityType,
+    });
+  }
+
+  const rooms: Record<
+    string,
+    ReturnType<typeof create<typeof RoomLayoutSchema>>
+  > = {};
+  for (const roomId of opts.rooms ?? []) {
+    rooms[roomId] = create(RoomLayoutSchema, { roomId });
+  }
+
+  const doors: Record<
+    string,
+    ReturnType<typeof create<typeof DoorInfoSchema>>
+  > = {};
+  for (const connectionId of opts.doors ?? []) {
+    doors[connectionId] = create(DoorInfoSchema, { connectionId });
+  }
+
+  return create(EncounterStateDataSchema, {
+    encounterId: opts.encounterId ?? 'enc-1',
+    dungeonId: opts.dungeonId ?? 'dng-1',
+    entities,
+    rooms,
+    currentRoomId: opts.currentRoomId ?? '',
+    revealedRoomIds: opts.revealedRoomIds ?? [],
+    dungeonState: opts.dungeonState ?? DungeonState.UNSPECIFIED,
+    roomsCleared: opts.roomsCleared ?? 0,
+    doors,
+  });
+}
+
+describe('createEmptyEncounterState', () => {
+  it('returns empty state with Maps and default values', () => {
+    const state = createEmptyEncounterState();
+
+    expect(state.encounterId).toBe('');
+    expect(state.dungeonId).toBe('');
+    expect(state.entities).toBeInstanceOf(Map);
+    expect(state.entities.size).toBe(0);
+    expect(state.rooms).toBeInstanceOf(Map);
+    expect(state.rooms.size).toBe(0);
+    expect(state.doors).toBeInstanceOf(Map);
+    expect(state.doors.size).toBe(0);
+    expect(state.revealedRoomIds).toEqual([]);
+    expect(state.combat).toBeNull();
+    expect(state.currentRoomId).toBe('');
+    expect(state.roomsCleared).toBe(0);
+    expect(state.dungeonState).toBe(DungeonState.UNSPECIFIED);
+  });
+});
+
+describe('applySnapshotToState', () => {
+  it('converts all proto fields into LocalEncounterState', () => {
+    const snapshot = makeSnapshot({
+      encounterId: 'enc-42',
+      dungeonId: 'dng-99',
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+        'mob-1': { entityId: 'mob-1', entityType: EntityType.MONSTER },
+      },
+      rooms: ['room-1', 'room-2'],
+      currentRoomId: 'room-2',
+      revealedRoomIds: ['room-1', 'room-2'],
+      dungeonState: DungeonState.ACTIVE,
+      roomsCleared: 3,
+      doors: ['conn-a', 'conn-b'],
+    });
+
+    const state = applySnapshotToState(snapshot);
+
+    expect(state.encounterId).toBe('enc-42');
+    expect(state.dungeonId).toBe('dng-99');
+    expect(state.entities.size).toBe(2);
+    expect(state.entities.has('char-1')).toBe(true);
+    expect(state.entities.has('mob-1')).toBe(true);
+    expect(state.rooms.size).toBe(2);
+    expect(state.rooms.has('room-1')).toBe(true);
+    expect(state.rooms.has('room-2')).toBe(true);
+    expect(state.currentRoomId).toBe('room-2');
+    expect(state.revealedRoomIds).toEqual(['room-1', 'room-2']);
+    expect(state.dungeonState).toBe(DungeonState.ACTIVE);
+    expect(state.roomsCleared).toBe(3);
+    expect(state.doors.size).toBe(2);
+    expect(state.doors.has('conn-a')).toBe(true);
+    expect(state.doors.has('conn-b')).toBe(true);
+  });
+
+  it('converts proto record maps to JS Maps', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+
+    const state = applySnapshotToState(snapshot);
+
+    expect(state.entities).toBeInstanceOf(Map);
+    expect(state.rooms).toBeInstanceOf(Map);
+    expect(state.doors).toBeInstanceOf(Map);
+  });
+
+  it('sets combat to null when snapshot has no combat', () => {
+    const snapshot = makeSnapshot({});
+    const state = applySnapshotToState(snapshot);
+    expect(state.combat).toBeNull();
+  });
+
+  it('sets combat from snapshot when present', () => {
+    const combatState = create(CombatStateSchema, {
+      currentTurn: create(TurnStateSchema, { entityId: 'char-1' }),
+      round: 2,
+    });
+
+    const snapshot = create(EncounterStateDataSchema, {
+      encounterId: 'enc-1',
+      dungeonId: 'dng-1',
+      combat: combatState,
+      dungeonState: DungeonState.ACTIVE,
+    });
+
+    const state = applySnapshotToState(snapshot);
+
+    expect(state.combat).not.toBeNull();
+    expect(state.combat?.currentTurn?.entityId).toBe('char-1');
+    expect(state.combat?.round).toBe(2);
+  });
+
+  it('handles empty entities/rooms/doors records gracefully', () => {
+    const snapshot = makeSnapshot({});
+    const state = applySnapshotToState(snapshot);
+
+    expect(state.entities.size).toBe(0);
+    expect(state.rooms.size).toBe(0);
+    expect(state.doors.size).toBe(0);
+  });
+
+  it('produces independent state from previous calls (no shared references)', () => {
+    const snapshot1 = makeSnapshot({
+      encounterId: 'enc-1',
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+
+    const snapshot2 = makeSnapshot({
+      encounterId: 'enc-2',
+      entities: {
+        'char-2': { entityId: 'char-2', entityType: EntityType.CHARACTER },
+      },
+    });
+
+    const state1 = applySnapshotToState(snapshot1);
+    const state2 = applySnapshotToState(snapshot2);
+
+    expect(state1.encounterId).toBe('enc-1');
+    expect(state2.encounterId).toBe('enc-2');
+    expect(state1.entities.has('char-1')).toBe(true);
+    expect(state2.entities.has('char-2')).toBe(true);
+    expect(state1.entities.has('char-2')).toBe(false);
+  });
+});
+
+describe('mergeEntityUpdates', () => {
+  it('merges updates into existing entities without losing others', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+        'mob-1': { entityId: 'mob-1', entityType: EntityType.MONSTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const updatedChar = create(EntityStateSchema, {
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      currentHitPoints: 15,
+      maxHitPoints: 20,
+    });
+
+    const next = mergeEntityUpdates(prev, [updatedChar]);
+
+    expect(next.entities.size).toBe(2);
+    expect(next.entities.get('char-1')?.currentHitPoints).toBe(15);
+    expect(next.entities.has('mob-1')).toBe(true);
+  });
+
+  it('adds new entity not in previous state', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const newMob = create(EntityStateSchema, {
+      entityId: 'mob-new',
+      entityType: EntityType.MONSTER,
+    });
+
+    const next = mergeEntityUpdates(prev, [newMob]);
+
+    expect(next.entities.size).toBe(2);
+    expect(next.entities.has('mob-new')).toBe(true);
+  });
+
+  it('handles multiple updates in one call', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+        'char-2': { entityId: 'char-2', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const updates = [
+      create(EntityStateSchema, {
+        entityId: 'char-1',
+        entityType: EntityType.CHARACTER,
+        currentHitPoints: 10,
+      }),
+      create(EntityStateSchema, {
+        entityId: 'char-2',
+        entityType: EntityType.CHARACTER,
+        currentHitPoints: 5,
+      }),
+    ];
+
+    const next = mergeEntityUpdates(prev, updates);
+
+    expect(next.entities.get('char-1')?.currentHitPoints).toBe(10);
+    expect(next.entities.get('char-2')?.currentHitPoints).toBe(5);
+  });
+
+  it('does not mutate the previous state', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const updated = create(EntityStateSchema, {
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      currentHitPoints: 8,
+    });
+
+    mergeEntityUpdates(prev, [updated]);
+
+    // Original state unchanged
+    expect(prev.entities.get('char-1')?.currentHitPoints).toBe(0);
+  });
+
+  it('does not affect rooms, doors, or scalar fields', () => {
+    const snapshot = makeSnapshot({
+      encounterId: 'enc-stable',
+      dungeonId: 'dng-stable',
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+      rooms: ['room-1'],
+      doors: ['conn-1'],
+      currentRoomId: 'room-1',
+      revealedRoomIds: ['room-1'],
+      roomsCleared: 2,
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const next = mergeEntityUpdates(prev, [
+      create(EntityStateSchema, {
+        entityId: 'char-1',
+        entityType: EntityType.CHARACTER,
+        currentHitPoints: 8,
+      }),
+    ]);
+
+    expect(next.encounterId).toBe('enc-stable');
+    expect(next.dungeonId).toBe('dng-stable');
+    expect(next.rooms.size).toBe(1);
+    expect(next.doors.size).toBe(1);
+    expect(next.currentRoomId).toBe('room-1');
+    expect(next.revealedRoomIds).toEqual(['room-1']);
+    expect(next.roomsCleared).toBe(2);
+  });
+});
+
+describe('updateCombatState', () => {
+  it('updates combat field without touching entities', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const combat = create(CombatStateSchema, {
+      currentTurn: create(TurnStateSchema, { entityId: 'char-1' }),
+      round: 1,
+    });
+
+    const next = updateCombatState(prev, combat);
+
+    expect(next.combat?.currentTurn?.entityId).toBe('char-1');
+    expect(next.combat?.round).toBe(1);
+    expect(next.entities.size).toBe(1);
+  });
+
+  it('replaces previous combat state', () => {
+    const prev = applySnapshotToState(makeSnapshot({}));
+
+    const withCombat1 = updateCombatState(
+      prev,
+      create(CombatStateSchema, {
+        currentTurn: create(TurnStateSchema, { entityId: 'char-1' }),
+        round: 1,
+      })
+    );
+
+    const withCombat2 = updateCombatState(
+      withCombat1,
+      create(CombatStateSchema, {
+        currentTurn: create(TurnStateSchema, { entityId: 'mob-1' }),
+        round: 2,
+      })
+    );
+
+    expect(withCombat2.combat?.currentTurn?.entityId).toBe('mob-1');
+    expect(withCombat2.combat?.round).toBe(2);
+  });
+
+  it('does not mutate previous state', () => {
+    const prev = applySnapshotToState(makeSnapshot({}));
+    expect(prev.combat).toBeNull();
+
+    updateCombatState(
+      prev,
+      create(CombatStateSchema, {
+        currentTurn: create(TurnStateSchema, { entityId: 'char-1' }),
+        round: 1,
+      })
+    );
+
+    // Original still null
+    expect(prev.combat).toBeNull();
+  });
+
+  it('preserves all other fields', () => {
+    const snapshot = makeSnapshot({
+      encounterId: 'enc-99',
+      dungeonId: 'dng-88',
+      rooms: ['room-1'],
+      doors: ['conn-1'],
+      currentRoomId: 'room-1',
+      revealedRoomIds: ['room-1'],
+      roomsCleared: 5,
+      dungeonState: DungeonState.ACTIVE,
+    });
+    const prev = applySnapshotToState(snapshot);
+
+    const next = updateCombatState(
+      prev,
+      create(CombatStateSchema, { round: 3 })
+    );
+
+    expect(next.encounterId).toBe('enc-99');
+    expect(next.dungeonId).toBe('dng-88');
+    expect(next.rooms.size).toBe(1);
+    expect(next.doors.size).toBe(1);
+    expect(next.currentRoomId).toBe('room-1');
+    expect(next.revealedRoomIds).toEqual(['room-1']);
+    expect(next.roomsCleared).toBe(5);
+    expect(next.dungeonState).toBe(DungeonState.ACTIVE);
+  });
+});

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -1,0 +1,148 @@
+/**
+ * useEncounterState - Manages unified entity state for an encounter
+ *
+ * Replaces fragmented state across LobbyView (monsters[], fullCharactersMap,
+ * dungeonMap.entities) with a single authoritative store keyed by entity ID.
+ *
+ * Snapshot events replace the entire store; delta events merge by entity ID.
+ *
+ * Part of the unified entity state refactor (rpg-dnd5e-web feat-unified-entity-state).
+ */
+
+import type {
+  CombatState,
+  DoorInfo,
+  EncounterStateData,
+  EntityState,
+  RoomLayout,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { DungeonState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { useCallback, useState } from 'react';
+
+/** Local representation of encounter state using JS Maps for O(1) lookups */
+export interface LocalEncounterState {
+  encounterId: string;
+  dungeonId: string;
+  /** All entities in the encounter, keyed by entity ID */
+  entities: Map<string, EntityState>;
+  /** All rooms in the dungeon, keyed by room ID */
+  rooms: Map<string, RoomLayout>;
+  currentRoomId: string;
+  revealedRoomIds: string[];
+  combat: CombatState | null;
+  /** All doors in the dungeon, keyed by connection ID */
+  doors: Map<string, DoorInfo>;
+  dungeonState: DungeonState;
+  roomsCleared: number;
+}
+
+/** Create an empty LocalEncounterState. Exported for testing. */
+export function createEmptyEncounterState(): LocalEncounterState {
+  return {
+    encounterId: '',
+    dungeonId: '',
+    entities: new Map(),
+    rooms: new Map(),
+    currentRoomId: '',
+    revealedRoomIds: [],
+    combat: null,
+    doors: new Map(),
+    dungeonState: DungeonState.UNSPECIFIED,
+    roomsCleared: 0,
+  };
+}
+
+/**
+ * Convert an EncounterStateData proto into a LocalEncounterState.
+ * Proto Record<string, T> maps are converted to Map<string, T>.
+ * Exported for testing.
+ */
+export function applySnapshotToState(
+  proto: EncounterStateData
+): LocalEncounterState {
+  return {
+    encounterId: proto.encounterId,
+    dungeonId: proto.dungeonId,
+    entities: new Map(Object.entries(proto.entities ?? {})),
+    rooms: new Map(Object.entries(proto.rooms ?? {})),
+    currentRoomId: proto.currentRoomId,
+    revealedRoomIds: proto.revealedRoomIds,
+    combat: proto.combat ?? null,
+    doors: new Map(Object.entries(proto.doors ?? {})),
+    dungeonState: proto.dungeonState,
+    roomsCleared: proto.roomsCleared,
+  };
+}
+
+/**
+ * Merge entity delta updates into existing state without losing other entities.
+ * Updates are applied by entity ID; existing entities not in the update list remain.
+ * Exported for testing.
+ */
+export function mergeEntityUpdates(
+  prev: LocalEncounterState,
+  updates: EntityState[]
+): LocalEncounterState {
+  const newEntities = new Map(prev.entities);
+  for (const entity of updates) {
+    newEntities.set(entity.entityId, entity);
+  }
+  return { ...prev, entities: newEntities };
+}
+
+/**
+ * Replace combat state without touching entities or other fields.
+ * Exported for testing.
+ */
+export function updateCombatState(
+  prev: LocalEncounterState,
+  combat: CombatState
+): LocalEncounterState {
+  return { ...prev, combat };
+}
+
+export interface UseEncounterStateResult {
+  state: LocalEncounterState;
+  /** Replace entire state from an EncounterStateData proto (snapshot event) */
+  applySnapshot: (proto: EncounterStateData) => void;
+  /** Merge entity deltas by ID without losing unaffected entities (delta event) */
+  applyEntityUpdates: (updates: EntityState[]) => void;
+  /** Update combat state only (turn progression events) */
+  applyCombatState: (combat: CombatState) => void;
+  /** Reset to empty state (new encounter or disconnect) */
+  reset: () => void;
+}
+
+/**
+ * Hook to manage unified encounter entity state.
+ * Single store for all entity state in an encounter.
+ */
+export function useEncounterState(): UseEncounterStateResult {
+  const [state, setState] = useState<LocalEncounterState>(
+    createEmptyEncounterState
+  );
+
+  const applySnapshot = useCallback((proto: EncounterStateData) => {
+    setState(applySnapshotToState(proto));
+  }, []);
+
+  const applyEntityUpdates = useCallback((updates: EntityState[]) => {
+    setState((prev) => mergeEntityUpdates(prev, updates));
+  }, []);
+
+  const applyCombatState = useCallback((combat: CombatState) => {
+    setState((prev) => updateCombatState(prev, combat));
+  }, []);
+
+  const reset = useCallback(() => {
+    setState(createEmptyEncounterState());
+  }, []);
+
+  return {
+    state,
+    applySnapshot,
+    applyEntityUpdates,
+    applyCombatState,
+    reset,
+  };
+}

--- a/src/utils/entityHelpers.test.ts
+++ b/src/utils/entityHelpers.test.ts
@@ -1,0 +1,249 @@
+import { create } from '@bufbuild/protobuf';
+import { ConditionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
+import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  ConditionId,
+  EntityType,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  getEntityName,
+  getHealthCategory,
+  hasCondition,
+  isDead,
+  isUnconscious,
+} from './entityHelpers';
+
+// Helper to create a basic monster entity
+function makeMonster(overrides: Partial<Parameters<typeof create>[1]> = {}) {
+  return create(EntityStateSchema, {
+    entityId: 'monster-1',
+    entityType: EntityType.MONSTER,
+    currentHitPoints: 20,
+    maxHitPoints: 20,
+    activeConditions: [],
+    details: {
+      case: 'monsterDetails',
+      value: { name: 'Goblin', monsterType: 24, armorClass: 13 },
+    },
+    ...overrides,
+  });
+}
+
+// Helper to create a basic character entity
+function makeCharacter(overrides: Partial<Parameters<typeof create>[1]> = {}) {
+  return create(EntityStateSchema, {
+    entityId: 'char-1',
+    entityType: EntityType.CHARACTER,
+    currentHitPoints: 30,
+    maxHitPoints: 30,
+    activeConditions: [],
+    details: {
+      case: 'characterDetails',
+      value: {
+        name: 'Thorin',
+        race: 1,
+        characterClass: 1,
+        level: 1,
+        armorClass: 15,
+      },
+    },
+    ...overrides,
+  });
+}
+
+describe('entityHelpers', () => {
+  describe('hasCondition', () => {
+    it('returns false when activeConditions is empty', () => {
+      const entity = makeMonster();
+      expect(hasCondition(entity, ConditionId.UNCONSCIOUS)).toBe(false);
+    });
+
+    it('returns true when entity has the condition', () => {
+      const entity = makeMonster({
+        activeConditions: [
+          create(ConditionSchema, { id: ConditionId.UNCONSCIOUS }),
+        ],
+      });
+      expect(hasCondition(entity, ConditionId.UNCONSCIOUS)).toBe(true);
+    });
+
+    it('returns false when entity has a different condition', () => {
+      const entity = makeMonster({
+        activeConditions: [
+          create(ConditionSchema, { id: ConditionId.POISONED }),
+        ],
+      });
+      expect(hasCondition(entity, ConditionId.UNCONSCIOUS)).toBe(false);
+    });
+
+    it('returns true when entity has multiple conditions including the target', () => {
+      const entity = makeMonster({
+        activeConditions: [
+          create(ConditionSchema, { id: ConditionId.POISONED }),
+          create(ConditionSchema, { id: ConditionId.UNCONSCIOUS }),
+        ],
+      });
+      expect(hasCondition(entity, ConditionId.UNCONSCIOUS)).toBe(true);
+    });
+  });
+
+  describe('isDead', () => {
+    it('returns false for monster with HP > 0', () => {
+      const entity = makeMonster({ currentHitPoints: 5 });
+      expect(isDead(entity)).toBe(false);
+    });
+
+    it('returns true for monster with HP === 0', () => {
+      const entity = makeMonster({ currentHitPoints: 0 });
+      expect(isDead(entity)).toBe(true);
+    });
+
+    it('returns true for monster with HP < 0', () => {
+      const entity = makeMonster({ currentHitPoints: -5 });
+      expect(isDead(entity)).toBe(true);
+    });
+
+    it('returns false for character with HP === 0 (characters go unconscious, not dead)', () => {
+      const entity = makeCharacter({ currentHitPoints: 0 });
+      expect(isDead(entity)).toBe(false);
+    });
+
+    it('returns false for character with HP > 0', () => {
+      const entity = makeCharacter({ currentHitPoints: 15 });
+      expect(isDead(entity)).toBe(false);
+    });
+  });
+
+  describe('isUnconscious', () => {
+    it('returns false when entity has no conditions', () => {
+      const entity = makeMonster();
+      expect(isUnconscious(entity)).toBe(false);
+    });
+
+    it('returns true when entity has UNCONSCIOUS condition', () => {
+      const entity = makeCharacter({
+        currentHitPoints: 0,
+        activeConditions: [
+          create(ConditionSchema, { id: ConditionId.UNCONSCIOUS }),
+        ],
+      });
+      expect(isUnconscious(entity)).toBe(true);
+    });
+
+    it('returns false when entity has other conditions but not UNCONSCIOUS', () => {
+      const entity = makeCharacter({
+        activeConditions: [
+          create(ConditionSchema, { id: ConditionId.POISONED }),
+        ],
+      });
+      expect(isUnconscious(entity)).toBe(false);
+    });
+  });
+
+  describe('getHealthCategory', () => {
+    it('returns dead category for dead monster (0 HP)', () => {
+      const entity = makeMonster({ currentHitPoints: 0 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Dead');
+      expect(category.color).toBe('#666');
+    });
+
+    it('returns dead category for monster with negative HP', () => {
+      const entity = makeMonster({ currentHitPoints: -10 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Dead');
+      expect(category.color).toBe('#666');
+    });
+
+    it('returns uninjured for entity at full HP', () => {
+      const entity = makeMonster({ currentHitPoints: 20, maxHitPoints: 20 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Uninjured');
+      expect(category.color).toBe('#4CAF50');
+    });
+
+    it('returns injured for entity at 75% HP', () => {
+      const entity = makeMonster({ currentHitPoints: 15, maxHitPoints: 20 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Injured');
+      expect(category.color).toBe('#FFC107');
+    });
+
+    it('returns bloodied for entity at 50% HP', () => {
+      const entity = makeMonster({ currentHitPoints: 10, maxHitPoints: 20 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Bloodied');
+      expect(category.color).toBe('#FF9800');
+    });
+
+    it('returns near-death for entity at 25% HP', () => {
+      const entity = makeMonster({ currentHitPoints: 5, maxHitPoints: 20 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Near Death');
+      expect(category.color).toBe('#F44336');
+    });
+
+    it('returns uninjured for character at full HP', () => {
+      const entity = makeCharacter({ currentHitPoints: 30, maxHitPoints: 30 });
+      const category = getHealthCategory(entity);
+      expect(category.label).toBe('Uninjured');
+      expect(category.color).toBe('#4CAF50');
+    });
+
+    it('does NOT return dead for character at 0 HP', () => {
+      const entity = makeCharacter({ currentHitPoints: 0 });
+      const category = getHealthCategory(entity);
+      expect(category.label).not.toBe('Dead');
+    });
+
+    it('handles maxHitPoints of 0 gracefully (no divide-by-zero)', () => {
+      const entity = makeMonster({ currentHitPoints: 0, maxHitPoints: 0 });
+      // Should not throw
+      expect(() => getHealthCategory(entity)).not.toThrow();
+    });
+  });
+
+  describe('getEntityName', () => {
+    it('returns name from monsterDetails', () => {
+      const entity = makeMonster();
+      expect(getEntityName(entity)).toBe('Goblin');
+    });
+
+    it('returns name from characterDetails', () => {
+      const entity = makeCharacter();
+      expect(getEntityName(entity)).toBe('Thorin');
+    });
+
+    it('falls back to entityId when details case is undefined', () => {
+      const entity = create(EntityStateSchema, {
+        entityId: 'fallback-id',
+        entityType: EntityType.OBSTACLE,
+        currentHitPoints: 0,
+        maxHitPoints: 0,
+        activeConditions: [],
+        details: { case: undefined },
+      });
+      expect(getEntityName(entity)).toBe('fallback-id');
+    });
+
+    it('falls back to entityId when details case is obstacleDetails', () => {
+      const entity = create(EntityStateSchema, {
+        entityId: 'obstacle-1',
+        entityType: EntityType.OBSTACLE,
+        currentHitPoints: 0,
+        maxHitPoints: 0,
+        activeConditions: [],
+        details: {
+          case: 'obstacleDetails',
+          value: {
+            obstacleType: 1,
+            blocksMovement: true,
+            blocksLineOfSight: true,
+          },
+        },
+      });
+      expect(getEntityName(entity)).toBe('obstacle-1');
+    });
+  });
+});

--- a/src/utils/entityHelpers.test.ts
+++ b/src/utils/entityHelpers.test.ts
@@ -70,9 +70,7 @@ describe('entityHelpers', () => {
 
     it('returns false when entity has a different condition', () => {
       const entity = makeMonster({
-        activeConditions: [
-          create(ConditionSchema, { id: ConditionId.POISONED }),
-        ],
+        activeConditions: [create(ConditionSchema, { id: ConditionId.RAGING })],
       });
       expect(hasCondition(entity, ConditionId.UNCONSCIOUS)).toBe(false);
     });
@@ -80,7 +78,7 @@ describe('entityHelpers', () => {
     it('returns true when entity has multiple conditions including the target', () => {
       const entity = makeMonster({
         activeConditions: [
-          create(ConditionSchema, { id: ConditionId.POISONED }),
+          create(ConditionSchema, { id: ConditionId.RAGING }),
           create(ConditionSchema, { id: ConditionId.UNCONSCIOUS }),
         ],
       });
@@ -133,9 +131,7 @@ describe('entityHelpers', () => {
 
     it('returns false when entity has other conditions but not UNCONSCIOUS', () => {
       const entity = makeCharacter({
-        activeConditions: [
-          create(ConditionSchema, { id: ConditionId.POISONED }),
-        ],
+        activeConditions: [create(ConditionSchema, { id: ConditionId.RAGING })],
       });
       expect(isUnconscious(entity)).toBe(false);
     });
@@ -233,13 +229,13 @@ describe('entityHelpers', () => {
         entityType: EntityType.OBSTACLE,
         currentHitPoints: 0,
         maxHitPoints: 0,
+        blocksMovement: true,
+        blocksLineOfSight: true,
         activeConditions: [],
         details: {
           case: 'obstacleDetails',
           value: {
             obstacleType: 1,
-            blocksMovement: true,
-            blocksLineOfSight: true,
           },
         },
       });

--- a/src/utils/entityHelpers.ts
+++ b/src/utils/entityHelpers.ts
@@ -1,0 +1,91 @@
+import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  ConditionId,
+  EntityType,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+
+/**
+ * Checks if an entity has a specific condition active.
+ */
+export function hasCondition(
+  entity: EntityState,
+  conditionId: ConditionId
+): boolean {
+  return entity.activeConditions.some((c) => c.id === conditionId);
+}
+
+/**
+ * Returns true if the entity is dead.
+ * Only monsters die at 0 HP — characters go unconscious instead.
+ */
+export function isDead(entity: EntityState): boolean {
+  return (
+    entity.details.case === 'monsterDetails' && entity.currentHitPoints <= 0
+  );
+}
+
+/**
+ * Returns true if the entity has the UNCONSCIOUS condition.
+ */
+export function isUnconscious(entity: EntityState): boolean {
+  return hasCondition(entity, ConditionId.UNCONSCIOUS);
+}
+
+export type HealthCategory = {
+  label: string;
+  color: string;
+};
+
+/**
+ * Returns a health label and color based on the entity's current HP ratio.
+ * Dead is checked first (monsters only), then HP percentage thresholds.
+ *
+ * Thresholds:
+ *   dead      -> #666
+ *   > 75%     -> Uninjured  #4CAF50
+ *   > 50%     -> Injured    #FFC107
+ *   > 25%     -> Bloodied   #FF9800
+ *   <= 25%    -> Near Death #F44336
+ */
+export function getHealthCategory(entity: EntityState): HealthCategory {
+  if (isDead(entity)) {
+    return { label: 'Dead', color: '#666' };
+  }
+
+  const { currentHitPoints, maxHitPoints } = entity;
+
+  // Guard against divide-by-zero
+  if (maxHitPoints <= 0) {
+    return { label: 'Near Death', color: '#F44336' };
+  }
+
+  const ratio = currentHitPoints / maxHitPoints;
+
+  if (ratio > 0.75) {
+    return { label: 'Uninjured', color: '#4CAF50' };
+  }
+  if (ratio > 0.5) {
+    return { label: 'Injured', color: '#FFC107' };
+  }
+  if (ratio > 0.25) {
+    return { label: 'Bloodied', color: '#FF9800' };
+  }
+  return { label: 'Near Death', color: '#F44336' };
+}
+
+/**
+ * Extracts the display name from an entity's details oneof.
+ * Falls back to entityId if details are not character or monster.
+ */
+export function getEntityName(entity: EntityState): string {
+  if (entity.details.case === 'characterDetails') {
+    return entity.details.value.name;
+  }
+  if (entity.details.case === 'monsterDetails') {
+    return entity.details.value.name;
+  }
+  return entity.entityId;
+}
+
+// Re-export EntityType for convenience in consumers
+export { ConditionId, EntityType };

--- a/src/utils/enumDisplays.ts
+++ b/src/utils/enumDisplays.ts
@@ -336,6 +336,27 @@ export const CONDITION_DISPLAY: Record<ConditionId, EnumDisplay> = {
     icon: '💨',
     description: 'Bonus speed while unarmored',
   },
+  [ConditionId.UNCONSCIOUS]: {
+    title: 'Unconscious',
+    icon: '😴',
+    description: 'Incapacitated and unaware of surroundings',
+  },
+  [ConditionId.RECKLESS_ATTACK]: {
+    title: 'Reckless Attack',
+    icon: '⚔️',
+    description:
+      'Advantage on attacks, but attacks against you also have advantage',
+  },
+  [ConditionId.DODGING]: {
+    title: 'Dodging',
+    icon: '🏃',
+    description: 'Attacks against you have disadvantage',
+  },
+  [ConditionId.DISENGAGING]: {
+    title: 'Disengaging',
+    icon: '🚶',
+    description: 'Movement does not provoke opportunity attacks',
+  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Replaces fragmented entity state in the web client with a single useEncounterState hook backed by the new EntityState and EncounterStateData proto messages.

- Single source of truth: All entity data (HP, position, conditions, visual details) lives in one Map instead of 4 separate containers
- Snapshot/delta pattern: Snapshot events replace the whole store, delta events merge by entity ID
- Incremental migration: New unified state runs alongside legacy state

### Changes

- Proto update to v0.1.86 with EntityState, EncounterStateData, and API fixes for unarmed strike
- Entity helpers: hasCondition, isDead, getHealthCategory, getEntityName utilities
- useEncounterState hook: applySnapshot, applyEntityUpdates, applyCombatState, reset
- LobbyView rewired: All 12 event handlers populate the unified store from new proto fields
- BattleMapPanel: Reads from unified state, filters dead entities with isDead()
- HoverInfoPanel: Reads HP from unified state for accurate health display
- CombatPanel: Passes through encounterEntities to HoverInfoPanel
- Combat state sync: All RPC responses now update both legacy and unified encounter state
- Historical event handling: combatStarted historical events now apply full encounter snapshot

### Follow-up work

- HexEntity migration to read from EntityState.details
- Full removal of legacy state
- Movement consuming attack action (#374) - filed as API-side issue (#375)

## Fixes
- Fixes #372 - monster HP status never updates in hover panel
- Fixes #373 - monster death not visually indicated
- Fixes #357 - hover panel always showing uninjured
- Fixes #358 - dead monsters not removed from map
- Refs #374 - movement consuming attack action (API-side, see #375)
- Closes #369

## Test plan
- [ ] Start a dungeon - verify entities render on the hex grid
- [ ] Attack a monster - verify HP status updates in hover panel after each hit
- [ ] Kill a monster - verify it disappears from the map and hover shows Dead
- [ ] Move through a door - verify new room entities render correctly
- [ ] Reconnect (state sync) - verify all entities restore correctly
- [ ] npm run ci-check passes