### PR TITLE
fix(web): wave 2 multi-room rendering + movement-render bundle

### DIFF
--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -140,17 +140,21 @@ function entityStateToPlacement(entity: EntityState): EntityPlacement {
 }
 
 /**
- * Build a legacy Room object from EncounterStateData for addRoomToMap compatibility.
- * Uses the current room's RoomLayout + entities assigned to that room.
+ * Build a legacy Room object from a single RoomLayout in EncounterStateData.
+ * `roomId` selects which room to materialize; entities are filtered to that
+ * room via `entity.roomId`.
  */
-function roomFromEncounterState(data: EncounterStateData): Room | undefined {
-  const roomLayout = data.rooms[data.currentRoomId];
+function buildLegacyRoom(
+  data: EncounterStateData,
+  roomId: string
+): Room | undefined {
+  const roomLayout = data.rooms[roomId];
   if (!roomLayout) return undefined;
 
-  // Collect entities that belong to the current room
+  // Collect entities that belong to this specific room
   const entities: { [key: string]: EntityPlacement } = {};
   for (const entity of Object.values(data.entities)) {
-    if (entity.roomId === data.currentRoomId) {
+    if (entity.roomId === roomId) {
       entities[entity.entityId] = entityStateToPlacement(entity);
     }
   }
@@ -167,6 +171,50 @@ function roomFromEncounterState(data: EncounterStateData): Room | undefined {
     $typeName: 'dnd5e.api.v1alpha1.Room' as const,
     $unknown: undefined,
   } as Room;
+}
+
+/**
+ * Build a legacy Room object from EncounterStateData for addRoomToMap compatibility.
+ * Uses the current room's RoomLayout + entities assigned to that room.
+ */
+function roomFromEncounterState(data: EncounterStateData): Room | undefined {
+  return buildLegacyRoom(data, data.currentRoomId);
+}
+
+/**
+ * Build legacy Room objects for every revealed room in EncounterStateData,
+ * ordered with the current room LAST.
+ *
+ * Why this exists: when the api emits `RoomRevealed` (player opened a door),
+ * `data.currentRoomId` is still the player's CURRENT room — opening a door
+ * does not move the player. The just-revealed room lives in `data.rooms`
+ * but `currentRoomId` does NOT point at it. Building only the current room
+ * (the prior `roomFromEncounterState` behavior) means `addRoomToMap` never
+ * sees the revealed room's RoomLayout, so its floor tiles never get
+ * generated and the revealed room ends up empty inside.
+ *
+ * Iterating every entry in `data.rooms` here mirrors the
+ * "revealed rooms are first-class" pattern already followed by
+ * `BattleMapPanel` (renders entities from every revealed room) and
+ * `openDoorWalkableKeys` (treats every open door as walkable). Current room
+ * is forced last so that `mergeRoom`'s `currentRoomId: room.id` write ends
+ * up correct.
+ *
+ * Returns rooms in deterministic order (alphabetical by id, current room
+ * forced to the end). Rooms with no RoomLayout are skipped.
+ */
+function roomsFromEncounterState(data: EncounterStateData): Room[] {
+  const allIds = Object.keys(data.rooms).sort();
+  const ordered = [
+    ...allIds.filter((id) => id !== data.currentRoomId),
+    ...(allIds.includes(data.currentRoomId) ? [data.currentRoomId] : []),
+  ];
+  const rooms: Room[] = [];
+  for (const id of ordered) {
+    const room = buildLegacyRoom(data, id);
+    if (room) rooms.push(room);
+  }
+  return rooms;
 }
 
 /**
@@ -350,12 +398,15 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
           applySnapshot(event.encounterStateData);
 
           // --- Legacy path: build Room/CombatState from encounterStateData ---
-          const legacyRoom = roomFromEncounterState(event.encounterStateData);
-          if (legacyRoom) {
-            addRoomToMap(
-              legacyRoom,
-              doorsFromEncounterState(event.encounterStateData)
-            );
+          // Iterate every revealed room so the freshly-revealed room's floor
+          // tiles get generated. `data.currentRoomId` still points at the
+          // player's current room here — the revealed room only exists in
+          // `data.rooms`. See roomsFromEncounterState for full reasoning.
+          const doors = doorsFromEncounterState(event.encounterStateData);
+          for (const legacyRoom of roomsFromEncounterState(
+            event.encounterStateData
+          )) {
+            addRoomToMap(legacyRoom, doors);
           }
           setCombatState(event.encounterStateData.combat ?? null);
           setRoomsCleared(event.encounterStateData.roomsCleared);

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -329,6 +329,18 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   // Dungeon stream event handlers
   const handleRoomRevealed = useCallback(
     (event: RoomRevealedEvent) => {
+      console.log('🚪 RoomRevealed event received:', {
+        connectionId: event.connectionId,
+        revealedRoomId: event.encounterStateData?.currentRoomId,
+        roomCount: event.encounterStateData
+          ? Object.keys(event.encounterStateData.rooms).length
+          : 0,
+        revealedRoomIds: event.encounterStateData?.revealedRoomIds,
+        entityCount: event.encounterStateData
+          ? Object.keys(event.encounterStateData.entities).length
+          : 0,
+      });
+
       // Trigger fade transition
       setIsTransitioning(true);
 

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -252,6 +252,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     state: encounterState,
     applySnapshot,
     applyEntityUpdates,
+    applyEntityPositionUpdate,
     applyCombatState: applyEncounterCombatState,
     reset: resetEncounterState,
   } = useEncounterState();
@@ -631,7 +632,20 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       console.log('🚶 MovementCompleted event received:', event);
 
       // --- New path: populate unified encounter state ---
-      if (event.updatedEntity) applyEntityUpdates([event.updatedEntity]);
+      if (event.updatedEntity) {
+        // Preferred: API sent a full entity snapshot. Use it as-is.
+        applyEntityUpdates([event.updatedEntity]);
+      } else if (event.entityId && event.path.length > 0) {
+        // Fallback: API sent only a path (e.g. player moves currently omit
+        // updatedEntity — see rpg-api fix/cross-room-state-wave2). Mirror the
+        // applyMonsterMovement pattern: use the final path coordinate as the
+        // new position for the existing entity. No-op if the entity is not
+        // already in encounter state.
+        const finalPosition = event.path[event.path.length - 1];
+        if (finalPosition) {
+          applyEntityPositionUpdate(event.entityId, finalPosition);
+        }
+      }
       if (event.combatState) applyEncounterCombatState(event.combatState);
 
       // --- Legacy path ---
@@ -640,7 +654,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         setCombatState(event.combatState);
       }
     },
-    [applyEntityUpdates, applyEncounterCombatState]
+    [applyEntityUpdates, applyEntityPositionUpdate, applyEncounterCombatState]
   );
 
   // Multiplayer sync: Feature activated - sync feature usage

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -32,6 +32,7 @@ import {
   formatEntityId,
   monsterTurnsToLogEntries,
 } from '@/utils/monsterTurnUtils';
+import { getMovementRemainingFromCombat } from '@/utils/movementUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import {
   EncounterEndReason,
@@ -692,7 +693,22 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   // Multiplayer sync: Movement completed - sync entity positions and movement resources
   const handleMovementCompleted = useCallback(
     (event: MovementCompletedEvent) => {
-      console.log('🚶 MovementCompleted event received:', event);
+      // [wave2-debug] Surface what the api carried for movement budget so we
+      // can confirm `actionEconomy.movementRemaining` arrived non-zero.
+      // Reading through the deprecated subtraction was the Wave 2 OpenDoor
+      // regression — log both so divergences are obvious in the console.
+      const ae = event.combatState?.currentTurn?.actionEconomy;
+      const dep = event.combatState?.currentTurn;
+      console.log('🚶 MovementCompleted event received:', {
+        entityId: event.entityId,
+        pathLen: event.path.length,
+        hasUpdatedEntity: !!event.updatedEntity,
+        movementRemaining_canonical: ae?.movementRemaining,
+        movementMax_canonical: ae?.movementMax,
+        movementUsed_deprecated: dep?.movementUsed,
+        movementMax_deprecated: dep?.movementMax,
+        currentTurnEntityId: dep?.entityId,
+      });
 
       // --- New path: populate unified encounter state ---
       if (event.updatedEntity) {
@@ -1399,12 +1415,15 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         walkableTileKeys
       );
 
-      // Validate total movement cost
+      // Validate total movement cost. Read remaining feet through
+      // getMovementRemainingFromCombat, which prefers the canonical
+      // `actionEconomy.movementRemaining` field over the deprecated
+      // `movementMax - movementUsed` subtraction (the latter desyncs after
+      // OpenDoor — see utils/movementUtils.ts).
       const pathCost = (movementPath.length + newSegment.length) * 5; // 5ft per hex
-      const maxMovement = combatState?.currentTurn?.movementMax || 30;
-      const usedMovement = combatState?.currentTurn?.movementUsed || 0;
+      const movementRemaining = getMovementRemainingFromCombat(combatState);
 
-      if (pathCost > maxMovement - usedMovement) {
+      if (pathCost > movementRemaining) {
         console.warn('Not enough movement remaining');
         return; // Don't add to path
       }

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -194,21 +194,25 @@ function roomFromEncounterState(data: EncounterStateData): Room | undefined {
  * sees the revealed room's RoomLayout, so its floor tiles never get
  * generated and the revealed room ends up empty inside.
  *
- * Iterating every entry in `data.rooms` here mirrors the
- * "revealed rooms are first-class" pattern already followed by
- * `BattleMapPanel` (renders entities from every revealed room) and
- * `openDoorWalkableKeys` (treats every open door as walkable). Current room
- * is forced last so that `mergeRoom`'s `currentRoomId: room.id` write ends
- * up correct.
+ * Iterating `data.revealedRoomIds` here mirrors the "revealed rooms are
+ * first-class" pattern already followed by `BattleMapPanel` (renders
+ * entities from every revealed room) and `openDoorWalkableKeys` (treats
+ * every open door as walkable). Current room is forced last so that
+ * `mergeRoom`'s `currentRoomId: room.id` write ends up correct.
+ *
+ * Defensive: iterates `revealedRoomIds` rather than `Object.keys(data.rooms)`
+ * so we never materialize a room layout that arrived but wasn't revealed
+ * (the API contract says `data.rooms` only contains revealed rooms today,
+ * but we don't depend on that). Rooms with no RoomLayout are skipped.
  *
  * Returns rooms in deterministic order (alphabetical by id, current room
- * forced to the end). Rooms with no RoomLayout are skipped.
+ * forced to the end).
  */
 function roomsFromEncounterState(data: EncounterStateData): Room[] {
-  const allIds = Object.keys(data.rooms).sort();
+  const revealed = data.revealedRoomIds.filter((id) => data.rooms[id]).sort();
   const ordered = [
-    ...allIds.filter((id) => id !== data.currentRoomId),
-    ...(allIds.includes(data.currentRoomId) ? [data.currentRoomId] : []),
+    ...revealed.filter((id) => id !== data.currentRoomId),
+    ...(revealed.includes(data.currentRoomId) ? [data.currentRoomId] : []),
   ];
   const rooms: Room[] = [];
   for (const id of ordered) {
@@ -380,7 +384,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     (event: RoomRevealedEvent) => {
       console.log('🚪 RoomRevealed event received:', {
         connectionId: event.connectionId,
-        revealedRoomId: event.encounterStateData?.currentRoomId,
+        currentRoomId: event.encounterStateData?.currentRoomId,
         roomCount: event.encounterStateData
           ? Object.keys(event.encounterStateData.rooms).length
           : 0,
@@ -895,18 +899,26 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         // Set monsters (for monsterType texture selection)
         setMonsters(monstersFromEncounterState(esd));
 
-        // Build legacy Room and add to dungeon map
+        // Build legacy Room and add to dungeon map. processMonsterTurns
+        // applies monster movement to the current room only (its scope) —
+        // other revealed rooms are added as-is.
         let legacyRoom = roomFromEncounterState(esd);
-
-        // Process monster turns if present (monsters won initiative)
         legacyRoom = processMonsterTurns(
           event.monsterTurns,
           esd.combat,
           legacyRoom
         );
 
+        const doors = doorsFromEncounterState(esd);
+        // Add other revealed rooms first; current room added last so
+        // mergeRoom's currentRoomId write resolves correctly.
+        for (const room of roomsFromEncounterState(esd)) {
+          if (room.id !== esd.currentRoomId) {
+            addRoomToMap(room, doors);
+          }
+        }
         if (legacyRoom) {
-          addRoomToMap(legacyRoom, doorsFromEncounterState(esd));
+          addRoomToMap(legacyRoom, doors);
         }
 
         // Extract party character IDs from character entities for selectedCharacterIds
@@ -949,8 +961,17 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
         }
       }
 
-      // Apply room from snapshot into dungeon map
-      if (snapshot.room) {
+      // Apply rooms from snapshot into dungeon map. Prefer multi-room
+      // iteration from encounterStateData (matches the RoomRevealed flow);
+      // fall back to legacy single-room `snapshot.room` only when
+      // encounterStateData is absent.
+      if (snapshot.encounterStateData) {
+        const esd = snapshot.encounterStateData;
+        const doors = doorsFromEncounterState(esd);
+        for (const room of roomsFromEncounterState(esd)) {
+          addRoomToMap(room, doors);
+        }
+      } else if (snapshot.room) {
         addRoomToMap(snapshot.room, snapshot.doors ?? []);
       }
 
@@ -2273,10 +2294,11 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
                   // Legacy: set monsters for texture selection
                   setMonsters(monstersFromEncounterState(esd));
 
-                  // Legacy: build Room and add to dungeon map
+                  // Legacy: build Room and add to dungeon map.
+                  // processMonsterTurns scope is the current room only;
+                  // other revealed rooms are added as-is for multi-room
+                  // rendering parity with handleCombatStarted.
                   let legacyRoom = roomFromEncounterState(esd);
-
-                  // Process monster turns and get updated room
                   legacyRoom = processMonsterTurns(
                     event.monsterTurns,
                     esd.combat,
@@ -2284,7 +2306,13 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
                   );
 
                   if (legacyRoom) {
-                    addRoomToMap(legacyRoom, doorsFromEncounterState(esd));
+                    const doors = doorsFromEncounterState(esd);
+                    for (const room of roomsFromEncounterState(esd)) {
+                      if (room.id !== esd.currentRoomId) {
+                        addRoomToMap(room, doors);
+                      }
+                    }
+                    addRoomToMap(legacyRoom, doors);
                     addToast({
                       type: 'success',
                       message: 'Combat started!',

--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -1,5 +1,5 @@
 import type { DungeonMapState } from '@/hooks/useDungeonMap';
-import { getEntityName, isDead } from '@/utils/entityHelpers';
+import { mapEntitiesForRender } from '@/utils/entityHelpers';
 import type { CubeCoord } from '@/utils/hexUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type {
@@ -68,38 +68,19 @@ export function BattleMapPanel({
 
   // Build entities array, preferring unified entity state when available.
   // Falls back to accumulated dungeonMap entities (legacy path).
+  //
+  // Render every entity in the unified state regardless of `entity.roomId`.
+  // `dungeonMap.floorTiles` accumulates tiles for every revealed room, so once
+  // a room is revealed its entities are first-class and must render alongside
+  // the player's current room. Filtering by `currentRoomId` here was the cause
+  // of "the new room is always empty" / "player vanishes when door opens" —
+  // see Wave 2 cross-room render bug. Per `feedback_no_logic_in_web`, the web
+  // renders what the API sends; visibility decisions belong to the API.
   const entities = useMemo(() => {
-    // Prefer unified entity state when available
+    // Prefer unified entity state when available — render every entity, no
+    // filter on `entity.roomId`. See header comment above.
     if (encounterEntities && encounterEntities.size > 0) {
-      return Array.from(encounterEntities.values())
-        .filter((entity) => {
-          // Only show entities in the current room (if they have a roomId)
-          if (entity.roomId && dungeonMap.currentRoomId) {
-            return entity.roomId === dungeonMap.currentRoomId;
-          }
-          return true;
-        })
-        .map((entity) => {
-          let displayType: 'player' | 'monster' | 'obstacle';
-          if (entity.entityType === EntityType.CHARACTER) {
-            displayType = 'player';
-          } else if (entity.entityType === EntityType.MONSTER) {
-            displayType = 'monster';
-          } else {
-            displayType = 'obstacle';
-          }
-          return {
-            entityId: entity.entityId,
-            name: getEntityName(entity),
-            position: {
-              x: entity.position?.x || 0,
-              y: entity.position?.y || 0,
-              z: entity.position?.z || 0,
-            },
-            type: displayType,
-            isDead: isDead(entity),
-          };
-        });
+      return mapEntitiesForRender(encounterEntities.values());
     }
 
     // Fallback to legacy dungeonMap.entities
@@ -131,7 +112,6 @@ export function BattleMapPanel({
   }, [
     encounterEntities,
     dungeonMap.entities,
-    dungeonMap.currentRoomId,
     allPartyCharacters,
     deadMonsterIds,
   ]);

--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -1,6 +1,7 @@
 import type { DungeonMapState } from '@/hooks/useDungeonMap';
 import { mapEntitiesForRender } from '@/utils/entityHelpers';
 import type { CubeCoord } from '@/utils/hexUtils';
+import { getMovementRemainingFromCombat } from '@/utils/movementUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type {
   CombatState,
@@ -148,12 +149,15 @@ export function BattleMapPanel({
         characters={allPartyCharacters}
         monsters={monsters}
         currentEntityId={combatState?.currentTurn?.entityId}
-        movementRemaining={
-          combatState?.currentTurn
-            ? (combatState.currentTurn.movementMax || 30) -
-              (combatState.currentTurn.movementUsed || 0)
-            : 0
-        }
+        // Read from `actionEconomy.movementRemaining` (canonical) with a
+        // fallback to the deprecated `movementMax - movementUsed` subtraction.
+        // The deprecated fields desync after OpenDoor (Wave 2 regression):
+        // they reported 0 ft remaining while actionEconomy correctly carried
+        // 30 ft. Reading the deprecated path was the root cause of "no range
+        // indicator after opening a door", "cannot path into the revealed
+        // room", and "cannot attack monster requiring even one step of
+        // movement". See utils/movementUtils.ts for the resolution order.
+        movementRemaining={getMovementRemainingFromCombat(combatState)}
         isPlayerTurn={
           combatState?.currentTurn?.entityId
             ? availableCharacters.some(

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -12,7 +12,11 @@
  * - Turn order overlay
  */
 
-import { wallKey, type AbsoluteFloorTile } from '@/hooks/useDungeonMap';
+import {
+  openDoorWalkableKeys,
+  wallKey,
+  type AbsoluteFloorTile,
+} from '@/hooks/useDungeonMap';
 import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type {
@@ -203,12 +207,22 @@ function Scene({
     };
   }, [currentEntityId, entities]);
 
-  // Check if a hex is blocked (not a floor tile or has an entity)
+  // Build a Set of door-position keys so OPEN doors are walkable even when
+  // their hex is not a floor tile (the door sits on the boundary between
+  // rooms and is omitted from both rooms' floor-tile bboxes). Without this,
+  // A* sees the door as an impassable wall and refuses to path between
+  // revealed rooms — the "my pathing on the client never lets me cross" bug.
+  // Closed doors stay impassable to pathfinding; the door-click flow is what
+  // opens them.
+  const doorOpenKeys = useMemo(() => openDoorWalkableKeys(doors), [doors]);
+
+  // Check if a hex is blocked (not a floor tile or has an entity).
+  // Open doors are treated as walkable even when not a floor tile.
   // Uses useCallback to ensure stable function reference for downstream memoization
   const isBlocked = useCallback(
     (coord: CubeCoord) => {
       const key = `${coord.x},${coord.y},${coord.z}`;
-      if (!floorTiles.has(key)) {
+      if (!floorTiles.has(key) && !doorOpenKeys.has(key)) {
         return true;
       }
       return entities.some(
@@ -220,7 +234,7 @@ function Scene({
           entity.entityId !== currentEntityId
       );
     },
-    [entities, currentEntityId, floorTiles]
+    [entities, currentEntityId, floorTiles, doorOpenKeys]
   );
 
   // Use the interaction hook for hover/click detection with path preview

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -276,12 +276,40 @@ function Scene({
   }, [hoveredEntity, onHoverChange]);
 
   // Use movement range hook for boundary visualization
-  const { boundaryEdges } = useMovementRange({
+  const { boundaryEdges, reachableHexes } = useMovementRange({
     entityPosition: currentEntityPosition,
     movementRemaining,
     hexSize: HEX_SIZE,
     isBlocked,
   });
+
+  // [wave2-debug] Surface reachable-tiles size when movement-range
+  // visualization is expected to render. If `reachableHexes.size === 0` while
+  // `isPlayerTurn` is true, something upstream is reporting "no movement
+  // left" — the fix is in utils/movementUtils.ts (canonical actionEconomy
+  // path). Logged once per change.
+  useEffect(() => {
+    if (!isPlayerTurn) return;
+    const sample = Array.from(reachableHexes).slice(0, 3);
+    console.log('[wave2-debug] movement range:', {
+      isPlayerTurn,
+      currentEntityId,
+      currentEntityPosition,
+      movementRemaining,
+      reachableSize: reachableHexes.size,
+      reachableSample: sample,
+      floorTilesSize: floorTiles.size,
+      doorOpenKeysSize: doorOpenKeys.size,
+    });
+  }, [
+    isPlayerTurn,
+    currentEntityId,
+    currentEntityPosition,
+    movementRemaining,
+    reachableHexes,
+    floorTiles.size,
+    doorOpenKeys.size,
+  ]);
 
   // Extract door positions for tile coloring
   const doorPositions = useMemo((): CubeCoord[] => {

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -276,40 +276,12 @@ function Scene({
   }, [hoveredEntity, onHoverChange]);
 
   // Use movement range hook for boundary visualization
-  const { boundaryEdges, reachableHexes } = useMovementRange({
+  const { boundaryEdges } = useMovementRange({
     entityPosition: currentEntityPosition,
     movementRemaining,
     hexSize: HEX_SIZE,
     isBlocked,
   });
-
-  // [wave2-debug] Surface reachable-tiles size when movement-range
-  // visualization is expected to render. If `reachableHexes.size === 0` while
-  // `isPlayerTurn` is true, something upstream is reporting "no movement
-  // left" — the fix is in utils/movementUtils.ts (canonical actionEconomy
-  // path). Logged once per change.
-  useEffect(() => {
-    if (!isPlayerTurn) return;
-    const sample = Array.from(reachableHexes).slice(0, 3);
-    console.log('[wave2-debug] movement range:', {
-      isPlayerTurn,
-      currentEntityId,
-      currentEntityPosition,
-      movementRemaining,
-      reachableSize: reachableHexes.size,
-      reachableSample: sample,
-      floorTilesSize: floorTiles.size,
-      doorOpenKeysSize: doorOpenKeys.size,
-    });
-  }, [
-    isPlayerTurn,
-    currentEntityId,
-    currentEntityPosition,
-    movementRemaining,
-    reachableHexes,
-    floorTiles.size,
-    doorOpenKeys.size,
-  ]);
 
   // Extract door positions for tile coloring
   const doorPositions = useMemo((): CubeCoord[] => {

--- a/src/components/hex-grid/MovementRangeBorder.tsx
+++ b/src/components/hex-grid/MovementRangeBorder.tsx
@@ -21,7 +21,14 @@ interface MovementRangeBorderProps {
 const DEFAULT_COLOR = '#00bcd4'; // Cyan
 const DEFAULT_OPACITY = 0.8;
 const DEFAULT_GLOW_INTENSITY = 2.0;
-const BORDER_Y_OFFSET = 0.05; // Slightly above ground to prevent z-fighting
+// Y offset must clear the floor extrusion top to be visible. ShadedHexFloor
+// extrudes hex tiles from y=0.05 to y=0.15 (depth 0.1, then translated by
+// 0.05). The previous 0.05 placed the border at the floor's BOTTOM face —
+// invisible from above and only peeking through z-fighting from below,
+// matching Kirk's "renders below the floor" Wave 2 playtest report.
+// Raise to 0.17 so it sits above the floor's top face with a small margin
+// that prevents z-fighting against PathPreview at 0.16.
+const BORDER_Y_OFFSET = 0.17;
 const LINE_WIDTH = 0.08; // Width of the border line
 
 /**

--- a/src/components/hex-grid/PathPreview.tsx
+++ b/src/components/hex-grid/PathPreview.tsx
@@ -18,7 +18,12 @@ interface PathPreviewProps {
 
 const DEFAULT_COLOR = '#3b82f6'; // blue
 const DEFAULT_OPACITY = 0.4;
-const PATH_Y_OFFSET = 0.03; // Slightly above ground
+// Y offset must clear the floor extrusion top to be visible. ShadedHexFloor
+// extrudes from y=0.05 to y=0.15. The previous 0.03 sat under the floor
+// entirely — same Wave 2 "below the floor" symptom as MovementRangeBorder.
+// Sits just above the floor top, slightly below MovementRangeBorder (0.17)
+// so the cyan range outline reads on top when both render the same edge.
+const PATH_Y_OFFSET = 0.16;
 
 /**
  * Creates a flat hexagon shape for pointy-top orientation

--- a/src/components/hex-grid/floorOverlayHeights.test.ts
+++ b/src/components/hex-grid/floorOverlayHeights.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Floor overlay Y-offset regression tests
+ *
+ * Why this test exists:
+ *
+ * `ShadedHexFloor` (the canonical floor tile renderer) extrudes each hex
+ * tile from y=0.05 to y=0.15 in world space. Two overlay components draw
+ * on top of those tiles:
+ *
+ *   - `MovementRangeBorder` — cyan glowing perimeter around reachable hexes
+ *   - `PathPreview`         — blue path-fill on hexes the player will cross
+ *
+ * Both predate the move from flat `ShapeGeometry` (`InstancedHexTiles`) to
+ * the extruded `ExtrudeGeometry` in `ShadedHexFloor`. Their original
+ * Y-offsets (0.05 for the border, 0.03 for the path) were chosen for the
+ * flat tiles at y=0 and were never raised when the floor grew an extrusion.
+ *
+ * Result: the cyan range indicator rendered AT the bottom face of the
+ * floor extrusion (y=0.05) and the blue path rendered UNDER it (y=0.03).
+ * Both were occluded by the opaque top face at y=0.15 — the Wave 2
+ * playtest "range indicator below the floor" symptom.
+ *
+ * This test is a hard regression guard: any future change that drops these
+ * offsets back below the floor extrusion top will fail loudly.
+ *
+ * Source-text inspection (matching AdvancedCharacterShader.test.ts) avoids
+ * needing a real WebGL context.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Floor extrusion top in world Y.
+ *
+ * Derivation from `ShadedHexFloor.tsx`:
+ *   - `ExtrudeGeometry({ depth: 0.1 })` extrudes the 2D hex shape from
+ *     local z=0 to local z=0.1.
+ *   - `geometry.rotateX(-Math.PI / 2)` maps local +z to world +y, so
+ *     the extruded volume now spans world y in [0, 0.1].
+ *   - `geometry.translate(0, 0.05, 0)` shifts the whole mesh up by 0.05,
+ *     so the volume spans world y in [0.05, 0.15].
+ *
+ * Any overlay drawn at y < 0.15 is INSIDE or BELOW the floor extrusion.
+ */
+const FLOOR_TOP_Y = 0.15;
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(HERE, relativePath), 'utf-8');
+}
+
+function extractNumberConst(src: string, name: string): number {
+  const re = new RegExp(`const\\s+${name}\\s*=\\s*(-?\\d+(?:\\.\\d+)?)\\b`);
+  const match = re.exec(src);
+  if (!match) {
+    throw new Error(`Could not find numeric const ${name} in source`);
+  }
+  return Number(match[1]);
+}
+
+describe('floor overlay Y offsets clear the floor extrusion top', () => {
+  it('MovementRangeBorder Y offset is above the floor top', () => {
+    const src = readSource('./MovementRangeBorder.tsx');
+    const offset = extractNumberConst(src, 'BORDER_Y_OFFSET');
+    expect(offset).toBeGreaterThan(FLOOR_TOP_Y);
+  });
+
+  it('PathPreview Y offset is above the floor top', () => {
+    const src = readSource('./PathPreview.tsx');
+    const offset = extractNumberConst(src, 'PATH_Y_OFFSET');
+    expect(offset).toBeGreaterThan(FLOOR_TOP_Y);
+  });
+
+  it('MovementRangeBorder draws above PathPreview to win z-fighting on shared edges', () => {
+    // The cyan range outline should read on top of the blue path fill on
+    // hexes that are simultaneously reachable-edge AND on the previewed
+    // path. Equal offsets would z-fight; the border must be strictly higher.
+    const borderSrc = readSource('./MovementRangeBorder.tsx');
+    const pathSrc = readSource('./PathPreview.tsx');
+    const borderOffset = extractNumberConst(borderSrc, 'BORDER_Y_OFFSET');
+    const pathOffset = extractNumberConst(pathSrc, 'PATH_Y_OFFSET');
+    expect(borderOffset).toBeGreaterThan(pathOffset);
+  });
+
+  it('floor extrusion math has not drifted from the documented top y', () => {
+    // Guard against ShadedHexFloor changing its extrusion depth or vertical
+    // translate without this regression test being updated alongside.
+    const src = readSource('./ShadedHexFloor.tsx');
+    expect(src).toContain('depth: 0.1');
+    expect(src).toContain('geometry.translate(0, 0.05, 0)');
+  });
+});

--- a/src/components/hex-grid/useHexInteraction.test.ts
+++ b/src/components/hex-grid/useHexInteraction.test.ts
@@ -324,4 +324,74 @@ describe('useHexInteraction logic', () => {
       expect(hasBlockedHex).toBe(false);
     });
   });
+
+  describe('cross-room pathing through doors (Wave 2)', () => {
+    /**
+     * Mirrors the HexGrid `isBlocked` shape: a hex is blocked unless it's in
+     * `floorTiles` OR in `openDoorKeys`. This is the contract that lets A*
+     * find a path from room A through an open door into room B. Without it,
+     * the door tile (which is in NEITHER room's floor-tile bbox) reads as a
+     * wall and pathing fails — the "client never lets me cross" bug.
+     */
+    function makeIsBlocked(opts: {
+      floorTiles: Map<string, AbsoluteFloorTile>;
+      openDoorKeys: Set<string>;
+    }) {
+      return (coord: CubeCoord) => {
+        const key = `${coord.x},${coord.y},${coord.z}`;
+        return !opts.floorTiles.has(key) && !opts.openDoorKeys.has(key);
+      };
+    }
+
+    it('finds a path from room A through an open door into room B', () => {
+      // Room A floor tiles {(0,0,0), (1,-1,0)}, Room B floor tiles
+      // {(3,-3,0), (4,-4,0)}, door at (2,-2,0).
+      const tiles: Array<[string, AbsoluteFloorTile]> = [
+        ['0,0,0', { x: 0, y: 0, z: 0, roomId: 'A' }],
+        ['1,-1,0', { x: 1, y: -1, z: 0, roomId: 'A' }],
+        ['3,-3,0', { x: 3, y: -3, z: 0, roomId: 'B' }],
+        ['4,-4,0', { x: 4, y: -4, z: 0, roomId: 'B' }],
+      ];
+      const floorTiles = new Map<string, AbsoluteFloorTile>(tiles);
+      const openDoorKeys = new Set<string>(['2,-2,0']);
+
+      const isBlocked = makeIsBlocked({ floorTiles, openDoorKeys });
+
+      const path = findPath(
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: -4, z: 0 },
+        isBlocked
+      );
+
+      // Path includes start, through door, to end
+      expect(path.length).toBeGreaterThan(0);
+      expect(path[0]).toEqual({ x: 0, y: 0, z: 0 });
+      expect(path[path.length - 1]).toEqual({ x: 4, y: -4, z: 0 });
+      const onPath = (c: CubeCoord) =>
+        path.some((p) => p.x === c.x && p.y === c.y && p.z === c.z);
+      expect(onPath({ x: 2, y: -2, z: 0 })).toBe(true);
+    });
+
+    it('refuses to path when the door is closed', () => {
+      const tiles: Array<[string, AbsoluteFloorTile]> = [
+        ['0,0,0', { x: 0, y: 0, z: 0, roomId: 'A' }],
+        ['1,-1,0', { x: 1, y: -1, z: 0, roomId: 'A' }],
+        ['3,-3,0', { x: 3, y: -3, z: 0, roomId: 'B' }],
+        ['4,-4,0', { x: 4, y: -4, z: 0, roomId: 'B' }],
+      ];
+      const floorTiles = new Map<string, AbsoluteFloorTile>(tiles);
+      const openDoorKeys = new Set<string>(); // door is closed
+
+      const isBlocked = makeIsBlocked({ floorTiles, openDoorKeys });
+
+      const path = findPath(
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: -4, z: 0 },
+        isBlocked
+      );
+
+      // No path — closed door is impassable
+      expect(path).toEqual([]);
+    });
+  });
 });

--- a/src/hooks/useDungeonMap.test.ts
+++ b/src/hooks/useDungeonMap.test.ts
@@ -29,6 +29,7 @@ import {
   createEmptyState,
   generateFloorTiles,
   mergeRoom,
+  openDoorWalkableKeys,
   updateEntitiesFromRoom,
   wallKey,
 } from './useDungeonMap';
@@ -877,5 +878,61 @@ describe('mergeRoom wall deduplication', () => {
 
     // Should be 1, not 2 — the reversed wall is the same physical wall
     expect(state.walls.size).toBe(1);
+  });
+});
+
+describe('openDoorWalkableKeys', () => {
+  it('returns only OPEN doors as walkable cube keys', () => {
+    const closed = createDoor('conn-closed', 5, -5, 0, false);
+    const open = createDoor('conn-open', 0, -17, 17, true);
+
+    const keys = openDoorWalkableKeys([closed, open]);
+
+    expect(keys.size).toBe(1);
+    expect(keys.has('0,-17,17')).toBe(true);
+    expect(keys.has('5,-5,0')).toBe(false);
+  });
+
+  it('returns empty set when no doors', () => {
+    expect(openDoorWalkableKeys([]).size).toBe(0);
+  });
+
+  it('skips doors with no position', () => {
+    const noPos = create(DoorInfoSchema, {
+      connectionId: 'no-pos',
+      isOpen: true,
+    });
+    const keys = openDoorWalkableKeys([noPos]);
+    expect(keys.size).toBe(0);
+  });
+
+  it('used as walkable in a room-A → room-B path: door tile traversable when open', () => {
+    // Two rooms separated by a door tile that is in NEITHER room's bbox.
+    // Room A: 2x1 at origin (0,0,0) → tiles {(0,0,0), (1,-1,0)}
+    // Room B: 2x1 at origin (3,_,0) → tiles {(3,-3,0), (4,-4,0)}
+    // Door at (2,-2,0) bridges them. Without openDoorWalkableKeys, the door
+    // tile is a "wall" to A* and pathing fails.
+    let state = createEmptyState();
+    state = mergeRoom(
+      state,
+      createRoom({ id: 'room-A', width: 2, height: 1 }),
+      []
+    );
+    state = mergeRoom(
+      state,
+      createRoom({ id: 'room-B', width: 2, height: 1, originX: 3, originZ: 0 }),
+      [createDoor('conn-AB', 2, -2, 0, true)]
+    );
+
+    const walkable = openDoorWalkableKeys(state.doors.values());
+    expect(walkable.has('2,-2,0')).toBe(true);
+
+    // Combined walkable set is what HexGrid's isBlocked treats as passable.
+    const combined = new Set<string>([...state.floorTiles.keys(), ...walkable]);
+    expect(combined.has('0,0,0')).toBe(true); // room A start
+    expect(combined.has('1,-1,0')).toBe(true); // room A
+    expect(combined.has('2,-2,0')).toBe(true); // open door
+    expect(combined.has('3,-3,0')).toBe(true); // room B
+    expect(combined.has('4,-4,0')).toBe(true); // room B end
   });
 });

--- a/src/hooks/useDungeonMap.ts
+++ b/src/hooks/useDungeonMap.ts
@@ -57,6 +57,24 @@ function coordKey(x: number, y: number, z: number): string {
 }
 
 /**
+ * Build a Set of cube-coord keys for every OPEN door.
+ * Used by HexGrid's `isBlocked` to treat open doors as walkable, since the
+ * door's hex sits on the boundary between two rooms and is not part of either
+ * room's floor-tile bbox. Closed doors are excluded — they remain "walls" to
+ * pathfinding until the player opens them via the door click flow.
+ *
+ * Exported for unit testing without rendering HexGrid.
+ */
+export function openDoorWalkableKeys(doors: Iterable<DoorInfo>): Set<string> {
+  const set = new Set<string>();
+  for (const door of doors) {
+    if (!door.position || !door.isOpen) continue;
+    set.add(coordKey(door.position.x, door.position.y, door.position.z));
+  }
+  return set;
+}
+
+/**
  * Create a canonical key for a wall segment.
  * Normalizes direction so that (A->B) and (B->A) produce the same key,
  * preventing duplicate walls when adjacent rooms both report a shared boundary.

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { create } from '@bufbuild/protobuf';
+import { PositionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import {
   CombatStateSchema,
   DoorInfoSchema,
@@ -25,6 +26,7 @@ import { describe, expect, it } from 'vitest';
 import {
   applySnapshotToState,
   createEmptyEncounterState,
+  mergeEntityPosition,
   mergeEntityUpdates,
   updateCombatState,
 } from './useEncounterState';
@@ -328,6 +330,100 @@ describe('mergeEntityUpdates', () => {
 
     expect(next.encounterId).toBe('enc-stable');
     expect(next.dungeonId).toBe('dng-stable');
+    expect(next.rooms.size).toBe(1);
+    expect(next.doors.size).toBe(1);
+    expect(next.currentRoomId).toBe('room-1');
+    expect(next.revealedRoomIds).toEqual(['room-1']);
+    expect(next.roomsCleared).toBe(2);
+  });
+});
+
+describe('mergeEntityPosition', () => {
+  it('updates position of an existing entity', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+    const newPos = create(PositionSchema, { x: 3, y: -1, z: -2 });
+
+    const next = mergeEntityPosition(prev, 'char-1', newPos);
+
+    expect(next.entities.get('char-1')?.position).toEqual(newPos);
+  });
+
+  it('preserves other fields on the updated entity', () => {
+    const snapshot = makeSnapshot({});
+    let prev = applySnapshotToState(snapshot);
+    // Seed an entity with non-position fields populated
+    const seeded = create(EntityStateSchema, {
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      currentHitPoints: 12,
+      maxHitPoints: 20,
+    });
+    prev = mergeEntityUpdates(prev, [seeded]);
+
+    const newPos = create(PositionSchema, { x: 5, y: -3, z: -2 });
+    const next = mergeEntityPosition(prev, 'char-1', newPos);
+
+    const updated = next.entities.get('char-1');
+    expect(updated?.position).toEqual(newPos);
+    expect(updated?.currentHitPoints).toBe(12);
+    expect(updated?.maxHitPoints).toBe(20);
+    expect(updated?.entityType).toBe(EntityType.CHARACTER);
+  });
+
+  it('returns prev unchanged when entity is not present', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+    const newPos = create(PositionSchema, { x: 1, y: 0, z: -1 });
+
+    const next = mergeEntityPosition(prev, 'char-missing', newPos);
+
+    // Same reference — pure no-op when entity isn't tracked
+    expect(next).toBe(prev);
+  });
+
+  it('does not mutate the previous state', () => {
+    const snapshot = makeSnapshot({
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+    });
+    const prev = applySnapshotToState(snapshot);
+    const originalEntity = prev.entities.get('char-1');
+    const newPos = create(PositionSchema, { x: 7, y: -3, z: -4 });
+
+    mergeEntityPosition(prev, 'char-1', newPos);
+
+    // Original state's entity reference unchanged
+    expect(prev.entities.get('char-1')).toBe(originalEntity);
+  });
+
+  it('does not affect rooms, doors, or combat fields', () => {
+    const snapshot = makeSnapshot({
+      encounterId: 'enc-stable',
+      entities: {
+        'char-1': { entityId: 'char-1', entityType: EntityType.CHARACTER },
+      },
+      rooms: ['room-1'],
+      doors: ['conn-1'],
+      currentRoomId: 'room-1',
+      revealedRoomIds: ['room-1'],
+      roomsCleared: 2,
+    });
+    const prev = applySnapshotToState(snapshot);
+    const newPos = create(PositionSchema, { x: 2, y: 1, z: -3 });
+
+    const next = mergeEntityPosition(prev, 'char-1', newPos);
+
+    expect(next.encounterId).toBe('enc-stable');
     expect(next.rooms.size).toBe(1);
     expect(next.doors.size).toBe(1);
     expect(next.currentRoomId).toBe('room-1');

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -9,6 +9,7 @@
  * Part of the unified entity state refactor (rpg-dnd5e-web feat-unified-entity-state).
  */
 
+import type { Position } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import type {
   CombatState,
   DoorInfo,
@@ -91,6 +92,32 @@ export function mergeEntityUpdates(
 }
 
 /**
+ * Update only the position of an entity already present in state.
+ *
+ * Used as a fallback consumer for MovementCompletedEvent when the API does
+ * not include a full updatedEntity but does include a path[] — we synthesize
+ * the position update from path[path.length-1]. Mirrors the legacy
+ * applyMonsterMovement pattern (clone-with-new-position) but writes to the
+ * unified entity store.
+ *
+ * If the entity is not present, returns prev unchanged — we don't fabricate
+ * entities from a position alone.
+ *
+ * Exported for testing.
+ */
+export function mergeEntityPosition(
+  prev: LocalEncounterState,
+  entityId: string,
+  position: Position
+): LocalEncounterState {
+  const existing = prev.entities.get(entityId);
+  if (!existing) return prev;
+  const newEntities = new Map(prev.entities);
+  newEntities.set(entityId, { ...existing, position });
+  return { ...prev, entities: newEntities };
+}
+
+/**
  * Replace combat state without touching entities or other fields.
  * Exported for testing.
  */
@@ -107,6 +134,12 @@ export interface UseEncounterStateResult {
   applySnapshot: (proto: EncounterStateData) => void;
   /** Merge entity deltas by ID without losing unaffected entities (delta event) */
   applyEntityUpdates: (updates: EntityState[]) => void;
+  /**
+   * Update only the position of an existing entity. Used as a fallback for
+   * MovementCompletedEvent when the API omits updatedEntity but sends path[].
+   * No-op if the entity is not already in state.
+   */
+  applyEntityPositionUpdate: (entityId: string, position: Position) => void;
   /** Update combat state only (turn progression events) */
   applyCombatState: (combat: CombatState) => void;
   /** Reset to empty state (new encounter or disconnect) */
@@ -130,6 +163,13 @@ export function useEncounterState(): UseEncounterStateResult {
     setState((prev) => mergeEntityUpdates(prev, updates));
   }, []);
 
+  const applyEntityPositionUpdate = useCallback(
+    (entityId: string, position: Position) => {
+      setState((prev) => mergeEntityPosition(prev, entityId, position));
+    },
+    []
+  );
+
   const applyCombatState = useCallback((combat: CombatState) => {
     setState((prev) => updateCombatState(prev, combat));
   }, []);
@@ -142,6 +182,7 @@ export function useEncounterState(): UseEncounterStateResult {
     state,
     applySnapshot,
     applyEntityUpdates,
+    applyEntityPositionUpdate,
     applyCombatState,
     reset,
   };

--- a/src/shaders/AdvancedCharacterShader.test.ts
+++ b/src/shaders/AdvancedCharacterShader.test.ts
@@ -1,0 +1,88 @@
+/**
+ * AdvancedCharacterShader instancing-support regression tests
+ *
+ * Why this test exists:
+ *
+ * `ShadedHexFloor` (Drop-in replacement for `InstancedHexTiles`) uses this
+ * shader on a `THREE.InstancedMesh` to render every revealed-room floor tile
+ * in one draw call. Three.js auto-defines `USE_INSTANCING` and provides the
+ * `instanceMatrix` attribute when a material is on an InstancedMesh, BUT it
+ * does NOT auto-rewrite a custom ShaderMaterial's `vertexShader` source —
+ * the shader has to multiply by `instanceMatrix` itself.
+ *
+ * If the multiply is missing, every instance renders at the geometry's local
+ * origin → all 18*16 = 288 hex tiles stack on top of each other at world
+ * (0,0,0) and the player only ever sees a single floor hex at the corner.
+ * That was the Wave 2 "only the (0,0,0) hex shows" bug.
+ *
+ * These tests inspect the GLSL source string. They are intentionally lo-fi:
+ * we want a hard regression guard, not a full GPU pipeline test (the latter
+ * needs a real WebGL context which vitest's jsdom env can't provide).
+ */
+
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+import { createAdvancedCharacterShader } from './AdvancedCharacterShader';
+
+function newShader(): THREE.ShaderMaterial {
+  // Minimal 1x1 texture so createSolidColorTexture-style code paths don't
+  // crash inside jsdom.
+  const data = new Uint8Array([255, 255, 255, 255]);
+  const texture = new THREE.DataTexture(data, 1, 1, THREE.RGBAFormat);
+  texture.needsUpdate = true;
+  return createAdvancedCharacterShader(texture);
+}
+
+describe('AdvancedCharacterShader instancing support', () => {
+  it('vertex shader applies instanceMatrix when USE_INSTANCING is defined', () => {
+    const material = newShader();
+    const src = material.vertexShader;
+
+    // Must reference instanceMatrix gated by USE_INSTANCING. Without this,
+    // every InstancedMesh instance renders at the geometry's local origin.
+    expect(src).toContain('USE_INSTANCING');
+    expect(src).toContain('instanceMatrix');
+    // The actual multiply that puts each instance at its own world position.
+    expect(src).toMatch(/instanceMatrix\s*\*\s*vec4\(\s*position/);
+  });
+
+  it('vertex shader passes per-instance color through a varying', () => {
+    const material = newShader();
+    const src = material.vertexShader;
+
+    // Per-tile shading variation + hover/selected/door/wall highlights flow
+    // through `instanceColor` -> `vInstanceColor` for the fragment shader.
+    expect(src).toContain('USE_INSTANCING_COLOR');
+    expect(src).toContain('varying vec3 vInstanceColor');
+    expect(src).toContain('vInstanceColor = instanceColor');
+    // Non-instanced meshes (characters, hair) must still get a sane default
+    // so the fragment shader doesn't read undefined and clobber the texture
+    // marker pipeline.
+    expect(src).toMatch(/vInstanceColor\s*=\s*vec3\(\s*1\.0\s*\)/);
+  });
+
+  it('fragment shader replaces final color with vInstanceColor when instancing color is enabled', () => {
+    const material = newShader();
+    const src = material.fragmentShader;
+
+    expect(src).toContain('varying vec3 vInstanceColor');
+    // Override is gated so character (non-instanced) rendering keeps using
+    // the texture-marker color pipeline.
+    expect(src).toMatch(
+      /#ifdef\s+USE_INSTANCING_COLOR[\s\S]+finalColor\s*=\s*vInstanceColor/
+    );
+  });
+
+  it('keeps the non-instanced (character) path intact', () => {
+    const material = newShader();
+    const vsrc = material.vertexShader;
+
+    // The non-instanced branch must still compute mvPosition and vNormal
+    // without instanceMatrix, so MediumHumanoid / CharacterHair render
+    // correctly at the mesh's own transform.
+    expect(vsrc).toMatch(
+      /#else[\s\S]+modelViewMatrix\s*\*\s*vec4\(\s*position/
+    );
+    expect(vsrc).toMatch(/#else[\s\S]+normalMatrix\s*\*\s*normal/);
+  });
+});

--- a/src/shaders/AdvancedCharacterShader.ts
+++ b/src/shaders/AdvancedCharacterShader.ts
@@ -159,16 +159,45 @@ export function createAdvancedCharacterShader(
             varying vec2 vUv;
             varying vec3 vNormal;
             varying vec3 vViewPosition;
+            varying vec3 vInstanceColor;
 
+            // NOTE on instancing:
+            // Three.js auto-defines USE_INSTANCING (and declares
+            // \`attribute mat4 instanceMatrix;\`) when this material is used on
+            // an InstancedMesh. Same for USE_INSTANCING_COLOR + instanceColor.
+            // Without the instanceMatrix multiply below, every InstancedMesh
+            // instance renders at the geometry's local origin — i.e. all
+            // floor tiles stack on top of each other at world (0,0,0). This
+            // was the "only the (0,0,0) hex shows" Wave 2 bug.
             void main() {
                 // Pass UV coordinates for texture sampling
                 vUv = uv;
 
-                // Pass normals for lighting
-                vNormal = normalize(normalMatrix * normal);
+                // Per-instance color (defaults to white when not instanced)
+                #ifdef USE_INSTANCING_COLOR
+                    vInstanceColor = instanceColor;
+                #else
+                    vInstanceColor = vec3(1.0);
+                #endif
+
+                // Apply instanceMatrix for InstancedMesh instances. For
+                // non-instanced meshes, this branch is compiled out and the
+                // standard non-instanced path runs (preserves character /
+                // hair / non-instanced wall rendering).
+                #ifdef USE_INSTANCING
+                    vec4 instancedPosition = instanceMatrix * vec4(position, 1.0);
+                    vec4 mvPosition = modelViewMatrix * instancedPosition;
+
+                    // Transform normal through instanceMatrix's rotation/scale
+                    // (mat3 strips translation). This keeps lighting correct
+                    // when instances rotate or scale individually.
+                    vNormal = normalize(normalMatrix * (mat3(instanceMatrix) * normal));
+                #else
+                    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+                    vNormal = normalize(normalMatrix * normal);
+                #endif
 
                 // Calculate view position for advanced lighting
-                vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
                 vViewPosition = -mvPosition.xyz;
 
                 // Standard vertex transformation
@@ -181,6 +210,9 @@ export function createAdvancedCharacterShader(
             varying vec2 vUv;
             varying vec3 vNormal;
             varying vec3 vViewPosition;
+            // Per-instance color, defaults to vec3(1.0) for non-instanced
+            // meshes. Used for InstancedMesh tile shading variation.
+            varying vec3 vInstanceColor;
 
             // Uniforms
             uniform sampler2D characterTexture;
@@ -334,6 +366,18 @@ export function createAdvancedCharacterShader(
                 else {
                     finalColor = texColor.rgb;
                 }
+
+                // Per-instance color override for InstancedMesh tiles. Floor
+                // tiles use a solid-color texture, so marker matching above
+                // is a no-op for them; the per-tile shading variation and
+                // hover/selected/door/wall highlights live in instanceColor.
+                // For non-instanced meshes (characters, hair, non-instanced
+                // walls), USE_INSTANCING_COLOR is undefined and this branch
+                // is compiled out, so the marker-color pipeline above is
+                // preserved unchanged.
+                #ifdef USE_INSTANCING_COLOR
+                    finalColor = vInstanceColor;
+                #endif
 
                 // === LIGHTING ===
                 vec3 lightDir = normalize(vec3(0.5, 1.0, 0.5));

--- a/src/utils/entityHelpers.test.ts
+++ b/src/utils/entityHelpers.test.ts
@@ -1,4 +1,5 @@
 import { create } from '@bufbuild/protobuf';
+import { PositionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import { ConditionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import {
@@ -12,6 +13,7 @@ import {
   hasCondition,
   isDead,
   isUnconscious,
+  mapEntitiesForRender,
 } from './entityHelpers';
 
 // Helper to create a basic monster entity
@@ -240,6 +242,104 @@ describe('entityHelpers', () => {
         },
       });
       expect(getEntityName(entity)).toBe('obstacle-1');
+    });
+  });
+
+  describe('mapEntitiesForRender', () => {
+    it('maps every entity regardless of roomId (no filter)', () => {
+      // Player in room A, monster in room B — multi-room render scenario
+      const player = create(EntityStateSchema, {
+        entityId: 'player-1',
+        entityType: EntityType.CHARACTER,
+        roomId: 'room-A',
+        position: create(PositionSchema, { x: 0, y: 0, z: 0 }),
+        currentHitPoints: 30,
+        maxHitPoints: 30,
+        activeConditions: [],
+        details: {
+          case: 'characterDetails',
+          value: {
+            name: 'Thorin',
+            race: 1,
+            characterClass: 1,
+            level: 1,
+            armorClass: 15,
+          },
+        },
+      });
+      const monsterRoomB = create(EntityStateSchema, {
+        entityId: 'monster-58b260da',
+        entityType: EntityType.MONSTER,
+        roomId: 'room-B',
+        position: create(PositionSchema, { x: 5, y: -22, z: 17 }),
+        currentHitPoints: 7,
+        maxHitPoints: 7,
+        activeConditions: [],
+        details: {
+          case: 'monsterDetails',
+          value: { name: 'Goblin', monsterType: 24, armorClass: 13 },
+        },
+      });
+
+      const result = mapEntitiesForRender([player, monsterRoomB]);
+
+      // Both entities present — the regression at BattleMapPanel.tsx:75-81
+      // would have dropped one based on currentRoomId.
+      expect(result).toHaveLength(2);
+      const ids = result.map((e) => e.entityId);
+      expect(ids).toContain('player-1');
+      expect(ids).toContain('monster-58b260da');
+    });
+
+    it('translates EntityType into display type', () => {
+      const player = makeCharacter({ entityId: 'p1' });
+      const monster = makeMonster({ entityId: 'm1' });
+      const obstacle = create(EntityStateSchema, {
+        entityId: 'o1',
+        entityType: EntityType.OBSTACLE,
+        details: {
+          case: 'obstacleDetails',
+          value: { obstacleType: 1 },
+        },
+        activeConditions: [],
+      });
+
+      const result = mapEntitiesForRender([player, monster, obstacle]);
+      const byId = new Map(result.map((e) => [e.entityId, e]));
+      expect(byId.get('p1')!.type).toBe('player');
+      expect(byId.get('m1')!.type).toBe('monster');
+      expect(byId.get('o1')!.type).toBe('obstacle');
+    });
+
+    it('marks dead monsters but keeps them in the result', () => {
+      const deadMonster = makeMonster({
+        entityId: 'm1',
+        currentHitPoints: 0,
+      });
+      const result = mapEntitiesForRender([deadMonster]);
+      expect(result).toHaveLength(1);
+      expect(result[0].isDead).toBe(true);
+    });
+
+    it('defaults missing position to {0,0,0}', () => {
+      // Construct without position — proto messages can omit optional fields
+      const entity = create(EntityStateSchema, {
+        entityId: 'no-pos',
+        entityType: EntityType.CHARACTER,
+        activeConditions: [],
+        details: {
+          case: 'characterDetails',
+          value: {
+            name: 'Ghost',
+            race: 1,
+            characterClass: 1,
+            level: 1,
+            armorClass: 10,
+          },
+        },
+      });
+      const result = mapEntitiesForRender([entity]);
+      expect(result[0].position).toEqual({ x: 0, y: 0, z: 0 });
     });
   });
 });

--- a/src/utils/entityHelpers.ts
+++ b/src/utils/entityHelpers.ts
@@ -74,6 +74,56 @@ export function getHealthCategory(entity: EntityState): HealthCategory {
 }
 
 /**
+ * Renderable shape consumed by HexGrid / BattleMapPanel.
+ * Pure data — no dependence on render state.
+ */
+export interface RenderableEntity {
+  entityId: string;
+  name: string;
+  position: { x: number; y: number; z: number };
+  type: 'player' | 'monster' | 'obstacle';
+  isDead: boolean;
+}
+
+function entityDisplayType(
+  entity: EntityState
+): 'player' | 'monster' | 'obstacle' {
+  if (entity.entityType === EntityType.CHARACTER) return 'player';
+  if (entity.entityType === EntityType.MONSTER) return 'monster';
+  return 'obstacle';
+}
+
+/**
+ * Map every EntityState in the unified encounter store into the renderable
+ * shape consumed by HexGrid. Iterates over ALL entities — does not filter by
+ * `entity.roomId`. Multi-room rendering depends on the player and monsters in
+ * other revealed rooms staying on screen even when `currentRoomId` changes.
+ *
+ * Use this for the unified-state path (preferred). The legacy
+ * `dungeonMap.entities` fallback in BattleMapPanel uses a slightly different
+ * shape (no `getEntityName`, has `deadMonsterIds` set) and is not covered here.
+ */
+export function mapEntitiesForRender(
+  entities: Iterable<EntityState>
+): RenderableEntity[] {
+  const result: RenderableEntity[] = [];
+  for (const entity of entities) {
+    result.push({
+      entityId: entity.entityId,
+      name: getEntityName(entity),
+      position: {
+        x: entity.position?.x || 0,
+        y: entity.position?.y || 0,
+        z: entity.position?.z || 0,
+      },
+      type: entityDisplayType(entity),
+      isDead: isDead(entity),
+    });
+  }
+  return result;
+}
+
+/**
  * Extracts the display name from an entity's details oneof.
  * Falls back to entityId if details are not character or monster.
  */

--- a/src/utils/movementUtils.test.ts
+++ b/src/utils/movementUtils.test.ts
@@ -1,0 +1,164 @@
+import type {
+  ActionEconomy,
+  CombatState,
+  TurnState,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MOVEMENT_FEET,
+  getMovementMax,
+  getMovementRemaining,
+  getMovementRemainingFromCombat,
+} from './movementUtils';
+
+function makeTurn(overrides: Partial<TurnState> = {}): TurnState {
+  return {
+    entityId: 'player-1',
+    movementUsed: 0,
+    movementMax: 0,
+    actionUsed: false,
+    bonusActionUsed: false,
+    reactionAvailable: true,
+    position: undefined,
+    actionEconomy: undefined,
+    $typeName: 'dnd5e.api.v1alpha1.TurnState',
+    $unknown: undefined,
+    ...overrides,
+  } as TurnState;
+}
+
+function makeActionEconomy(
+  overrides: Partial<ActionEconomy> = {}
+): ActionEconomy {
+  return {
+    movementRemaining: 30,
+    movementMax: 30,
+    attacksRemaining: 1,
+    standardActionAvailable: true,
+    bonusActionAvailable: true,
+    reactionAvailable: true,
+    offHandAttacksRemaining: 0,
+    flurryStrikesRemaining: 0,
+    $typeName: 'dnd5e.api.v1alpha1.ActionEconomy',
+    $unknown: undefined,
+    ...overrides,
+  } as ActionEconomy;
+}
+
+describe('getMovementRemaining', () => {
+  it('returns actionEconomy.movementRemaining when present', () => {
+    const turn = makeTurn({
+      actionEconomy: makeActionEconomy({ movementRemaining: 25 }),
+      // Deliberately desynced deprecated values — the canonical actionEconomy
+      // value must win. This is the Wave 2 OpenDoor regression: deprecated
+      // fields said "no movement left" while actionEconomy said "30 ft left".
+      movementMax: 30,
+      movementUsed: 30,
+    });
+    expect(getMovementRemaining(turn)).toBe(25);
+  });
+
+  it('returns 0 from actionEconomy when actionEconomy says 0', () => {
+    const turn = makeTurn({
+      actionEconomy: makeActionEconomy({ movementRemaining: 0 }),
+      movementMax: 30,
+      movementUsed: 0,
+    });
+    expect(getMovementRemaining(turn)).toBe(0);
+  });
+
+  it('returns full canonical value even when deprecated fields are zero', () => {
+    // Repro the exact Wave 2 OpenDoor symptom: api populates actionEconomy
+    // correctly but deprecated movementMax/movementUsed are both zero
+    // (because the converter sees state.MovementRemaining=0 transiently).
+    // Old code path: (0 || 30) - (0 || 0) = 30 — but other variants of the
+    // bug had movementUsed=30. This test pins the canonical-first behavior.
+    const turn = makeTurn({
+      actionEconomy: makeActionEconomy({ movementRemaining: 30 }),
+      movementMax: 30,
+      movementUsed: 30, // deprecated says "spent all 30"
+    });
+    expect(getMovementRemaining(turn)).toBe(30);
+  });
+
+  it('falls back to deprecated subtraction when actionEconomy is absent', () => {
+    const turn = makeTurn({
+      actionEconomy: undefined,
+      movementMax: 30,
+      movementUsed: 10,
+    });
+    expect(getMovementRemaining(turn)).toBe(20);
+  });
+
+  it('uses the 30ft default when movementMax is zero and actionEconomy missing', () => {
+    const turn = makeTurn({
+      actionEconomy: undefined,
+      movementMax: 0,
+      movementUsed: 0,
+    });
+    expect(getMovementRemaining(turn)).toBe(DEFAULT_MOVEMENT_FEET);
+  });
+
+  it('returns 0 when turn is null/undefined', () => {
+    expect(getMovementRemaining(null)).toBe(0);
+    expect(getMovementRemaining(undefined)).toBe(0);
+  });
+});
+
+describe('getMovementRemainingFromCombat', () => {
+  it('reads from currentTurn', () => {
+    const combat = {
+      currentTurn: makeTurn({
+        actionEconomy: makeActionEconomy({ movementRemaining: 15 }),
+      }),
+    } as CombatState;
+    expect(getMovementRemainingFromCombat(combat)).toBe(15);
+  });
+
+  it('returns 0 when combat or currentTurn is missing', () => {
+    expect(getMovementRemainingFromCombat(null)).toBe(0);
+    expect(getMovementRemainingFromCombat(undefined)).toBe(0);
+    expect(
+      getMovementRemainingFromCombat({ currentTurn: undefined } as CombatState)
+    ).toBe(0);
+  });
+});
+
+describe('getMovementMax', () => {
+  it('prefers actionEconomy.movementMax', () => {
+    const turn = makeTurn({
+      actionEconomy: makeActionEconomy({ movementMax: 60 }), // dashed
+      movementMax: 30,
+    });
+    expect(getMovementMax(turn)).toBe(60);
+  });
+
+  it('ignores actionEconomy.movementMax when zero (treats as unset)', () => {
+    const turn = makeTurn({
+      actionEconomy: makeActionEconomy({ movementMax: 0 }),
+      movementMax: 30,
+    });
+    expect(getMovementMax(turn)).toBe(30);
+  });
+
+  it('falls back to deprecated movementMax when actionEconomy missing', () => {
+    const turn = makeTurn({
+      actionEconomy: undefined,
+      movementMax: 30,
+    });
+    expect(getMovementMax(turn)).toBe(30);
+  });
+
+  it('returns the 30ft default when nothing is set', () => {
+    const turn = makeTurn({
+      actionEconomy: undefined,
+      movementMax: 0,
+    });
+    expect(getMovementMax(turn)).toBe(DEFAULT_MOVEMENT_FEET);
+  });
+
+  it('returns the default when turn is null/undefined', () => {
+    expect(getMovementMax(null)).toBe(DEFAULT_MOVEMENT_FEET);
+    expect(getMovementMax(undefined)).toBe(DEFAULT_MOVEMENT_FEET);
+  });
+});

--- a/src/utils/movementUtils.ts
+++ b/src/utils/movementUtils.ts
@@ -1,0 +1,76 @@
+/**
+ * Movement utilities — single source of truth for "feet of movement remaining
+ * this turn" on the web client.
+ *
+ * Why this helper exists
+ * ----------------------
+ * `TurnState.movementUsed` and `TurnState.movementMax` are deprecated proto
+ * fields. The api still populates them (derived from
+ * `30 - state.MovementRemaining` and a hardcoded 30), but the canonical source
+ * is `TurnState.actionEconomy.movementRemaining` — which is what the api
+ * orchestrator actually carries through across turns and across OpenDoor.
+ *
+ * The deprecated fields can desync from the canonical value. Wave 2 hit this:
+ * after OpenDoor, the api was setting `actionEconomy.movementRemaining = 30`
+ * correctly but the deprecated `movementUsed` was being computed off a
+ * different code path that read 0 from `state.MovementRemaining` (the
+ * orchestrator wrote it back as 0 transiently). Web call sites that did
+ * `(movementMax || 30) - (movementUsed || 0)` saw `30 - 30 = 0` and rendered
+ * "no movement left" — no range indicator, no pathing into the revealed room,
+ * and adjacent attacks worked but any attack requiring even a 1-hex step did
+ * not.
+ *
+ * Always read movement-remaining through this helper. Prefer
+ * `actionEconomy.movementRemaining` when present; fall back to the deprecated
+ * subtraction only when actionEconomy is absent (older snapshots, tests).
+ */
+
+import type {
+  CombatState,
+  TurnState,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+
+/** Default base movement in feet when nothing is reported. */
+export const DEFAULT_MOVEMENT_FEET = 30;
+
+/**
+ * Returns feet of movement remaining for the active turn.
+ *
+ * Resolution order:
+ *   1. `currentTurn.actionEconomy.movementRemaining` (canonical, non-deprecated)
+ *   2. `(currentTurn.movementMax || 30) - (currentTurn.movementUsed || 0)`
+ *      (deprecated subtraction, kept as fallback)
+ *   3. 0 when no `currentTurn` is present
+ */
+export function getMovementRemaining(
+  turn: TurnState | null | undefined
+): number {
+  if (!turn) return 0;
+  if (turn.actionEconomy) {
+    return turn.actionEconomy.movementRemaining;
+  }
+  const max = turn.movementMax || DEFAULT_MOVEMENT_FEET;
+  const used = turn.movementUsed || 0;
+  return max - used;
+}
+
+/** Convenience: read movement-remaining from an arbitrary CombatState shape. */
+export function getMovementRemainingFromCombat(
+  combat: CombatState | null | undefined
+): number {
+  return getMovementRemaining(combat?.currentTurn);
+}
+
+/**
+ * Returns the maximum movement budget for the active turn (used for progress
+ * bars / display, NOT for range gating). Prefers
+ * `actionEconomy.movementMax`, falls back to deprecated `movementMax`, then
+ * to the 30 ft default.
+ */
+export function getMovementMax(turn: TurnState | null | undefined): number {
+  if (!turn) return DEFAULT_MOVEMENT_FEET;
+  if (turn.actionEconomy && turn.actionEconomy.movementMax > 0) {
+    return turn.actionEconomy.movementMax;
+  }
+  return turn.movementMax || DEFAULT_MOVEMENT_FEET;
+}


### PR DESCRIPTION
## Summary

Five small fixes that surfaced during wave-2 / wave-2.5 prep work. Bundled here because they accumulated together on the same branch; the dominant theme is multi-room rendering + movement render correctness.

**Cross-room rendering (closes #385):**
- `26238ee` — fix cross-room render and pathing through open doors
- `573fa40` — render every InstancedMesh tile, iterate every revealed room

**Movement-render correctness:**
- `0d82258` — render player movement when API omits `updatedEntity` (synthesizes position from `path[]`)
- `86694de` — read movement-remaining from canonical `actionEconomy` field
- `bd6c2db` — raise movement-range and path-preview Y above floor extrusion

## Notes

- All five fixes are on the v1alpha1 movement / rendering path. They're additive — no behavior change for code paths that already worked.
- `0d82258` becomes dead code under wave-2.5 slice 2 (web stops registering `onMovementCompleted`); slice 3 cleanup will remove the orphaned handler. Landing it here keeps the v1 path correct in the meantime, which matters because slice 2 keeps v1 alive in parallel until playtest verifies v2.
- Closes the user-visible half of wave 2's cross-room rendering goal per #385's acceptance criteria.

## Test plan

- [ ] CI green (typecheck, lint, build, vitest — pre-push hook ran clean)
- [ ] Manual: open door, verify revealed rooms render with floor/walls/doors visible
- [ ] Manual: click a hex inside a newly-revealed room, verify the character paths there
- [ ] Manual: verify movement-range overlay sits above floor (no z-fighting)
- [ ] Manual: verify movement event renders correctly when API omits `updatedEntity` but sends `path[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)