### PR TITLE
fix: add all snapshot rooms to dungeon map on RoomRevealed

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -170,6 +170,51 @@ function roomFromEncounterState(data: EncounterStateData): Room | undefined {
 }
 
 /**
+ * Build legacy Room objects from EncounterStateData for ALL revealed rooms.
+ * Used in handleRoomRevealed to ensure newly revealed rooms (not just currentRoomId)
+ * are added to the dungeon map.
+ *
+ * Returns rooms with the current room last so that mergeRoom sets currentRoomId
+ * correctly to the player's actual location.
+ */
+function allRoomsFromEncounterState(data: EncounterStateData): Room[] {
+  const rooms: Room[] = [];
+
+  for (const [roomId, roomLayout] of Object.entries(data.rooms)) {
+    if (!roomLayout) continue;
+    if (roomId === data.currentRoomId) continue; // add current room last
+
+    const entities: { [key: string]: EntityPlacement } = {};
+    for (const entity of Object.values(data.entities)) {
+      if (entity.roomId === roomId) {
+        entities[entity.entityId] = entityStateToPlacement(entity);
+      }
+    }
+
+    rooms.push({
+      id: roomLayout.id,
+      type: roomLayout.type,
+      width: roomLayout.width,
+      height: roomLayout.height,
+      gridType: roomLayout.gridType,
+      walls: roomLayout.walls,
+      origin: roomLayout.origin,
+      entities,
+      $typeName: 'dnd5e.api.v1alpha1.Room' as const,
+      $unknown: undefined,
+    } as Room);
+  }
+
+  // Add current room last so mergeRoom sets currentRoomId to the player's room
+  const currentRoom = roomFromEncounterState(data);
+  if (currentRoom) {
+    rooms.push(currentRoom);
+  }
+
+  return rooms;
+}
+
+/**
  * Extract DoorInfo array from EncounterStateData for addRoomToMap compatibility.
  */
 function doorsFromEncounterState(data: EncounterStateData): DoorInfo[] {
@@ -337,12 +382,13 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           applySnapshot(event.encounterStateData);
 
           // --- Legacy path: build Room/CombatState from encounterStateData ---
-          const legacyRoom = roomFromEncounterState(event.encounterStateData);
-          if (legacyRoom) {
-            addRoomToMap(
-              legacyRoom,
-              doorsFromEncounterState(event.encounterStateData)
-            );
+          // Iterate ALL rooms in the snapshot so newly revealed rooms (not just
+          // currentRoomId) get added to the dungeon map. mergeRoom handles
+          // deduplication for rooms already present.
+          const allRooms = allRoomsFromEncounterState(event.encounterStateData);
+          const doors = doorsFromEncounterState(event.encounterStateData);
+          for (const room of allRooms) {
+            addRoomToMap(room, doors);
           }
           setCombatState(event.encounterStateData.combat ?? null);
           setRoomsCleared(event.encounterStateData.roomsCleared);

--- a/src/hooks/useDungeonMap.test.ts
+++ b/src/hooks/useDungeonMap.test.ts
@@ -879,3 +879,64 @@ describe('mergeRoom wall deduplication', () => {
     expect(state.walls.size).toBe(1);
   });
 });
+
+describe('multi-room reveal scenario (issue #376)', () => {
+  it('adds floor tiles for both rooms when mergeRoom is called for each', () => {
+    // Simulates what handleRoomRevealed does after the fix:
+    // allRoomsFromEncounterState returns [room2, room1] (current room last),
+    // and addRoomToMap is called for each. Both rooms' tiles must end up in the map.
+    let state = createEmptyState();
+
+    // room-1 is the player's current room (5x4 = 20 tiles at origin)
+    const room1 = createRoom({
+      id: 'room-1',
+      width: 5,
+      height: 4,
+      originX: 0,
+      originZ: 0,
+    });
+
+    // room-2 is the newly revealed room (3x3 = 9 tiles, offset origin)
+    const room2 = createRoom({
+      id: 'room-2',
+      width: 3,
+      height: 3,
+      originX: 6,
+      originZ: 0,
+    });
+
+    // Add non-current room first, then current room last (matches allRoomsFromEncounterState order)
+    state = mergeRoom(state, room2, []);
+    state = mergeRoom(state, room1, []);
+
+    // Both rooms must have contributed floor tiles
+    expect(state.revealedRoomIds.has('room-1')).toBe(true);
+    expect(state.revealedRoomIds.has('room-2')).toBe(true);
+
+    // room-1 contributes 5*4=20 tiles, room-2 contributes 3*3=9 tiles
+    expect(state.floorTiles.size).toBe(29);
+
+    // currentRoomId must be room-1 (added last — player's actual room)
+    expect(state.currentRoomId).toBe('room-1');
+
+    // Spot-check a tile from room-2 is present
+    const room2Tile = state.floorTiles.get('6,-6,0');
+    expect(room2Tile).toBeDefined();
+    expect(room2Tile?.roomId).toBe('room-2');
+  });
+
+  it('mergeRoom deduplicates tiles when called again for an already-revealed room', () => {
+    // Ensures the existing deduplication logic is preserved: if a room is already
+    // in the map, a second mergeRoom call updates entities/doors but does not
+    // re-add floor tiles.
+    let state = createEmptyState();
+
+    const room1 = createRoom({ id: 'room-1', width: 3, height: 2 });
+    state = mergeRoom(state, room1, []);
+    expect(state.floorTiles.size).toBe(6);
+
+    // Second call for the same room must not grow the tile count
+    state = mergeRoom(state, room1, []);
+    expect(state.floorTiles.size).toBe(6);
+  });
+});


### PR DESCRIPTION
Fixes #376

## Problem

When a player opens a door, `RoomRevealedEvent` arrives with an `encounterStateData` snapshot containing ALL revealed rooms in `data.rooms`. However, `handleRoomRevealed` was calling `roomFromEncounterState()` which only extracts `data.rooms[data.currentRoomId]`.

After `OpenDoor`, the player hasn't moved — `currentRoomId` is still room 1. Room 2 was in the snapshot's rooms map but never got extracted or added to the dungeon map. Result: door opens but no new room renders.

## Fix

Added `allRoomsFromEncounterState(data)` that iterates ALL rooms in the snapshot and builds a `Room` for each (with entities filtered by `roomId`). `handleRoomRevealed` now calls `addRoomToMap` for every room instead of just the current one.

Non-current rooms are added first so that `mergeRoom` sets `currentRoomId` correctly to the player's actual location (current room is added last).

`mergeRoom` already handles deduplication — calling it for an already-revealed room updates entities/doors without re-adding floor tiles. No changes needed to `useDungeonMap`.

## Changes

- `src/components/LobbyView.tsx`: Added `allRoomsFromEncounterState()` helper; updated `handleRoomRevealed` to iterate all rooms
- `src/hooks/useDungeonMap.test.ts`: Added 2 tests for the multi-room reveal scenario and deduplication guarantee

## Test plan

- [ ] Run `npm run ci-check` (all passing)
- [ ] Verify: when `handleRoomRevealed` receives a snapshot with 2 rooms, both rooms' tiles end up in the dungeon map (new test: `multi-room reveal scenario`)
- [ ] Verify: `currentRoomId` remains the player's current room after multi-room add (non-current rooms added first)
- [ ] Verify: calling `mergeRoom` a second time for the same room does not duplicate floor tiles
- [ ] Manual: open door in game, confirm room 2 renders with its layout and monsters

🤖 Generated with [Claude Code](https://claude.com/claude-code)