### PR TITLE
feat(encounter/v2): consume DoorOpened event + add open-door harness button (#392)

### DIFF
--- a/src/api/encounterStream2Dispatch.test.ts
+++ b/src/api/encounterStream2Dispatch.test.ts
@@ -64,6 +64,21 @@ describe('dispatchEncounterStream2Event', () => {
     expect(onEntityDisappeared).toHaveBeenCalledTimes(1);
   });
 
+  it('routes doorOpened to onDoorOpened', () => {
+    const onDoorOpened = vi.fn();
+    const options: EncounterStream2Options = { onDoorOpened };
+    // Wave 2.7: revealedHexes/walls/removedWalls intentionally empty here;
+    // the geometry side flows on a separate GeometryRevealed event.
+    const event = makeEvent('doorOpened', {
+      doorEntityId: 'door-east',
+      revealedHexes: [],
+      revealedWalls: [],
+      removedWalls: [],
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onDoorOpened).toHaveBeenCalledTimes(1);
+  });
+
   it('logs a warning for unknown event cases without throwing', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const event = makeEvent('someUnknownCase' as 'snapshotDelivered', {});

--- a/src/api/encounterStream2Dispatch.ts
+++ b/src/api/encounterStream2Dispatch.ts
@@ -1,4 +1,5 @@
 import type {
+  DoorOpened,
   EncounterEvent,
   EntityAppeared,
   EntityDisappeared,
@@ -14,6 +15,11 @@ import type {
  * NOTE: onSnapshotDelivered is called every time the stream opens (initial
  * connect + every reconnect). The payload's `encounter` field is empty in
  * slice 1 — DO NOT apply it as state. Treat as a stream-up sync barrier.
+ *
+ * Cause/effect split: DoorOpened (cause) carries only the door identity in
+ * Wave 2.7; the actual reveal data (newly-visible hexes) flows on a parallel
+ * GeometryRevealed (effect) event from the toolkit's deliberate two-phase
+ * emission. Consumers should subscribe to BOTH; do not try to combine them.
  */
 export interface EncounterStream2Options {
   /** slice-1: encounter field is empty; treat as connect-confirm only. */
@@ -22,6 +28,12 @@ export interface EncounterStream2Options {
   onGeometryRevealed?: (event: GeometryRevealed) => void;
   onEntityAppeared?: (event: EntityAppeared) => void;
   onEntityDisappeared?: (event: EntityDisappeared) => void;
+  /**
+   * Wave 2.7: door state transitions to open. The event's revealedHexes /
+   * revealedWalls / removedWalls fields are intentionally empty — the
+   * geometry side flows on a separate GeometryRevealed event.
+   */
+  onDoorOpened?: (event: DoorOpened) => void;
 }
 
 /**
@@ -50,12 +62,15 @@ export function dispatchEncounterStream2Event(
     case 'entityDisappeared':
       options.onEntityDisappeared?.(payload.value);
       break;
+    case 'doorOpened':
+      options.onDoorOpened?.(payload.value);
+      break;
     default:
-      // Either out-of-slice-2-scope but known to the proto (entityDamaged,
-      // turnStarted, encounterEnded, etc. — the proto defines 22 event cases;
-      // slice 2 handles 5) OR a genuinely unknown case from a proto version
-      // mismatch. Either way: warn + continue so the stream doesn't tear down.
-      // Add a case arm + callback when the feature lands in a future slice.
+      // Either out-of-current-scope but known to the proto (entityDamaged,
+      // turnStarted, encounterEnded, etc. — the proto defines 20+ event cases;
+      // we currently handle 6) OR a genuinely unknown case from a proto
+      // version mismatch. Either way: warn + continue so the stream doesn't
+      // tear down. Add a case arm + callback when the feature lands.
       // The cast strips the narrowed-to-undefined `case` so we can log it.
       console.warn(
         '[useEncounterStream2] unhandled event case:',

--- a/src/api/useEncounterStream2.integration.test.tsx
+++ b/src/api/useEncounterStream2.integration.test.tsx
@@ -73,6 +73,9 @@ function useTestHarness(encounterId: string) {
         );
       }
     },
+    onDoorOpened: (e) => {
+      state.applyDoorOpened(e.doorEntityId);
+    },
   });
   return state.state;
 }
@@ -172,6 +175,40 @@ describe('useEncounterStream2 + useEncounterState — integration', () => {
       ).toBe(true);
       expect(
         result.current.revealedHexes.has(hexKey({ q: 6, r: -3, s: -3 }))
+      ).toBe(true);
+    });
+  });
+
+  it('DoorOpened + GeometryRevealed flow into both openDoors and revealedHexes (cause/effect split)', async () => {
+    // Wave 2.7: the toolkit emits DoorOpened (cause, no hex data) and a
+    // parallel GeometryRevealed (effect, with newly-visible hexes). The two
+    // reducers must update independently — door state on one, hex set on the
+    // other — without either swallowing the other.
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('doorOpened', {
+          doorEntityId: 'door-east',
+          revealedHexes: [],
+          revealedWalls: [],
+          removedWalls: [],
+        })
+      )
+    );
+    act(() =>
+      fake.push(
+        makeEvent('geometryRevealed', {
+          hexes: [{ position: { x: 4, y: -2, z: -2 } }],
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(result.current.openDoors.has('door-east')).toBe(true);
+      expect(
+        result.current.revealedHexes.has(hexKey({ q: 4, r: -2, s: -2 }))
       ).toBe(true);
     });
   });

--- a/src/api/useInteractV2.test.ts
+++ b/src/api/useInteractV2.test.ts
@@ -1,0 +1,137 @@
+import type { InteractResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted lets us reference these before imports are evaluated
+const hoisted = vi.hoisted(() => ({
+  interactFn: vi.fn<() => Promise<InteractResponse>>(),
+}));
+
+vi.mock('./client', () => ({
+  encounterClientV2: {
+    interact: hoisted.interactFn,
+  },
+}));
+
+// Import AFTER vi.mock so the mock is applied
+import { useInteractV2 } from './useInteractV2';
+
+beforeEach(() => {
+  hoisted.interactFn.mockReset();
+});
+
+describe('useInteractV2', () => {
+  it('starts with loading=false and no error', () => {
+    const { result } = renderHook(() => useInteractV2());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls encounterClientV2.interact with correct request shape', async () => {
+    const fakeResponse = {} as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(fakeResponse);
+
+    const { result } = renderHook(() => useInteractV2());
+
+    let response: InteractResponse | undefined;
+    await act(async () => {
+      response = await result.current.interact('enc-1', 'door-east', 'open');
+    });
+
+    expect(response).toBe(fakeResponse);
+    expect(hoisted.interactFn).toHaveBeenCalledOnce();
+
+    expect(hoisted.interactFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        targetEntityId: 'door-east',
+        interactionKind: 'open',
+      })
+    );
+  });
+
+  it('omits interactionKind when not provided', async () => {
+    hoisted.interactFn.mockResolvedValue({} as InteractResponse);
+
+    const { result } = renderHook(() => useInteractV2());
+
+    await act(async () => {
+      await result.current.interact('enc-1', 'door-east');
+    });
+
+    expect(hoisted.interactFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        targetEntityId: 'door-east',
+      })
+    );
+    // The proto Schema leaves optional fields undefined when not passed.
+    // Pull the recorded request out via an unknown[] cast to dodge the
+    // zero-arg vi.fn signature (kept in lockstep with useMoveEntityV2.test).
+    const calls = hoisted.interactFn.mock.calls as unknown as Array<
+      Array<{ interactionKind?: string }>
+    >;
+    expect(calls[0][0].interactionKind).toBeUndefined();
+  });
+
+  it('sets loading=true during the call and false after success', async () => {
+    let resolveRpc!: (v: InteractResponse) => void;
+    const pendingRpc = new Promise<InteractResponse>(
+      (resolve) => (resolveRpc = resolve)
+    );
+    hoisted.interactFn.mockReturnValue(pendingRpc);
+
+    const { result } = renderHook(() => useInteractV2());
+
+    // Kick off the interact without awaiting
+    act(() => {
+      void result.current.interact('enc-1', 'door-east', 'open');
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Resolve the RPC
+    act(() => resolveRpc({} as InteractResponse));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('sets error on RPC failure, loading=false, and promise rejects', async () => {
+    const rpcError = new Error('door is locked');
+    hoisted.interactFn.mockRejectedValue(rpcError);
+
+    const { result } = renderHook(() => useInteractV2());
+
+    await act(async () => {
+      await expect(
+        result.current.interact('enc-1', 'door-east', 'open')
+      ).rejects.toThrow('door is locked');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(rpcError);
+  });
+
+  it('clears error on subsequent successful call', async () => {
+    hoisted.interactFn
+      .mockRejectedValueOnce(new Error('first fail'))
+      .mockResolvedValue({} as InteractResponse);
+
+    const { result } = renderHook(() => useInteractV2());
+
+    // First call fails
+    await act(async () => {
+      await expect(
+        result.current.interact('enc-1', 'door-east', 'open')
+      ).rejects.toThrow('first fail');
+    });
+    expect(result.current.error).not.toBeNull();
+
+    // Second call succeeds
+    await act(async () => {
+      await result.current.interact('enc-1', 'door-east', 'open');
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/api/useInteractV2.ts
+++ b/src/api/useInteractV2.ts
@@ -1,0 +1,67 @@
+import { create } from '@bufbuild/protobuf';
+import type { InteractResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { InteractRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { useCallback, useState } from 'react';
+import { encounterClientV2 } from './client';
+
+export interface UseInteractV2Result {
+  /**
+   * Calls the v1alpha2 Interact unary RPC. The world-changing effects of the
+   * interaction (door opens, hexes revealed, etc.) flow back as separate
+   * events on the StreamEncounter; the response itself only carries
+   * caller-private follow-ups (skill check prompts, dialogue choices).
+   */
+  interact: (
+    encounterId: string,
+    targetEntityId: string,
+    interactionKind?: string
+  ) => Promise<InteractResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Thin wrapper around the v1alpha2 Interact unary RPC.
+ *
+ * - loading=true while the RPC is in-flight, false on resolve/reject
+ * - error is set on failure, cleared on the next successful call
+ * - The returned promise rejects on RPC error so callers can surface it
+ *
+ * Mirrors useMoveEntityV2 — one file per v1alpha2 verb under src/api/.
+ */
+export function useInteractV2(): UseInteractV2Result {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const interact = useCallback(
+    async (
+      encounterId: string,
+      targetEntityId: string,
+      interactionKind?: string
+    ): Promise<InteractResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(InteractRequestSchema, {
+        encounterId,
+        targetEntityId,
+        interactionKind,
+      });
+
+      try {
+        const response = await encounterClientV2.interact(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('Interact RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { interact, loading, error };
+}

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -1,6 +1,9 @@
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
-import type { MoveEntityResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import type {
+  InteractResponse,
+  MoveEntityResponse,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 import {
   act,
   fireEvent,
@@ -22,6 +25,7 @@ function makeEvent(caseName: string, value: unknown): EncounterEvent {
 const hoisted = vi.hoisted(() => ({
   fakeRef: { current: null as FakeStream | null },
   moveEntityFn: vi.fn<() => Promise<MoveEntityResponse>>(),
+  interactFn: vi.fn<() => Promise<InteractResponse>>(),
 }));
 
 vi.mock('../../api/client', () => ({
@@ -33,6 +37,7 @@ vi.mock('../../api/client', () => ({
       return hoisted.fakeRef.current.iterator;
     }),
     moveEntity: hoisted.moveEntityFn,
+    interact: hoisted.interactFn,
   },
 }));
 
@@ -46,6 +51,8 @@ beforeEach(() => {
   hoisted.fakeRef.current = fake;
   hoisted.moveEntityFn.mockReset();
   hoisted.moveEntityFn.mockResolvedValue({} as MoveEntityResponse);
+  hoisted.interactFn.mockReset();
+  hoisted.interactFn.mockResolvedValue({} as InteractResponse);
 
   // Set up URL with both params
   window.history.pushState({}, '', '?encounterId=enc-1&playerId=alice');
@@ -221,6 +228,126 @@ describe('PlaytestHarness', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/EntityMoved/i)).toBeTruthy();
+    });
+  });
+
+  it('renders the open-door section with input and button disabled by default', () => {
+    render(<PlaytestHarness />);
+    // The "Open door" heading should render (the button has the same text,
+    // so use the role:heading filter to disambiguate)
+    expect(screen.getByRole('heading', { name: /^open door$/i })).toBeTruthy();
+    expect(screen.getByText(/Open doors \(0\)/)).toBeTruthy();
+    const input = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    const btn = screen.getByRole('button', {
+      name: /open door/i,
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('calls interact RPC with target door id and "open" kind on click', async () => {
+    render(<PlaytestHarness />);
+
+    const input = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'door-east' } });
+    });
+
+    const btn = screen.getByRole('button', {
+      name: /open door/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(btn.disabled).toBe(false));
+
+    act(() => fireEvent.click(btn));
+
+    await waitFor(() => {
+      expect(hoisted.interactFn).toHaveBeenCalledOnce();
+    });
+
+    expect(hoisted.interactFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        targetEntityId: 'door-east',
+        interactionKind: 'open',
+      })
+    );
+  });
+
+  it('logs DoorOpened and reflects open door in the open-doors list on event', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('doorOpened', {
+          doorEntityId: 'door-east',
+          revealedHexes: [],
+          revealedWalls: [],
+          removedWalls: [],
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/DoorOpened door-east/i)).toBeTruthy();
+    });
+    expect(screen.getByText(/Open doors \(1\):.*door-east/)).toBeTruthy();
+  });
+
+  it('logs both DoorOpened and GeometryRevealed independently (cause/effect split)', async () => {
+    // Wave 2.7: the toolkit emits the cause (DoorOpened, no hexes) and the
+    // effect (GeometryRevealed, with hexes) as two separate events. The
+    // harness must surface both in the log; the dispatcher must not collapse
+    // them.
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('doorOpened', {
+          doorEntityId: 'door-east',
+          revealedHexes: [],
+          revealedWalls: [],
+          removedWalls: [],
+        })
+      )
+    );
+    act(() =>
+      fake.push(
+        makeEvent('geometryRevealed', {
+          hexes: [
+            { position: { x: 1, y: -1, z: 0 } },
+            { position: { x: 2, y: -2, z: 0 } },
+          ],
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/DoorOpened door-east/i)).toBeTruthy();
+      expect(screen.getByText(/GeometryRevealed 2 hex/i)).toBeTruthy();
+    });
+  });
+
+  it('shows interact error when RPC fails', async () => {
+    hoisted.interactFn.mockRejectedValue(new Error('door is locked'));
+
+    render(<PlaytestHarness />);
+
+    const input = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'door-east' } });
+    });
+
+    const btn = screen.getByRole('button', {
+      name: /open door/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(btn.disabled).toBe(false));
+
+    act(() => fireEvent.click(btn));
+
+    await waitFor(() => {
+      expect(screen.getByText(/door is locked/i)).toBeTruthy();
     });
   });
 });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { v2PositionToV1 } from '../../api/positionConvert';
 import { useDevPlayerIdAuth } from '../../api/useDevPlayerIdAuth';
 import { useEncounterStream2 } from '../../api/useEncounterStream2';
