### PR TITLE
test: extract and test room reveal transform functions

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -14,6 +14,11 @@ import { useDiscord } from '@/discord';
 import { useDungeonMap } from '@/hooks/useDungeonMap';
 import { useEncounterState } from '@/hooks/useEncounterState';
 import { mergeCharacterUpdate } from '@/utils/characterMerge';
+import {
+  doorsFromEncounterState,
+  monstersFromEncounterState,
+  roomFromEncounterState,
+} from '@/utils/encounterStateTransforms';
 import { getEntityName } from '@/utils/entityHelpers';
 import {
   getAbilityDisplay,
@@ -41,12 +46,9 @@ import {
   type AvailableAction,
   type CombatStartedEvent,
   type CombatState,
-  type DoorInfo,
   type DungeonFailureEvent,
   type DungeonVictoryEvent,
   type EncounterEvent,
-  type EncounterStateData,
-  type EntityPlacement,
   type EntityState,
   type FeatureActivatedEvent,
   type MonsterCombatState,
@@ -111,97 +113,6 @@ function applyMonsterMovement(room: Room, turns: MonsterTurnResult[]): Room {
     ...room,
     entities: updatedEntities,
   };
-}
-
-/**
- * Convert an EntityState to an EntityPlacement for legacy addRoomToMap compatibility.
- * EntityPlacement is a subset of EntityState (spatial + visual only, no HP/conditions).
- */
-function entityStateToPlacement(entity: EntityState): EntityPlacement {
-  const placement: EntityPlacement = {
-    entityId: entity.entityId,
-    entityType: entity.entityType,
-    position: entity.position,
-    size: entity.size,
-    blocksMovement: entity.blocksMovement,
-    blocksLineOfSight: entity.blocksLineOfSight,
-    visualType: { case: undefined, value: undefined },
-    $typeName: 'dnd5e.api.v1alpha1.EntityPlacement' as const,
-    $unknown: undefined,
-  };
-  // Map monster details to visual type
-  if (entity.details.case === 'monsterDetails') {
-    (placement as EntityPlacement).visualType = {
-      case: 'monsterType' as const,
-      value: entity.details.value.monsterType,
-    };
-  }
-  return placement;
-}
-
-/**
- * Build a legacy Room object from EncounterStateData for addRoomToMap compatibility.
- * Uses the current room's RoomLayout + entities assigned to that room.
- */
-function roomFromEncounterState(data: EncounterStateData): Room | undefined {
-  const roomLayout = data.rooms[data.currentRoomId];
-  if (!roomLayout) return undefined;
-
-  // Collect entities that belong to the current room
-  const entities: { [key: string]: EntityPlacement } = {};
-  for (const entity of Object.values(data.entities)) {
-    if (entity.roomId === data.currentRoomId) {
-      entities[entity.entityId] = entityStateToPlacement(entity);
-    }
-  }
-
-  return {
-    id: roomLayout.id,
-    type: roomLayout.type,
-    width: roomLayout.width,
-    height: roomLayout.height,
-    gridType: roomLayout.gridType,
-    walls: roomLayout.walls,
-    origin: roomLayout.origin,
-    entities,
-    $typeName: 'dnd5e.api.v1alpha1.Room' as const,
-    $unknown: undefined,
-  } as Room;
-}
-
-/**
- * Extract DoorInfo array from EncounterStateData for addRoomToMap compatibility.
- */
-function doorsFromEncounterState(data: EncounterStateData): DoorInfo[] {
-  return Object.values(data.doors);
-}
-
-/**
- * Build MonsterCombatState array from EncounterStateData entities.
- * Used to feed the legacy `monsters` state for monsterType texture selection.
- */
-function monstersFromEncounterState(
-  data: EncounterStateData
-): MonsterCombatState[] {
-  const result: MonsterCombatState[] = [];
-  for (const entity of Object.values(data.entities)) {
-    if (
-      entity.entityType === EntityType.MONSTER &&
-      entity.details.case === 'monsterDetails'
-    ) {
-      result.push({
-        monsterId: entity.entityId,
-        monsterName: entity.details.value.name,
-        monsterType: entity.details.value.monsterType,
-        currentHitPoints: entity.currentHitPoints,
-        maxHitPoints: entity.maxHitPoints,
-        armorClass: entity.details.value.armorClass,
-        $typeName: 'dnd5e.api.v1alpha1.MonsterCombatState' as const,
-        $unknown: undefined,
-      } as MonsterCombatState);
-    }
-  }
-  return result;
 }
 
 interface LobbyViewProps {

--- a/src/utils/encounterStateTransforms.test.ts
+++ b/src/utils/encounterStateTransforms.test.ts
@@ -1,0 +1,723 @@
+/**
+ * Tests for encounterStateTransforms pure functions
+ *
+ * These functions convert EncounterStateData snapshots into Room, DoorInfo,
+ * and EntityPlacement objects for dungeon map rendering.
+ *
+ * The allRoomsFromEncounterState function was the source of the Round 2 bug
+ * where only the current room appeared on the map instead of all revealed rooms.
+ *
+ * Related: rpg-dnd5e-web multi-room rendering (#311, #312)
+ */
+
+import { create } from '@bufbuild/protobuf';
+import { PositionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import type {
+  DoorInfo,
+  EncounterStateData,
+  EntityState,
+  RoomLayout,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  DoorInfoSchema,
+  EncounterStateDataSchema,
+  EntityStateSchema,
+  RoomLayoutSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  EntitySize,
+  EntityType,
+  MonsterType,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  createEmptyState,
+  generateFloorTiles,
+  mergeRoom,
+} from '../hooks/useDungeonMap';
+import {
+  allRoomsFromEncounterState,
+  doorsFromEncounterState,
+  entityStateToPlacement,
+  roomFromEncounterState,
+} from './encounterStateTransforms';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal RoomLayout proto message */
+function createRoomLayout(opts?: {
+  id?: string;
+  width?: number;
+  height?: number;
+  originX?: number;
+  originZ?: number;
+}): RoomLayout {
+  const id = opts?.id ?? 'room-1';
+  const width = opts?.width ?? 5;
+  const height = opts?.height ?? 5;
+  const originX = opts?.originX ?? 0;
+  const originZ = opts?.originZ ?? 0;
+
+  return create(RoomLayoutSchema, {
+    id,
+    width,
+    height,
+    origin: create(PositionSchema, {
+      x: originX,
+      y: -originX - originZ,
+      z: originZ,
+    }),
+  });
+}
+
+/** Build a minimal EntityState proto message */
+function createEntityState(opts?: {
+  entityId?: string;
+  entityType?: EntityType;
+  roomId?: string;
+  x?: number;
+  z?: number;
+}): EntityState {
+  return create(EntityStateSchema, {
+    entityId: opts?.entityId ?? 'entity-1',
+    entityType: opts?.entityType ?? EntityType.CHARACTER,
+    roomId: opts?.roomId ?? 'room-1',
+    size: EntitySize.MEDIUM,
+    blocksMovement: true,
+    blocksLineOfSight: false,
+    position: create(PositionSchema, {
+      x: opts?.x ?? 0,
+      y: -(opts?.x ?? 0) - (opts?.z ?? 0),
+      z: opts?.z ?? 0,
+    }),
+    details: { case: undefined },
+  });
+}
+
+/** Build a monster EntityState with monsterDetails populated */
+function createMonsterEntityState(opts?: {
+  entityId?: string;
+  roomId?: string;
+  x?: number;
+  z?: number;
+  monsterType?: MonsterType;
+}): EntityState {
+  return create(EntityStateSchema, {
+    entityId: opts?.entityId ?? 'monster-1',
+    entityType: EntityType.MONSTER,
+    roomId: opts?.roomId ?? 'room-1',
+    size: EntitySize.MEDIUM,
+    blocksMovement: true,
+    blocksLineOfSight: true,
+    position: create(PositionSchema, {
+      x: opts?.x ?? 1,
+      y: -(opts?.x ?? 1) - (opts?.z ?? 0),
+      z: opts?.z ?? 0,
+    }),
+    details: {
+      case: 'monsterDetails',
+      value: {
+        name: 'Goblin',
+        monsterType: opts?.monsterType ?? MonsterType.GOBLIN,
+        armorClass: 15,
+        $typeName: 'dnd5e.api.v1alpha1.MonsterDetails',
+        $unknown: undefined,
+      },
+    },
+  });
+}
+
+/** Build an EncounterStateData proto with given rooms, entities, and doors */
+function createEncounterStateData(opts?: {
+  encounterId?: string;
+  currentRoomId?: string;
+  rooms?: Record<string, RoomLayout>;
+  entities?: Record<string, EntityState>;
+  doors?: Record<string, DoorInfo>;
+}): EncounterStateData {
+  return create(EncounterStateDataSchema, {
+    encounterId: opts?.encounterId ?? 'enc-1',
+    dungeonId: 'dng-1',
+    currentRoomId: opts?.currentRoomId ?? 'room-1',
+    rooms: opts?.rooms ?? {},
+    entities: opts?.entities ?? {},
+    doors: opts?.doors ?? {},
+  });
+}
+
+// ---------------------------------------------------------------------------
+// entityStateToPlacement
+// ---------------------------------------------------------------------------
+
+describe('entityStateToPlacement', () => {
+  it('converts basic character entity correctly', () => {
+    const entity = createEntityState({
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      roomId: 'room-1',
+      x: 2,
+      z: 3,
+    });
+
+    const placement = entityStateToPlacement(entity);
+
+    expect(placement.entityId).toBe('char-1');
+    expect(placement.entityType).toBe(EntityType.CHARACTER);
+    expect(placement.position?.x).toBe(2);
+    expect(placement.position?.z).toBe(3);
+    expect(placement.blocksMovement).toBe(true);
+    expect(placement.blocksLineOfSight).toBe(false);
+    expect(placement.$typeName).toBe('dnd5e.api.v1alpha1.EntityPlacement');
+  });
+
+  it('sets visualType to monsterType for monster entities', () => {
+    const entity = createMonsterEntityState({
+      entityId: 'mob-1',
+      monsterType: MonsterType.GOBLIN,
+    });
+
+    const placement = entityStateToPlacement(entity);
+
+    expect(placement.visualType.case).toBe('monsterType');
+    expect(placement.visualType.value).toBe(MonsterType.GOBLIN);
+  });
+
+  it('leaves visualType undefined for character entities', () => {
+    const entity = createEntityState({ entityType: EntityType.CHARACTER });
+
+    const placement = entityStateToPlacement(entity);
+
+    expect(placement.visualType.case).toBeUndefined();
+  });
+
+  it('preserves size from entity state', () => {
+    const entity = createEntityState({ entityType: EntityType.CHARACTER });
+
+    const placement = entityStateToPlacement(entity);
+
+    expect(placement.size).toBe(EntitySize.MEDIUM);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// roomFromEncounterState
+// ---------------------------------------------------------------------------
+
+describe('roomFromEncounterState', () => {
+  it('returns undefined when currentRoomId has no matching room', () => {
+    const data = createEncounterStateData({
+      currentRoomId: 'missing-room',
+      rooms: {},
+    });
+
+    expect(roomFromEncounterState(data)).toBeUndefined();
+  });
+
+  it('returns room with correct fields from RoomLayout', () => {
+    const layout = createRoomLayout({
+      id: 'room-1',
+      width: 8,
+      height: 6,
+      originX: 0,
+      originZ: 0,
+    });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-1',
+      rooms: { 'room-1': layout },
+    });
+
+    const room = roomFromEncounterState(data);
+
+    expect(room).not.toBeUndefined();
+    expect(room!.id).toBe('room-1');
+    expect(room!.width).toBe(8);
+    expect(room!.height).toBe(6);
+  });
+
+  it('preserves origin from RoomLayout', () => {
+    const layout = createRoomLayout({
+      id: 'room-1',
+      originX: 4,
+      originZ: 3,
+    });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-1',
+      rooms: { 'room-1': layout },
+    });
+
+    const room = roomFromEncounterState(data);
+
+    expect(room!.origin?.x).toBe(4);
+    expect(room!.origin?.z).toBe(3);
+  });
+
+  it('filters entities to only those in the current room', () => {
+    const layout = createRoomLayout({ id: 'room-1' });
+    const charInRoom = createEntityState({
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      roomId: 'room-1',
+    });
+    const mobInOtherRoom = createEntityState({
+      entityId: 'mob-1',
+      entityType: EntityType.MONSTER,
+      roomId: 'room-2',
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-1',
+      rooms: { 'room-1': layout },
+      entities: {
+        'char-1': charInRoom,
+        'mob-1': mobInOtherRoom,
+      },
+    });
+
+    const room = roomFromEncounterState(data);
+
+    expect(Object.keys(room!.entities)).toHaveLength(1);
+    expect(room!.entities['char-1']).toBeDefined();
+    expect(room!.entities['mob-1']).toBeUndefined();
+  });
+
+  it('returns empty entities object when no entities belong to current room', () => {
+    const layout = createRoomLayout({ id: 'room-1' });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-1',
+      rooms: { 'room-1': layout },
+      entities: {},
+    });
+
+    const room = roomFromEncounterState(data);
+
+    expect(room!.entities).toBeDefined();
+    expect(Object.keys(room!.entities)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allRoomsFromEncounterState
+// ---------------------------------------------------------------------------
+
+describe('allRoomsFromEncounterState', () => {
+  it('returns empty array when snapshot has no rooms', () => {
+    const data = createEncounterStateData({
+      currentRoomId: '',
+      rooms: {},
+    });
+
+    expect(allRoomsFromEncounterState(data)).toHaveLength(0);
+  });
+
+  it('returns single room when snapshot has one room', () => {
+    const layout = createRoomLayout({ id: 'room-1', width: 5, height: 5 });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-1',
+      rooms: { 'room-1': layout },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+
+    expect(rooms).toHaveLength(1);
+    expect(rooms[0].id).toBe('room-1');
+  });
+
+  it('returns all rooms when snapshot has 2 rooms', () => {
+    const room1Layout = createRoomLayout({ id: 'room-1', width: 5, height: 5 });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      width: 4,
+      height: 4,
+      originX: 0,
+      originZ: 6,
+    });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: {
+        'room-1': room1Layout,
+        'room-2': room2Layout,
+      },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+
+    expect(rooms).toHaveLength(2);
+    const ids = rooms.map((r) => r.id);
+    expect(ids).toContain('room-1');
+    expect(ids).toContain('room-2');
+  });
+
+  it('places non-current rooms first, current room last', () => {
+    const room1Layout = createRoomLayout({ id: 'room-1' });
+    const room2Layout = createRoomLayout({ id: 'room-2', originZ: 6 });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: {
+        'room-1': room1Layout,
+        'room-2': room2Layout,
+      },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+
+    // Current room ('room-2') must be last
+    expect(rooms[rooms.length - 1].id).toBe('room-2');
+    // Non-current room ('room-1') must come first
+    expect(rooms[0].id).toBe('room-1');
+  });
+
+  it('each room has correct origin from its RoomLayout', () => {
+    const room1Layout = createRoomLayout({
+      id: 'room-1',
+      originX: 0,
+      originZ: 0,
+    });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      originX: 0,
+      originZ: 17,
+    });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: {
+        'room-1': room1Layout,
+        'room-2': room2Layout,
+      },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+    const byId = Object.fromEntries(rooms.map((r) => [r.id, r]));
+
+    expect(byId['room-1'].origin?.x).toBe(0);
+    expect(byId['room-1'].origin?.z).toBe(0);
+    expect(byId['room-2'].origin?.z).toBe(17);
+  });
+
+  it('filters entities per room by roomId', () => {
+    const room1Layout = createRoomLayout({ id: 'room-1' });
+    const room2Layout = createRoomLayout({ id: 'room-2', originZ: 6 });
+    const charInRoom1 = createEntityState({
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      roomId: 'room-1',
+    });
+    const mobInRoom2 = createMonsterEntityState({
+      entityId: 'mob-1',
+      roomId: 'room-2',
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: {
+        'room-1': room1Layout,
+        'room-2': room2Layout,
+      },
+      entities: {
+        'char-1': charInRoom1,
+        'mob-1': mobInRoom2,
+      },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+    const byId = Object.fromEntries(rooms.map((r) => [r.id, r]));
+
+    expect(Object.keys(byId['room-1'].entities)).toContain('char-1');
+    expect(Object.keys(byId['room-1'].entities)).not.toContain('mob-1');
+    expect(Object.keys(byId['room-2'].entities)).toContain('mob-1');
+    expect(Object.keys(byId['room-2'].entities)).not.toContain('char-1');
+  });
+
+  it('returns empty entities object for rooms with no entities', () => {
+    const room1Layout = createRoomLayout({ id: 'room-1' });
+    const data = createEncounterStateData({
+      currentRoomId: 'room-1',
+      rooms: { 'room-1': room1Layout },
+      entities: {},
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+
+    expect(rooms[0].entities).toBeDefined();
+    expect(Object.keys(rooms[0].entities)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// doorsFromEncounterState
+// ---------------------------------------------------------------------------
+
+describe('doorsFromEncounterState', () => {
+  it('returns empty array when no doors in snapshot', () => {
+    const data = createEncounterStateData({ doors: {} });
+
+    expect(doorsFromEncounterState(data)).toHaveLength(0);
+  });
+
+  it('returns all doors from snapshot', () => {
+    const door1 = create(DoorInfoSchema, {
+      connectionId: 'conn-a',
+      isOpen: false,
+    });
+    const door2 = create(DoorInfoSchema, {
+      connectionId: 'conn-b',
+      isOpen: true,
+    });
+
+    const data = createEncounterStateData({
+      doors: { 'conn-a': door1, 'conn-b': door2 },
+    });
+
+    const doors = doorsFromEncounterState(data);
+
+    expect(doors).toHaveLength(2);
+    const connIds = doors.map((d) => d.connectionId);
+    expect(connIds).toContain('conn-a');
+    expect(connIds).toContain('conn-b');
+  });
+
+  it('preserves door open/closed state', () => {
+    const openDoor = create(DoorInfoSchema, {
+      connectionId: 'conn-open',
+      isOpen: true,
+    });
+    const data = createEncounterStateData({
+      doors: { 'conn-open': openDoor },
+    });
+
+    const [door] = doorsFromEncounterState(data);
+
+    expect(door.isOpen).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full pipeline: allRoomsFromEncounterState -> mergeRoom (integration)
+// ---------------------------------------------------------------------------
+
+describe('full pipeline: allRoomsFromEncounterState + mergeRoom', () => {
+  it('both rooms contribute floor tiles to the dungeon map', () => {
+    const room1Layout = createRoomLayout({
+      id: 'room-1',
+      width: 5,
+      height: 4,
+      originX: 0,
+      originZ: 0,
+    });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      width: 4,
+      height: 4,
+      originX: 0,
+      originZ: 6,
+    });
+    const charInRoom1 = createEntityState({
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      roomId: 'room-1',
+      x: 1,
+      z: 0,
+    });
+    const mobInRoom2 = createMonsterEntityState({
+      entityId: 'mob-1',
+      roomId: 'room-2',
+      x: 1,
+      z: 7,
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: {
+        'room-1': room1Layout,
+        'room-2': room2Layout,
+      },
+      entities: {
+        'char-1': charInRoom1,
+        'mob-1': mobInRoom2,
+      },
+    });
+
+    // Extract rooms and merge them into a dungeon map
+    const rooms = allRoomsFromEncounterState(data);
+    let dungeonMap = createEmptyState();
+    for (const room of rooms) {
+      dungeonMap = mergeRoom(dungeonMap, room, []);
+    }
+
+    // Total tile count should be room1 (5*4=20) + room2 (4*4=16) = 36
+    expect(dungeonMap.floorTiles.size).toBe(36);
+  });
+
+  it('room2 tiles start at the correct z offset', () => {
+    const room1Layout = createRoomLayout({
+      id: 'room-1',
+      width: 5,
+      height: 4,
+      originX: 0,
+      originZ: 0,
+    });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      width: 4,
+      height: 4,
+      originX: 0,
+      originZ: 17,
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: {
+        'room-1': room1Layout,
+        'room-2': room2Layout,
+      },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+    let dungeonMap = createEmptyState();
+    for (const room of rooms) {
+      dungeonMap = mergeRoom(dungeonMap, room, []);
+    }
+
+    // room2 starts at z=17, so its first tile should be at (0, -17, 17)
+    expect(dungeonMap.floorTiles.has('0,-17,17')).toBe(true);
+
+    // room1 tiles should still be at z=0
+    expect(dungeonMap.floorTiles.has('0,0,0')).toBe(true);
+  });
+
+  it('total tile count equals room1.width*height + room2.width*height', () => {
+    const r1w = 6;
+    const r1h = 5;
+    const r2w = 4;
+    const r2h = 3;
+
+    const room1Layout = createRoomLayout({
+      id: 'room-1',
+      width: r1w,
+      height: r1h,
+    });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      width: r2w,
+      height: r2h,
+      originZ: 10,
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: { 'room-1': room1Layout, 'room-2': room2Layout },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+    let dungeonMap = createEmptyState();
+    for (const room of rooms) {
+      dungeonMap = mergeRoom(dungeonMap, room, []);
+    }
+
+    expect(dungeonMap.floorTiles.size).toBe(r1w * r1h + r2w * r2h);
+  });
+
+  it('entities are placed in correct rooms after pipeline', () => {
+    const room1Layout = createRoomLayout({ id: 'room-1', width: 5, height: 4 });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      width: 4,
+      height: 4,
+      originZ: 6,
+    });
+
+    const charInRoom1 = createEntityState({
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      roomId: 'room-1',
+      x: 2,
+      z: 1,
+    });
+    const mobInRoom2 = createMonsterEntityState({
+      entityId: 'mob-1',
+      roomId: 'room-2',
+      x: 1,
+      z: 7,
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: { 'room-1': room1Layout, 'room-2': room2Layout },
+      entities: { 'char-1': charInRoom1, 'mob-1': mobInRoom2 },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+    let dungeonMap = createEmptyState();
+    for (const room of rooms) {
+      dungeonMap = mergeRoom(dungeonMap, room, []);
+    }
+
+    // Both entities should be in the dungeon map
+    expect(dungeonMap.entities.has('char-1')).toBe(true);
+    expect(dungeonMap.entities.has('mob-1')).toBe(true);
+    expect(dungeonMap.entities.size).toBe(2);
+
+    // char-1 should be at room-1 position
+    expect(dungeonMap.entities.get('char-1')?.position?.x).toBe(2);
+    expect(dungeonMap.entities.get('char-1')?.position?.z).toBe(1);
+
+    // mob-1 should be at room-2 position
+    expect(dungeonMap.entities.get('mob-1')?.position?.z).toBe(7);
+  });
+
+  it('floor tiles satisfy cube coordinate invariant x + y + z = 0 for both rooms', () => {
+    const room1Layout = createRoomLayout({
+      id: 'room-1',
+      width: 3,
+      height: 3,
+      originX: 0,
+      originZ: 0,
+    });
+    const room2Layout = createRoomLayout({
+      id: 'room-2',
+      width: 3,
+      height: 3,
+      originX: 0,
+      originZ: 4,
+    });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: { 'room-1': room1Layout, 'room-2': room2Layout },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+
+    // Verify invariant holds for all tiles generated by the rooms
+    for (const room of rooms) {
+      const tiles = generateFloorTiles(room);
+      for (const tile of tiles) {
+        expect(tile.x + tile.y + tile.z).toBe(0);
+      }
+    }
+  });
+
+  it('current room becomes the active room in dungeon map after processing all rooms', () => {
+    const room1Layout = createRoomLayout({ id: 'room-1' });
+    const room2Layout = createRoomLayout({ id: 'room-2', originZ: 6 });
+
+    const data = createEncounterStateData({
+      currentRoomId: 'room-2',
+      rooms: { 'room-1': room1Layout, 'room-2': room2Layout },
+    });
+
+    const rooms = allRoomsFromEncounterState(data);
+    let dungeonMap = createEmptyState();
+    for (const room of rooms) {
+      dungeonMap = mergeRoom(dungeonMap, room, []);
+    }
+
+    // mergeRoom sets currentRoomId to the last-processed room,
+    // which is always the current room since allRoomsFromEncounterState
+    // places it last
+    expect(dungeonMap.currentRoomId).toBe('room-2');
+    expect(dungeonMap.revealedRoomIds.has('room-1')).toBe(true);
+    expect(dungeonMap.revealedRoomIds.has('room-2')).toBe(true);
+  });
+});

--- a/src/utils/encounterStateTransforms.ts
+++ b/src/utils/encounterStateTransforms.ts
@@ -1,0 +1,177 @@
+/**
+ * Pure transform functions for converting EncounterStateData into Room/Door/EntityPlacement objects.
+ *
+ * These functions were extracted from LobbyView.tsx to enable unit testing.
+ * They are the critical path for multi-room dungeon map rendering.
+ *
+ * Background: roomFromEncounterState was the source of the Round 2 bug where
+ * only the current room's tiles appeared on the dungeon map instead of all
+ * revealed rooms.
+ */
+
+import type {
+  DoorInfo,
+  EncounterStateData,
+  EntityPlacement,
+  EntityState,
+  Room,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+
+/**
+ * Convert an EntityState to an EntityPlacement for dungeon map compatibility.
+ * EntityPlacement is a spatial/visual subset of EntityState — no HP, conditions, etc.
+ */
+export function entityStateToPlacement(entity: EntityState): EntityPlacement {
+  const placement: EntityPlacement = {
+    entityId: entity.entityId,
+    entityType: entity.entityType,
+    position: entity.position,
+    size: entity.size,
+    blocksMovement: entity.blocksMovement,
+    blocksLineOfSight: entity.blocksLineOfSight,
+    visualType: { case: undefined, value: undefined },
+    $typeName: 'dnd5e.api.v1alpha1.EntityPlacement' as const,
+    $unknown: undefined,
+  };
+
+  if (entity.details.case === 'monsterDetails') {
+    placement.visualType = {
+      case: 'monsterType' as const,
+      value: entity.details.value.monsterType,
+    };
+  }
+
+  return placement;
+}
+
+/**
+ * Build a Room from EncounterStateData for the current room only.
+ * Returns undefined if currentRoomId has no matching RoomLayout.
+ *
+ * Entities are filtered to only those whose roomId matches currentRoomId.
+ */
+export function roomFromEncounterState(
+  data: EncounterStateData
+): Room | undefined {
+  const roomLayout = data.rooms[data.currentRoomId];
+  if (!roomLayout) return undefined;
+
+  const entities: { [key: string]: EntityPlacement } = {};
+  for (const entity of Object.values(data.entities)) {
+    if (entity.roomId === data.currentRoomId) {
+      entities[entity.entityId] = entityStateToPlacement(entity);
+    }
+  }
+
+  return {
+    id: roomLayout.id,
+    type: roomLayout.type,
+    width: roomLayout.width,
+    height: roomLayout.height,
+    gridType: roomLayout.gridType,
+    walls: roomLayout.walls,
+    origin: roomLayout.origin,
+    entities,
+    $typeName: 'dnd5e.api.v1alpha1.Room' as const,
+    $unknown: undefined,
+  } as Room;
+}
+
+/**
+ * Build Room objects for ALL rooms in the EncounterStateData snapshot.
+ *
+ * Non-current rooms come first; the current room is appended last.
+ * This ordering ensures the current room is always the "top" of the
+ * accumulated dungeon map when processing with mergeRoom().
+ *
+ * Entities are filtered per room by their roomId field.
+ */
+export function allRoomsFromEncounterState(data: EncounterStateData): Room[] {
+  const rooms: Room[] = [];
+
+  // Build entity lists keyed by roomId for efficient lookup
+  const entitiesByRoom: {
+    [roomId: string]: { [entityId: string]: EntityPlacement };
+  } = {};
+  for (const entity of Object.values(data.entities)) {
+    if (!entitiesByRoom[entity.roomId]) {
+      entitiesByRoom[entity.roomId] = {};
+    }
+    entitiesByRoom[entity.roomId][entity.entityId] =
+      entityStateToPlacement(entity);
+  }
+
+  // Non-current rooms first
+  for (const [roomId, roomLayout] of Object.entries(data.rooms)) {
+    if (roomId === data.currentRoomId) continue;
+
+    rooms.push({
+      id: roomLayout.id,
+      type: roomLayout.type,
+      width: roomLayout.width,
+      height: roomLayout.height,
+      gridType: roomLayout.gridType,
+      walls: roomLayout.walls,
+      origin: roomLayout.origin,
+      entities: entitiesByRoom[roomId] ?? {},
+      $typeName: 'dnd5e.api.v1alpha1.Room' as const,
+      $unknown: undefined,
+    } as Room);
+  }
+
+  // Current room last
+  const currentLayout = data.rooms[data.currentRoomId];
+  if (currentLayout) {
+    rooms.push({
+      id: currentLayout.id,
+      type: currentLayout.type,
+      width: currentLayout.width,
+      height: currentLayout.height,
+      gridType: currentLayout.gridType,
+      walls: currentLayout.walls,
+      origin: currentLayout.origin,
+      entities: entitiesByRoom[data.currentRoomId] ?? {},
+      $typeName: 'dnd5e.api.v1alpha1.Room' as const,
+      $unknown: undefined,
+    } as Room);
+  }
+
+  return rooms;
+}
+
+/**
+ * Extract DoorInfo array from EncounterStateData.
+ * Doors are stored as a map keyed by connectionId; this returns just the values.
+ */
+export function doorsFromEncounterState(data: EncounterStateData): DoorInfo[] {
+  return Object.values(data.doors);
+}
+
+/**
+ * Build MonsterCombatState-compatible data from EncounterStateData entities.
+ * Returns only MONSTER entities with monsterDetails.
+ *
+ * Used to feed monster type information for texture selection.
+ */
+export function monstersFromEncounterState(data: EncounterStateData) {
+  const result = [];
+  for (const entity of Object.values(data.entities)) {
+    if (
+      entity.entityType === EntityType.MONSTER &&
+      entity.details.case === 'monsterDetails'
+    ) {
+      result.push({
+        monsterId: entity.entityId,
+        monsterName: entity.details.value.name,
+        monsterType: entity.details.value.monsterType,
+        currentHitPoints: entity.currentHitPoints,
+        maxHitPoints: entity.maxHitPoints,
+        armorClass: entity.details.value.armorClass,
+        $typeName: 'dnd5e.api.v1alpha1.MonsterCombatState' as const,
+        $unknown: undefined,
+      });
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- Extract pure transform functions from `LobbyView.tsx` into `src/utils/encounterStateTransforms.ts` so they can be unit tested
- Add new `allRoomsFromEncounterState` function that returns ALL rooms from a snapshot (non-current first, current last) — this was the missing piece that caused the Round 2 bug where only the current room's tiles appeared on the dungeon map
- Write 25 tests covering all transform functions and a full pipeline integration test that verifies both rooms contribute tiles to the dungeon map at correct offsets

## What was extracted

The following functions moved from `LobbyView.tsx` to `src/utils/encounterStateTransforms.ts`:

- `entityStateToPlacement(entity: EntityState): EntityPlacement` — converts entity state to dungeon map placement
- `roomFromEncounterState(data: EncounterStateData): Room | undefined` — builds a Room for the current room only
- `allRoomsFromEncounterState(data: EncounterStateData): Room[]` — NEW: builds Rooms for all revealed rooms, current room last
- `doorsFromEncounterState(data: EncounterStateData): DoorInfo[]` — extracts door array from snapshot
- `monstersFromEncounterState(data: EncounterStateData)` — extracts monster combat state data

`LobbyView.tsx` now imports from the new module. Behavior is identical.

## Test plan

- [x] `npm run test:run` — 323 tests pass (25 new)
- [x] `npm run build` — build succeeds
- [x] `npm run ci-check` — all checks pass (format, lint, typecheck, build, tests)
- [x] Full pipeline test: 2-room snapshot → `allRoomsFromEncounterState` → `mergeRoom` → correct tile count and offsets
- [x] Entity distribution: entities correctly filtered to their room in each Room object
- [x] Ordering guarantee: non-current rooms before current room so `mergeRoom` sets the right `currentRoomId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)