### PR TITLE
feat(encounter): wave 2.5 slice 2 — consume v1alpha2 StreamEncounter + playtest harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.86",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#0443dec906644a53e31adbc0aa0efc3e0ddd0c24",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1347,7 +1347,8 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#74c83378eaf59db31e33fbf6fe5649f88c9c9891",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#0443dec906644a53e31adbc0aa0efc3e0ddd0c24",
+      "integrity": "sha512-G7FvSSpsHio23+yGvsyaQ2yPl9V8HqlSwA7w5eGi0d4J72N7MsMKKlymY91+BASn9BWtbxamv8+lmp7GthzmuQ==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,8 @@
       "devDependencies": {
         "@eslint/js": "^9.38.0",
         "@tailwindcss/postcss": "^4.1.11",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.0.13",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -59,6 +61,13 @@
       "version": "0.9.29",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.29.tgz",
       "integrity": "sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2727,11 +2736,95 @@
         "tailwindcss": "4.1.17"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3469,6 +3562,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3864,6 +3967,13 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssstyle": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.4.tgz",
@@ -3937,6 +4047,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-gpu": {
       "version": "5.0.70",
       "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
@@ -3961,6 +4081,14 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -4664,6 +4792,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5275,6 +5413,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/maath": {
       "version": "0.10.8",
       "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
@@ -5342,6 +5491,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -5701,6 +5860,47 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
@@ -5757,6 +5957,14 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-reconciler": {
       "version": "0.31.0",
@@ -5874,6 +6082,20 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-from-string": {
@@ -6174,6 +6396,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.86",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#0443dec906644a53e31adbc0aa0efc3e0ddd0c24",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "devDependencies": {
     "@eslint/js": "^9.38.0",
     "@tailwindcss/postcss": "^4.1.11",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.0.13",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,15 @@ function AppContent() {
 
   // In production, require Discord auth. In dev, allow test player
   const isDevelopment = import.meta.env.MODE === 'development';
-  const playerId = discord.user?.id || (isDevelopment ? 'test-player' : null);
+  // Dev override: ?playerId=alice|bob lets two tabs run as different players
+  // without Discord (slice 2 playtest infrastructure)
+  const devPlayerIdOverride = isDevelopment
+    ? new URLSearchParams(window.location.search).get('playerId')
+    : null;
+  const playerId =
+    discord.user?.id ||
+    devPlayerIdOverride ||
+    (isDevelopment ? 'test-player' : null);
 
   const handleCreateCharacter = async () => {
     try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { useState } from 'react';
 import { useListCharacters, useListDrafts } from './api/hooks';
+import { useDevPlayerIdAuth } from './api/useDevPlayerIdAuth';
 import './App.css';
 import { CharacterDraftProvider } from './character/creation/CharacterDraftContext';
 import { InteractiveCharacterSheet } from './character/creation/InteractiveCharacterSheet';
@@ -53,6 +54,9 @@ function AppContent() {
   const devPlayerIdOverride = isDevelopment
     ? new URLSearchParams(window.location.search).get('playerId')
     : null;
+  // Sync dev override into gRPC auth store so outbound RPCs carry the right
+  // player ID. useLayoutEffect fires before child effects, preventing races.
+  useDevPlayerIdAuth(devPlayerIdOverride);
   const playerId =
     discord.user?.id ||
     devPlayerIdOverride ||

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useCharacterDraft } from './character/creation/useCharacterDraft';
 import { CharacterSheet } from './character/sheet/CharacterSheet';
 import { CharacterCarousel, SelectedCharacterPanel } from './components/home';
 import { LobbyView } from './components/LobbyView';
+import { PlaytestHarness } from './components/playtest/PlaytestHarness';
 import { ThemeSelector } from './components/ThemeSelector';
 import { ConceptsView } from './concepts/ConceptsView';
 import { DiscordDebugPanel, useDiscord } from './discord';
@@ -20,6 +21,15 @@ type AppView =
   | 'concepts';
 
 function AppContent() {
+  // Stable gate: dev mode + encounterId URL param → render PlaytestHarness.
+  // Computed once on mount via useState initializer so route doesn't flicker.
+  // DELETE in slice 3 cleanup.
+  const [showPlaytestHarness] = useState(
+    () =>
+      import.meta.env.MODE === 'development' &&
+      !!new URLSearchParams(window.location.search).get('encounterId')
+  );
+
   const [currentView, setCurrentView] = useState<AppView>('home');
   const [showDebugPanel, setShowDebugPanel] = useState(false);
   const [currentCharacterId, setCurrentCharacterId] = useState<string | null>(
@@ -128,6 +138,14 @@ function AppContent() {
       setSelectedType(null);
     }
   };
+
+  if (showPlaytestHarness) {
+    return (
+      <div className="min-h-screen">
+        <PlaytestHarness />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,6 +4,7 @@ import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { DiceService } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/dice_pb';
 import { CharacterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { EncounterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { EncounterService as EncounterServiceV2 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 
 import { getDiscordToken, getPlayerId } from './auth';
 
@@ -84,3 +85,6 @@ export const diceClient = createClient(DiceService, transport);
 
 // Create the encounter service client
 export const encounterClient = createClient(EncounterService, transport);
+
+// Create the v1alpha2 encounter service client
+export const encounterClientV2 = createClient(EncounterServiceV2, transport);

--- a/src/api/encounterStream2Dispatch.test.ts
+++ b/src/api/encounterStream2Dispatch.test.ts
@@ -1,0 +1,82 @@
+import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  dispatchEncounterStream2Event,
+  type EncounterStream2Options,
+} from './encounterStream2Dispatch';
+
+function makeEvent<K extends string, V>(caseName: K, value: V): EncounterEvent {
+  return {
+    event: { case: caseName, value },
+    // Other EncounterEvent fields (eventId, deliveredAt) — minimal shape;
+    // tests are checking dispatch only, not full proto validity
+  } as unknown as EncounterEvent;
+}
+
+describe('dispatchEncounterStream2Event', () => {
+  it('routes snapshotDelivered to onSnapshotDelivered', () => {
+    const onSnapshotDelivered = vi.fn();
+    const options: EncounterStream2Options = { onSnapshotDelivered };
+    const event = makeEvent('snapshotDelivered', { encounter: undefined });
+    dispatchEncounterStream2Event(event, options);
+    expect(onSnapshotDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes entityMoved to onEntityMoved', () => {
+    const onEntityMoved = vi.fn();
+    const options: EncounterStream2Options = { onEntityMoved };
+    const event = makeEvent('entityMoved', {
+      entityId: 'a',
+      actualPath: [{ x: 0, y: 0, z: 0 }],
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onEntityMoved).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes geometryRevealed to onGeometryRevealed', () => {
+    const onGeometryRevealed = vi.fn();
+    const options: EncounterStream2Options = { onGeometryRevealed };
+    const event = makeEvent('geometryRevealed', { hexes: [] });
+    dispatchEncounterStream2Event(event, options);
+    expect(onGeometryRevealed).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes entityAppeared to onEntityAppeared', () => {
+    const onEntityAppeared = vi.fn();
+    const options: EncounterStream2Options = { onEntityAppeared };
+    // NOTE: v1alpha2 Entity uses `id` (not `entityId`); see types_pb.ts.
+    const event = makeEvent('entityAppeared', {
+      entity: { id: 'g', position: { x: 1, y: -1, z: 0 } },
+      reason: '',
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onEntityAppeared).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes entityDisappeared to onEntityDisappeared', () => {
+    const onEntityDisappeared = vi.fn();
+    const options: EncounterStream2Options = { onEntityDisappeared };
+    const event = makeEvent('entityDisappeared', {
+      entityId: 'g',
+      lastKnownPosition: { x: 2, y: -2, z: 0 },
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onEntityDisappeared).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning for unknown event cases without throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const event = makeEvent('someUnknownCase' as 'snapshotDelivered', {});
+    expect(() => dispatchEncounterStream2Event(event, {})).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('is a no-op when no callback is registered for the event type', () => {
+    const event = makeEvent('entityMoved', {
+      entityId: 'x',
+      actualPath: [],
+    });
+    expect(() => dispatchEncounterStream2Event(event, {})).not.toThrow();
+  });
+});

--- a/src/api/encounterStream2Dispatch.ts
+++ b/src/api/encounterStream2Dispatch.ts
@@ -1,0 +1,60 @@
+import type {
+  EncounterEvent,
+  EntityAppeared,
+  EntityDisappeared,
+  EntityMoved,
+  GeometryRevealed,
+  SnapshotDelivered,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+
+/**
+ * Per-event-type callbacks for the v1alpha2 encounter stream.
+ * Mirrors the v1 hook's options shape (one optional callback per event type).
+ *
+ * NOTE: onSnapshotDelivered is called every time the stream opens (initial
+ * connect + every reconnect). The payload's `encounter` field is empty in
+ * slice 1 — DO NOT apply it as state. Treat as a stream-up sync barrier.
+ */
+export interface EncounterStream2Options {
+  onSnapshotDelivered?: (event: SnapshotDelivered) => void;
+  onEntityMoved?: (event: EntityMoved) => void;
+  onGeometryRevealed?: (event: GeometryRevealed) => void;
+  onEntityAppeared?: (event: EntityAppeared) => void;
+  onEntityDisappeared?: (event: EntityDisappeared) => void;
+}
+
+/**
+ * Dispatches a typed v1alpha2 EncounterEvent to the appropriate callback.
+ * Pure function; no side effects beyond callback invocation + a console.warn
+ * on unknown event cases (gap to file as a toolkit/proto issue).
+ */
+export function dispatchEncounterStream2Event(
+  event: EncounterEvent,
+  options: EncounterStream2Options
+): void {
+  const payload = event.event;
+  switch (payload.case) {
+    case 'snapshotDelivered':
+      options.onSnapshotDelivered?.(payload.value);
+      break;
+    case 'entityMoved':
+      options.onEntityMoved?.(payload.value);
+      break;
+    case 'geometryRevealed':
+      options.onGeometryRevealed?.(payload.value);
+      break;
+    case 'entityAppeared':
+      options.onEntityAppeared?.(payload.value);
+      break;
+    case 'entityDisappeared':
+      options.onEntityDisappeared?.(payload.value);
+      break;
+    default:
+      // Unknown event type — toolkit/proto gap. Log + continue so the stream
+      // doesn't tear down. File as an issue if seen in playtest.
+      console.warn(
+        '[useEncounterStream2] unknown event case:',
+        (payload as { case?: string }).case
+      );
+  }
+}

--- a/src/api/encounterStream2Dispatch.ts
+++ b/src/api/encounterStream2Dispatch.ts
@@ -16,6 +16,7 @@ import type {
  * slice 1 — DO NOT apply it as state. Treat as a stream-up sync barrier.
  */
 export interface EncounterStream2Options {
+  /** slice-1: encounter field is empty; treat as connect-confirm only. */
   onSnapshotDelivered?: (event: SnapshotDelivered) => void;
   onEntityMoved?: (event: EntityMoved) => void;
   onGeometryRevealed?: (event: GeometryRevealed) => void;
@@ -50,10 +51,14 @@ export function dispatchEncounterStream2Event(
       options.onEntityDisappeared?.(payload.value);
       break;
     default:
-      // Unknown event type — toolkit/proto gap. Log + continue so the stream
-      // doesn't tear down. File as an issue if seen in playtest.
+      // Either out-of-slice-2-scope but known to the proto (entityDamaged,
+      // turnStarted, encounterEnded, etc. — the proto defines 22 event cases;
+      // slice 2 handles 5) OR a genuinely unknown case from a proto version
+      // mismatch. Either way: warn + continue so the stream doesn't tear down.
+      // Add a case arm + callback when the feature lands in a future slice.
+      // The cast strips the narrowed-to-undefined `case` so we can log it.
       console.warn(
-        '[useEncounterStream2] unknown event case:',
+        '[useEncounterStream2] unhandled event case:',
         (payload as { case?: string }).case
       );
   }

--- a/src/api/fakeEncounterStream2.ts
+++ b/src/api/fakeEncounterStream2.ts
@@ -1,0 +1,82 @@
+import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+
+/**
+ * Test helper: an async iterable that yields events from a controllable queue.
+ * Use to simulate a server-streaming gRPC response in tests without real network.
+ *
+ * Pattern:
+ *   const stream = createFakeStream();
+ *   stream.push(makeEvent('snapshotDelivered', {}));
+ *   stream.push(makeEvent('entityMoved', { ... }));
+ *   stream.close();   // signals end-of-stream
+ *   stream.error(new Error('boom'));   // simulates transport error
+ *   stream.reset();   // drop pending state for next test
+ */
+export interface FakeStream {
+  iterator: AsyncIterable<EncounterEvent>;
+  push: (event: EncounterEvent) => void;
+  close: () => void;
+  error: (err: Error) => void;
+  reset: () => void;
+}
+
+export function createFakeStream(): FakeStream {
+  let queue: EncounterEvent[] = [];
+  let closed = false;
+  let pendingError: Error | null = null;
+  let resolve: ((v: void) => void) | null = null;
+
+  const wakeup = () => {
+    if (resolve) {
+      const r = resolve;
+      resolve = null;
+      r();
+    }
+  };
+
+  const iterator: AsyncIterable<EncounterEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<EncounterEvent>> {
+          while (queue.length === 0 && !closed && !pendingError) {
+            await new Promise<void>((r) => {
+              resolve = r;
+            });
+          }
+          if (pendingError) {
+            const e = pendingError;
+            pendingError = null;
+            throw e;
+          }
+          if (queue.length > 0) {
+            return { value: queue.shift()!, done: false };
+          }
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+
+  return {
+    iterator,
+    push(event) {
+      queue.push(event);
+      wakeup();
+    },
+    close() {
+      closed = true;
+      wakeup();
+    },
+    error(err) {
+      pendingError = err;
+      wakeup();
+    },
+    reset() {
+      queue = [];
+      closed = false;
+      pendingError = null;
+      // Don't wake current waiters — they'd see done:true incorrectly.
+      // Each test should construct its own stream via vi.hoisted (see hook tests).
+    },
+  };
+}

--- a/src/api/positionConvert.test.ts
+++ b/src/api/positionConvert.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { v2PositionToV1 } from './positionConvert';
+
+describe('v2PositionToV1', () => {
+  it('converts field values from v2 to v1', () => {
+    const v2 = { x: 3, y: -2, z: -1 } as Parameters<typeof v2PositionToV1>[0];
+    const v1 = v2PositionToV1(v2);
+    expect(v1.x).toBe(3);
+    expect(v1.y).toBe(-2);
+    expect(v1.z).toBe(-1);
+  });
+
+  it('output has the v1 $typeName brand', () => {
+    const v1 = v2PositionToV1({ x: 1, y: -1, z: 0 } as Parameters<
+      typeof v2PositionToV1
+    >[0]);
+    // The bufbuild protobuf runtime sets $typeName on schema-constructed messages.
+    expect((v1 as unknown as { $typeName: string }).$typeName).toBe(
+      'api.v1alpha1.Position'
+    );
+  });
+
+  it('handles zero coordinates', () => {
+    const v1 = v2PositionToV1({ x: 0, y: 0, z: 0 } as Parameters<
+      typeof v2PositionToV1
+    >[0]);
+    expect(v1.x).toBe(0);
+    expect(v1.y).toBe(0);
+    expect(v1.z).toBe(0);
+  });
+});

--- a/src/api/positionConvert.ts
+++ b/src/api/positionConvert.ts
@@ -1,0 +1,15 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  PositionSchema,
+  type Position as V1Position,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import type { Position as V2Position } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+
+/**
+ * Converts a v1alpha2 Position to a v1alpha1 Position via schema construction
+ * so the resulting message has the correct $typeName branding for v1 consumers
+ * (encounter state reducers, equality checks). Both shapes are {x,y,z} int32.
+ */
+export function v2PositionToV1(p: V2Position): V1Position {
+  return create(PositionSchema, { x: p.x, y: p.y, z: p.z });
+}

--- a/src/api/streamReconnect.ts
+++ b/src/api/streamReconnect.ts
@@ -1,0 +1,16 @@
+/**
+ * Reconnect schedule shared by useEncounterStream (v1alpha1) and
+ * useEncounterStream2 (v1alpha2). Single source of truth — preventing
+ * drift between the two hooks.
+ *
+ * Schedule: 1s initial, 2x backoff multiplier, 30s cap, 10 max attempts.
+ * Total backoff window if all attempts fail: ~5 minutes.
+ */
+export const RECONNECT_CONFIG = {
+  initialDelayMs: 1000,
+  maxDelayMs: 30000,
+  backoffMultiplier: 2,
+  maxAttempts: 10,
+} as const;
+
+export type ReconnectConfig = typeof RECONNECT_CONFIG;

--- a/src/api/useDevPlayerIdAuth.test.ts
+++ b/src/api/useDevPlayerIdAuth.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./auth', () => ({
+  setAuth: vi.fn(),
+}));
+
+import { setAuth } from './auth';
+import { useDevPlayerIdAuth } from './useDevPlayerIdAuth';
+
+const mockSetAuth = vi.mocked(setAuth);
+
+beforeEach(() => {
+  mockSetAuth.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDevPlayerIdAuth', () => {
+  it('calls setAuth with the override when devPlayerIdOverride is provided', () => {
+    renderHook(() => useDevPlayerIdAuth('alice'));
+    expect(mockSetAuth).toHaveBeenCalledOnce();
+    expect(mockSetAuth).toHaveBeenCalledWith(null, 'alice');
+  });
+
+  it('does NOT call setAuth when devPlayerIdOverride is null', () => {
+    renderHook(() => useDevPlayerIdAuth(null));
+    expect(mockSetAuth).not.toHaveBeenCalled();
+  });
+
+  it('re-calls setAuth when override changes', () => {
+    const { rerender } = renderHook(
+      ({ override }: { override: string | null }) =>
+        useDevPlayerIdAuth(override),
+      { initialProps: { override: 'alice' as string | null } }
+    );
+    expect(mockSetAuth).toHaveBeenCalledWith(null, 'alice');
+
+    mockSetAuth.mockReset();
+    rerender({ override: 'bob' });
+    expect(mockSetAuth).toHaveBeenCalledWith(null, 'bob');
+  });
+
+  it('does NOT call setAuth when override transitions from set to null', () => {
+    const { rerender } = renderHook(
+      ({ override }: { override: string | null }) =>
+        useDevPlayerIdAuth(override),
+      { initialProps: { override: 'alice' as string | null } }
+    );
+    mockSetAuth.mockReset();
+    rerender({ override: null });
+    expect(mockSetAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/useDevPlayerIdAuth.ts
+++ b/src/api/useDevPlayerIdAuth.ts
@@ -1,0 +1,19 @@
+import { useLayoutEffect } from 'react';
+import { setAuth } from './auth';
+
+/**
+ * Syncs a dev-mode `?playerId=` URL override into the gRPC auth store so
+ * outbound RPCs are attributed to the overridden player. Without this, the
+ * auth interceptor falls back to VITE_DEV_PLAYER_ID and 2-tab dev sessions
+ * authenticate as the same player.
+ *
+ * useLayoutEffect (not useEffect) so auth is set BEFORE any child useEffect
+ * fires its first request.
+ */
+export function useDevPlayerIdAuth(devPlayerIdOverride: string | null): void {
+  useLayoutEffect(() => {
+    if (devPlayerIdOverride) {
+      setAuth(null, devPlayerIdOverride);
+    }
+  }, [devPlayerIdOverride]);
+}

--- a/src/api/useEncounterStream.ts
+++ b/src/api/useEncounterStream.ts
@@ -28,6 +28,7 @@ import {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { useEffect, useRef, useState } from 'react';
 import { encounterClient } from './client';
+import { RECONNECT_CONFIG } from './streamReconnect';
 
 type ConnectionState =
   | 'idle'
@@ -79,13 +80,6 @@ interface UseEncounterStreamResult {
   connectionState: ConnectionState;
   error: Error | null;
 }
-
-const RECONNECT_CONFIG = {
-  initialDelayMs: 1000, // Start with 1 second
-  maxDelayMs: 30000, // Cap at 30 seconds
-  backoffMultiplier: 2, // Double each attempt
-  maxAttempts: 10, // Give up after 10 attempts
-};
 
 /**
  * Dispatches an encounter event to the appropriate callback handler

--- a/src/api/useEncounterStream2.integration.test.tsx
+++ b/src/api/useEncounterStream2.integration.test.tsx
@@ -1,0 +1,245 @@
+import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEncounterState } from '../hooks/useEncounterState';
+import { hexKey, protoPositionToHex } from '../utils/hexCoord';
+import { createFakeStream, type FakeStream } from './fakeEncounterStream2';
+
+function makeEvent(caseName: string, value: unknown): EncounterEvent {
+  return { event: { case: caseName, value } } as unknown as EncounterEvent;
+}
+
+const hoisted = vi.hoisted(() => ({
+  fakeRef: { current: null as FakeStream | null },
+}));
+
+vi.mock('./client', () => ({
+  encounterClientV2: {
+    streamEncounter: vi.fn(() => hoisted.fakeRef.current!.iterator),
+  },
+}));
+
+import { useEncounterStream2 } from './useEncounterStream2';
+
+let fake: FakeStream;
+beforeEach(() => {
+  fake = createFakeStream();
+  hoisted.fakeRef.current = fake;
+});
+afterEach(() => {
+  hoisted.fakeRef.current = null;
+});
+
+/**
+ * Test harness — exactly mirrors LobbyView's v2 wiring (Task 7.3) so the
+ * integration test exercises the same callback graph the production code uses.
+ * Returns the encounter state directly for assertions.
+ */
+function useTestHarness(encounterId: string) {
+  const state = useEncounterState();
+  useEncounterStream2(encounterId, 'alice', {
+    onSnapshotDelivered: () => {
+      /* noop — payload empty in slice 1, just a sync barrier */
+    },
+    onEntityMoved: (e) => {
+      const last = e.actualPath[e.actualPath.length - 1];
+      if (last)
+        state.applyEntityPositionUpdate(
+          e.entityId,
+          last as unknown as Parameters<
+            typeof state.applyEntityPositionUpdate
+          >[1]
+        );
+    },
+    onGeometryRevealed: (e) => {
+      const positions = e.hexes
+        .map((h) => h.position)
+        .filter((p): p is NonNullable<typeof p> => p !== undefined);
+      state.applyHexRevealed(positions.map(protoPositionToHex));
+    },
+    onEntityAppeared: (e) => {
+      if (!e.entity || !e.entity.position) return;
+      // v1alpha2 Entity.id ↔ v1 EntityState.entityId; minimal stub for slice 2
+      const stub = {
+        entityId: e.entity.id,
+        position: e.entity.position,
+      } as unknown as EntityState;
+      state.applyEntityAppeared(stub);
+    },
+    onEntityDisappeared: (e) => {
+      if (e.lastKnownPosition) {
+        state.applyEntityDisappeared(
+          e.entityId,
+          protoPositionToHex(e.lastKnownPosition)
+        );
+      }
+    },
+  });
+  return state.state;
+}
+
+describe('useEncounterStream2 + useEncounterState — integration', () => {
+  it('EntityMoved teleports the entity to last hex of actual_path', async () => {
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    // Stream up
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+
+    // Seed alice via EntityAppeared so subsequent move has a target
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: { id: 'alice', position: { x: 0, y: 0, z: 0 }, reason: '' },
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.entities.has('alice')).toBe(true);
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('entityMoved', {
+          entityId: 'alice',
+          actualPath: [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: -1, z: 0 },
+            { x: 2, y: -2, z: 0 },
+          ],
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.entities.get('alice')?.position).toEqual({
+        x: 2,
+        y: -2,
+        z: 0,
+      });
+    });
+  });
+
+  it('EntityDisappeared marks ghost and updates position to last_known', async () => {
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: { id: 'goblin', position: { x: 1, y: -1, z: 0 } },
+        })
+      )
+    );
+    act(() =>
+      fake.push(
+        makeEvent('entityDisappeared', {
+          entityId: 'goblin',
+          lastKnownPosition: { x: 3, y: -2, z: -1 },
+        })
+      )
+    );
+
+    await waitFor(() => {
+      const g = result.current.entities.get('goblin');
+      expect(g?.ghost).toBe(true);
+      // applyEntityDisappeared uses create(PositionSchema) which adds $typeName;
+      // individual field assertions avoid proto-branding false negatives.
+      expect(g?.position?.x).toBe(3);
+      expect(g?.position?.y).toBe(-2);
+      expect(g?.position?.z).toBe(-1);
+    });
+  });
+
+  it('GeometryRevealed adds to revealedHexes set', async () => {
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    // GeometryRevealed.hexes is Hex[]; each Hex wraps a Position via .position.
+    act(() =>
+      fake.push(
+        makeEvent('geometryRevealed', {
+          hexes: [
+            { position: { x: 5, y: -3, z: -2 }, terrain: 0 },
+            { position: { x: 6, y: -3, z: -3 }, terrain: 0 },
+          ],
+          walls: [],
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.revealedHexes.has(hexKey({ q: 5, r: -3, s: -2 }))
+      ).toBe(true);
+      expect(
+        result.current.revealedHexes.has(hexKey({ q: 6, r: -3, s: -3 }))
+      ).toBe(true);
+    });
+  });
+
+  it('appear → move → disappear → appear sequence settles cleanly', async () => {
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: { id: 'mover', position: { x: 0, y: 0, z: 0 } },
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.entities.get('mover')?.ghost).toBeFalsy();
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('entityMoved', {
+          entityId: 'mover',
+          actualPath: [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: -1, z: 0 },
+          ],
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.entities.get('mover')?.position).toEqual({
+        x: 1,
+        y: -1,
+        z: 0,
+      });
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('entityDisappeared', {
+          entityId: 'mover',
+          lastKnownPosition: { x: 2, y: -1, z: -1 },
+        })
+      )
+    );
+    await waitFor(() => {
+      const m = result.current.entities.get('mover');
+      expect(m?.ghost).toBe(true);
+      // applyEntityDisappeared uses create(PositionSchema) which adds $typeName;
+      // individual field assertions avoid proto-branding false negatives.
+      expect(m?.position?.x).toBe(2);
+      expect(m?.position?.y).toBe(-1);
+      expect(m?.position?.z).toBe(-1);
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: { id: 'mover', position: { x: 5, y: -3, z: -2 } },
+        })
+      )
+    );
+    await waitFor(() => {
+      const m = result.current.entities.get('mover');
+      expect(m?.ghost).toBeFalsy();
+      expect(m?.position).toEqual({ x: 5, y: -3, z: -2 });
+    });
+  });
+});

--- a/src/api/useEncounterStream2.integration.test.tsx
+++ b/src/api/useEncounterStream2.integration.test.tsx
@@ -1,10 +1,13 @@
-import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { create } from '@bufbuild/protobuf';
+import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEncounterState } from '../hooks/useEncounterState';
 import { hexKey, protoPositionToHex } from '../utils/hexCoord';
 import { createFakeStream, type FakeStream } from './fakeEncounterStream2';
+import { v2PositionToV1 } from './positionConvert';
 
 function makeEvent(caseName: string, value: unknown): EncounterEvent {
   return { event: { case: caseName, value } } as unknown as EncounterEvent;
@@ -44,16 +47,8 @@ function useTestHarness(encounterId: string) {
     },
     onEntityMoved: (e) => {
       const last = e.actualPath[e.actualPath.length - 1];
-      // v2 Position and v1 Position are both {x,y,z} structs but different
-      // TS brands. Double-cast through unknown to satisfy the type checker.
-      // Mirrors LobbyView's wiring at the equivalent dispatch site.
       if (last)
-        state.applyEntityPositionUpdate(
-          e.entityId,
-          last as unknown as Parameters<
-            typeof state.applyEntityPositionUpdate
-          >[1]
-        );
+        state.applyEntityPositionUpdate(e.entityId, v2PositionToV1(last));
     },
     onGeometryRevealed: (e) => {
       const positions = e.hexes
@@ -63,11 +58,11 @@ function useTestHarness(encounterId: string) {
     },
     onEntityAppeared: (e) => {
       if (!e.entity || !e.entity.position) return;
-      // v1alpha2 Entity.id ↔ v1 EntityState.entityId; minimal stub for slice 2
-      const stub = {
+      const stub = create(EntityStateSchema, {
         entityId: e.entity.id,
-        position: e.entity.position,
-      } as unknown as EntityState;
+        position: v2PositionToV1(e.entity.position),
+        entityType: EntityType.UNSPECIFIED,
+      });
       state.applyEntityAppeared(stub);
     },
     onEntityDisappeared: (e) => {
@@ -114,11 +109,12 @@ describe('useEncounterStream2 + useEncounterState — integration', () => {
       )
     );
     await waitFor(() => {
-      expect(result.current.entities.get('alice')?.position).toEqual({
-        x: 2,
-        y: -2,
-        z: 0,
-      });
+      // v2PositionToV1 uses create(PositionSchema) which adds $typeName;
+      // individual field assertions avoid proto-branding false negatives.
+      const pos = result.current.entities.get('alice')?.position;
+      expect(pos?.x).toBe(2);
+      expect(pos?.y).toBe(-2);
+      expect(pos?.z).toBe(0);
     });
   });
 
@@ -207,11 +203,12 @@ describe('useEncounterStream2 + useEncounterState — integration', () => {
       )
     );
     await waitFor(() => {
-      expect(result.current.entities.get('mover')?.position).toEqual({
-        x: 1,
-        y: -1,
-        z: 0,
-      });
+      // v2PositionToV1 uses create(PositionSchema) which adds $typeName;
+      // individual field assertions avoid proto-branding false negatives.
+      const pos = result.current.entities.get('mover')?.position;
+      expect(pos?.x).toBe(1);
+      expect(pos?.y).toBe(-1);
+      expect(pos?.z).toBe(0);
     });
 
     act(() =>
@@ -242,7 +239,11 @@ describe('useEncounterStream2 + useEncounterState — integration', () => {
     await waitFor(() => {
       const m = result.current.entities.get('mover');
       expect(m?.ghost).toBeFalsy();
-      expect(m?.position).toEqual({ x: 5, y: -3, z: -2 });
+      // v2PositionToV1 uses create(PositionSchema) which adds $typeName;
+      // individual field assertions avoid proto-branding false negatives.
+      expect(m?.position?.x).toBe(5);
+      expect(m?.position?.y).toBe(-3);
+      expect(m?.position?.z).toBe(-2);
     });
   });
 });

--- a/src/api/useEncounterStream2.integration.test.tsx
+++ b/src/api/useEncounterStream2.integration.test.tsx
@@ -44,6 +44,9 @@ function useTestHarness(encounterId: string) {
     },
     onEntityMoved: (e) => {
       const last = e.actualPath[e.actualPath.length - 1];
+      // v2 Position and v1 Position are both {x,y,z} structs but different
+      // TS brands. Double-cast through unknown to satisfy the type checker.
+      // Mirrors LobbyView's wiring at the equivalent dispatch site.
       if (last)
         state.applyEntityPositionUpdate(
           e.entityId,

--- a/src/api/useEncounterStream2.test.ts
+++ b/src/api/useEncounterStream2.test.ts
@@ -1,0 +1,164 @@
+import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFakeStream, type FakeStream } from './fakeEncounterStream2';
+
+function makeEvent(caseName: string, value: unknown): EncounterEvent {
+  return { event: { case: caseName, value } } as unknown as EncounterEvent;
+}
+
+// vi.hoisted allows the mock factory to use these refs even though hoisting
+// runs the factory before regular imports. The wrapper object is mutable so
+// beforeEach can swap the underlying stream.
+const hoisted = vi.hoisted(() => {
+  return {
+    fakeRef: { current: null as FakeStream | null },
+  };
+});
+
+vi.mock('./client', () => {
+  return {
+    encounterClientV2: {
+      streamEncounter: vi.fn(() => {
+        if (!hoisted.fakeRef.current) {
+          throw new Error(
+            'fakeRef.current is null — test forgot to set it in beforeEach'
+          );
+        }
+        return hoisted.fakeRef.current.iterator;
+      }),
+    },
+  };
+});
+
+// Import the hook AFTER vi.mock so the mock is applied
+import { useEncounterStream2 } from './useEncounterStream2';
+
+let fake: FakeStream;
+
+beforeEach(() => {
+  fake = createFakeStream();
+  hoisted.fakeRef.current = fake;
+});
+
+afterEach(() => {
+  hoisted.fakeRef.current = null;
+});
+
+describe('useEncounterStream2', () => {
+  it('transitions to connected after the first SnapshotDelivered', async () => {
+    const onSnapshotDelivered = vi.fn();
+    const { result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', { onSnapshotDelivered })
+    );
+
+    expect(result.current.connectionState).toBe('connecting');
+
+    act(() => {
+      fake.push(makeEvent('snapshotDelivered', { encounter: undefined }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.connectionState).toBe('connected');
+    });
+    expect(onSnapshotDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches subsequent events through their typed callbacks', async () => {
+    const onEntityMoved = vi.fn();
+    const { result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', { onEntityMoved })
+    );
+
+    act(() => {
+      fake.push(makeEvent('snapshotDelivered', {}));
+    });
+    await waitFor(() =>
+      expect(result.current.connectionState).toBe('connected')
+    );
+
+    act(() => {
+      fake.push(
+        makeEvent('entityMoved', {
+          entityId: 'alice',
+          actualPath: [{ x: 0, y: 0, z: 0 }],
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(onEntityMoved).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not transition to connected before SnapshotDelivered arrives', async () => {
+    const { result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', {})
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.connectionState).toBe('connecting');
+  });
+
+  it('logs and continues on unknown event cases (no tear-down)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onEntityMoved = vi.fn();
+    const { result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', { onEntityMoved })
+    );
+
+    act(() => {
+      fake.push(makeEvent('snapshotDelivered', {}));
+      fake.push(makeEvent('totallyUnknownCase', {}));
+      fake.push(makeEvent('entityMoved', { entityId: 'a', actualPath: [] }));
+    });
+
+    await waitFor(() => {
+      expect(onEntityMoved).toHaveBeenCalledTimes(1);
+      expect(result.current.connectionState).toBe('connected');
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('aborts cleanly on unmount', () => {
+    const { unmount, result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', {})
+    );
+    expect(result.current.connectionState).toBe('connecting');
+    unmount();
+  });
+
+  it('handles encounterId === null by staying idle', () => {
+    const { result } = renderHook(() => useEncounterStream2(null, 'alice', {}));
+    expect(result.current.connectionState).toBe('idle');
+  });
+
+  it('reconnects with exponential backoff on stream error', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', {})
+    );
+
+    act(() => {
+      fake.push(makeEvent('snapshotDelivered', {}));
+    });
+    await vi.waitFor(() =>
+      expect(result.current.connectionState).toBe('connected')
+    );
+
+    act(() => {
+      fake.error(new Error('connection lost'));
+    });
+    await vi.waitFor(() =>
+      expect(result.current.connectionState).toBe('disconnected')
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await vi.waitFor(() =>
+      expect(result.current.connectionState).toBe('connecting')
+    );
+
+    vi.useRealTimers();
+  });
+});

--- a/src/api/useEncounterStream2.test.ts
+++ b/src/api/useEncounterStream2.test.ts
@@ -43,6 +43,9 @@ beforeEach(() => {
 
 afterEach(() => {
   hoisted.fakeRef.current = null;
+  // Defensive: ensure fake timers don't bleed into the next test if the
+  // reconnect test fails before reaching its inline vi.useRealTimers() call.
+  vi.useRealTimers();
 });
 
 describe('useEncounterStream2', () => {
@@ -133,6 +136,11 @@ describe('useEncounterStream2', () => {
   });
 
   it('reconnects with exponential backoff on stream error', async () => {
+    // Known: act() warnings appear here because fake.error() and
+    // vi.advanceTimersByTime() wake microtasks that scheduleReconnect/connect
+    // run on. The async setConnectionState calls escape the synchronous act()
+    // boundary; vi.waitFor compensates. This is a known rough edge in the
+    // React Testing Library + Vitest fake-timers combination, not a test bug.
     vi.useFakeTimers();
     const { result } = renderHook(() =>
       useEncounterStream2('enc-1', 'alice', {})

--- a/src/api/useEncounterStream2.ts
+++ b/src/api/useEncounterStream2.ts
@@ -1,0 +1,130 @@
+import { create } from '@bufbuild/protobuf';
+import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { StreamEncounterRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { useEffect, useRef, useState } from 'react';
+import { encounterClientV2 } from './client';
+import {
+  dispatchEncounterStream2Event,
+  type EncounterStream2Options,
+} from './encounterStream2Dispatch';
+import { RECONNECT_CONFIG } from './streamReconnect';
+
+type ConnectionState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'error';
+
+interface UseEncounterStream2Result {
+  connectionState: ConnectionState;
+  error: Error | null;
+}
+
+/**
+ * Subscribes to the v1alpha2 StreamEncounter RPC. Sibling of useEncounterStream
+ * (v1alpha1) — runs in parallel for slice 2; v1 still owns lobby/combat events.
+ *
+ * Lifecycle:
+ *   1. encounterId set → open stream, state='connecting'
+ *   2. First message MUST be SnapshotDelivered → state='connected', fire callback
+ *   3. Subsequent events dispatched via encounterStream2Dispatch
+ *   4. Stream end / error → state='disconnected' → exponential backoff reconnect
+ *
+ * Slice 1 contract: SnapshotDelivered.encounter is empty. The hook acknowledges
+ * the message (transitions to 'connected') but does NOT apply payload as state.
+ * Treat as a stream-up sync barrier.
+ *
+ * Reconnect: shared RECONNECT_CONFIG with v1 hook (1s → 30s, 10 attempts).
+ */
+export function useEncounterStream2(
+  encounterId: string | null,
+  playerId: string,
+  options: EncounterStream2Options
+): UseEncounterStream2Result {
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>('idle');
+  const [error, setError] = useState<Error | null>(null);
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const retryCountRef = useRef(0);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const abortControllerRef = useRef<AbortController | undefined>(undefined);
+
+  useEffect(() => {
+    if (!encounterId) {
+      setConnectionState('idle');
+      return;
+    }
+
+    const scheduleReconnect = () => {
+      if (retryCountRef.current >= RECONNECT_CONFIG.maxAttempts) {
+        setConnectionState('error');
+        setError(new Error('Max reconnection attempts reached'));
+        return;
+      }
+      setConnectionState('disconnected');
+      const delay = Math.min(
+        RECONNECT_CONFIG.initialDelayMs *
+          Math.pow(RECONNECT_CONFIG.backoffMultiplier, retryCountRef.current),
+        RECONNECT_CONFIG.maxDelayMs
+      );
+      retryCountRef.current++;
+      retryTimeoutRef.current = setTimeout(connect, delay);
+    };
+
+    const connect = async () => {
+      setConnectionState('connecting');
+      setError(null);
+      abortControllerRef.current = new AbortController();
+
+      try {
+        const request = create(StreamEncounterRequestSchema, {
+          encounterId,
+          playerId,
+        });
+        const stream = encounterClientV2.streamEncounter(request, {
+          signal: abortControllerRef.current.signal,
+        });
+
+        let sawFirstSnapshot = false;
+        for await (const event of stream as AsyncIterable<EncounterEvent>) {
+          if (!sawFirstSnapshot) {
+            // Broker contract: first message is always SnapshotDelivered. We
+            // don't validate the case here — a violation is a server-side bug
+            // that the playtest will surface via missing snapshot effects.
+            // Loose handling matches v1's tolerance.
+            dispatchEncounterStream2Event(event, optionsRef.current);
+            sawFirstSnapshot = true;
+            setConnectionState('connected');
+            retryCountRef.current = 0;
+            continue;
+          }
+          dispatchEncounterStream2Event(event, optionsRef.current);
+        }
+
+        // Stream closed by server — schedule reconnect
+        scheduleReconnect();
+      } catch (err) {
+        if (abortControllerRef.current?.signal.aborted) {
+          return; // intentional abort, not an error
+        }
+        console.error('[useEncounterStream2] stream error:', err);
+        scheduleReconnect();
+      }
+    };
+
+    connect();
+
+    return () => {
+      abortControllerRef.current?.abort();
+      clearTimeout(retryTimeoutRef.current);
+    };
+  }, [encounterId, playerId]);
+
+  return { connectionState, error };
+}

--- a/src/api/useMoveEntityV2.test.ts
+++ b/src/api/useMoveEntityV2.test.ts
@@ -45,13 +45,17 @@ describe('useMoveEntityV2', () => {
     expect(response).toBe(fakeResponse);
     expect(hoisted.moveEntityFn).toHaveBeenCalledOnce();
 
-    const [req] = hoisted.moveEntityFn.mock.calls[0];
-    expect(req.encounterId).toBe('enc-1');
-    expect(req.entityId).toBe('char-alice');
-    expect(req.proposedPath).toHaveLength(3);
-    expect(req.proposedPath[0]).toMatchObject({ x: 0, y: 0, z: 0 });
-    expect(req.proposedPath[1]).toMatchObject({ x: 1, y: -1, z: 0 });
-    expect(req.proposedPath[2]).toMatchObject({ x: 2, y: -2, z: 0 });
+    expect(hoisted.moveEntityFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        proposedPath: [
+          expect.objectContaining({ x: 0, y: 0, z: 0 }),
+          expect.objectContaining({ x: 1, y: -1, z: 0 }),
+          expect.objectContaining({ x: 2, y: -2, z: 0 }),
+        ],
+      })
+    );
   });
 
   it('sets loading=true during the call and false after success', async () => {

--- a/src/api/useMoveEntityV2.test.ts
+++ b/src/api/useMoveEntityV2.test.ts
@@ -1,0 +1,117 @@
+import type { MoveEntityResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted lets us reference these before imports are evaluated
+const hoisted = vi.hoisted(() => ({
+  moveEntityFn: vi.fn<() => Promise<MoveEntityResponse>>(),
+}));
+
+vi.mock('./client', () => ({
+  encounterClientV2: {
+    moveEntity: hoisted.moveEntityFn,
+  },
+}));
+
+// Import AFTER vi.mock so the mock is applied
+import { useMoveEntityV2 } from './useMoveEntityV2';
+
+beforeEach(() => {
+  hoisted.moveEntityFn.mockReset();
+});
+
+describe('useMoveEntityV2', () => {
+  it('starts with loading=false and no error', () => {
+    const { result } = renderHook(() => useMoveEntityV2());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls encounterClientV2.moveEntity with correct request shape', async () => {
+    const fakeResponse = {} as MoveEntityResponse;
+    hoisted.moveEntityFn.mockResolvedValue(fakeResponse);
+
+    const { result } = renderHook(() => useMoveEntityV2());
+
+    let response: MoveEntityResponse | undefined;
+    await act(async () => {
+      response = await result.current.moveEntity('enc-1', 'char-alice', [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+        { x: 2, y: -2, z: 0 },
+      ]);
+    });
+
+    expect(response).toBe(fakeResponse);
+    expect(hoisted.moveEntityFn).toHaveBeenCalledOnce();
+
+    const [req] = hoisted.moveEntityFn.mock.calls[0];
+    expect(req.encounterId).toBe('enc-1');
+    expect(req.entityId).toBe('char-alice');
+    expect(req.proposedPath).toHaveLength(3);
+    expect(req.proposedPath[0]).toMatchObject({ x: 0, y: 0, z: 0 });
+    expect(req.proposedPath[1]).toMatchObject({ x: 1, y: -1, z: 0 });
+    expect(req.proposedPath[2]).toMatchObject({ x: 2, y: -2, z: 0 });
+  });
+
+  it('sets loading=true during the call and false after success', async () => {
+    let resolveRpc!: (v: MoveEntityResponse) => void;
+    const pendingRpc = new Promise<MoveEntityResponse>(
+      (resolve) => (resolveRpc = resolve)
+    );
+    hoisted.moveEntityFn.mockReturnValue(pendingRpc);
+
+    const { result } = renderHook(() => useMoveEntityV2());
+
+    // Kick off the move without awaiting
+    act(() => {
+      void result.current.moveEntity('enc-1', 'char-alice', []);
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Resolve the RPC
+    act(() => resolveRpc({} as MoveEntityResponse));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('sets error on RPC failure, loading=false, and promise rejects', async () => {
+    const rpcError = new Error('transport error');
+    hoisted.moveEntityFn.mockRejectedValue(rpcError);
+
+    const { result } = renderHook(() => useMoveEntityV2());
+
+    await act(async () => {
+      await expect(
+        result.current.moveEntity('enc-1', 'char-alice', [])
+      ).rejects.toThrow('transport error');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(rpcError);
+  });
+
+  it('clears error on subsequent successful call', async () => {
+    hoisted.moveEntityFn
+      .mockRejectedValueOnce(new Error('first fail'))
+      .mockResolvedValue({} as MoveEntityResponse);
+
+    const { result } = renderHook(() => useMoveEntityV2());
+
+    // First call fails
+    await act(async () => {
+      await expect(
+        result.current.moveEntity('enc-1', 'char-alice', [])
+      ).rejects.toThrow('first fail');
+    });
+    expect(result.current.error).not.toBeNull();
+
+    // Second call succeeds
+    await act(async () => {
+      await result.current.moveEntity('enc-1', 'char-alice', []);
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/api/useMoveEntityV2.ts
+++ b/src/api/useMoveEntityV2.ts
@@ -1,0 +1,75 @@
+import { create } from '@bufbuild/protobuf';
+import type { MoveEntityResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { MoveEntityRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import {
+  PositionSchema,
+  type Position,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { useCallback, useState } from 'react';
+import { encounterClientV2 } from './client';
+
+/** Plain {x,y,z} accepted by useMoveEntityV2 — hook constructs the proto Position internally. */
+export interface PlainPosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface UseMoveEntityV2Result {
+  moveEntity: (
+    encounterId: string,
+    entityId: string,
+    path: PlainPosition[]
+  ) => Promise<MoveEntityResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Thin wrapper around the v1alpha2 MoveEntity unary RPC.
+ * Accepts plain {x,y,z} objects; constructs proto Positions internally.
+ *
+ * - loading=true while the RPC is in-flight, false on resolve/reject
+ * - error is set on failure, cleared on the next successful call
+ * - The returned promise rejects on RPC error so callers can surface it
+ */
+export function useMoveEntityV2(): UseMoveEntityV2Result {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const moveEntity = useCallback(
+    async (
+      encounterId: string,
+      entityId: string,
+      path: PlainPosition[]
+    ): Promise<MoveEntityResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const proposedPath: Position[] = path.map((p) =>
+        create(PositionSchema, { x: p.x, y: p.y, z: p.z })
+      );
+
+      const request = create(MoveEntityRequestSchema, {
+        encounterId,
+        entityId,
+        proposedPath,
+      });
+
+      try {
+        const response = await encounterClientV2.moveEntity(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('MoveEntity RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { moveEntity, loading, error };
+}

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -2413,6 +2413,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
                 availableCharacters={availableCharacters}
                 allPartyCharacters={Array.from(fullCharactersMap.values())}
                 encounterEntities={encounterState.entities}
+                revealedHexes={encounterState.revealedHexes}
                 onEntityClick={handleEntityClick}
                 onCellClick={handleCellClick}
                 encounterId={encounterId}

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -276,7 +276,15 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   const { addToast } = useToast();
   const discord = useDiscord();
   const isDevelopment = import.meta.env.MODE === 'development';
-  const playerId = discord.user?.id || (isDevelopment ? 'test-player' : '');
+  // Dev override: ?playerId=alice|bob lets two tabs run as different players
+  // without Discord (slice 2 playtest infrastructure)
+  const devPlayerIdOverride = isDevelopment
+    ? new URLSearchParams(window.location.search).get('playerId')
+    : null;
+  const playerId =
+    discord.user?.id ||
+    devPlayerIdOverride ||
+    (isDevelopment ? 'test-player' : '');
 
   // Fetch user's characters
   const { data: allCharacters = [], loading: charactersLoading } =

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -33,9 +33,11 @@ import {
   monsterTurnsToLogEntries,
 } from '@/utils/monsterTurnUtils';
 import { getMovementRemainingFromCombat } from '@/utils/movementUtils';
+import { create } from '@bufbuild/protobuf';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import {
   EncounterEndReason,
+  EntityStateSchema,
   type ActionExecutedEvent,
   type AttackResolvedEvent,
   type AvailableAbility,
@@ -53,10 +55,8 @@ import {
   type MonsterCombatState,
   type MonsterTurnCompletedEvent,
   type MonsterTurnResult,
-  type MovementCompletedEvent,
   type PlayerJoinedEvent,
   type Room,
-  type RoomRevealedEvent,
   type TurnEndedEvent,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import {
@@ -71,6 +71,8 @@ import {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { ArrowLeft } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { v2PositionToV1 } from '../api/positionConvert';
+import { useDevPlayerIdAuth } from '../api/useDevPlayerIdAuth';
 import { useEncounterStream2 } from '../api/useEncounterStream2';
 import { protoPositionToHex } from '../utils/hexCoord';
 import { CombatPanel, type CombatLogEntry } from './combat-v2';
@@ -281,6 +283,9 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   const devPlayerIdOverride = isDevelopment
     ? new URLSearchParams(window.location.search).get('playerId')
     : null;
+  // Sync dev override into gRPC auth store so outbound RPCs carry the right
+  // player ID. useLayoutEffect fires before child effects, preventing races.
+  useDevPlayerIdAuth(devPlayerIdOverride);
   const playerId =
     discord.user?.id ||
     devPlayerIdOverride ||
@@ -331,7 +336,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
 
   // Dungeon/door state
   const [dungeonId, setDungeonId] = useState<string | null>(null);
-  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [isTransitioning] = useState(false); // TODO slice 3: remove with v1 RoomRevealed handler
   const [roomsCleared, setRoomsCleared] = useState(0);
   const [dungeonResult, setDungeonResult] = useState<
     'victory' | 'failure' | null
@@ -393,69 +398,6 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   const playerName = discord.user?.username || 'Player';
 
   // Dungeon stream event handlers
-  // @ts-expect-error TS6133 -- slice 3 will remove this handler when v1 RoomRevealed is dropped
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for slice 3 removal
-  const handleRoomRevealed = useCallback(
-    (event: RoomRevealedEvent) => {
-      console.log('🚪 RoomRevealed event received:', {
-        connectionId: event.connectionId,
-        currentRoomId: event.encounterStateData?.currentRoomId,
-        roomCount: event.encounterStateData
-          ? Object.keys(event.encounterStateData.rooms).length
-          : 0,
-        revealedRoomIds: event.encounterStateData?.revealedRoomIds,
-        entityCount: event.encounterStateData
-          ? Object.keys(event.encounterStateData.entities).length
-          : 0,
-      });
-
-      // Trigger fade transition
-      setIsTransitioning(true);
-
-      setTimeout(() => {
-        // --- New path: populate unified encounter state ---
-        if (event.encounterStateData) {
-          applySnapshot(event.encounterStateData);
-
-          // --- Legacy path: build Room/CombatState from encounterStateData ---
-          // Iterate every revealed room so the freshly-revealed room's floor
-          // tiles get generated. `data.currentRoomId` still points at the
-          // player's current room here — the revealed room only exists in
-          // `data.rooms`. See roomsFromEncounterState for full reasoning.
-          const doors = doorsFromEncounterState(event.encounterStateData);
-          for (const legacyRoom of roomsFromEncounterState(
-            event.encounterStateData
-          )) {
-            addRoomToMap(legacyRoom, doors);
-          }
-          setCombatState(event.encounterStateData.combat ?? null);
-          setRoomsCleared(event.encounterStateData.roomsCleared);
-
-          // Update monsters from encounter state (for monsterType texture selection)
-          setMonsters(monstersFromEncounterState(event.encounterStateData));
-
-          // Select the current turn entity
-          if (event.encounterStateData.combat?.currentTurn?.entityId) {
-            setSelectedEntity(
-              event.encounterStateData.combat.currentTurn.entityId
-            );
-          }
-        }
-
-        // Clear movement state for new room
-        setMovementMode(false);
-        setMovementPath([]);
-        setAttackTarget(null);
-        // Reset two-level action economy for new room
-        setAvailableAbilities([]);
-        setAvailableActions([]);
-
-        // End fade
-        setIsTransitioning(false);
-      }, 300);
-    },
-    [addRoomToMap, applySnapshot]
-  );
 
   const handleDungeonVictory = useCallback(
     (event: DungeonVictoryEvent) => {
@@ -707,54 +649,6 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       }
     },
     [applyEntityUpdates, applyEncounterCombatState]
-  );
-
-  // Multiplayer sync: Movement completed - sync entity positions and movement resources
-  // @ts-expect-error TS6133 -- slice 3 will remove this handler when v1 MovementCompleted is dropped
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for slice 3 removal
-  const handleMovementCompleted = useCallback(
-    (event: MovementCompletedEvent) => {
-      // [wave2-debug] Surface what the api carried for movement budget so we
-      // can confirm `actionEconomy.movementRemaining` arrived non-zero.
-      // Reading through the deprecated subtraction was the Wave 2 OpenDoor
-      // regression — log both so divergences are obvious in the console.
-      const ae = event.combatState?.currentTurn?.actionEconomy;
-      const dep = event.combatState?.currentTurn;
-      console.log('🚶 MovementCompleted event received:', {
-        entityId: event.entityId,
-        pathLen: event.path.length,
-        hasUpdatedEntity: !!event.updatedEntity,
-        movementRemaining_canonical: ae?.movementRemaining,
-        movementMax_canonical: ae?.movementMax,
-        movementUsed_deprecated: dep?.movementUsed,
-        movementMax_deprecated: dep?.movementMax,
-        currentTurnEntityId: dep?.entityId,
-      });
-
-      // --- New path: populate unified encounter state ---
-      if (event.updatedEntity) {
-        // Preferred: API sent a full entity snapshot. Use it as-is.
-        applyEntityUpdates([event.updatedEntity]);
-      } else if (event.entityId && event.path.length > 0) {
-        // Fallback: API sent only a path (e.g. player moves currently omit
-        // updatedEntity — see rpg-api fix/cross-room-state-wave2). Mirror the
-        // applyMonsterMovement pattern: use the final path coordinate as the
-        // new position for the existing entity. No-op if the entity is not
-        // already in encounter state.
-        const finalPosition = event.path[event.path.length - 1];
-        if (finalPosition) {
-          applyEntityPositionUpdate(event.entityId, finalPosition);
-        }
-      }
-      if (event.combatState) applyEncounterCombatState(event.combatState);
-
-      // --- Legacy path ---
-      // Sync combat state (includes updated movement resources)
-      if (event.combatState) {
-        setCombatState(event.combatState);
-      }
-    },
-    [applyEntityUpdates, applyEntityPositionUpdate, applyEncounterCombatState]
   );
 
   // Multiplayer sync: Feature activated - sync feature usage
@@ -1228,12 +1122,7 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       // Teleport-to-final per spec; ignore intermediate path hexes in slice 2
       const last = event.actualPath[event.actualPath.length - 1];
       if (!last) return;
-      // v2 Position and v1 Position are both {x,y,z} structs but different
-      // TS brands. Double-cast through unknown to satisfy the type checker.
-      applyEntityPositionUpdate(
-        event.entityId,
-        last as unknown as Parameters<typeof applyEntityPositionUpdate>[1]
-      );
+      applyEntityPositionUpdate(event.entityId, v2PositionToV1(last));
     },
     onGeometryRevealed: (event) => {
       // GeometryRevealed.hexes is Hex[]; each Hex wraps a Position via .position.
@@ -1246,21 +1135,16 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     onEntityAppeared: (event) => {
       if (!event.entity || !event.entity.position) return;
       // v1alpha2 Entity uses `id` (not `entityId`); applyEntityAppeared takes
-      // v1's EntityState shape. Construct the minimum-viable EntityState from
-      // the v2 Entity — slice 2 only renders position. Default the fields that
-      // existing readers (getEntityName, entityDisplayType, hasCondition, etc.)
-      // dereference, so a stub-only entity doesn't crash when consumed:
-      //   - details: oneof wrapper with case=undefined (no character/monster details)
-      //   - activeConditions: empty array (hasCondition iterates this)
-      //   - entityType: UNSPECIFIED (entityDisplayType falls through to obstacle)
+      // v1's EntityState shape. Construct a schema-typed EntityState stub from
+      // the v2 Entity — slice 2 only renders position. Schema construction gives
+      // proto3 defaults (0/""/[]/undefined) for unset fields, so downstream
+      // readers like HoverInfoPanel don't see bare undefined on numeric fields.
       // Future slices that need richer v2→v1 mapping can extend the translation.
-      const stub = {
+      const stub = create(EntityStateSchema, {
         entityId: event.entity.id,
-        position: event.entity.position,
+        position: v2PositionToV1(event.entity.position),
         entityType: EntityType.UNSPECIFIED,
-        details: { case: undefined, value: undefined },
-        activeConditions: [],
-      } as unknown as EntityState;
+      });
       applyEntityAppeared(stub);
     },
     onEntityDisappeared: (event) => {

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -1210,9 +1210,11 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
 
   // Subscribe to v1alpha2 encounter stream (runs alongside v1 in slice 2)
   useEncounterStream2(encounterId, playerId, {
-    onSnapshotDelivered: (event) => {
-      // v1alpha2 stream barrier — payload empty in slice 1; just log
-      console.log('[v2] snapshot delivered, encounter:', event.encounter);
+    onSnapshotDelivered: () => {
+      // v1alpha2 stream-up barrier. Payload `encounter` is empty in slice 1
+      // (toolkit Snapshot doesn't map yet); fires on every connect/reconnect.
+      // Don't log the payload — empty proto noise on every reconnect.
+      console.log('[v2] snapshot delivered');
     },
     onEntityMoved: (event) => {
       // Teleport-to-final per spec; ignore intermediate path hexes in slice 2
@@ -1237,11 +1239,19 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
       if (!event.entity || !event.entity.position) return;
       // v1alpha2 Entity uses `id` (not `entityId`); applyEntityAppeared takes
       // v1's EntityState shape. Construct the minimum-viable EntityState from
-      // the v2 Entity — slice 2 only renders position; future slices that
-      // need richer fields (HP, type, etc.) can extend this translation.
+      // the v2 Entity — slice 2 only renders position. Default the fields that
+      // existing readers (getEntityName, entityDisplayType, hasCondition, etc.)
+      // dereference, so a stub-only entity doesn't crash when consumed:
+      //   - details: oneof wrapper with case=undefined (no character/monster details)
+      //   - activeConditions: empty array (hasCondition iterates this)
+      //   - entityType: UNSPECIFIED (entityDisplayType falls through to obstacle)
+      // Future slices that need richer v2→v1 mapping can extend the translation.
       const stub = {
         entityId: event.entity.id,
         position: event.entity.position,
+        entityType: EntityType.UNSPECIFIED,
+        details: { case: undefined, value: undefined },
+        activeConditions: [],
       } as unknown as EntityState;
       applyEntityAppeared(stub);
     },

--- a/src/components/LobbyView.tsx
+++ b/src/components/LobbyView.tsx
@@ -71,6 +71,8 @@ import {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { ArrowLeft } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEncounterStream2 } from '../api/useEncounterStream2';
+import { protoPositionToHex } from '../utils/hexCoord';
 import { CombatPanel, type CombatLogEntry } from './combat-v2';
 import { usePlayerTurn } from './combat-v2/hooks/usePlayerTurn';
 import { DungeonResultOverlay } from './dungeon';
@@ -308,6 +310,9 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     applyEntityPositionUpdate,
     applyCombatState: applyEncounterCombatState,
     reset: resetEncounterState,
+    applyHexRevealed,
+    applyEntityAppeared,
+    applyEntityDisappeared,
   } = useEncounterState();
 
   // Walkable tile keys for cross-room pathfinding
@@ -380,6 +385,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   const playerName = discord.user?.username || 'Player';
 
   // Dungeon stream event handlers
+  // @ts-expect-error TS6133 -- slice 3 will remove this handler when v1 RoomRevealed is dropped
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for slice 3 removal
   const handleRoomRevealed = useCallback(
     (event: RoomRevealedEvent) => {
       console.log('🚪 RoomRevealed event received:', {
@@ -695,6 +702,8 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
   );
 
   // Multiplayer sync: Movement completed - sync entity positions and movement resources
+  // @ts-expect-error TS6133 -- slice 3 will remove this handler when v1 MovementCompleted is dropped
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for slice 3 removal
   const handleMovementCompleted = useCallback(
     (event: MovementCompletedEvent) => {
       // [wave2-debug] Surface what the api carried for movement budget so we
@@ -1186,7 +1195,6 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     onStateSync: handleStateSync,
     onHistoricalEvents: handleHistoricalEvents,
     // Dungeon events
-    onRoomRevealed: handleRoomRevealed,
     onDungeonVictory: handleDungeonVictory,
     onDungeonFailure: handleDungeonFailure,
     // Combat sync events
@@ -1194,11 +1202,56 @@ export function LobbyView({ characterId, onBack }: LobbyViewProps) {
     onMonsterTurnCompleted: handleMonsterTurnCompleted,
     onAttackResolved: handleAttackResolved,
     onActionExecuted: handleActionExecuted,
-    onMovementCompleted: handleMovementCompleted,
     onFeatureActivated: handleFeatureActivated,
     // Player sync events
     onPlayerJoined: handlePlayerJoined,
     onCombatStarted: handleCombatStarted,
+  });
+
+  // Subscribe to v1alpha2 encounter stream (runs alongside v1 in slice 2)
+  useEncounterStream2(encounterId, playerId, {
+    onSnapshotDelivered: (event) => {
+      // v1alpha2 stream barrier — payload empty in slice 1; just log
+      console.log('[v2] snapshot delivered, encounter:', event.encounter);
+    },
+    onEntityMoved: (event) => {
+      // Teleport-to-final per spec; ignore intermediate path hexes in slice 2
+      const last = event.actualPath[event.actualPath.length - 1];
+      if (!last) return;
+      // v2 Position and v1 Position are both {x,y,z} structs but different
+      // TS brands. Double-cast through unknown to satisfy the type checker.
+      applyEntityPositionUpdate(
+        event.entityId,
+        last as unknown as Parameters<typeof applyEntityPositionUpdate>[1]
+      );
+    },
+    onGeometryRevealed: (event) => {
+      // GeometryRevealed.hexes is Hex[]; each Hex wraps a Position via .position.
+      // Skip any hex that's missing position (defensive — shouldn't happen).
+      const positions = event.hexes
+        .map((h) => h.position)
+        .filter((p): p is NonNullable<typeof p> => p !== undefined);
+      applyHexRevealed(positions.map(protoPositionToHex));
+    },
+    onEntityAppeared: (event) => {
+      if (!event.entity || !event.entity.position) return;
+      // v1alpha2 Entity uses `id` (not `entityId`); applyEntityAppeared takes
+      // v1's EntityState shape. Construct the minimum-viable EntityState from
+      // the v2 Entity — slice 2 only renders position; future slices that
+      // need richer fields (HP, type, etc.) can extend this translation.
+      const stub = {
+        entityId: event.entity.id,
+        position: event.entity.position,
+      } as unknown as EntityState;
+      applyEntityAppeared(stub);
+    },
+    onEntityDisappeared: (event) => {
+      if (!event.lastKnownPosition) return;
+      applyEntityDisappeared(
+        event.entityId,
+        protoPositionToHex(event.lastKnownPosition)
+      );
+    },
   });
 
   // Reset all dungeon-related state

--- a/src/components/ServerRollingDemo.tsx
+++ b/src/components/ServerRollingDemo.tsx
@@ -1,5 +1,6 @@
 import { AbilityScoresSectionV2 } from '@/character/creation/sections/AbilityScoresSectionV2';
 
+import { useDevPlayerIdAuth } from '@/api/useDevPlayerIdAuth';
 import { useDiscord } from '@/discord';
 
 export function ServerRollingDemo() {
@@ -13,6 +14,9 @@ export function ServerRollingDemo() {
   const devPlayerIdOverride = isDevelopment
     ? new URLSearchParams(window.location.search).get('playerId')
     : null;
+  // Sync dev override into gRPC auth store so outbound RPCs carry the right
+  // player ID. useLayoutEffect fires before child effects, preventing races.
+  useDevPlayerIdAuth(devPlayerIdOverride);
   const playerId =
     discord.user?.id ||
     devPlayerIdOverride ||

--- a/src/components/ServerRollingDemo.tsx
+++ b/src/components/ServerRollingDemo.tsx
@@ -8,7 +8,15 @@ export function ServerRollingDemo() {
   const testDraftId = 'demo_draft_' + Date.now();
   const discord = useDiscord();
   const isDevelopment = import.meta.env.MODE === 'development';
-  const playerId = discord.user?.id || (isDevelopment ? 'test-player' : '');
+  // Dev override: ?playerId=alice|bob lets two tabs run as different players
+  // without Discord (slice 2 playtest infrastructure)
+  const devPlayerIdOverride = isDevelopment
+    ? new URLSearchParams(window.location.search).get('playerId')
+    : null;
+  const playerId =
+    discord.user?.id ||
+    devPlayerIdOverride ||
+    (isDevelopment ? 'test-player' : '');
 
   return (
     <div

--- a/src/components/encounter/BattleMapPanel.tsx
+++ b/src/components/encounter/BattleMapPanel.tsx
@@ -1,4 +1,4 @@
-import type { DungeonMapState } from '@/hooks/useDungeonMap';
+import type { AbsoluteFloorTile, DungeonMapState } from '@/hooks/useDungeonMap';
 import { mapEntitiesForRender } from '@/utils/entityHelpers';
 import type { CubeCoord } from '@/utils/hexUtils';
 import { getMovementRemainingFromCombat } from '@/utils/movementUtils';
@@ -26,6 +26,12 @@ interface BattleMapPanelProps {
   monsters?: MonsterCombatState[];
   /** Unified entity state from useEncounterState - preferred over legacy props */
   encounterEntities?: Map<string, EntityState>;
+  /**
+   * v1alpha2 per-hex reveal set. Hexes here are rendered even if their room is
+   * not yet in revealedRoomIds. Layered on top of dungeonMap.floorTiles (which
+   * covers room-level reveals). Hex visible if either source covers it.
+   */
+  revealedHexes?: Set<string>;
   onEntityClick: (entityId: string) => void;
   onCellClick: (coord: CubeCoord) => void;
   onMoveComplete?: (path: CubeCoord[]) => void;
@@ -46,6 +52,7 @@ export function BattleMapPanel({
   combatState,
   monsters,
   encounterEntities,
+  revealedHexes,
   onEntityClick,
   onCellClick,
   onMoveComplete,
@@ -117,6 +124,27 @@ export function BattleMapPanel({
     deadMonsterIds,
   ]);
 
+  // Layer revealedHexes (v1alpha2 per-hex granularity) on top of dungeonMap.floorTiles
+  // (which covers room-level reveals from revealedRoomIds). A hex is visible if
+  // either source covers it — room-level via floorTiles, or per-hex via revealedHexes.
+  //
+  // revealedHexes keys are "q,r,s" (matching cube coord x,y,z). For hexes only
+  // in revealedHexes we synthesize a minimal AbsoluteFloorTile with roomId ''.
+  // v1 path: revealedHexes is undefined → floorTiles passes through unchanged.
+  const mergedFloorTiles = useMemo((): Map<string, AbsoluteFloorTile> => {
+    if (!revealedHexes || revealedHexes.size === 0) {
+      return dungeonMap.floorTiles;
+    }
+    const merged = new Map(dungeonMap.floorTiles);
+    for (const key of revealedHexes) {
+      if (!merged.has(key)) {
+        const [x, y, z] = key.split(',').map(Number);
+        merged.set(key, { x, y, z, roomId: '' });
+      }
+    }
+    return merged;
+  }, [dungeonMap.floorTiles, revealedHexes]);
+
   // Convert doors map to array for HexGrid
   const doorsArray = useMemo(
     () => Array.from(dungeonMap.doors.values()),
@@ -139,7 +167,7 @@ export function BattleMapPanel({
       }}
     >
       <HexGrid
-        floorTiles={dungeonMap.floorTiles}
+        floorTiles={mergedFloorTiles}
         entities={entities}
         selectedEntityId={selectedEntity || undefined}
         onHexClick={onCellClick}

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -16,7 +16,8 @@ import type { HeadVariant } from '@/config/characterModels';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import type { MonsterCombatState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { Race } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
-import { Suspense, useMemo, useRef } from 'react';
+import { useThree } from '@react-three/fiber';
+import { Suspense, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { cubeToWorld, type CubeCoord } from './hexMath';
 import { MediumHumanoid, type SkinTone } from './MediumHumanoid';
@@ -188,6 +189,16 @@ export function HexEntity({
   isGhost = false,
 }: HexEntityProps) {
   const meshRef = useRef<THREE.Mesh>(null);
+  const { invalidate } = useThree();
+
+  // R3F runs the canvas in frameloop="demand" mode (HexGrid.tsx). When only
+  // the ghost flag changes (entity stays at last_known position), no other
+  // prop change triggers a re-render request — the new shader material won't
+  // appear until the next user interaction. Force a frame on isGhost
+  // transitions so the visual swap is immediate.
+  useEffect(() => {
+    invalidate();
+  }, [isGhost, invalidate]);
 
   // Convert cube coords to world position
   const worldPos = useMemo(
@@ -205,17 +216,20 @@ export function HexEntity({
       ? COLORS[type].selected
       : COLORS[type].default;
 
-  // Handle click events - dead entities are not interactive
+  // Handle click events - dead and ghost entities are not interactive.
+  // Ghosts represent last-known position outside LoS — clicking would let a
+  // player attempt to attack/select an entity they technically can't see.
+  const isInert = isDead || isGhost;
   const handleClick = (event: { stopPropagation: () => void }) => {
     event.stopPropagation(); // Prevent hex click from firing
-    if (!isDead && onClick) {
+    if (!isInert && onClick) {
       onClick(entityId);
     }
   };
 
-  // Common interaction props for both character models and obstacles
-  // Dead entities get no hover/pointer interaction
-  const interactionProps = isDead
+  // Common interaction props for both character models and obstacles.
+  // Inert entities (dead or ghost) get no hover/pointer interaction.
+  const interactionProps = isInert
     ? {
         onClick: (e: { stopPropagation: () => void }) => e.stopPropagation(),
       }

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -41,6 +41,8 @@ export interface HexEntityProps {
   facialHairStyle?: FacialHairStyle;
   /** Whether the entity is dead (show visual dead state, disable interaction) */
   isDead?: boolean;
+  /** Whether the entity is outside LoS (v1alpha2). Render at last-known position with ghost shader (semi-transparent, desaturated). */
+  isGhost?: boolean;
 }
 
 // Visual state colors
@@ -183,6 +185,7 @@ export function HexEntity({
   hairColor,
   facialHairStyle,
   isDead = false,
+  isGhost = false,
 }: HexEntityProps) {
   const meshRef = useRef<THREE.Mesh>(null);
 
@@ -258,7 +261,7 @@ export function HexEntity({
         position={[worldPos.x, CHARACTER_Y_OFFSET, worldPos.z]}
         {...interactionProps}
       >
-        {/* Dead entities rendered with tilt and reduced opacity */}
+        {/* Dead entities rendered with tilt; ghost entities rendered with ghost shader */}
         <group rotation={isDead ? [0, 0, Math.PI / 3] : [0, 0, 0]}>
           <Suspense
             fallback={<LoadingPlaceholder color={color} hexSize={hexSize} />}
@@ -282,6 +285,7 @@ export function HexEntity({
               offHandWeapon={offHandWeapon}
               shield={shield}
               showOutline={!isDead}
+              ghostAmount={isGhost ? 1.0 : 0.0}
             />
           </Suspense>
         </group>

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -48,6 +48,8 @@ export interface HexGridProps {
     position: { x: number; y: number; z: number };
     type: 'player' | 'monster' | 'obstacle';
     isDead?: boolean;
+    /** True when entity is outside LoS (v1alpha2 ghost). Render at last-known position with ghost visuals. */
+    isGhost?: boolean;
   }>;
   selectedEntityId?: string;
   onHexClick?: (coord: { x: number; y: number; z: number }) => void;
@@ -430,6 +432,7 @@ function Scene({
           character={characterMap.get(entity.entityId)}
           monster={monsterMap.get(entity.entityId)}
           isDead={entity.isDead}
+          isGhost={entity.isGhost}
         />
       ))}
     </>

--- a/src/components/hex-grid/MediumHumanoid.tsx
+++ b/src/components/hex-grid/MediumHumanoid.tsx
@@ -101,6 +101,8 @@ export interface MediumHumanoidProps {
   shield?: ShieldType;
   /** Show cel-shaded outline (default: true) */
   showOutline?: boolean;
+  /** Ghost effect intensity (0.0=solid, 1.0=full ghost). Set to 1.0 for LoS-lost entities. */
+  ghostAmount?: number;
 }
 
 /** Default scale to convert ~137 Qubicle units to roughly 1.5 Three.js units */
@@ -479,6 +481,7 @@ export function MediumHumanoid({
   offHandWeapon,
   shield,
   showOutline = true,
+  ghostAmount = 0.0,
 }: MediumHumanoidProps) {
   const groupRef = useRef<THREE.Group>(null);
 
@@ -519,8 +522,10 @@ export function MediumHumanoid({
       shadingVariance: 0.15,
       selected: isSelected ? 1.0 : 0.0,
       selectionIntensity: 0.5,
+      // Ghost effect: desaturated + semi-transparent + pale-cyan rim glow
+      ghostAmount,
     }),
-    [skinTone, primaryColor, secondaryColor, isSelected]
+    [skinTone, primaryColor, secondaryColor, isSelected, ghostAmount]
   );
 
   // Resolve hair color to a number for the shader

--- a/src/components/lobby/LobbyScreen.tsx
+++ b/src/components/lobby/LobbyScreen.tsx
@@ -11,6 +11,7 @@ import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1a
 import type { CombatStartedEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { useState } from 'react';
 import { DEFAULT_DUNGEON_CONFIG, type DungeonConfig } from './dungeonConfig';
+import { friendlyJoinError } from './friendlyJoinError';
 import type { PartyMember } from './PartyMemberCard';
 import { WaitingRoom } from './WaitingRoom';
 
@@ -170,12 +171,7 @@ export function LobbyScreen({
       setLobbyState('waiting');
     } catch (error) {
       console.error('Failed to join encounter:', error);
-      // Surface the actual error so users see what went wrong (e.g. "player
-      // already in encounter", not just a generic "invalid code"). Connect-RPC
-      // errors expose .message; fall back to a generic string.
-      const message =
-        error instanceof Error ? error.message : 'Failed to join encounter';
-      setJoinError(message);
+      setJoinError(friendlyJoinError(error));
     }
   };
 

--- a/src/components/lobby/LobbyScreen.tsx
+++ b/src/components/lobby/LobbyScreen.tsx
@@ -170,7 +170,12 @@ export function LobbyScreen({
       setLobbyState('waiting');
     } catch (error) {
       console.error('Failed to join encounter:', error);
-      setJoinError('Invalid code or lobby not found');
+      // Surface the actual error so users see what went wrong (e.g. "player
+      // already in encounter", not just a generic "invalid code"). Connect-RPC
+      // errors expose .message; fall back to a generic string.
+      const message =
+        error instanceof Error ? error.message : 'Failed to join encounter';
+      setJoinError(message);
     }
   };
 

--- a/src/components/lobby/friendlyJoinError.test.ts
+++ b/src/components/lobby/friendlyJoinError.test.ts
@@ -1,0 +1,69 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+import { describe, expect, it } from 'vitest';
+import { friendlyJoinError } from './friendlyJoinError';
+
+describe('friendlyJoinError', () => {
+  it('returns a friendly message for "already in encounter"', () => {
+    const err = new ConnectError(
+      'player already in encounter',
+      Code.AlreadyExists
+    );
+    expect(friendlyJoinError(err)).toBe(
+      'You are already in an encounter. Leave your current game before joining another.'
+    );
+  });
+
+  it('matches "already in encounter" substring case-insensitively', () => {
+    const err = new Error('PLAYER ALREADY IN ENCOUNTER');
+    expect(friendlyJoinError(err)).toBe(
+      'You are already in an encounter. Leave your current game before joining another.'
+    );
+  });
+
+  it('returns a friendly message for "encounter not found"', () => {
+    const err = new ConnectError('encounter not found', Code.NotFound);
+    expect(friendlyJoinError(err)).toBe(
+      'Game not found. Check the code and try again.'
+    );
+  });
+
+  it('matches "invalid code" substring', () => {
+    const err = new Error('invalid code provided');
+    expect(friendlyJoinError(err)).toBe(
+      'Game not found. Check the code and try again.'
+    );
+  });
+
+  it('returns a friendly message for full lobby', () => {
+    const err = new ConnectError('lobby is full', Code.ResourceExhausted);
+    expect(friendlyJoinError(err)).toBe('This game is already full.');
+  });
+
+  it('matches "full" substring', () => {
+    const err = new Error('encounter full');
+    expect(friendlyJoinError(err)).toBe('This game is already full.');
+  });
+
+  it('returns generic message for unknown Connect errors', () => {
+    const err = new ConnectError('internal server error', Code.Internal);
+    expect(friendlyJoinError(err)).toBe(
+      'Failed to join lobby. Please try again or check the code.'
+    );
+  });
+
+  it('returns generic message for generic Error', () => {
+    const err = new Error('something unexpected');
+    expect(friendlyJoinError(err)).toBe(
+      'Failed to join lobby. Please try again or check the code.'
+    );
+  });
+
+  it('returns generic message for non-Error values', () => {
+    expect(friendlyJoinError('string error')).toBe(
+      'Failed to join lobby. Please try again or check the code.'
+    );
+    expect(friendlyJoinError(null)).toBe(
+      'Failed to join lobby. Please try again or check the code.'
+    );
+  });
+});

--- a/src/components/lobby/friendlyJoinError.ts
+++ b/src/components/lobby/friendlyJoinError.ts
@@ -1,0 +1,24 @@
+/**
+ * Maps Connect-RPC join errors to user-facing friendly messages.
+ * Raw error details (transport URLs, status codes) stay in console.error.
+ */
+export function friendlyJoinError(err: unknown): string {
+  const message = err instanceof Error ? err.message.toLowerCase() : '';
+
+  if (message.includes('already in encounter')) {
+    return 'You are already in an encounter. Leave your current game before joining another.';
+  }
+
+  if (
+    message.includes('encounter not found') ||
+    message.includes('invalid code')
+  ) {
+    return 'Game not found. Check the code and try again.';
+  }
+
+  if (message.includes('full')) {
+    return 'This game is already full.';
+  }
+
+  return 'Failed to join lobby. Please try again or check the code.';
+}

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -146,7 +146,7 @@ describe('PlaytestHarness', () => {
           entity: {
             id: 'char-alice',
             position: { x: 0, y: 0, z: 0 },
-          } as EntityState,
+          } as unknown as EntityState,
         })
       )
     );
@@ -165,11 +165,17 @@ describe('PlaytestHarness', () => {
       expect(hoisted.moveEntityFn).toHaveBeenCalledOnce();
     });
 
-    const [req] = hoisted.moveEntityFn.mock.calls[0];
-    expect(req.encounterId).toBe('enc-1');
-    expect(req.entityId).toBe('char-alice');
     // path = [current(0,0,0), target(0,0,0)] — 2 elements
-    expect(req.proposedPath).toHaveLength(2);
+    expect(hoisted.moveEntityFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        proposedPath: [
+          expect.objectContaining({ x: 0, y: 0, z: 0 }),
+          expect.objectContaining({ x: 0, y: 0, z: 0 }),
+        ],
+      })
+    );
   });
 
   it('shows move error when RPC fails', async () => {

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -1,0 +1,220 @@
+import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import type { MoveEntityResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createFakeStream,
+  type FakeStream,
+} from '../../api/fakeEncounterStream2';
+
+function makeEvent(caseName: string, value: unknown): EncounterEvent {
+  return { event: { case: caseName, value } } as unknown as EncounterEvent;
+}
+
+// vi.hoisted so the mock factory can close over the refs before imports run
+const hoisted = vi.hoisted(() => ({
+  fakeRef: { current: null as FakeStream | null },
+  moveEntityFn: vi.fn<() => Promise<MoveEntityResponse>>(),
+}));
+
+vi.mock('../../api/client', () => ({
+  encounterClientV2: {
+    streamEncounter: vi.fn(() => {
+      if (!hoisted.fakeRef.current) {
+        throw new Error('fakeRef.current is null — set it in beforeEach');
+      }
+      return hoisted.fakeRef.current.iterator;
+    }),
+    moveEntity: hoisted.moveEntityFn,
+  },
+}));
+
+// Import the component AFTER vi.mock
+import { PlaytestHarness } from './PlaytestHarness';
+
+let fake: FakeStream;
+
+beforeEach(() => {
+  fake = createFakeStream();
+  hoisted.fakeRef.current = fake;
+  hoisted.moveEntityFn.mockReset();
+  hoisted.moveEntityFn.mockResolvedValue({} as MoveEntityResponse);
+
+  // Set up URL with both params
+  window.history.pushState({}, '', '?encounterId=enc-1&playerId=alice');
+});
+
+afterEach(() => {
+  hoisted.fakeRef.current = null;
+  window.history.pushState({}, '', '/');
+});
+
+describe('PlaytestHarness', () => {
+  it('renders error when playerId is missing from URL', () => {
+    window.history.pushState({}, '', '?encounterId=enc-1');
+    render(<PlaytestHarness />);
+    // getByText throws if not found — presence is asserted implicitly
+    expect(screen.getByText(/playerId.*required/i)).toBeTruthy();
+  });
+
+  it('shows encounterId and playerId in the header', () => {
+    const { container } = render(<PlaytestHarness />);
+    // The header renders encounterId and playerId in separate <strong> elements;
+    // check the raw text content of the header div instead.
+    const header = container.querySelector('[data-testid="harness-header"]');
+    expect(header?.textContent).toContain('enc-1');
+    expect(header?.textContent).toContain('alice');
+  });
+
+  it('defaults encounterId to dev-encounter when not in URL', () => {
+    window.history.pushState({}, '', '?playerId=alice');
+    render(<PlaytestHarness />);
+    expect(screen.getByText(/dev-encounter/)).toBeTruthy();
+  });
+
+  it('shows entity in table after EntityAppeared event', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: {
+            id: 'char-alice',
+            position: { x: 0, y: 0, z: 0 },
+            reason: '',
+          },
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('char-alice')).toBeTruthy();
+    });
+  });
+
+  it('updates entity row after EntityMoved event', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: {
+            id: 'char-alice',
+            position: { x: 0, y: 0, z: 0 },
+            reason: '',
+          },
+        })
+      )
+    );
+    await waitFor(() => expect(screen.getByText('char-alice')).toBeTruthy());
+
+    act(() =>
+      fake.push(
+        makeEvent('entityMoved', {
+          entityId: 'char-alice',
+          actualPath: [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: -1, z: 0 },
+          ],
+        })
+      )
+    );
+
+    // Entity remains in table after move
+    await waitFor(() => {
+      expect(screen.getByText('char-alice')).toBeTruthy();
+    });
+  });
+
+  it('calls moveEntity with char-alice entityId and correct path on Move button click', async () => {
+    render(<PlaytestHarness />);
+
+    // Seed entity with position so the Move button becomes enabled
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: {
+            id: 'char-alice',
+            position: { x: 0, y: 0, z: 0 },
+          } as EntityState,
+        })
+      )
+    );
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /move there/i });
+      expect((btn as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    // Default inputs are Q=0, R=0, S=0 — click move
+    act(() =>
+      fireEvent.click(screen.getByRole('button', { name: /move there/i }))
+    );
+
+    await waitFor(() => {
+      expect(hoisted.moveEntityFn).toHaveBeenCalledOnce();
+    });
+
+    const [req] = hoisted.moveEntityFn.mock.calls[0];
+    expect(req.encounterId).toBe('enc-1');
+    expect(req.entityId).toBe('char-alice');
+    // path = [current(0,0,0), target(0,0,0)] — 2 elements
+    expect(req.proposedPath).toHaveLength(2);
+  });
+
+  it('shows move error when RPC fails', async () => {
+    hoisted.moveEntityFn.mockRejectedValue(new Error('network gone'));
+
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityAppeared', {
+          entity: { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
+        })
+      )
+    );
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /move there/i });
+      expect((btn as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    act(() =>
+      fireEvent.click(screen.getByRole('button', { name: /move there/i }))
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/network gone/i)).toBeTruthy();
+    });
+  });
+
+  it('shows event log entry after EntityMoved', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityMoved', {
+          entityId: 'char-alice',
+          actualPath: [{ x: 1, y: -1, z: 0 }],
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/EntityMoved/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,0 +1,328 @@
+import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { useState } from 'react';
+import { useEncounterStream2 } from '../../api/useEncounterStream2';
+import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
+import { useEncounterState } from '../../hooks/useEncounterState';
+import { protoPositionToHex } from '../../utils/hexCoord';
+
+function formatTime(d: Date): string {
+  return d.toTimeString().slice(0, 8);
+}
+
+/**
+ * Dev-only playtest verification harness for wave-2.5 slice 2.
+ * Renders at ?encounterId=<id>&playerId=<id> in development mode.
+ * Uses ONLY the v2 path (useEncounterStream2 + useMoveEntityV2).
+ * DELETE in slice 3 cleanup.
+ */
+export function PlaytestHarness() {
+  const params = new URLSearchParams(window.location.search);
+  const encounterId = params.get('encounterId') || 'dev-encounter';
+  const playerId = params.get('playerId');
+
+  const entityId = playerId ? `char-${playerId}` : '';
+
+  const [log, setLog] = useState<string[]>([]);
+  const [targetQ, setTargetQ] = useState(0);
+  const [targetR, setTargetR] = useState(0);
+  const [targetS, setTargetS] = useState(0);
+
+  const encounterState = useEncounterState();
+  const {
+    moveEntity,
+    loading: moveLoading,
+    error: moveError,
+  } = useMoveEntityV2();
+
+  const addLog = (msg: string) => {
+    const entry = `[${formatTime(new Date())}] ${msg}`;
+    setLog((prev) => [entry, ...prev].slice(0, 30));
+  };
+
+  const stream = useEncounterStream2(
+    playerId ? encounterId : null,
+    playerId ?? '',
+    {
+      onSnapshotDelivered: () => {
+        addLog('SnapshotDelivered (stream up)');
+      },
+      onEntityMoved: (e) => {
+        const last = e.actualPath[e.actualPath.length - 1];
+        if (last) {
+          encounterState.applyEntityPositionUpdate(
+            e.entityId,
+            last as unknown as Parameters<
+              typeof encounterState.applyEntityPositionUpdate
+            >[1]
+          );
+        }
+        const pos = last ? `(${last.x},${last.y},${last.z})` : '(no path)';
+        addLog(`EntityMoved ${e.entityId} → ${pos}`);
+      },
+      onGeometryRevealed: (e) => {
+        const positions = e.hexes
+          .map((h) => h.position)
+          .filter((p): p is NonNullable<typeof p> => p !== undefined);
+        encounterState.applyHexRevealed(positions.map(protoPositionToHex));
+        addLog(`GeometryRevealed ${positions.length} hex(es)`);
+      },
+      onEntityAppeared: (e) => {
+        if (!e.entity || !e.entity.position) return;
+        const stub = {
+          entityId: e.entity.id,
+          position: e.entity.position,
+        } as unknown as EntityState;
+        encounterState.applyEntityAppeared(stub);
+        addLog(`EntityAppeared ${e.entity.id}`);
+      },
+      onEntityDisappeared: (e) => {
+        if (e.lastKnownPosition) {
+          encounterState.applyEntityDisappeared(
+            e.entityId,
+            protoPositionToHex(e.lastKnownPosition)
+          );
+        }
+        addLog(`EntityDisappeared ${e.entityId}`);
+      },
+    }
+  );
+
+  if (!playerId) {
+    return (
+      <div style={{ padding: 16, color: 'red', fontFamily: 'monospace' }}>
+        Error: playerId is required — add ?playerId=alice to the URL
+      </div>
+    );
+  }
+
+  const myEntity = encounterState.state.entities.get(entityId);
+  const myPosition = myEntity?.position;
+  const canMove = !!myPosition;
+
+  const handleMove = async () => {
+    const currentPos = myPosition
+      ? { x: myPosition.x ?? 0, y: myPosition.y ?? 0, z: myPosition.z ?? 0 }
+      : { x: 0, y: 0, z: 0 };
+    const target = { x: targetQ, y: targetR, z: targetS };
+    try {
+      await moveEntity(encounterId, entityId, [currentPos, target]);
+    } catch {
+      // error is surfaced via moveError state — no rethrow needed here
+    }
+  };
+
+  const entitiesArray = Array.from(encounterState.state.entities.entries());
+  const revealedKeys = Array.from(encounterState.state.revealedHexes);
+
+  return (
+    <div
+      style={{
+        fontFamily: 'monospace',
+        padding: 16,
+        background: '#111',
+        color: '#eee',
+        minHeight: '100vh',
+      }}
+    >
+      {/* Header */}
+      <div
+        data-testid="harness-header"
+        style={{
+          background: '#222',
+          padding: '8px 12px',
+          marginBottom: 16,
+          borderRadius: 4,
+          display: 'flex',
+          gap: 24,
+        }}
+      >
+        <span>
+          Playtest <strong>{encounterId}</strong> as <strong>{playerId}</strong>
+        </span>
+        <span>
+          connection: <strong>{stream.connectionState}</strong>
+        </span>
+        <span>entityId: {entityId}</span>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        {/* Left column: entities + hexes */}
+        <div>
+          {/* Entities table */}
+          <h3 style={{ margin: '0 0 8px', color: '#aaa' }}>
+            Entities ({entitiesArray.length})
+          </h3>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              marginBottom: 16,
+              fontSize: 13,
+            }}
+          >
+            <thead>
+              <tr style={{ color: '#888', textAlign: 'left' }}>
+                <th style={{ padding: '4px 8px' }}>id</th>
+                <th style={{ padding: '4px 8px' }}>x</th>
+                <th style={{ padding: '4px 8px' }}>y</th>
+                <th style={{ padding: '4px 8px' }}>z</th>
+                <th style={{ padding: '4px 8px' }}>ghost?</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entitiesArray.map(([id, entity]) => (
+                <tr
+                  key={id}
+                  style={{
+                    background: id === entityId ? '#1a2a1a' : 'transparent',
+                    borderTop: '1px solid #333',
+                  }}
+                >
+                  <td style={{ padding: '4px 8px' }}>{id}</td>
+                  <td style={{ padding: '4px 8px' }}>
+                    {entity.position?.x ?? '—'}
+                  </td>
+                  <td style={{ padding: '4px 8px' }}>
+                    {entity.position?.y ?? '—'}
+                  </td>
+                  <td style={{ padding: '4px 8px' }}>
+                    {entity.position?.z ?? '—'}
+                  </td>
+                  <td style={{ padding: '4px 8px' }}>
+                    {entity.ghost ? 'yes' : ''}
+                  </td>
+                </tr>
+              ))}
+              {entitiesArray.length === 0 && (
+                <tr>
+                  <td colSpan={5} style={{ padding: '4px 8px', color: '#555' }}>
+                    (no entities yet)
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+
+          {/* Revealed hexes */}
+          <h3 style={{ margin: '0 0 8px', color: '#aaa' }}>
+            Revealed hexes ({encounterState.state.revealedHexes.size})
+          </h3>
+          <div style={{ fontSize: 12, color: '#777', marginBottom: 16 }}>
+            {revealedKeys.length === 0
+              ? '(none)'
+              : revealedKeys.slice(0, 20).join(', ') +
+                (revealedKeys.length > 20
+                  ? ` … +${revealedKeys.length - 20} more`
+                  : '')}
+          </div>
+
+          {/* Move controls */}
+          <h3 style={{ margin: '0 0 8px', color: '#aaa' }}>Move {entityId}</h3>
+          {!canMove && (
+            <div style={{ color: '#666', fontSize: 12, marginBottom: 8 }}>
+              (waiting for first event — position unknown)
+            </div>
+          )}
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <label style={{ fontSize: 12 }}>
+              Q{' '}
+              <input
+                type="number"
+                value={targetQ}
+                onChange={(e) => setTargetQ(Number(e.target.value))}
+                style={{
+                  width: 60,
+                  background: '#333',
+                  color: '#eee',
+                  border: '1px solid #555',
+                  padding: '2px 4px',
+                }}
+              />
+            </label>
+            <label style={{ fontSize: 12 }}>
+              R{' '}
+              <input
+                type="number"
+                value={targetR}
+                onChange={(e) => setTargetR(Number(e.target.value))}
+                style={{
+                  width: 60,
+                  background: '#333',
+                  color: '#eee',
+                  border: '1px solid #555',
+                  padding: '2px 4px',
+                }}
+              />
+            </label>
+            <label style={{ fontSize: 12 }}>
+              S{' '}
+              <input
+                type="number"
+                value={targetS}
+                onChange={(e) => setTargetS(Number(e.target.value))}
+                style={{
+                  width: 60,
+                  background: '#333',
+                  color: '#eee',
+                  border: '1px solid #555',
+                  padding: '2px 4px',
+                }}
+              />
+            </label>
+            <button
+              onClick={() => void handleMove()}
+              disabled={!canMove || moveLoading}
+              style={{
+                padding: '4px 12px',
+                background: canMove ? '#2a4a2a' : '#2a2a2a',
+                color: canMove ? '#8f8' : '#666',
+                border: '1px solid #555',
+                cursor: canMove && !moveLoading ? 'pointer' : 'not-allowed',
+              }}
+            >
+              {moveLoading ? 'Moving…' : 'Move there'}
+            </button>
+          </div>
+          {moveError && (
+            <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
+              Move error: {moveError.message}
+            </div>
+          )}
+        </div>
+
+        {/* Right column: event log */}
+        <div>
+          <h3 style={{ margin: '0 0 8px', color: '#aaa' }}>
+            Recent events ({log.length})
+          </h3>
+          <div
+            style={{
+              background: '#0a0a0a',
+              border: '1px solid #333',
+              padding: 8,
+              fontSize: 11,
+              height: 400,
+              overflowY: 'auto',
+            }}
+          >
+            {log.length === 0 && (
+              <span style={{ color: '#555' }}>(waiting for events…)</span>
+            )}
+            {log.map((entry, i) => (
+              <div key={i} style={{ color: '#9d9', marginBottom: 2 }}>
+                {entry}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,5 +1,6 @@
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { useState } from 'react';
+import { setAuth } from '../../api/auth';
 import { useEncounterStream2 } from '../../api/useEncounterStream2';
 import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
@@ -19,6 +20,15 @@ export function PlaytestHarness() {
   const params = new URLSearchParams(window.location.search);
   const encounterId = params.get('encounterId') || 'dev-encounter';
   const playerId = params.get('playerId');
+
+  // The grpc auth interceptor reads playerId from the auth store to set the
+  // `Authorization: Dev <playerId>` header. The lobby flow primes this via
+  // DiscordProvider; harness flow has no provider, so we sync it here BEFORE
+  // useEncounterStream2 mounts. Sync (not useEffect) so the first request
+  // can't race with auth being unset.
+  if (playerId) {
+    setAuth(null, playerId);
+  }
 
   const entityId = playerId ? `char-${playerId}` : '';
 

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,6 +1,9 @@
-import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { create } from '@bufbuild/protobuf';
+import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { useState } from 'react';
-import { setAuth } from '../../api/auth';
+import { v2PositionToV1 } from '../../api/positionConvert';
+import { useDevPlayerIdAuth } from '../../api/useDevPlayerIdAuth';
 import { useEncounterStream2 } from '../../api/useEncounterStream2';
 import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
@@ -21,14 +24,10 @@ export function PlaytestHarness() {
   const encounterId = params.get('encounterId') || 'dev-encounter';
   const playerId = params.get('playerId');
 
-  // The grpc auth interceptor reads playerId from the auth store to set the
-  // `Authorization: Dev <playerId>` header. The lobby flow primes this via
-  // DiscordProvider; harness flow has no provider, so we sync it here BEFORE
-  // useEncounterStream2 mounts. Sync (not useEffect) so the first request
-  // can't race with auth being unset.
-  if (playerId) {
-    setAuth(null, playerId);
-  }
+  // Sync dev playerId override into the gRPC auth store before stream mounts.
+  // useLayoutEffect fires before any child useEffect, preventing a race where
+  // the first request goes out without the override applied.
+  useDevPlayerIdAuth(playerId);
 
   const entityId = playerId ? `char-${playerId}` : '';
 
@@ -61,9 +60,7 @@ export function PlaytestHarness() {
         if (last) {
           encounterState.applyEntityPositionUpdate(
             e.entityId,
-            last as unknown as Parameters<
-              typeof encounterState.applyEntityPositionUpdate
-            >[1]
+            v2PositionToV1(last)
           );
         }
         const pos = last ? `(${last.x},${last.y},${last.z})` : '(no path)';
@@ -78,10 +75,11 @@ export function PlaytestHarness() {
       },
       onEntityAppeared: (e) => {
         if (!e.entity || !e.entity.position) return;
-        const stub = {
+        const stub = create(EntityStateSchema, {
           entityId: e.entity.id,
-          position: e.entity.position,
-        } as unknown as EntityState;
+          position: v2PositionToV1(e.entity.position),
+          entityType: EntityType.UNSPECIFIED,
+        });
         encounterState.applyEntityAppeared(stub);
         addLog(`EntityAppeared ${e.entity.id}`);
       },

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -107,12 +107,25 @@ export function PlaytestHarness() {
 
   const myEntity = encounterState.state.entities.get(entityId);
   const myPosition = myEntity?.position;
-  const canMove = !!myPosition;
+
+  // Slice 1's SnapshotDelivered.encounter field is empty by design, so the
+  // harness has no current position until the first move triggers events.
+  // Without a fallback the move button stays permanently disabled. These
+  // hardcoded values match the manually-seeded encounter (`enc:v2:dev-encounter`
+  // in Redis) so the first move can dispatch correctly. After it lands,
+  // EntityMoved updates real state and the fallback is unused.
+  const SEEDED_FALLBACK: Record<string, { x: number; y: number; z: number }> = {
+    alice: { x: 0, y: 0, z: 0 },
+    bob: { x: 1, y: -1, z: 0 },
+  };
+  const fallback = playerId ? SEEDED_FALLBACK[playerId] : undefined;
+  const usingFallback = !myPosition && !!fallback;
+  const canMove = !!myPosition || !!fallback;
 
   const handleMove = async () => {
     const currentPos = myPosition
       ? { x: myPosition.x ?? 0, y: myPosition.y ?? 0, z: myPosition.z ?? 0 }
-      : { x: 0, y: 0, z: 0 };
+      : (fallback ?? { x: 0, y: 0, z: 0 });
     const target = { x: targetQ, y: targetR, z: targetS };
     try {
       await moveEntity(encounterId, entityId, [currentPos, target]);
@@ -231,6 +244,11 @@ export function PlaytestHarness() {
           {!canMove && (
             <div style={{ color: '#666', fontSize: 12, marginBottom: 8 }}>
               (waiting for first event — position unknown)
+            </div>
+          )}
+          {usingFallback && (
+            <div style={{ color: '#aa8', fontSize: 12, marginBottom: 8 }}>
+              (using seeded fallback position — no events received yet)
             </div>
           )}
           <div

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -101,6 +101,8 @@ describe('createEmptyEncounterState', () => {
     expect(state.doors).toBeInstanceOf(Map);
     expect(state.doors.size).toBe(0);
     expect(state.revealedRoomIds).toEqual([]);
+    expect(state.revealedHexes).toBeInstanceOf(Set);
+    expect(state.revealedHexes.size).toBe(0);
     expect(state.combat).toBeNull();
     expect(state.currentRoomId).toBe('');
     expect(state.roomsCleared).toBe(0);
@@ -575,6 +577,9 @@ describe('v1alpha2 reducer additions', () => {
       const stored = after.entities.get('goblin-1');
       expect(stored).toBeDefined();
       expect(stored?.ghost).toBeFalsy();
+      expect(stored?.position?.x).toBe(3);
+      expect(stored?.position?.y).toBe(-2);
+      expect(stored?.position?.z).toBe(-1);
     });
 
     it('clears the ghost flag on a previously-disappeared entity', () => {
@@ -621,6 +626,10 @@ describe('v1alpha2 reducer additions', () => {
         s: 0,
       });
       expect(after.entities.size).toBe(0);
+      // Reference identity preserved on no-op — matches mergeEntityPosition's
+      // pattern; prevents needless React re-renders if a stream loop fires
+      // EntityDisappeared for an entity we never saw.
+      expect(after).toBe(prev);
     });
   });
 

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -14,6 +14,7 @@ import {
   CombatStateSchema,
   DoorInfoSchema,
   EncounterStateDataSchema,
+  type EntityState,
   EntityStateSchema,
   RoomLayoutSchema,
   TurnStateSchema,
@@ -23,7 +24,11 @@ import {
   EntityType,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { describe, expect, it } from 'vitest';
+import { hexKey } from '../utils/hexCoord';
 import {
+  applyEntityAppeared,
+  applyEntityDisappeared,
+  applyHexRevealed,
   applySnapshotToState,
   createEmptyEncounterState,
   mergeEntityPosition,
@@ -518,5 +523,139 @@ describe('updateCombatState', () => {
     expect(next.revealedRoomIds).toEqual(['room-1']);
     expect(next.roomsCleared).toBe(5);
     expect(next.dungeonState).toBe(DungeonState.ACTIVE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper for v1alpha2 tests
+// ---------------------------------------------------------------------------
+
+function makeTestEntity(
+  id: string,
+  pos: { x: number; y: number; z: number }
+): EntityState {
+  return create(EntityStateSchema, {
+    entityId: id,
+    position: create(PositionSchema, { x: pos.x, y: pos.y, z: pos.z }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// v1alpha2 reducer additions
+// ---------------------------------------------------------------------------
+
+describe('v1alpha2 reducer additions', () => {
+  describe('applyHexRevealed', () => {
+    it('adds hexes to revealedHexes without dropping existing reveals', () => {
+      const prev = createEmptyEncounterState();
+      const after1 = applyHexRevealed(prev, [{ q: 0, r: 0, s: 0 }]);
+      expect(after1.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))).toBe(true);
+
+      const after2 = applyHexRevealed(after1, [{ q: 1, r: -1, s: 0 }]);
+      expect(after2.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))).toBe(true);
+      expect(after2.revealedHexes.has(hexKey({ q: 1, r: -1, s: 0 }))).toBe(
+        true
+      );
+    });
+
+    it('is idempotent on duplicate hexes', () => {
+      const prev = applyHexRevealed(createEmptyEncounterState(), [
+        { q: 2, r: -1, s: -1 },
+      ]);
+      const after = applyHexRevealed(prev, [{ q: 2, r: -1, s: -1 }]);
+      expect(after.revealedHexes.size).toBe(1);
+    });
+  });
+
+  describe('applyEntityAppeared', () => {
+    it('adds a new entity at first-visible position with ghost cleared', () => {
+      const prev = createEmptyEncounterState();
+      const entity = makeTestEntity('goblin-1', { x: 3, y: -2, z: -1 });
+      const after = applyEntityAppeared(prev, entity);
+      const stored = after.entities.get('goblin-1');
+      expect(stored).toBeDefined();
+      expect(stored?.ghost).toBeFalsy();
+    });
+
+    it('clears the ghost flag on a previously-disappeared entity', () => {
+      const entity = makeTestEntity('alice', { x: 0, y: 0, z: 0 });
+      const withEntity = mergeEntityUpdates(createEmptyEncounterState(), [
+        entity,
+      ]);
+      const ghosted = applyEntityDisappeared(withEntity, 'alice', {
+        q: 1,
+        r: -1,
+        s: 0,
+      });
+      expect(ghosted.entities.get('alice')?.ghost).toBe(true);
+
+      const reappeared = applyEntityAppeared(
+        ghosted,
+        makeTestEntity('alice', { x: 5, y: -3, z: -2 })
+      );
+      expect(reappeared.entities.get('alice')?.ghost).toBeFalsy();
+    });
+  });
+
+  describe('applyEntityDisappeared', () => {
+    it('keeps entity in store, sets ghost=true, updates position to last_known', () => {
+      const entity = makeTestEntity('bob', { x: 0, y: 0, z: 0 });
+      const prev = mergeEntityUpdates(createEmptyEncounterState(), [entity]);
+      const after = applyEntityDisappeared(prev, 'bob', {
+        q: 4,
+        r: -2,
+        s: -2,
+      });
+      const stored = after.entities.get('bob');
+      expect(stored?.ghost).toBe(true);
+      expect(stored?.position?.x).toBe(4);
+      expect(stored?.position?.y).toBe(-2);
+      expect(stored?.position?.z).toBe(-2);
+    });
+
+    it('is a no-op if the entity is not in state (defensive)', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyEntityDisappeared(prev, 'unknown', {
+        q: 0,
+        r: 0,
+        s: 0,
+      });
+      expect(after.entities.size).toBe(0);
+    });
+  });
+
+  describe('appear/disappear sequences', () => {
+    it('survives appeared → moved → disappeared → appeared cleanly', () => {
+      let state = createEmptyEncounterState();
+      state = applyEntityAppeared(
+        state,
+        makeTestEntity('mover', { x: 0, y: 0, z: 0 })
+      );
+      expect(state.entities.get('mover')?.ghost).toBeFalsy();
+
+      state = mergeEntityPosition(
+        state,
+        'mover',
+        create(PositionSchema, { x: 1, y: -1, z: 0 })
+      );
+      expect(state.entities.get('mover')?.position?.x).toBe(1);
+      expect(state.entities.get('mover')?.position?.y).toBe(-1);
+      expect(state.entities.get('mover')?.position?.z).toBe(0);
+
+      state = applyEntityDisappeared(state, 'mover', { q: 2, r: -1, s: -1 });
+      expect(state.entities.get('mover')?.ghost).toBe(true);
+      expect(state.entities.get('mover')?.position?.x).toBe(2);
+      expect(state.entities.get('mover')?.position?.y).toBe(-1);
+      expect(state.entities.get('mover')?.position?.z).toBe(-1);
+
+      state = applyEntityAppeared(
+        state,
+        makeTestEntity('mover', { x: 5, y: -3, z: -2 })
+      );
+      expect(state.entities.get('mover')?.ghost).toBeFalsy();
+      expect(state.entities.get('mover')?.position?.x).toBe(5);
+      expect(state.entities.get('mover')?.position?.y).toBe(-3);
+      expect(state.entities.get('mover')?.position?.z).toBe(-2);
+    });
   });
 });

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -9,7 +9,11 @@
  * Part of the unified entity state refactor (rpg-dnd5e-web feat-unified-entity-state).
  */
 
-import type { Position } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import { create } from '@bufbuild/protobuf';
+import {
+  PositionSchema,
+  type Position,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import type {
   CombatState,
   DoorInfo,
@@ -19,17 +23,20 @@ import type {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { DungeonState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { useCallback, useState } from 'react';
+import { hexKey, type CubeHexCoord } from '../utils/hexCoord';
 
 /** Local representation of encounter state using JS Maps for O(1) lookups */
 export interface LocalEncounterState {
   encounterId: string;
   dungeonId: string;
-  /** All entities in the encounter, keyed by entity ID */
-  entities: Map<string, EntityState>;
+  /** All entities, keyed by entity ID. v2 may set entity.ghost on LoS loss. */
+  entities: Map<string, EntityState & { ghost?: boolean }>;
   /** All rooms in the dungeon, keyed by room ID */
   rooms: Map<string, RoomLayout>;
   currentRoomId: string;
   revealedRoomIds: string[];
+  /** v1alpha2-revealed hexes (per-hex granularity). UI renders revealed if either revealedHexes covers it OR the room is in revealedRoomIds. */
+  revealedHexes: Set<string>;
   combat: CombatState | null;
   /** All doors in the dungeon, keyed by connection ID */
   doors: Map<string, DoorInfo>;
@@ -46,6 +53,7 @@ export function createEmptyEncounterState(): LocalEncounterState {
     rooms: new Map(),
     currentRoomId: '',
     revealedRoomIds: [],
+    revealedHexes: new Set(),
     combat: null,
     doors: new Map(),
     dungeonState: DungeonState.UNSPECIFIED,
@@ -68,6 +76,7 @@ export function applySnapshotToState(
     rooms: new Map(Object.entries(proto.rooms ?? {})),
     currentRoomId: proto.currentRoomId,
     revealedRoomIds: proto.revealedRoomIds,
+    revealedHexes: new Set(), // v2 reveals come back via the stream's GeometryRevealed deltas
     combat: proto.combat ?? null,
     doors: new Map(Object.entries(proto.doors ?? {})),
     dungeonState: proto.dungeonState,
@@ -118,6 +127,65 @@ export function mergeEntityPosition(
 }
 
 /**
+ * Add hexes to the per-hex reveal set without dropping previously revealed hexes.
+ * Uses hexKey() for stable 'q,r,s' string keys. Idempotent — re-adding an
+ * already-revealed hex is a no-op (Set semantics).
+ * Exported for testing.
+ */
+export function applyHexRevealed(
+  prev: LocalEncounterState,
+  hexes: CubeHexCoord[]
+): LocalEncounterState {
+  const next = new Set(prev.revealedHexes);
+  for (const h of hexes) {
+    next.add(hexKey(h));
+  }
+  return { ...prev, revealedHexes: next };
+}
+
+/**
+ * Add or revive an entity in the store at its first-visible position.
+ * Clears the ghost flag unconditionally — the entity is now visible.
+ * Overwrites any prior entry with the same entityId (e.g. a ghosted entity
+ * that just re-entered the player's line of sight).
+ * Exported for testing.
+ */
+export function applyEntityAppeared(
+  prev: LocalEncounterState,
+  entity: EntityState
+): LocalEncounterState {
+  const newEntities = new Map(prev.entities);
+  newEntities.set(entity.entityId, { ...entity, ghost: false });
+  return { ...prev, entities: newEntities };
+}
+
+/**
+ * Mark an entity as ghosted (no longer visible) and update its position to
+ * the last known hex. Renders ghosts at the last place the player saw them.
+ * No-op if the entity is not currently tracked (defensive guard).
+ * Exported for testing.
+ */
+export function applyEntityDisappeared(
+  prev: LocalEncounterState,
+  entityId: string,
+  lastKnown: CubeHexCoord
+): LocalEncounterState {
+  const existing = prev.entities.get(entityId);
+  if (!existing) return prev;
+  const newEntities = new Map(prev.entities);
+  newEntities.set(entityId, {
+    ...existing,
+    ghost: true,
+    position: create(PositionSchema, {
+      x: lastKnown.q,
+      y: lastKnown.r,
+      z: lastKnown.s,
+    }),
+  });
+  return { ...prev, entities: newEntities };
+}
+
+/**
  * Replace combat state without touching entities or other fields.
  * Exported for testing.
  */
@@ -144,6 +212,13 @@ export interface UseEncounterStateResult {
   applyCombatState: (combat: CombatState) => void;
   /** Reset to empty state (new encounter or disconnect) */
   reset: () => void;
+  // v1alpha2 additions
+  /** Add hexes to the per-hex reveal set (additive, idempotent) */
+  applyHexRevealed: (hexes: CubeHexCoord[]) => void;
+  /** Add or revive an entity at its first-visible position, clearing ghost */
+  applyEntityAppeared: (entity: EntityState) => void;
+  /** Mark entity as ghosted at last known position; no-op if not tracked */
+  applyEntityDisappeared: (entityId: string, lastKnown: CubeHexCoord) => void;
 }
 
 /**
@@ -178,6 +253,21 @@ export function useEncounterState(): UseEncounterStateResult {
     setState(createEmptyEncounterState());
   }, []);
 
+  const applyHexRevealedCallback = useCallback((hexes: CubeHexCoord[]) => {
+    setState((prev) => applyHexRevealed(prev, hexes));
+  }, []);
+
+  const applyEntityAppearedCallback = useCallback((entity: EntityState) => {
+    setState((prev) => applyEntityAppeared(prev, entity));
+  }, []);
+
+  const applyEntityDisappearedCallback = useCallback(
+    (entityId: string, lastKnown: CubeHexCoord) => {
+      setState((prev) => applyEntityDisappeared(prev, entityId, lastKnown));
+    },
+    []
+  );
+
   return {
     state,
     applySnapshot,
@@ -185,5 +275,8 @@ export function useEncounterState(): UseEncounterStateResult {
     applyEntityPositionUpdate,
     applyCombatState,
     reset,
+    applyHexRevealed: applyHexRevealedCallback,
+    applyEntityAppeared: applyEntityAppearedCallback,
+    applyEntityDisappeared: applyEntityDisappearedCallback,
   };
 }

--- a/src/utils/entityHelpers.ts
+++ b/src/utils/entityHelpers.ts
@@ -83,6 +83,8 @@ export interface RenderableEntity {
   position: { x: number; y: number; z: number };
   type: 'player' | 'monster' | 'obstacle';
   isDead: boolean;
+  /** True when the entity has left the player's LoS (v1alpha2). Render at last-known position with ghost visuals. */
+  isGhost?: boolean;
 }
 
 function entityDisplayType(
@@ -104,7 +106,7 @@ function entityDisplayType(
  * shape (no `getEntityName`, has `deadMonsterIds` set) and is not covered here.
  */
 export function mapEntitiesForRender(
-  entities: Iterable<EntityState>
+  entities: Iterable<EntityState & { ghost?: boolean }>
 ): RenderableEntity[] {
   const result: RenderableEntity[] = [];
   for (const entity of entities) {
@@ -118,6 +120,7 @@ export function mapEntitiesForRender(
       },
       type: entityDisplayType(entity),
       isDead: isDead(entity),
+      isGhost: entity.ghost === true,
     });
   }
   return result;

--- a/src/utils/hexCoord.test.ts
+++ b/src/utils/hexCoord.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { hexToProtoPosition, protoPositionToHex } from './hexCoord';
+
+// HexCoord uses (q, r, s); Position uses (x, y, z). Both cube; 1:1 mapping.
+
+describe('protoPositionToHex', () => {
+  it('maps cube position (1, -1, 0) to hex (1, -1, 0)', () => {
+    const pos = { x: 1, y: -1, z: 0 };
+    expect(protoPositionToHex(pos)).toEqual({ q: 1, r: -1, s: 0 });
+  });
+
+  it('preserves the cube invariant x + y + z = 0', () => {
+    const cases = [
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: -1, z: -1 },
+      { x: -3, y: 5, z: -2 },
+    ];
+    for (const pos of cases) {
+      const hex = protoPositionToHex(pos);
+      expect(hex.q + hex.r + hex.s).toBe(0);
+    }
+  });
+});
+
+describe('hexToProtoPosition', () => {
+  it('round-trips through protoPositionToHex', () => {
+    const cases = [
+      { q: 0, r: 0, s: 0 },
+      { q: 1, r: -1, s: 0 },
+      { q: -2, r: 1, s: 1 },
+      { q: 5, r: -3, s: -2 },
+    ];
+    for (const hex of cases) {
+      const pos = hexToProtoPosition(hex);
+      expect(protoPositionToHex(pos)).toEqual(hex);
+    }
+  });
+});

--- a/src/utils/hexCoord.ts
+++ b/src/utils/hexCoord.ts
@@ -1,8 +1,13 @@
 /**
- * Cube hex coordinates (q, r, s) used by src/components/hex-grid/hexMath.ts.
+ * Cube hex coordinates (q, r, s) — the v1alpha2 coordinate-transform path.
  * The cube invariant q + r + s = 0 holds for valid hexes.
+ *
+ * Distinct from src/rendering/FloorBuilder.ts's `HexCoord` (2-field axial
+ * `{q, r}`) and src/components/hex-grid/hexMath.ts's `CubeCoord` (3-field
+ * `{x, y, z}`). The intentional rename to `CubeHexCoord` avoids structural-
+ * typing collisions with those neighbors.
  */
-export interface HexCoord {
+export interface CubeHexCoord {
   q: number;
   r: number;
   s: number;
@@ -20,17 +25,17 @@ export interface ProtoPosition {
   z: number;
 }
 
-export function protoPositionToHex(pos: ProtoPosition): HexCoord {
+export function protoPositionToHex(pos: ProtoPosition): CubeHexCoord {
   return { q: pos.x, r: pos.y, s: pos.z };
 }
 
-export function hexToProtoPosition(hex: HexCoord): ProtoPosition {
+export function hexToProtoPosition(hex: CubeHexCoord): ProtoPosition {
   return { x: hex.q, y: hex.r, z: hex.s };
 }
 
 /**
  * Stable string key for a hex coord — usable in Set<string> / Map<string, T>.
  */
-export function hexKey(hex: HexCoord): string {
+export function hexKey(hex: CubeHexCoord): string {
   return `${hex.q},${hex.r},${hex.s}`;
 }

--- a/src/utils/hexCoord.ts
+++ b/src/utils/hexCoord.ts
@@ -1,0 +1,36 @@
+/**
+ * Cube hex coordinates (q, r, s) used by src/components/hex-grid/hexMath.ts.
+ * The cube invariant q + r + s = 0 holds for valid hexes.
+ */
+export interface HexCoord {
+  q: number;
+  r: number;
+  s: number;
+}
+
+/**
+ * v1alpha2's Position is cube (x, y, z) with the same invariant
+ * (x + y + z = 0). Mapping is direct: q := x, r := y, s := z.
+ *
+ * Wrapped in this helper so a future proto field rename is a one-place fix.
+ */
+export interface ProtoPosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export function protoPositionToHex(pos: ProtoPosition): HexCoord {
+  return { q: pos.x, r: pos.y, s: pos.z };
+}
+
+export function hexToProtoPosition(hex: HexCoord): ProtoPosition {
+  return { x: hex.q, y: hex.r, z: hex.s };
+}
+
+/**
+ * Stable string key for a hex coord — usable in Set<string> / Map<string, T>.
+ */
+export function hexKey(hex: HexCoord): string {
+  return `${hex.q},${hex.r},${hex.s}`;
+}


### PR DESCRIPTION
Closes #387. Coordinates with rpg-api PR #496 (slice 1) — both must merge for the wave to flip.

## Wave goal (verified end-to-end on two-browser playtest)

> **Two players in one encounter, one moves, the broker delivers per-viewer projected events to each — and the web renders the move from each player's perspective with no client-side filtering.**

Verified locally on 2026-05-07: two browsers (alice + bob), seeded `enc:v2:dev-encounter` in Redis, alice moves → bob's tab gets `EntityMoved char-alice`; bob moves → alice's tab gets `EntityMoved char-bob`. Hex reveal counts differ between tabs (per-viewer LoS projection working).

## What ships

**Strictly additive.** No v1alpha1 paths deleted; v1 movement rendering still alive (slice 3 cleanup territory).

### Stream + state

- `src/api/useEncounterStream2.ts` — v1alpha2 `StreamEncounter` hook with typed callback bag, async-iterator → callback dispatch, exponential-backoff reconnect (shared `RECONNECT_CONFIG`), AbortController unmount cleanup
- `src/api/encounterStream2Dispatch.ts` — typed dispatcher for the 5 wave-2.5 event cases (`SnapshotDelivered`, `EntityMoved`, `GeometryRevealed`, `EntityAppeared`, `EntityDisappeared`)
- `src/api/useMoveEntityV2.ts` — v1alpha2 `MoveEntity` unary RPC hook (wraps `encounterClientV2.moveEntity`)
- `src/api/fakeEncounterStream2.ts` — async-iterable test helper
- `src/hooks/useEncounterState.ts` — adds `revealedHexes: Set<string>`, `entities: Map<string, EntityState & {ghost?: boolean}>`, plus reducers `applyHexRevealed`, `applyEntityAppeared`, `applyEntityDisappeared`

### Rendering

- `src/components/LobbyView.tsx` — mounts v2 stream alongside existing v1; drops v1 movement callbacks (v2 owns those now); adds URL-param `?playerId=` override so 2-tab dev sessions can run as different players
- `src/components/encounter/BattleMapPanel.tsx` — accepts `revealedHexes` prop, merges with floor tiles for rendering
- `src/components/hex-grid/HexEntity.tsx` — `isGhost` prop drives ghost shader + suppresses click/cursor (last-known-position render for entities outside LoS); `useThree().invalidate()` on ghost transitions because R3F runs `frameloop="demand"`
- `src/components/hex-grid/MediumHumanoid.tsx` — wires `ghostAmount` to existing shader uniform

### Verification harness (`/playtest` route, dev-only)

Slice 2 had a verification gap: the original plan consumed v2 events but never wired v2 `MoveEntity` (web's existing click-to-move calls v1). The wave goal sentence ("alice clicks a hex to move, both see EntityMoved") couldn't actually be exercised from the browser without v2-side action wiring.

To close the gap, this PR adds a deletable harness:

- `src/components/playtest/PlaytestHarness.tsx` — debug-style render: connection state, entities table, revealed-hex set, recent-events log, click-to-move via `useMoveEntityV2`. Synchronously calls `setAuth(null, playerId)` so the gRPC interceptor's `Authorization: Dev <playerId>` header matches the URL playerId param.
- `src/App.tsx` — gate: when `?encounterId=` URL param is present in dev mode, render `<PlaytestHarness/>` instead of the normal flow
- Hardcoded seeded fallback positions (alice at 0,0,0; bob at 1,-1,0) so the move button enables on first load — slice 1's `SnapshotDelivered.encounter` is empty by design, and the v2 server doesn't replay `EntityAppeared` for already-visible entities at connect (deferred to a followup)

Slice 3 (post-wave) deletes the harness along with v1alpha1 movement paths.

## Tests

23 commits. New tests:

- `useEncounterStream2.test.ts` — connection lifecycle, dispatch, unknown-case logging, unmount, null encounterId, exponential-backoff reconnect (8 tests)
- `useEncounterStream2.integration.test.tsx` — full callback chain into `useEncounterState` via fake stream (4 tests)
- `useMoveEntityV2.test.ts` — request shape, loading state, error handling (5 tests)
- `PlaytestHarness.test.tsx` — URL param parsing, event flow, click-to-move (8 tests)
- `useEncounterState.test.ts` — new reducers (existing test file extended)
- `encounterStream2Dispatch.test.ts` — typed dispatch coverage

All CI checks green: format, lint, typecheck, build, full vitest suite (375 tests).

## Spec / plan / docs

- Spec: `rpg-project/ideas/encounter/v1alpha2/sdk-direction-web.md`
- Plan: `rpg-project/ideas/encounter/v1alpha2/plans/04-web-walking-skeleton.md`
- Coordinated with: rpg-api PR #496 (slice 1 — service registration, MoveEntity, StreamEncounter, Redis-backed v2 Repository)

## Followups (filed, not blocking)

- rpg-project#17 — R&D for modular debug tooling (the harness's debug panel + interactive space-component idea)
- Server-side: emit `EntityAppeared` / `GeometryRevealed` for already-visible entities at stream connect (slice 1's deferred SnapshotDelivered.encounter)
- Toolkit: Move accepts pathing onto another entity's hex without collision rejection
- Slice 3: delete v1alpha1 movement callbacks + the playtest harness

## Test plan

- [x] Two-browser local playtest passes wave-2.5 sentence
- [x] CI green on all checks
- [x] No v1alpha1 callback removals beyond the spec-allowed movement-specific ones
- [ ] Reviewer confirms additive scope (nothing removed that slice 3 should remove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)