+import { useInteractV2 } from '../../api/useInteractV2';
 import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
 import { protoPositionToHex } from '../../utils/hexCoord';
@@ -35,6 +36,7 @@ export function PlaytestHarness() {
   const [targetQ, setTargetQ] = useState(0);
   const [targetR, setTargetR] = useState(0);
   const [targetS, setTargetS] = useState(0);
+  const [targetDoorId, setTargetDoorId] = useState('');
 
   const encounterState = useEncounterState();
   const {
@@ -42,6 +44,11 @@ export function PlaytestHarness() {
     loading: moveLoading,
     error: moveError,
   } = useMoveEntityV2();
+  const {
+    interact,
+    loading: interactLoading,
+    error: interactError,
+  } = useInteractV2();
 
   const addLog = (msg: string) => {
     const entry = `[${formatTime(new Date())}] ${msg}`;
@@ -92,6 +99,13 @@ export function PlaytestHarness() {
         }
         addLog(`EntityDisappeared ${e.entityId}`);
       },
+      onDoorOpened: (e) => {
+        // Cause/effect split: DoorOpened only carries the door identity in
+        // Wave 2.7; the newly-visible hexes flow on a parallel
+        // GeometryRevealed event handled above. Log both lines independently.
+        encounterState.applyDoorOpened(e.doorEntityId);
+        addLog(`DoorOpened ${e.doorEntityId}`);
+      },
     }
   );
 
@@ -132,8 +146,20 @@ export function PlaytestHarness() {
     }
   };
 
+  const handleOpenDoor = async () => {
+    const id = targetDoorId.trim();
+    if (!id) return;
+    try {
+      await interact(encounterId, id, 'open');
+      addLog(`Interact(open) → ${id}`);
+    } catch {
+      // error is surfaced via interactError state
+    }
+  };
+
   const entitiesArray = Array.from(encounterState.state.entities.entries());
   const revealedKeys = Array.from(encounterState.state.revealedHexes);
+  const openDoorKeys = Array.from(encounterState.state.openDoors);
 
   return (
     <div
@@ -319,6 +345,60 @@ export function PlaytestHarness() {
           {moveError && (
             <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
               Move error: {moveError.message}
+            </div>
+          )}
+
+          {/* Open-door controls (Wave 2.7 verification scaffold; deleted in slice 3) */}
+          <h3 style={{ margin: '16px 0 8px', color: '#aaa' }}>Open door</h3>
+          <div style={{ fontSize: 12, color: '#777', marginBottom: 8 }}>
+            Open doors ({openDoorKeys.length}):{' '}
+            {openDoorKeys.length === 0 ? '(none)' : openDoorKeys.join(', ')}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <label style={{ fontSize: 12 }}>
+              Door id{' '}
+              <input
+                type="text"
+                value={targetDoorId}
+                onChange={(e) => setTargetDoorId(e.target.value)}
+                placeholder="door-east"
+                aria-label="door id"
+                style={{
+                  width: 140,
+                  background: '#333',
+                  color: '#eee',
+                  border: '1px solid #555',
+                  padding: '2px 4px',
+                }}
+              />
+            </label>
+            <button
+              onClick={() => void handleOpenDoor()}
+              disabled={!targetDoorId.trim() || interactLoading}
+              style={{
+                padding: '4px 12px',
+                background: targetDoorId.trim() ? '#2a4a2a' : '#2a2a2a',
+                color: targetDoorId.trim() ? '#8f8' : '#666',
+                border: '1px solid #555',
+                cursor:
+                  targetDoorId.trim() && !interactLoading
+                    ? 'pointer'
+                    : 'not-allowed',
+              }}
+            >
+              {interactLoading ? 'Opening…' : 'Open door'}
+            </button>
+          </div>
+          {interactError && (
+            <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
+              Interact error: {interactError.message}
             </div>
           )}
         </div>

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -679,6 +679,78 @@ describe('v1alpha2 reducer additions', () => {
     });
   });
 
+  describe('applySnapshotToState — v2 delta preservation across v1 snapshots', () => {
+    // Regression: v1alpha1 snapshots don't carry v2-only delta fields like
+    // openDoors / revealedHexes, and v2 deltas aren't replayed on sync. The
+    // main app calls applySnapshot on multiple v1 paths (LobbyView's
+    // state-sync handlers), so a naive rebuild would silently wipe every
+    // door we'd opened mid-session. applySnapshotToState carries these
+    // fields forward when prev is for the same encounter.
+    it('preserves openDoors when applying a same-encounter v1 snapshot', () => {
+      // Seed: open a door via the v2 reducer
+      let state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }));
+      state = applyDoorOpened(state, 'door-1');
+      state = applyDoorOpened(state, 'door-east');
+      expect(state.openDoors.size).toBe(2);
+
+      // Simulate a v1 snapshot sync for the same encounter
+      const refreshed = applySnapshotToState(
+        makeSnapshot({ encounterId: 'enc-1' }),
+        state
+      );
+
+      expect(refreshed.openDoors.has('door-1')).toBe(true);
+      expect(refreshed.openDoors.has('door-east')).toBe(true);
+      expect(refreshed.openDoors.size).toBe(2);
+    });
+
+    it('preserves revealedHexes when applying a same-encounter v1 snapshot', () => {
+      let state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }));
+      state = applyHexRevealed(state, [
+        { q: 1, r: -1, s: 0 },
+        { q: 2, r: -2, s: 0 },
+      ]);
+      expect(state.revealedHexes.size).toBe(2);
+
+      const refreshed = applySnapshotToState(
+        makeSnapshot({ encounterId: 'enc-1' }),
+        state
+      );
+
+      expect(refreshed.revealedHexes.size).toBe(2);
+      expect(refreshed.revealedHexes.has(hexKey({ q: 1, r: -1, s: 0 }))).toBe(
+        true
+      );
+      expect(refreshed.revealedHexes.has(hexKey({ q: 2, r: -2, s: 0 }))).toBe(
+        true
+      );
+    });
+
+    it('resets v2 delta state on encounter switch (different encounterId)', () => {
+      // Crossing into a new encounter is a clean break — v2 deltas from the
+      // prior encounter must not leak into the new one.
+      let state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }));
+      state = applyDoorOpened(state, 'door-1');
+      state = applyHexRevealed(state, [{ q: 1, r: -1, s: 0 }]);
+
+      const switched = applySnapshotToState(
+        makeSnapshot({ encounterId: 'enc-2' }),
+        state
+      );
+
+      expect(switched.openDoors.size).toBe(0);
+      expect(switched.revealedHexes.size).toBe(0);
+    });
+
+    it('starts with empty v2 delta state when prev is omitted (first snapshot)', () => {
+      const state = applySnapshotToState(
+        makeSnapshot({ encounterId: 'enc-1' })
+      );
+      expect(state.openDoors.size).toBe(0);
+      expect(state.revealedHexes.size).toBe(0);
+    });
+  });
+
   describe('appear/disappear sequences', () => {
     it('survives appeared → moved → disappeared → appeared cleanly', () => {
       let state = createEmptyEncounterState();

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -26,6 +26,7 @@ import {
 import { describe, expect, it } from 'vitest';
 import { hexKey } from '../utils/hexCoord';
 import {
+  applyDoorOpened,
   applyEntityAppeared,
   applyEntityDisappeared,
   applyHexRevealed,
@@ -103,6 +104,8 @@ describe('createEmptyEncounterState', () => {
     expect(state.revealedRoomIds).toEqual([]);
     expect(state.revealedHexes).toBeInstanceOf(Set);
     expect(state.revealedHexes.size).toBe(0);
+    expect(state.openDoors).toBeInstanceOf(Set);
+    expect(state.openDoors.size).toBe(0);
     expect(state.combat).toBeNull();
     expect(state.currentRoomId).toBe('');
     expect(state.roomsCleared).toBe(0);
@@ -630,6 +633,49 @@ describe('v1alpha2 reducer additions', () => {
       // pattern; prevents needless React re-renders if a stream loop fires
       // EntityDisappeared for an entity we never saw.
       expect(after).toBe(prev);
+    });
+  });
+
+  describe('applyDoorOpened', () => {
+    it('adds the door entity id to openDoors', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyDoorOpened(prev, 'door-east');
+      expect(after.openDoors.has('door-east')).toBe(true);
+      expect(after.openDoors.size).toBe(1);
+    });
+
+    it('preserves previously-opened doors when a new one opens', () => {
+      let state = createEmptyEncounterState();
+      state = applyDoorOpened(state, 'door-east');
+      state = applyDoorOpened(state, 'door-north');
+      expect(state.openDoors.has('door-east')).toBe(true);
+      expect(state.openDoors.has('door-north')).toBe(true);
+      expect(state.openDoors.size).toBe(2);
+    });
+
+    it('is idempotent — re-opening returns the same reference (no re-render)', () => {
+      const opened = applyDoorOpened(createEmptyEncounterState(), 'door-east');
+      const reopened = applyDoorOpened(opened, 'door-east');
+      expect(reopened).toBe(opened);
+      expect(reopened.openDoors.size).toBe(1);
+    });
+
+    it('does not mutate the previous state', () => {
+      const prev = createEmptyEncounterState();
+      applyDoorOpened(prev, 'door-east');
+      expect(prev.openDoors.size).toBe(0);
+    });
+
+    it('does not touch revealedHexes (cause/effect split)', () => {
+      // The toolkit emits DoorOpened (cause) and GeometryRevealed (effect)
+      // as two events. applyDoorOpened only updates door state; the hex
+      // reveal flows through applyHexRevealed independently.
+      let state = createEmptyEncounterState();
+      state = applyHexRevealed(state, [{ q: 1, r: -1, s: 0 }]);
+      const beforeOpen = state.revealedHexes;
+      state = applyDoorOpened(state, 'door-east');
+      expect(state.revealedHexes).toBe(beforeOpen);
+      expect(state.revealedHexes.size).toBe(1);
     });
   });
 

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -38,8 +38,15 @@ export interface LocalEncounterState {
   /** v1alpha2-revealed hexes (per-hex granularity). UI renders revealed if either revealedHexes covers it OR the room is in revealedRoomIds. */
   revealedHexes: Set<string>;
   combat: CombatState | null;
-  /** All doors in the dungeon, keyed by connection ID */
+  /** All doors in the dungeon, keyed by connection ID (v1alpha1 snapshot data). */
   doors: Map<string, DoorInfo>;
+  /**
+   * v1alpha2 open-door entity IDs. Populated by `applyDoorOpened` from the
+   * DoorOpened event. Keyed by the proto's `door_entity_id` (distinct from
+   * the v1alpha1 connectionId in `doors`). Renderers consult this set to
+   * decide whether to draw a door's wall as a passage.
+   */
+  openDoors: Set<string>;
   dungeonState: DungeonState;
   roomsCleared: number;
 }
@@ -56,6 +63,7 @@ export function createEmptyEncounterState(): LocalEncounterState {
     revealedHexes: new Set(),
     combat: null,
     doors: new Map(),
+    openDoors: new Set(),
     dungeonState: DungeonState.UNSPECIFIED,
     roomsCleared: 0,
   };
@@ -79,6 +87,7 @@ export function applySnapshotToState(
     revealedHexes: new Set(), // v2 reveals come back via the stream's GeometryRevealed deltas
     combat: proto.combat ?? null,
     doors: new Map(Object.entries(proto.doors ?? {})),
+    openDoors: new Set(), // v2 door state comes back via the stream's DoorOpened deltas
     dungeonState: proto.dungeonState,
     roomsCleared: proto.roomsCleared,
   };
@@ -186,6 +195,24 @@ export function applyEntityDisappeared(
 }
 
 /**
+ * Mark a door as open by entity id (v1alpha2 DoorOpened.doorEntityId).
+ * Idempotent — re-opening an already-open door is a no-op (Set semantics).
+ * Does not touch the per-hex revealedHexes set; the toolkit emits a parallel
+ * GeometryRevealed event for the newly-visible cells (cause/effect split),
+ * which the existing applyHexRevealed reducer handles.
+ * Exported for testing.
+ */
+export function applyDoorOpened(
+  prev: LocalEncounterState,
+  doorEntityId: string
+): LocalEncounterState {
+  if (prev.openDoors.has(doorEntityId)) return prev;
+  const next = new Set(prev.openDoors);
+  next.add(doorEntityId);
+  return { ...prev, openDoors: next };
+}
+
+/**
  * Replace combat state without touching entities or other fields.
  * Exported for testing.
  */
@@ -219,6 +246,8 @@ export interface UseEncounterStateResult {
   applyEntityAppeared: (entity: EntityState) => void;
   /** Mark entity as ghosted at last known position; no-op if not tracked */
   applyEntityDisappeared: (entityId: string, lastKnown: CubeHexCoord) => void;
+  /** Mark a door entity as open; idempotent. */
+  applyDoorOpened: (doorEntityId: string) => void;
 }
 
 /**
@@ -268,6 +297,10 @@ export function useEncounterState(): UseEncounterStateResult {
     []
   );
 
+  const applyDoorOpenedCallback = useCallback((doorEntityId: string) => {
+    setState((prev) => applyDoorOpened(prev, doorEntityId));
+  }, []);
+
   return {
     state,
     applySnapshot,
@@ -278,5 +311,6 @@ export function useEncounterState(): UseEncounterStateResult {
     applyHexRevealed: applyHexRevealedCallback,
     applyEntityAppeared: applyEntityAppearedCallback,
     applyEntityDisappeared: applyEntityDisappearedCallback,
+    applyDoorOpened: applyDoorOpenedCallback,
   };
 }

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -72,11 +72,30 @@ export function createEmptyEncounterState(): LocalEncounterState {
 /**
  * Convert an EncounterStateData proto into a LocalEncounterState.
  * Proto Record<string, T> maps are converted to Map<string, T>.
+ *
+ * v2-only delta state preservation: `applySnapshot` is called on v1alpha1
+ * sync events (LobbyView wires it onto multiple v1 paths). v1 snapshots do
+ * NOT carry v2 deltas like `openDoors` or `revealedHexes` — those flow only
+ * via the v2 StreamEncounter (DoorOpened, GeometryRevealed) and are not
+ * replayed on reconnect or v1 state-sync events. If we rebuilt the whole
+ * state on every snapshot we'd silently wipe every v2 door we'd opened in
+ * the session.
+ *
+ * Mitigation: when `prev` is provided AND the snapshot is for the SAME
+ * encounter (same encounterId), carry forward v2-only fields (`openDoors`,
+ * `revealedHexes`). On encounter switch (different encounterId) we reset.
+ *
  * Exported for testing.
  */
 export function applySnapshotToState(
-  proto: EncounterStateData
+  proto: EncounterStateData,
+  prev?: LocalEncounterState
 ): LocalEncounterState {
+  // Same-encounter snapshot: preserve v2-only delta state. Different
+  // encounter (or no prev): start fresh — v2 deltas don't apply.
+  const sameEncounter =
+    prev !== undefined && prev.encounterId === proto.encounterId;
+
   return {
     encounterId: proto.encounterId,
     dungeonId: proto.dungeonId,
@@ -84,10 +103,14 @@ export function applySnapshotToState(
     rooms: new Map(Object.entries(proto.rooms ?? {})),
     currentRoomId: proto.currentRoomId,
     revealedRoomIds: proto.revealedRoomIds,
-    revealedHexes: new Set(), // v2 reveals come back via the stream's GeometryRevealed deltas
+    // v2 reveals come back via the stream's GeometryRevealed deltas; preserve
+    // across same-encounter v1 snapshots (deltas aren't replayed on sync).
+    revealedHexes: sameEncounter ? prev.revealedHexes : new Set(),
     combat: proto.combat ?? null,
     doors: new Map(Object.entries(proto.doors ?? {})),
-    openDoors: new Set(), // v2 door state comes back via the stream's DoorOpened deltas
+    // v2 door state comes back via the stream's DoorOpened deltas; preserve
+    // across same-encounter v1 snapshots (deltas aren't replayed on sync).
+    openDoors: sameEncounter ? prev.openDoors : new Set(),
     dungeonState: proto.dungeonState,
     roomsCleared: proto.roomsCleared,
   };
@@ -260,7 +283,11 @@ export function useEncounterState(): UseEncounterStateResult {
   );
 
   const applySnapshot = useCallback((proto: EncounterStateData) => {
-    setState(applySnapshotToState(proto));
+    // Pass `prev` so v2-only delta state (openDoors, revealedHexes) survives
+    // a v1alpha1 snapshot for the same encounter. v1 snapshots don't carry
+    // these fields and v2 deltas aren't replayed on sync, so without this
+    // any v1 state-sync mid-session would silently wipe opened doors.
+    setState((prev) => applySnapshotToState(proto, prev));
   }, []);
 
   const applyEntityUpdates = useCallback((updates: EntityState[]) => {


### PR DESCRIPTION
Closes #392. Wave 2.7 (OpenDoor) web consumer half. Pairs with rpg-api#504 (Interact handler) — both must merge for the wave to flip end-to-end.

## What ships

Strictly additive. Mirrors the slice-2 pattern (PR #389): one v2 verb hook, one new dispatch arm, one new reducer, one new harness section.

### v2 RPC hook

- `src/api/useInteractV2.ts` — `Interact(encounterId, targetEntityId, kind?)` wrapper around `encounterClientV2.interact`. Loading/error state, promise rejects on RPC failure, error clears on next success — same shape as `useMoveEntityV2`.

### Stream dispatch + reducer

- `src/api/encounterStream2Dispatch.ts` — adds `doorOpened` arm + `onDoorOpened` callback. Inline doc explains the cause/effect split: `DoorOpened` carries only the door identity in Wave 2.7; the newly-visible hexes flow on a parallel `GeometryRevealed` event from the toolkit. Consumers subscribe to both; the dispatcher does not collapse them.
- `src/hooks/useEncounterState.ts` — adds `openDoors: Set<string>` to `LocalEncounterState`, plus `applyDoorOpened(doorEntityId)` reducer. Idempotent (re-opening returns the same state reference, no needless re-renders). Doesn't touch `revealedHexes` — `applyHexRevealed` still owns that.

The `doors: Map<string, DoorInfo>` field is preserved as-is (v1alpha1 snapshot data, keyed by `connectionId`); `openDoors` is the v2 view (keyed by `doorEntityId`). Two distinct identifiers from two distinct emission paths — kept separate, marked in code comments.

### Harness

- `src/components/playtest/PlaytestHarness.tsx` — adds an "Open door" section below the Move section: text input for `doorEntityId` + button calling `useInteractV2().interact(encounterId, doorId, 'open')`. Wires `onDoorOpened` into the stream options bag: applies the reducer and logs `DoorOpened <id>`. The existing `onGeometryRevealed` handler logs `GeometryRevealed N hex(es)` independently — both lines appear in the harness log when a door opens, demonstrating the cause/effect split end-to-end.
- The harness is still slated for slice-3 deletion (#391); the open-door section is dev-only verification scaffolding.

### Door seeding (Option A vs B)

The brief flagged a choice: extend Wave 2.6 `CreateEncounter` to seed a door (Option A), or add a dev-only seed step in the harness (Option B). Neither is implemented in this PR — door seeding is rpg-api scope. The harness lets you type any door id, so once rpg-api#504 + a seeded door land (per Option A discussion in that PR), the two-browser playtest works directly. If Option A blocks, a followup can expand the harness to seed a door from the web side.

## Tests

- `src/api/useInteractV2.test.ts` — 6 tests: initial state, request shape with kind, kind-omitted shape, loading transition, error path, error-clears-on-success
- `src/api/encounterStream2Dispatch.test.ts` — +1 test: doorOpened dispatch arm
- `src/hooks/useEncounterState.test.ts` — +5 tests: adds doorEntityId, preserves prior open doors, idempotent on duplicate, no-mutation, doesn't touch revealedHexes (cause/effect separation)
- `src/components/playtest/PlaytestHarness.test.tsx` — +5 tests: section renders disabled, RPC called with correct shape on click, log shows DoorOpened + open-doors list updates on event, both DoorOpened and GeometryRevealed log lines appear independently, interact error surfaces in UI
- `src/api/useEncounterStream2.integration.test.tsx` — +1 test: full callback chain flows DoorOpened into `openDoors` and GeometryRevealed into `revealedHexes` independently

Total: 18 new tests. Full suite: 409 tests passing (was 391 on main).

`npm run ci-check` green: format, lint, typecheck, build, vitest.

## Test plan

- [x] CI green on all checks
- [x] New unit + integration tests cover dispatch, reducer, hook, and harness
- [x] Cause/effect split preserved — DoorOpened and GeometryRevealed dispatched and logged separately
- [ ] Two-browser playtest with rpg-api#504 once a door is seeded in the dev encounter

## Cross-references

- Wave plan: `rpg-project/ideas/encounter/v1alpha2/plans/05-wave-2.7-open-door.md`
- rpg-api server-side pair: rpg-api#504
- Slice-2 template: PR #389
- Wave 2.7 tracker: rpg-project#21

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>