### PR TITLE
feat(encounter/v2): combat reducers + useTakeActionV2 + useEndTurnV2 + harness combat controls (#393)

### DIFF
--- a/src/api/encounterStream2Dispatch.test.ts
+++ b/src/api/encounterStream2Dispatch.test.ts
@@ -79,6 +79,68 @@ describe('dispatchEncounterStream2Event', () => {
     expect(onDoorOpened).toHaveBeenCalledTimes(1);
   });
 
+  it('routes entityDamaged to onEntityDamaged', () => {
+    const onEntityDamaged = vi.fn();
+    const options: EncounterStream2Options = { onEntityDamaged };
+    const event = makeEvent('entityDamaged', {
+      entityId: 'goblin-1',
+      amount: 5,
+      hpAfter: { current: 2, max: 7 },
+      sourceEntityId: 'char-alice',
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onEntityDamaged).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes statusApplied to onStatusApplied', () => {
+    const onStatusApplied = vi.fn();
+    const options: EncounterStream2Options = { onStatusApplied };
+    const event = makeEvent('statusApplied', {
+      entityId: 'char-alice',
+      status: {
+        source: { module: 'dnd5e', type: 'condition', id: 'poisoned' },
+        displayName: 'Poisoned',
+      },
+      sourceEntityId: 'goblin-1',
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onStatusApplied).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes modeChanged to onModeChanged', () => {
+    const onModeChanged = vi.fn();
+    const options: EncounterStream2Options = { onModeChanged };
+    // EncounterMode enum values: UNSPECIFIED=0, FREE_ROAM=1, TURN_BASED=2.
+    const event = makeEvent('modeChanged', {
+      from: 1,
+      to: 2,
+      reason: 'ambush',
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onModeChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes turnStarted to onTurnStarted', () => {
+    const onTurnStarted = vi.fn();
+    const options: EncounterStream2Options = { onTurnStarted };
+    const event = makeEvent('turnStarted', {
+      entityId: 'char-alice',
+      round: 1,
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onTurnStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes turnEnded to onTurnEnded', () => {
+    const onTurnEnded = vi.fn();
+    const options: EncounterStream2Options = { onTurnEnded };
+    const event = makeEvent('turnEnded', {
+      entityId: 'char-alice',
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onTurnEnded).toHaveBeenCalledTimes(1);
+  });
+
   it('logs a warning for unknown event cases without throwing', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const event = makeEvent('someUnknownCase' as 'snapshotDelivered', {});

--- a/src/api/encounterStream2Dispatch.ts
+++ b/src/api/encounterStream2Dispatch.ts
@@ -2,10 +2,15 @@ import type {
   DoorOpened,
   EncounterEvent,
   EntityAppeared,
+  EntityDamaged,
   EntityDisappeared,
   EntityMoved,
   GeometryRevealed,
+  ModeChanged,
   SnapshotDelivered,
+  StatusApplied,
+  TurnEnded,
+  TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 
 /**
@@ -20,6 +25,11 @@ import type {
  * Wave 2.7; the actual reveal data (newly-visible hexes) flows on a parallel
  * GeometryRevealed (effect) event from the toolkit's deliberate two-phase
  * emission. Consumers should subscribe to BOTH; do not try to combine them.
+ *
+ * The same cause/effect split applies in Wave 2.8 for combat: the toolkit
+ * emits its `AttackResolvedEvent` (cause/narration) but the rpg-api translator
+ * drops it on the wire (no proto event for cause-only attacks); HP changes
+ * arrive as `EntityDamaged` (effect) and conditions as `StatusApplied` (effect).
  */
 export interface EncounterStream2Options {
   /** slice-1: encounter field is empty; treat as connect-confirm only. */
@@ -34,6 +44,17 @@ export interface EncounterStream2Options {
    * geometry side flows on a separate GeometryRevealed event.
    */
   onDoorOpened?: (event: DoorOpened) => void;
+  // Wave 2.8: combat events (TURN_BASED mode + attacks + turn cycle).
+  /** Authoritative HP update; carries `hp_after` and `amount`. */
+  onEntityDamaged?: (event: EntityDamaged) => void;
+  /** Condition applied to a target; carries the StatusEffect ref + display. */
+  onStatusApplied?: (event: StatusApplied) => void;
+  /** Encounter-mode transition (e.g. FREE_ROAM → TURN_BASED). */
+  onModeChanged?: (event: ModeChanged) => void;
+  /** Active actor + round update; signals "X's turn now". */
+  onTurnStarted?: (event: TurnStarted) => void;
+  /** Active actor finished; the next TurnStarted is authoritative for who's next. */
+  onTurnEnded?: (event: TurnEnded) => void;
 }
 
 /**
@@ -65,10 +86,25 @@ export function dispatchEncounterStream2Event(
     case 'doorOpened':
       options.onDoorOpened?.(payload.value);
       break;
+    case 'entityDamaged':
+      options.onEntityDamaged?.(payload.value);
+      break;
+    case 'statusApplied':
+      options.onStatusApplied?.(payload.value);
+      break;
+    case 'modeChanged':
+      options.onModeChanged?.(payload.value);
+      break;
+    case 'turnStarted':
+      options.onTurnStarted?.(payload.value);
+      break;
+    case 'turnEnded':
+      options.onTurnEnded?.(payload.value);
+      break;
     default:
-      // Either out-of-current-scope but known to the proto (entityDamaged,
-      // turnStarted, encounterEnded, etc. — the proto defines 20+ event cases;
-      // we currently handle 6) OR a genuinely unknown case from a proto
+      // Either out-of-current-scope but known to the proto (entityHealed,
+      // encounterEnded, dialogue, etc. — the proto defines 20+ event cases;
+      // we currently handle 11) OR a genuinely unknown case from a proto
       // version mismatch. Either way: warn + continue so the stream doesn't
       // tear down. Add a case arm + callback when the feature lands.
       // The cast strips the narrowed-to-undefined `case` so we can log it.

--- a/src/api/useEncounterStream2.integration.test.tsx
+++ b/src/api/useEncounterStream2.integration.test.tsx
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEncounterState } from '../hooks/useEncounterState';
@@ -75,6 +76,21 @@ function useTestHarness(encounterId: string) {
     },
     onDoorOpened: (e) => {
       state.applyDoorOpened(e.doorEntityId);
+    },
+    onEntityDamaged: (e) => {
+      state.applyEntityDamaged(e);
+    },
+    onStatusApplied: (e) => {
+      state.applyStatusApplied(e);
+    },
+    onModeChanged: (e) => {
+      state.applyModeChanged(e);
+    },
+    onTurnStarted: (e) => {
+      state.applyTurnStarted(e);
+    },
+    onTurnEnded: () => {
+      state.applyTurnEnded();
     },
   });
   return state.state;
@@ -281,6 +297,92 @@ describe('useEncounterStream2 + useEncounterState — integration', () => {
       expect(m?.position?.x).toBe(5);
       expect(m?.position?.y).toBe(-3);
       expect(m?.position?.z).toBe(-2);
+    });
+  });
+
+  it('combat sequence: ModeChanged → TurnStarted → EntityDamaged → StatusApplied → TurnEnded', async () => {
+    // Wave 2.8: a player's combat round threads five distinct event types
+    // through the dispatcher into the unified state. Verifies the dispatch
+    // graph wires every reducer correctly and the v2 combat delta state
+    // accumulates as expected.
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: 'ambush',
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.mode).toBe(EncounterMode.TURN_BASED);
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('turnStarted', {
+          entityId: 'alice',
+          round: 1,
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.activeEntityId).toBe('alice');
+      expect(result.current.round).toBe(1);
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('entityDamaged', {
+          entityId: 'goblin-1',
+          amount: 5,
+          hpAfter: { current: 2, max: 7 },
+          sourceEntityId: 'alice',
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.entityHP.get('goblin-1')).toEqual({
+        current: 2,
+        max: 7,
+      });
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('statusApplied', {
+          entityId: 'goblin-1',
+          status: {
+            source: { module: 'dnd5e', type: 'condition', id: 'frightened' },
+            displayName: 'Frightened',
+          },
+          sourceEntityId: 'alice',
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(result.current.entityStatuses.get('goblin-1')).toHaveLength(1);
+      expect(result.current.entityStatuses.get('goblin-1')?.[0].source.id).toBe(
+        'frightened'
+      );
+    });
+
+    act(() => fake.push(makeEvent('turnEnded', { entityId: 'alice' })));
+    // TurnEnded is a no-op on local state — activeEntityId stays as alice
+    // until the next TurnStarted overwrites it.
+    await waitFor(() => {
+      expect(result.current.activeEntityId).toBe('alice');
+    });
+
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'goblin-1', round: 1 }))
+    );
+    await waitFor(() => {
+      expect(result.current.activeEntityId).toBe('goblin-1');
     });
   });
 });

--- a/src/api/useEndTurnV2.test.ts
+++ b/src/api/useEndTurnV2.test.ts
@@ -1,0 +1,112 @@
+import type { EndTurnResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted lets us reference these before imports are evaluated
+const hoisted = vi.hoisted(() => ({
+  endTurnFn: vi.fn<() => Promise<EndTurnResponse>>(),
+}));
+
+vi.mock('./client', () => ({
+  encounterClientV2: {
+    endTurn: hoisted.endTurnFn,
+  },
+}));
+
+// Import AFTER vi.mock so the mock is applied
+import { useEndTurnV2 } from './useEndTurnV2';
+
+beforeEach(() => {
+  hoisted.endTurnFn.mockReset();
+});
+
+describe('useEndTurnV2', () => {
+  it('starts with loading=false and no error', () => {
+    const { result } = renderHook(() => useEndTurnV2());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls encounterClientV2.endTurn with correct request shape', async () => {
+    const fakeResponse = {} as EndTurnResponse;
+    hoisted.endTurnFn.mockResolvedValue(fakeResponse);
+
+    const { result } = renderHook(() => useEndTurnV2());
+
+    let response: EndTurnResponse | undefined;
+    await act(async () => {
+      response = await result.current.endTurn('enc-1', 'char-alice');
+    });
+
+    expect(response).toBe(fakeResponse);
+    expect(hoisted.endTurnFn).toHaveBeenCalledOnce();
+
+    expect(hoisted.endTurnFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+      })
+    );
+  });
+
+  it('sets loading=true during the call and false after success', async () => {
+    let resolveRpc!: (v: EndTurnResponse) => void;
+    const pendingRpc = new Promise<EndTurnResponse>(
+      (resolve) => (resolveRpc = resolve)
+    );
+    hoisted.endTurnFn.mockReturnValue(pendingRpc);
+
+    const { result } = renderHook(() => useEndTurnV2());
+
+    // Kick off the endTurn without awaiting
+    act(() => {
+      void result.current.endTurn('enc-1', 'char-alice');
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Resolve the RPC
+    act(() => resolveRpc({} as EndTurnResponse));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('sets error on RPC failure, loading=false, and promise rejects', async () => {
+    const rpcError = new Error('not your turn');
+    hoisted.endTurnFn.mockRejectedValue(rpcError);
+
+    const { result } = renderHook(() => useEndTurnV2());
+
+    await act(async () => {
+      await expect(
+        result.current.endTurn('enc-1', 'char-alice')
+      ).rejects.toThrow('not your turn');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(rpcError);
+  });
+
+  it('clears error on subsequent successful call', async () => {
+    hoisted.endTurnFn
+      .mockRejectedValueOnce(new Error('first fail'))
+      .mockResolvedValue({} as EndTurnResponse);
+
+    const { result } = renderHook(() => useEndTurnV2());
+
+    // First call fails
+    await act(async () => {
+      await expect(
+        result.current.endTurn('enc-1', 'char-alice')
+      ).rejects.toThrow('first fail');
+    });
+    expect(result.current.error).not.toBeNull();
+
+    // Second call succeeds
+    await act(async () => {
+      await result.current.endTurn('enc-1', 'char-alice');
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/api/useEndTurnV2.ts
+++ b/src/api/useEndTurnV2.ts
@@ -1,0 +1,58 @@
+import { create } from '@bufbuild/protobuf';
+import type { EndTurnResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { EndTurnRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { useCallback, useState } from 'react';
+import { encounterClientV2 } from './client';
+
+export interface UseEndTurnV2Result {
+  /**
+   * Calls the v1alpha2 EndTurn unary RPC. The next actor's turn (and any NPC
+   * turns the orchestrator dispatches before returning to a player) flow back
+   * as TurnEnded / TurnStarted / EntityDamaged events on the StreamEncounter.
+   */
+  endTurn: (encounterId: string, entityId: string) => Promise<EndTurnResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Thin wrapper around the v1alpha2 EndTurn unary RPC.
+ *
+ * - loading=true while the RPC is in-flight, false on resolve/reject
+ * - error is set on failure, cleared on the next successful call
+ * - The returned promise rejects on RPC error so callers can surface it
+ *
+ * Mirrors useMoveEntityV2 / useInteractV2 — one file per v1alpha2 verb under
+ * src/api/.
+ */
+export function useEndTurnV2(): UseEndTurnV2Result {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const endTurn = useCallback(
+    async (encounterId: string, entityId: string): Promise<EndTurnResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(EndTurnRequestSchema, {
+        encounterId,
+        entityId,
+      });
+
+      try {
+        const response = await encounterClientV2.endTurn(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('EndTurn RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { endTurn, loading, error };
+}

--- a/src/api/useTakeActionV2.test.ts
+++ b/src/api/useTakeActionV2.test.ts
@@ -1,0 +1,157 @@
+import type {
+  ActionTarget,
+  TakeActionResponse,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted lets us reference these before imports are evaluated
+const hoisted = vi.hoisted(() => ({
+  takeActionFn: vi.fn<() => Promise<TakeActionResponse>>(),
+}));
+
+vi.mock('./client', () => ({
+  encounterClientV2: {
+    takeAction: hoisted.takeActionFn,
+  },
+}));
+
+// Import AFTER vi.mock so the mock is applied
+import { useTakeActionV2 } from './useTakeActionV2';
+
+beforeEach(() => {
+  hoisted.takeActionFn.mockReset();
+});
+
+const ATTACK_REF = { module: 'dnd5e', type: 'action', id: 'attack' } as const;
+
+const ENTITY_TARGET: ActionTarget = {
+  kind: { case: 'entityId', value: 'goblin-1' },
+} as unknown as ActionTarget;
+
+describe('useTakeActionV2', () => {
+  it('starts with loading=false and no error', () => {
+    const { result } = renderHook(() => useTakeActionV2());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls encounterClientV2.takeAction with correct request shape', async () => {
+    const fakeResponse = {} as TakeActionResponse;
+    hoisted.takeActionFn.mockResolvedValue(fakeResponse);
+
+    const { result } = renderHook(() => useTakeActionV2());
+
+    let response: TakeActionResponse | undefined;
+    await act(async () => {
+      response = await result.current.takeAction({
+        encounterId: 'enc-1',
+        actorEntityId: 'char-alice',
+        actionRef: ATTACK_REF,
+        target: ENTITY_TARGET,
+      });
+    });
+
+    expect(response).toBe(fakeResponse);
+    expect(hoisted.takeActionFn).toHaveBeenCalledOnce();
+
+    expect(hoisted.takeActionFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        actorEntityId: 'char-alice',
+        actionRef: expect.objectContaining({
+          module: 'dnd5e',
+          type: 'action',
+          id: 'attack',
+        }),
+        target: expect.objectContaining({
+          kind: expect.objectContaining({
+            case: 'entityId',
+            value: 'goblin-1',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('sets loading=true during the call and false after success', async () => {
+    let resolveRpc!: (v: TakeActionResponse) => void;
+    const pendingRpc = new Promise<TakeActionResponse>(
+      (resolve) => (resolveRpc = resolve)
+    );
+    hoisted.takeActionFn.mockReturnValue(pendingRpc);
+
+    const { result } = renderHook(() => useTakeActionV2());
+
+    // Kick off the takeAction without awaiting
+    act(() => {
+      void result.current.takeAction({
+        encounterId: 'enc-1',
+        actorEntityId: 'char-alice',
+        actionRef: ATTACK_REF,
+        target: ENTITY_TARGET,
+      });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Resolve the RPC
+    act(() => resolveRpc({} as TakeActionResponse));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('sets error on RPC failure, loading=false, and promise rejects', async () => {
+    const rpcError = new Error('not your turn');
+    hoisted.takeActionFn.mockRejectedValue(rpcError);
+
+    const { result } = renderHook(() => useTakeActionV2());
+
+    await act(async () => {
+      await expect(
+        result.current.takeAction({
+          encounterId: 'enc-1',
+          actorEntityId: 'char-alice',
+          actionRef: ATTACK_REF,
+          target: ENTITY_TARGET,
+        })
+      ).rejects.toThrow('not your turn');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(rpcError);
+  });
+
+  it('clears error on subsequent successful call', async () => {
+    hoisted.takeActionFn
+      .mockRejectedValueOnce(new Error('first fail'))
+      .mockResolvedValue({} as TakeActionResponse);
+
+    const { result } = renderHook(() => useTakeActionV2());
+
+    // First call fails
+    await act(async () => {
+      await expect(
+        result.current.takeAction({
+          encounterId: 'enc-1',
+          actorEntityId: 'char-alice',
+          actionRef: ATTACK_REF,
+          target: ENTITY_TARGET,
+        })
+      ).rejects.toThrow('first fail');
+    });
+    expect(result.current.error).not.toBeNull();
+
+    // Second call succeeds
+    await act(async () => {
+      await result.current.takeAction({
+        encounterId: 'enc-1',
+        actorEntityId: 'char-alice',
+        actionRef: ATTACK_REF,
+        target: ENTITY_TARGET,
+      });
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/src/api/useTakeActionV2.ts
+++ b/src/api/useTakeActionV2.ts
@@ -1,0 +1,85 @@
+import { create } from '@bufbuild/protobuf';
+import type {
+  ActionTarget,
+  TakeActionResponse,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { TakeActionRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { useCallback, useState } from 'react';
+import { encounterClientV2 } from './client';
+
+/** Plain {module,type,id} accepted by useTakeActionV2 — hook constructs the proto Ref via the schema internally. */
+export interface PlainRef {
+  module: string;
+  type: string;
+  id: string;
+}
+
+export interface TakeActionParams {
+  encounterId: string;
+  actorEntityId: string;
+  /** {module:"dnd5e", type:"action", id:"attack"} for Wave 2.8's only action. */
+  actionRef: PlainRef;
+  /**
+   * Wave 2.8 only uses `entityId` targets (single-target attacks). Other
+   * variants (`position`, `area`, `self`) are accepted by the proto but not
+   * exercised by this wave. Pass the proto-shaped ActionTarget directly so the
+   * caller controls the oneof case.
+   */
+  target: ActionTarget;
+}
+
+export interface UseTakeActionV2Result {
+  /**
+   * Calls the v1alpha2 TakeAction unary RPC. The world-changing effects
+   * (damage, conditions, mode/turn transitions) flow back as separate events
+   * on the StreamEncounter — the response itself only carries caller-private
+   * follow-ups (e.g. an InputRequired prompt for spell-slot choices).
+   */
+  takeAction: (params: TakeActionParams) => Promise<TakeActionResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Thin wrapper around the v1alpha2 TakeAction unary RPC.
+ *
+ * - loading=true while the RPC is in-flight, false on resolve/reject
+ * - error is set on failure, cleared on the next successful call
+ * - The returned promise rejects on RPC error so callers can surface it
+ *
+ * Mirrors useMoveEntityV2 / useInteractV2 — one file per v1alpha2 verb under
+ * src/api/.
+ */
+export function useTakeActionV2(): UseTakeActionV2Result {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const takeAction = useCallback(
+    async (params: TakeActionParams): Promise<TakeActionResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(TakeActionRequestSchema, {
+        encounterId: params.encounterId,
+        actorEntityId: params.actorEntityId,
+        actionRef: params.actionRef,
+        target: params.target,
+      });
+
+      try {
+        const response = await encounterClientV2.takeAction(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('TakeAction RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { takeAction, loading, error };
+}

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -1,9 +1,12 @@
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import type {
+  EndTurnResponse,
   InteractResponse,
   MoveEntityResponse,
+  TakeActionResponse,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   act,
   fireEvent,
@@ -26,6 +29,8 @@ const hoisted = vi.hoisted(() => ({
   fakeRef: { current: null as FakeStream | null },
   moveEntityFn: vi.fn<() => Promise<MoveEntityResponse>>(),
   interactFn: vi.fn<() => Promise<InteractResponse>>(),
+  takeActionFn: vi.fn<() => Promise<TakeActionResponse>>(),
+  endTurnFn: vi.fn<() => Promise<EndTurnResponse>>(),
 }));
 
 vi.mock('../../api/client', () => ({
@@ -38,6 +43,8 @@ vi.mock('../../api/client', () => ({
     }),
     moveEntity: hoisted.moveEntityFn,
     interact: hoisted.interactFn,
+    takeAction: hoisted.takeActionFn,
+    endTurn: hoisted.endTurnFn,
   },
 }));
 
@@ -53,6 +60,10 @@ beforeEach(() => {
   hoisted.moveEntityFn.mockResolvedValue({} as MoveEntityResponse);
   hoisted.interactFn.mockReset();
   hoisted.interactFn.mockResolvedValue({} as InteractResponse);
+  hoisted.takeActionFn.mockReset();
+  hoisted.takeActionFn.mockResolvedValue({} as TakeActionResponse);
+  hoisted.endTurnFn.mockReset();
+  hoisted.endTurnFn.mockResolvedValue({} as EndTurnResponse);
 
   // Set up URL with both params
   window.history.pushState({}, '', '?encounterId=enc-1&playerId=alice');
@@ -348,6 +359,329 @@ describe('PlaytestHarness', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/door is locked/i)).toBeTruthy();
+    });
+  });
+
+  // ---------- Wave 2.8 combat -----------------------------------------------
+
+  it('renders mode + active actor + round in the header', async () => {
+    render(<PlaytestHarness />);
+
+    // Header initially shows UNSPECIFIED + (none) + round 0 — pre-stream defaults.
+    const header = screen
+      .getByTestId('harness-header')
+      .textContent?.toLowerCase();
+    expect(header).toContain('mode:');
+    expect(header).toContain('unspecified');
+    expect(header).toContain('active:');
+    expect(header).toContain('(none)');
+    expect(header).toContain('round:');
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: 'ambush',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+
+    await waitFor(() => {
+      const updated = screen
+        .getByTestId('harness-header')
+        .textContent?.toLowerCase();
+      expect(updated).toContain('turn_based');
+      expect(updated).toContain('char-alice');
+      expect(updated).toContain('round:');
+    });
+  });
+
+  it('renders the combat section with attack + end turn buttons disabled outside TURN_BASED', () => {
+    render(<PlaytestHarness />);
+
+    expect(screen.getByRole('heading', { name: /^combat$/i })).toBeTruthy();
+    expect(
+      screen.getByText(/combat actions enabled only in TURN_BASED mode/i)
+    ).toBeTruthy();
+    const attackBtn = screen.getByRole('button', {
+      name: /^attack$/i,
+    }) as HTMLButtonElement;
+    const endTurnBtn = screen.getByRole('button', {
+      name: /^end turn$/i,
+    }) as HTMLButtonElement;
+    expect(attackBtn.disabled).toBe(true);
+    expect(endTurnBtn.disabled).toBe(true);
+  });
+
+  it('enables combat buttons only when TURN_BASED + active actor is local player', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: '',
+        })
+      )
+    );
+    // Wrong active actor: end turn stays disabled.
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'goblin-1', round: 1 }))
+    );
+    await waitFor(() => {
+      const endTurnBtn = screen.getByRole('button', {
+        name: /^end turn$/i,
+      }) as HTMLButtonElement;
+      expect(endTurnBtn.disabled).toBe(true);
+      expect(screen.getByText(/waiting for your turn/i)).toBeTruthy();
+    });
+
+    // Correct active actor: end turn enables.
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+    await waitFor(() => {
+      const endTurnBtn = screen.getByRole('button', {
+        name: /^end turn$/i,
+      }) as HTMLButtonElement;
+      expect(endTurnBtn.disabled).toBe(false);
+    });
+  });
+
+  it('calls takeAction with correct request shape on Attack click', async () => {
+    render(<PlaytestHarness />);
+
+    // Flip into TURN_BASED + alice's turn so combat enables
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: '',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+
+    const input = screen.getByLabelText(
+      /attack target id/i
+    ) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'goblin-1' } });
+    });
+
+    const attackBtn = screen.getByRole('button', {
+      name: /^attack$/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(attackBtn.disabled).toBe(false));
+
+    act(() => fireEvent.click(attackBtn));
+
+    await waitFor(() => {
+      expect(hoisted.takeActionFn).toHaveBeenCalledOnce();
+    });
+
+    expect(hoisted.takeActionFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        actorEntityId: 'char-alice',
+        actionRef: expect.objectContaining({
+          module: 'dnd5e',
+          type: 'action',
+          id: 'attack',
+        }),
+        target: expect.objectContaining({
+          kind: expect.objectContaining({
+            case: 'entityId',
+            value: 'goblin-1',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('calls endTurn with encounterId + entityId on End turn click', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: '',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+
+    const endTurnBtn = screen.getByRole('button', {
+      name: /^end turn$/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(endTurnBtn.disabled).toBe(false));
+
+    act(() => fireEvent.click(endTurnBtn));
+
+    await waitFor(() => {
+      expect(hoisted.endTurnFn).toHaveBeenCalledOnce();
+    });
+
+    expect(hoisted.endTurnFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+      })
+    );
+  });
+
+  it('renders HP table after EntityDamaged event', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('entityDamaged', {
+          entityId: 'goblin-1',
+          amount: 5,
+          hpAfter: { current: 2, max: 7 },
+          sourceEntityId: 'char-alice',
+        } as unknown as EntityState)
+      )
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/EntityDamaged goblin-1/i)).toBeTruthy();
+      expect(screen.getByText('2/7')).toBeTruthy();
+    });
+  });
+
+  it('logs ModeChanged, TurnStarted, EntityDamaged, StatusApplied, TurnEnded independently', async () => {
+    // Wave 2.8: each event type is its own line in the harness log. The
+    // dispatcher must not collapse them; the log must show the flow.
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: 'ambush',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+    act(() =>
+      fake.push(
+        makeEvent('entityDamaged', {
+          entityId: 'goblin-1',
+          amount: 5,
+          hpAfter: { current: 2, max: 7 },
+        })
+      )
+    );
+    act(() =>
+      fake.push(
+        makeEvent('statusApplied', {
+          entityId: 'goblin-1',
+          status: {
+            source: { module: 'dnd5e', type: 'condition', id: 'frightened' },
+            displayName: 'Frightened',
+          },
+        })
+      )
+    );
+    act(() => fake.push(makeEvent('turnEnded', { entityId: 'char-alice' })));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ModeChanged FREE_ROAM/i)).toBeTruthy();
+      expect(screen.getByText(/TurnStarted char-alice/i)).toBeTruthy();
+      expect(screen.getByText(/EntityDamaged goblin-1/i)).toBeTruthy();
+      expect(screen.getByText(/StatusApplied goblin-1/i)).toBeTruthy();
+      expect(screen.getByText(/TurnEnded char-alice/i)).toBeTruthy();
+    });
+  });
+
+  it('shows takeAction error when RPC fails', async () => {
+    hoisted.takeActionFn.mockRejectedValue(new Error('not your turn'));
+
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: '',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+
+    const input = screen.getByLabelText(
+      /attack target id/i
+    ) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'goblin-1' } });
+    });
+
+    const attackBtn = screen.getByRole('button', {
+      name: /^attack$/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(attackBtn.disabled).toBe(false));
+
+    act(() => fireEvent.click(attackBtn));
+
+    await waitFor(() => {
+      expect(screen.getByText(/not your turn/i)).toBeTruthy();
+    });
+  });
+
+  it('shows endTurn error when RPC fails', async () => {
+    hoisted.endTurnFn.mockRejectedValue(new Error('cannot end turn now'));
+
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: '',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+
+    const endTurnBtn = screen.getByRole('button', {
+      name: /^end turn$/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(endTurnBtn.disabled).toBe(false));
+
+    act(() => fireEvent.click(endTurnBtn));
+
+    await waitFor(() => {
+      expect(screen.getByText(/cannot end turn now/i)).toBeTruthy();
     });
   });
 });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,14 +1,30 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useState } from 'react';
 import { v2PositionToV1 } from '../../api/positionConvert';
 import { useDevPlayerIdAuth } from '../../api/useDevPlayerIdAuth';
 import { useEncounterStream2 } from '../../api/useEncounterStream2';
+import { useEndTurnV2 } from '../../api/useEndTurnV2';
 import { useInteractV2 } from '../../api/useInteractV2';
 import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
+import { useTakeActionV2 } from '../../api/useTakeActionV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
 import { protoPositionToHex } from '../../utils/hexCoord';
+
+const ATTACK_ACTION_REF = {
+  module: 'dnd5e',
+  type: 'action',
+  id: 'attack',
+} as const;
+
+const MODE_LABEL: Record<EncounterMode, string> = {
+  [EncounterMode.UNSPECIFIED]: 'UNSPECIFIED',
+  [EncounterMode.FREE_ROAM]: 'FREE_ROAM',
+  [EncounterMode.TURN_BASED]: 'TURN_BASED',
+};
 
 function formatTime(d: Date): string {
   return d.toTimeString().slice(0, 8);
@@ -37,6 +53,7 @@ export function PlaytestHarness() {
   const [targetR, setTargetR] = useState(0);
   const [targetS, setTargetS] = useState(0);
   const [targetDoorId, setTargetDoorId] = useState('');
+  const [attackTargetId, setAttackTargetId] = useState('');
 
   const encounterState = useEncounterState();
   const {
@@ -49,6 +66,16 @@ export function PlaytestHarness() {
     loading: interactLoading,
     error: interactError,
   } = useInteractV2();
+  const {
+    takeAction,
+    loading: takeActionLoading,
+    error: takeActionError,
+  } = useTakeActionV2();
+  const {
+    endTurn,
+    loading: endTurnLoading,
+    error: endTurnError,
+  } = useEndTurnV2();
 
   const addLog = (msg: string) => {
     const entry = `[${formatTime(new Date())}] ${msg}`;
@@ -106,6 +133,31 @@ export function PlaytestHarness() {
         encounterState.applyDoorOpened(e.doorEntityId);
         addLog(`DoorOpened ${e.doorEntityId}`);
       },
+      onEntityDamaged: (e) => {
+        encounterState.applyEntityDamaged(e);
+        const hp = e.hpAfter;
+        const hpStr = hp ? ` hp_after=${hp.current}/${hp.max}` : '';
+        addLog(`EntityDamaged ${e.entityId} amount=${e.amount}${hpStr}`);
+      },
+      onStatusApplied: (e) => {
+        encounterState.applyStatusApplied(e);
+        const id = e.status?.source?.id ?? '?';
+        addLog(`StatusApplied ${e.entityId} <- ${id}`);
+      },
+      onModeChanged: (e) => {
+        encounterState.applyModeChanged(e);
+        addLog(
+          `ModeChanged ${MODE_LABEL[e.from]} → ${MODE_LABEL[e.to]} (${e.reason || '—'})`
+        );
+      },
+      onTurnStarted: (e) => {
+        encounterState.applyTurnStarted(e);
+        addLog(`TurnStarted ${e.entityId} round=${e.round}`);
+      },
+      onTurnEnded: (e) => {
+        encounterState.applyTurnEnded();
+        addLog(`TurnEnded ${e.entityId}`);
+      },
     }
   );
 
@@ -157,9 +209,47 @@ export function PlaytestHarness() {
     }
   };
 
+  const handleAttack = async () => {
+    const id = attackTargetId.trim();
+    if (!id) return;
+    // Construct the v2 ActionTarget oneof for entity-target attacks.
+    // The proto's `kind` is a oneof; setting case='entityId' picks the
+    // single-target variant.
+    const target = {
+      kind: { case: 'entityId', value: id },
+    } as unknown as ActionTarget;
+    try {
+      await takeAction({
+        encounterId,
+        actorEntityId: entityId,
+        actionRef: ATTACK_ACTION_REF,
+        target,
+      });
+      addLog(`TakeAction(attack) → ${id}`);
+    } catch {
+      // error is surfaced via takeActionError state
+    }
+  };
+
+  const handleEndTurn = async () => {
+    try {
+      await endTurn(encounterId, entityId);
+      addLog(`EndTurn → ${entityId}`);
+    } catch {
+      // error is surfaced via endTurnError state
+    }
+  };
+
   const entitiesArray = Array.from(encounterState.state.entities.entries());
   const revealedKeys = Array.from(encounterState.state.revealedHexes);
   const openDoorKeys = Array.from(encounterState.state.openDoors);
+  const myHP = encounterState.state.entityHP.get(entityId);
+  const myStatuses = encounterState.state.entityStatuses.get(entityId) ?? [];
+  const isMyTurn =
+    encounterState.state.mode === EncounterMode.TURN_BASED &&
+    encounterState.state.activeEntityId === entityId;
+  const combatEnabled =
+    encounterState.state.mode === EncounterMode.TURN_BASED && isMyTurn;
 
   return (
     <div
@@ -181,6 +271,7 @@ export function PlaytestHarness() {
           borderRadius: 4,
           display: 'flex',
           gap: 24,
+          flexWrap: 'wrap',
         }}
       >
         <span>
@@ -190,6 +281,19 @@ export function PlaytestHarness() {
           connection: <strong>{stream.connectionState}</strong>
         </span>
         <span>entityId: {entityId}</span>
+        <span>
+          mode: <strong>{MODE_LABEL[encounterState.state.mode]}</strong>
+        </span>
+        <span>
+          active:{' '}
+          <strong>{encounterState.state.activeEntityId || '(none)'}</strong>
+        </span>
+        <span>
+          round: <strong>{encounterState.state.round}</strong>
+        </span>
+        <span>
+          HP: <strong>{myHP ? `${myHP.current}/${myHP.max}` : '—'}</strong>
+        </span>
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
@@ -399,6 +503,128 @@ export function PlaytestHarness() {
           {interactError && (
             <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
               Interact error: {interactError.message}
+            </div>
+          )}
+
+          {/* Combat controls (Wave 2.8 verification scaffold; deleted in slice 3) */}
+          <h3 style={{ margin: '16px 0 8px', color: '#aaa' }}>Combat</h3>
+          <div style={{ fontSize: 12, color: '#777', marginBottom: 8 }}>
+            Statuses ({myStatuses.length}):{' '}
+            {myStatuses.length === 0
+              ? '(none)'
+              : myStatuses.map((s) => s.source.id).join(', ')}
+          </div>
+          {/* Per-entity HP table for visible monsters (Wave 2.8 ships goblin-1 only). */}
+          {encounterState.state.entityHP.size > 0 && (
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                marginBottom: 8,
+                fontSize: 12,
+              }}
+            >
+              <thead>
+                <tr style={{ color: '#888', textAlign: 'left' }}>
+                  <th style={{ padding: '4px 8px' }}>id</th>
+                  <th style={{ padding: '4px 8px' }}>HP</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from(encounterState.state.entityHP.entries()).map(
+                  ([id, hp]) => (
+                    <tr key={id} style={{ borderTop: '1px solid #333' }}>
+                      <td style={{ padding: '4px 8px' }}>{id}</td>
+                      <td style={{ padding: '4px 8px' }}>
+                        {hp.current}/{hp.max}
+                      </td>
+                    </tr>
+                  )
+                )}
+              </tbody>
+            </table>
+          )}
+          {!isMyTurn &&
+            encounterState.state.mode === EncounterMode.TURN_BASED && (
+              <div style={{ color: '#aa8', fontSize: 12, marginBottom: 8 }}>
+                (waiting for your turn — active actor:{' '}
+                {encounterState.state.activeEntityId || 'none'})
+              </div>
+            )}
+          {encounterState.state.mode !== EncounterMode.TURN_BASED && (
+            <div style={{ color: '#666', fontSize: 12, marginBottom: 8 }}>
+              (combat actions enabled only in TURN_BASED mode)
+            </div>
+          )}
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <label style={{ fontSize: 12 }}>
+              Target id{' '}
+              <input
+                type="text"
+                value={attackTargetId}
+                onChange={(e) => setAttackTargetId(e.target.value)}
+                placeholder="goblin-1"
+                aria-label="attack target id"
+                style={{
+                  width: 140,
+                  background: '#333',
+                  color: '#eee',
+                  border: '1px solid #555',
+                  padding: '2px 4px',
+                }}
+              />
+            </label>
+            <button
+              onClick={() => void handleAttack()}
+              disabled={
+                !combatEnabled || !attackTargetId.trim() || takeActionLoading
+              }
+              style={{
+                padding: '4px 12px',
+                background:
+                  combatEnabled && attackTargetId.trim()
+                    ? '#4a2a2a'
+                    : '#2a2a2a',
+                color: combatEnabled && attackTargetId.trim() ? '#f88' : '#666',
+                border: '1px solid #555',
+                cursor:
+                  combatEnabled && attackTargetId.trim() && !takeActionLoading
+                    ? 'pointer'
+                    : 'not-allowed',
+              }}
+            >
+              {takeActionLoading ? 'Attacking…' : 'Attack'}
+            </button>
+            <button
+              onClick={() => void handleEndTurn()}
+              disabled={!combatEnabled || endTurnLoading}
+              style={{
+                padding: '4px 12px',
+                background: combatEnabled ? '#2a4a2a' : '#2a2a2a',
+                color: combatEnabled ? '#8f8' : '#666',
+                border: '1px solid #555',
+                cursor:
+                  combatEnabled && !endTurnLoading ? 'pointer' : 'not-allowed',
+              }}
+            >
+              {endTurnLoading ? 'Ending…' : 'End turn'}
+            </button>
+          </div>
+          {takeActionError && (
+            <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
+              TakeAction error: {takeActionError.message}
+            </div>
+          )}
+          {endTurnError && (
+            <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
+              EndTurn error: {endTurnError.message}
             </div>
           )}
         </div>

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -23,14 +23,26 @@ import {
   DungeonState,
   EntityType,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import type {
+  EntityDamaged,
+  ModeChanged,
+  StatusApplied,
+  TurnStarted,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
 import { hexKey } from '../utils/hexCoord';
 import {
   applyDoorOpened,
   applyEntityAppeared,
+  applyEntityDamaged,
   applyEntityDisappeared,
   applyHexRevealed,
+  applyModeChanged,
   applySnapshotToState,
+  applyStatusApplied,
+  applyTurnEnded,
+  applyTurnStarted,
   createEmptyEncounterState,
   mergeEntityPosition,
   mergeEntityUpdates,
@@ -106,6 +118,13 @@ describe('createEmptyEncounterState', () => {
     expect(state.revealedHexes.size).toBe(0);
     expect(state.openDoors).toBeInstanceOf(Set);
     expect(state.openDoors.size).toBe(0);
+    expect(state.entityHP).toBeInstanceOf(Map);
+    expect(state.entityHP.size).toBe(0);
+    expect(state.entityStatuses).toBeInstanceOf(Map);
+    expect(state.entityStatuses.size).toBe(0);
+    expect(state.mode).toBe(EncounterMode.UNSPECIFIED);
+    expect(state.activeEntityId).toBe('');
+    expect(state.round).toBe(0);
     expect(state.combat).toBeNull();
     expect(state.currentRoomId).toBe('');
     expect(state.roomsCleared).toBe(0);
@@ -546,6 +565,53 @@ function makeTestEntity(
 }
 
 // ---------------------------------------------------------------------------
+// Helpers for combat reducer tests — minimal proto-shape stubs. We don't
+// build via create(...) because these are read-only test inputs and the
+// reducers don't validate $typeName.
+// ---------------------------------------------------------------------------
+
+function makeDamaged(
+  entityId: string,
+  current: number,
+  max: number,
+  amount = 0
+): EntityDamaged {
+  return {
+    entityId,
+    amount,
+    hpAfter: { current, max, temp: 0 },
+  } as unknown as EntityDamaged;
+}
+
+function makeStatusApplied(
+  entityId: string,
+  module: string,
+  type: string,
+  id: string,
+  displayName = id
+): StatusApplied {
+  return {
+    entityId,
+    status: {
+      source: { module, type, id },
+      displayName,
+    },
+  } as unknown as StatusApplied;
+}
+
+function makeModeChanged(
+  from: EncounterMode,
+  to: EncounterMode,
+  reason = ''
+): ModeChanged {
+  return { from, to, reason } as unknown as ModeChanged;
+}
+
+function makeTurnStarted(entityId: string, round: number): TurnStarted {
+  return { entityId, round } as unknown as TurnStarted;
+}
+
+// ---------------------------------------------------------------------------
 // v1alpha2 reducer additions
 // ---------------------------------------------------------------------------
 
@@ -732,6 +798,12 @@ describe('v1alpha2 reducer additions', () => {
       let state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }));
       state = applyDoorOpened(state, 'door-1');
       state = applyHexRevealed(state, [{ q: 1, r: -1, s: 0 }]);
+      state = applyEntityDamaged(state, makeDamaged('goblin-1', 5, 5));
+      state = applyTurnStarted(state, makeTurnStarted('char-alice', 1));
+      state = applyModeChanged(
+        state,
+        makeModeChanged(EncounterMode.FREE_ROAM, EncounterMode.TURN_BASED)
+      );
 
       const switched = applySnapshotToState(
         makeSnapshot({ encounterId: 'enc-2' }),
@@ -740,6 +812,11 @@ describe('v1alpha2 reducer additions', () => {
 
       expect(switched.openDoors.size).toBe(0);
       expect(switched.revealedHexes.size).toBe(0);
+      expect(switched.entityHP.size).toBe(0);
+      expect(switched.entityStatuses.size).toBe(0);
+      expect(switched.mode).toBe(EncounterMode.UNSPECIFIED);
+      expect(switched.activeEntityId).toBe('');
+      expect(switched.round).toBe(0);
     });
 
     it('starts with empty v2 delta state when prev is omitted (first snapshot)', () => {
@@ -748,6 +825,47 @@ describe('v1alpha2 reducer additions', () => {
       );
       expect(state.openDoors.size).toBe(0);
       expect(state.revealedHexes.size).toBe(0);
+      expect(state.entityHP.size).toBe(0);
+      expect(state.entityStatuses.size).toBe(0);
+      expect(state.mode).toBe(EncounterMode.UNSPECIFIED);
+      expect(state.activeEntityId).toBe('');
+      expect(state.round).toBe(0);
+    });
+
+    it('preserves v2 combat delta state across same-encounter v1 snapshot', () => {
+      // Wave 2.8: combat events (HP, status, mode, active actor, round) flow
+      // only on the v2 stream; v1 snapshots don't carry them and don't
+      // replay deltas. Same survival rule as openDoors / revealedHexes.
+      let state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }));
+      state = applyEntityDamaged(state, makeDamaged('goblin-1', 5, 7));
+      state = applyEntityDamaged(state, makeDamaged('char-alice', 3, 14));
+      state = applyStatusApplied(
+        state,
+        makeStatusApplied('char-alice', 'dnd5e', 'condition', 'poisoned')
+      );
+      state = applyModeChanged(
+        state,
+        makeModeChanged(EncounterMode.FREE_ROAM, EncounterMode.TURN_BASED)
+      );
+      state = applyTurnStarted(state, makeTurnStarted('char-alice', 2));
+
+      const refreshed = applySnapshotToState(
+        makeSnapshot({ encounterId: 'enc-1' }),
+        state
+      );
+
+      expect(refreshed.entityHP.get('goblin-1')).toEqual({
+        current: 5,
+        max: 7,
+      });
+      expect(refreshed.entityHP.get('char-alice')).toEqual({
+        current: 3,
+        max: 14,
+      });
+      expect(refreshed.entityStatuses.get('char-alice')).toHaveLength(1);
+      expect(refreshed.mode).toBe(EncounterMode.TURN_BASED);
+      expect(refreshed.activeEntityId).toBe('char-alice');
+      expect(refreshed.round).toBe(2);
     });
   });
 
@@ -783,6 +901,281 @@ describe('v1alpha2 reducer additions', () => {
       expect(state.entities.get('mover')?.position?.x).toBe(5);
       expect(state.entities.get('mover')?.position?.y).toBe(-3);
       expect(state.entities.get('mover')?.position?.z).toBe(-2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 2.8 combat reducers
+// ---------------------------------------------------------------------------
+
+describe('Wave 2.8 combat reducers', () => {
+  describe('applyEntityDamaged', () => {
+    it('sets entity HP from hp_after', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyEntityDamaged(prev, makeDamaged('goblin-1', 2, 7, 5));
+      expect(after.entityHP.get('goblin-1')).toEqual({ current: 2, max: 7 });
+    });
+
+    it('preserves HP for other entities', () => {
+      let state = createEmptyEncounterState();
+      state = applyEntityDamaged(state, makeDamaged('alice', 10, 14));
+      state = applyEntityDamaged(state, makeDamaged('goblin-1', 0, 7, 5));
+      expect(state.entityHP.get('alice')).toEqual({ current: 10, max: 14 });
+      expect(state.entityHP.get('goblin-1')).toEqual({ current: 0, max: 7 });
+    });
+
+    it('overwrites HP on subsequent damage events for the same entity', () => {
+      let state = createEmptyEncounterState();
+      state = applyEntityDamaged(state, makeDamaged('alice', 12, 14));
+      state = applyEntityDamaged(state, makeDamaged('alice', 8, 14));
+      expect(state.entityHP.get('alice')).toEqual({ current: 8, max: 14 });
+    });
+
+    it('is idempotent on identical hp_after (returns same reference)', () => {
+      const prev = applyEntityDamaged(
+        createEmptyEncounterState(),
+        makeDamaged('alice', 8, 14)
+      );
+      const next = applyEntityDamaged(prev, makeDamaged('alice', 8, 14));
+      expect(next).toBe(prev);
+    });
+
+    it('is a no-op when hp_after is missing (defensive)', () => {
+      const prev = createEmptyEncounterState();
+      const event = {
+        entityId: 'alice',
+        amount: 3,
+      } as unknown as EntityDamaged;
+      const next = applyEntityDamaged(prev, event);
+      expect(next).toBe(prev);
+      expect(next.entityHP.size).toBe(0);
+    });
+
+    it('does not mutate the previous state', () => {
+      const prev = createEmptyEncounterState();
+      applyEntityDamaged(prev, makeDamaged('alice', 5, 14));
+      expect(prev.entityHP.size).toBe(0);
+    });
+
+    it('does not touch entityStatuses, mode, or activeEntityId', () => {
+      let prev = createEmptyEncounterState();
+      prev = applyTurnStarted(prev, makeTurnStarted('alice', 3));
+      prev = applyStatusApplied(
+        prev,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned')
+      );
+      const next = applyEntityDamaged(prev, makeDamaged('alice', 5, 14));
+      expect(next.activeEntityId).toBe('alice');
+      expect(next.round).toBe(3);
+      expect(next.entityStatuses.get('alice')).toHaveLength(1);
+    });
+  });
+
+  describe('applyStatusApplied', () => {
+    it('appends a new condition to the entity status list', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyStatusApplied(
+        prev,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned', 'Poisoned')
+      );
+      const list = after.entityStatuses.get('alice');
+      expect(list).toHaveLength(1);
+      expect(list?.[0].source.id).toBe('poisoned');
+      expect(list?.[0].displayName).toBe('Poisoned');
+    });
+
+    it('replaces an existing condition with the same source ref', () => {
+      let state = createEmptyEncounterState();
+      state = applyStatusApplied(
+        state,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned', 'Old')
+      );
+      state = applyStatusApplied(
+        state,
+        makeStatusApplied(
+          'alice',
+          'dnd5e',
+          'condition',
+          'poisoned',
+          'Refreshed'
+        )
+      );
+      const list = state.entityStatuses.get('alice');
+      expect(list).toHaveLength(1);
+      expect(list?.[0].displayName).toBe('Refreshed');
+    });
+
+    it('stacks distinct conditions on the same entity', () => {
+      let state = createEmptyEncounterState();
+      state = applyStatusApplied(
+        state,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned')
+      );
+      state = applyStatusApplied(
+        state,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'frightened')
+      );
+      const list = state.entityStatuses.get('alice');
+      expect(list).toHaveLength(2);
+      expect(list?.map((s) => s.source.id).sort()).toEqual([
+        'frightened',
+        'poisoned',
+      ]);
+    });
+
+    it('is a no-op when status is missing (defensive)', () => {
+      const prev = createEmptyEncounterState();
+      const event = { entityId: 'alice' } as unknown as StatusApplied;
+      const next = applyStatusApplied(prev, event);
+      expect(next).toBe(prev);
+    });
+
+    it('does not mutate the previous state', () => {
+      const prev = createEmptyEncounterState();
+      applyStatusApplied(
+        prev,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned')
+      );
+      expect(prev.entityStatuses.size).toBe(0);
+    });
+
+    it('captures sourceEntityId when present', () => {
+      const event = {
+        entityId: 'alice',
+        status: {
+          source: { module: 'dnd5e', type: 'condition', id: 'poisoned' },
+          displayName: 'Poisoned',
+        },
+        sourceEntityId: 'goblin-1',
+      } as unknown as StatusApplied;
+      const after = applyStatusApplied(createEmptyEncounterState(), event);
+      expect(after.entityStatuses.get('alice')?.[0].sourceEntityId).toBe(
+        'goblin-1'
+      );
+    });
+  });
+
+  describe('applyModeChanged', () => {
+    it('updates the mode field to the new value', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyModeChanged(
+        prev,
+        makeModeChanged(EncounterMode.FREE_ROAM, EncounterMode.TURN_BASED)
+      );
+      expect(after.mode).toBe(EncounterMode.TURN_BASED);
+    });
+
+    it('is idempotent when mode is unchanged (returns same reference)', () => {
+      let state = applyModeChanged(
+        createEmptyEncounterState(),
+        makeModeChanged(EncounterMode.UNSPECIFIED, EncounterMode.TURN_BASED)
+      );
+      const before = state;
+      state = applyModeChanged(
+        state,
+        makeModeChanged(EncounterMode.TURN_BASED, EncounterMode.TURN_BASED)
+      );
+      expect(state).toBe(before);
+    });
+
+    it('does not touch HP, statuses, activeEntityId, round', () => {
+      let prev = createEmptyEncounterState();
+      prev = applyEntityDamaged(prev, makeDamaged('alice', 8, 14));
+      prev = applyStatusApplied(
+        prev,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned')
+      );
+      prev = applyTurnStarted(prev, makeTurnStarted('alice', 2));
+
+      const next = applyModeChanged(
+        prev,
+        makeModeChanged(EncounterMode.TURN_BASED, EncounterMode.FREE_ROAM)
+      );
+      expect(next.mode).toBe(EncounterMode.FREE_ROAM);
+      expect(next.entityHP.get('alice')).toEqual({ current: 8, max: 14 });
+      expect(next.entityStatuses.get('alice')).toHaveLength(1);
+      expect(next.activeEntityId).toBe('alice');
+      expect(next.round).toBe(2);
+    });
+
+    it('does not mutate the previous state', () => {
+      const prev = createEmptyEncounterState();
+      applyModeChanged(
+        prev,
+        makeModeChanged(EncounterMode.UNSPECIFIED, EncounterMode.TURN_BASED)
+      );
+      expect(prev.mode).toBe(EncounterMode.UNSPECIFIED);
+    });
+  });
+
+  describe('applyTurnStarted', () => {
+    it('sets activeEntityId and round', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyTurnStarted(prev, makeTurnStarted('char-alice', 1));
+      expect(after.activeEntityId).toBe('char-alice');
+      expect(after.round).toBe(1);
+    });
+
+    it('updates the active actor on subsequent turns', () => {
+      let state = createEmptyEncounterState();
+      state = applyTurnStarted(state, makeTurnStarted('char-alice', 1));
+      state = applyTurnStarted(state, makeTurnStarted('goblin-1', 1));
+      expect(state.activeEntityId).toBe('goblin-1');
+      expect(state.round).toBe(1);
+    });
+
+    it('advances the round when the turn cycle wraps', () => {
+      let state = applyTurnStarted(
+        createEmptyEncounterState(),
+        makeTurnStarted('char-alice', 1)
+      );
+      state = applyTurnStarted(state, makeTurnStarted('char-alice', 2));
+      expect(state.round).toBe(2);
+    });
+
+    it('is idempotent on a same-actor / same-round event (returns same reference)', () => {
+      const prev = applyTurnStarted(
+        createEmptyEncounterState(),
+        makeTurnStarted('char-alice', 1)
+      );
+      const next = applyTurnStarted(prev, makeTurnStarted('char-alice', 1));
+      expect(next).toBe(prev);
+    });
+
+    it('does not touch HP, statuses, mode', () => {
+      let prev = createEmptyEncounterState();
+      prev = applyEntityDamaged(prev, makeDamaged('alice', 8, 14));
+      prev = applyStatusApplied(
+        prev,
+        makeStatusApplied('alice', 'dnd5e', 'condition', 'poisoned')
+      );
+      prev = applyModeChanged(
+        prev,
+        makeModeChanged(EncounterMode.UNSPECIFIED, EncounterMode.TURN_BASED)
+      );
+
+      const next = applyTurnStarted(prev, makeTurnStarted('char-alice', 1));
+      expect(next.entityHP.get('alice')).toEqual({ current: 8, max: 14 });
+      expect(next.entityStatuses.get('alice')).toHaveLength(1);
+      expect(next.mode).toBe(EncounterMode.TURN_BASED);
+    });
+  });
+
+  describe('applyTurnEnded', () => {
+    it('does not clear activeEntityId or round (TurnStarted is authoritative)', () => {
+      // Per the reducer doc: clearing here would race the TurnStarted that
+      // follows on the wire and cause UI flicker. TurnEnded is currently a
+      // no-op on local state.
+      let state = applyTurnStarted(
+        createEmptyEncounterState(),
+        makeTurnStarted('char-alice', 2)
+      );
+      const before = state;
+      state = applyTurnEnded(state);
+      expect(state).toBe(before);
+      expect(state.activeEntityId).toBe('char-alice');
+      expect(state.round).toBe(2);
     });
   });
 });

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -22,8 +22,31 @@ import type {
   RoomLayout,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { DungeonState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import type {
+  EntityDamaged,
+  ModeChanged,
+  StatusApplied,
+  TurnStarted,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useCallback, useState } from 'react';
 import { hexKey, type CubeHexCoord } from '../utils/hexCoord';
+
+/** v1alpha2 per-entity HP, populated from EntityDamaged.hp_after. */
+export interface EntityHP {
+  current: number;
+  max: number;
+}
+
+/** v1alpha2 condition tag, populated from StatusApplied.status. */
+export interface EntityStatus {
+  /** {module, type:"condition", id:"poisoned"} — the condition's source ref. */
+  source: { module: string; type: string; id: string };
+  /** Display label from the proto's StatusEffect.display_name (may be empty). */
+  displayName: string;
+  /** Source entity that applied the condition (may be undefined). */
+  sourceEntityId?: string;
+}
 
 /** Local representation of encounter state using JS Maps for O(1) lookups */
 export interface LocalEncounterState {
@@ -47,6 +70,35 @@ export interface LocalEncounterState {
    * decide whether to draw a door's wall as a passage.
    */
   openDoors: Set<string>;
+  /**
+   * v1alpha2 per-entity hit points keyed by entity id. Populated by
+   * `applyEntityDamaged` from EntityDamaged.hp_after. Authoritative HP for
+   * combat rendering — server-emitted, never client-computed.
+   */
+  entityHP: Map<string, EntityHP>;
+  /**
+   * v1alpha2 active conditions per entity, keyed by entity id. Populated by
+   * `applyStatusApplied`. Conditions with the same `source` ref replace each
+   * other; multiple distinct conditions stack.
+   */
+  entityStatuses: Map<string, EntityStatus[]>;
+  /**
+   * v1alpha2 encounter mode. UNSPECIFIED until ModeChanged or a snapshot
+   * sets it. Combat controls in the harness gate on this being TURN_BASED.
+   */
+  mode: EncounterMode;
+  /**
+   * v1alpha2 active actor's entity id (whose turn it is). Empty string when
+   * not in TURN_BASED. Set by TurnStarted; not cleared by TurnEnded — the
+   * next TurnStarted overwrites it. The harness's "is it my turn?" check
+   * compares this to the local player's character id.
+   */
+  activeEntityId: string;
+  /**
+   * v1alpha2 turn-based round number. Set by TurnStarted; persists between
+   * turns of the same round.
+   */
+  round: number;
   dungeonState: DungeonState;
   roomsCleared: number;
 }
@@ -64,6 +116,11 @@ export function createEmptyEncounterState(): LocalEncounterState {
     combat: null,
     doors: new Map(),
     openDoors: new Set(),
+    entityHP: new Map(),
+    entityStatuses: new Map(),
+    mode: EncounterMode.UNSPECIFIED,
+    activeEntityId: '',
+    round: 0,
     dungeonState: DungeonState.UNSPECIFIED,
     roomsCleared: 0,
   };
@@ -75,15 +132,17 @@ export function createEmptyEncounterState(): LocalEncounterState {
  *
  * v2-only delta state preservation: `applySnapshot` is called on v1alpha1
  * sync events (LobbyView wires it onto multiple v1 paths). v1 snapshots do
- * NOT carry v2 deltas like `openDoors` or `revealedHexes` — those flow only
- * via the v2 StreamEncounter (DoorOpened, GeometryRevealed) and are not
- * replayed on reconnect or v1 state-sync events. If we rebuilt the whole
- * state on every snapshot we'd silently wipe every v2 door we'd opened in
- * the session.
+ * NOT carry v2 deltas like `openDoors`, `revealedHexes`, `entityHP`,
+ * `entityStatuses`, `mode`, `activeEntityId`, or `round` — those flow only
+ * via the v2 StreamEncounter (DoorOpened, GeometryRevealed, EntityDamaged,
+ * StatusApplied, ModeChanged, TurnStarted, TurnEnded) and are not replayed
+ * on reconnect or v1 state-sync events. If we rebuilt the whole state on
+ * every snapshot we'd silently wipe every v2 delta we'd accumulated in the
+ * session.
  *
  * Mitigation: when `prev` is provided AND the snapshot is for the SAME
- * encounter (same encounterId), carry forward v2-only fields (`openDoors`,
- * `revealedHexes`). On encounter switch (different encounterId) we reset.
+ * encounter (same encounterId), carry forward all v2-only fields. On
+ * encounter switch (different encounterId) we reset.
  *
  * Exported for testing.
  */
@@ -111,6 +170,14 @@ export function applySnapshotToState(
     // v2 door state comes back via the stream's DoorOpened deltas; preserve
     // across same-encounter v1 snapshots (deltas aren't replayed on sync).
     openDoors: sameEncounter ? prev.openDoors : new Set(),
+    // v2 combat state (HP, statuses, mode, active actor, round) flow only via
+    // EntityDamaged / StatusApplied / ModeChanged / TurnStarted events;
+    // preserve across same-encounter v1 snapshots (deltas aren't replayed).
+    entityHP: sameEncounter ? prev.entityHP : new Map(),
+    entityStatuses: sameEncounter ? prev.entityStatuses : new Map(),
+    mode: sameEncounter ? prev.mode : EncounterMode.UNSPECIFIED,
+    activeEntityId: sameEncounter ? prev.activeEntityId : '',
+    round: sameEncounter ? prev.round : 0,
     dungeonState: proto.dungeonState,
     roomsCleared: proto.roomsCleared,
   };
@@ -236,6 +303,134 @@ export function applyDoorOpened(
 }
 
 /**
+ * Apply an EntityDamaged event: writes the target's HP from `hp_after`.
+ *
+ * The server is authoritative — `event.amount` is informational; we do NOT
+ * subtract it from a client-cached value. Always read `hp_after.{current,max}`
+ * directly. Per #393's "no business logic in the web" rule, hit/miss/damage
+ * resolution happens server-side and the wire-shape carries the resulting HP.
+ *
+ * If `hp_after` is missing (defensive — proto field is optional), the entry
+ * is left untouched. Idempotent on identical hp_after values: returns the
+ * same reference to skip a re-render.
+ * Exported for testing.
+ */
+export function applyEntityDamaged(
+  prev: LocalEncounterState,
+  event: EntityDamaged
+): LocalEncounterState {
+  if (!event.hpAfter) return prev;
+  const next: EntityHP = {
+    current: event.hpAfter.current,
+    max: event.hpAfter.max,
+  };
+  const existing = prev.entityHP.get(event.entityId);
+  if (
+    existing !== undefined &&
+    existing.current === next.current &&
+    existing.max === next.max
+  ) {
+    return prev;
+  }
+  const newHP = new Map(prev.entityHP);
+  newHP.set(event.entityId, next);
+  return { ...prev, entityHP: newHP };
+}
+
+/**
+ * Apply a StatusApplied event: appends the condition to the target's status
+ * list. Conditions sharing the same source ref ({module,type,id}) replace
+ * each other (re-applying a condition extends/refreshes it server-side; the
+ * client just mirrors the latest authoritative entry). Distinct conditions
+ * stack.
+ *
+ * If `status` is missing (defensive — proto field is optional), the call is
+ * a no-op. Exported for testing.
+ */
+export function applyStatusApplied(
+  prev: LocalEncounterState,
+  event: StatusApplied
+): LocalEncounterState {
+  const status = event.status;
+  if (!status || !status.source) return prev;
+  const sourceRef = {
+    module: status.source.module,
+    type: status.source.type,
+    id: status.source.id,
+  };
+  const newStatus: EntityStatus = {
+    source: sourceRef,
+    displayName: status.displayName,
+    sourceEntityId: event.sourceEntityId,
+  };
+
+  const existingList = prev.entityStatuses.get(event.entityId) ?? [];
+  // Replace any prior entry with the same source ref; otherwise append.
+  const filtered = existingList.filter(
+    (s) =>
+      !(
+        s.source.module === sourceRef.module &&
+        s.source.type === sourceRef.type &&
+        s.source.id === sourceRef.id
+      )
+  );
+  const nextList = [...filtered, newStatus];
+
+  const newStatuses = new Map(prev.entityStatuses);
+  newStatuses.set(event.entityId, nextList);
+  return { ...prev, entityStatuses: newStatuses };
+}
+
+/**
+ * Apply a ModeChanged event: updates the encounter's mode field.
+ *
+ * Idempotent if the mode is unchanged (returns the same reference).
+ * Exported for testing.
+ */
+export function applyModeChanged(
+  prev: LocalEncounterState,
+  event: ModeChanged
+): LocalEncounterState {
+  if (prev.mode === event.to) return prev;
+  return { ...prev, mode: event.to };
+}
+
+/**
+ * Apply a TurnStarted event: updates `activeEntityId` and `round`.
+ *
+ * Idempotent on a same-actor / same-round event (returns the same reference).
+ * Exported for testing.
+ */
+export function applyTurnStarted(
+  prev: LocalEncounterState,
+  event: TurnStarted
+): LocalEncounterState {
+  if (prev.activeEntityId === event.entityId && prev.round === event.round) {
+    return prev;
+  }
+  return {
+    ...prev,
+    activeEntityId: event.entityId,
+    round: event.round,
+  };
+}
+
+/**
+ * Apply a TurnEnded event. The next TurnStarted is the authoritative source
+ * for the new active actor and round, so we do NOT clear `activeEntityId`
+ * here — clearing it would race the TurnStarted that follows on the wire and
+ * cause the harness to flicker through "(none)" between turns. This reducer
+ * is currently a no-op on local state and exists for symmetry with the wire
+ * event; future consumers (per-turn UI cleanup, animations) hook in here
+ * without changing the dispatcher contract.
+ *
+ * Exported for testing.
+ */
+export function applyTurnEnded(prev: LocalEncounterState): LocalEncounterState {
+  return prev;
+}
+
+/**
  * Replace combat state without touching entities or other fields.
  * Exported for testing.
  */
@@ -271,6 +466,17 @@ export interface UseEncounterStateResult {
   applyEntityDisappeared: (entityId: string, lastKnown: CubeHexCoord) => void;
   /** Mark a door entity as open; idempotent. */
   applyDoorOpened: (doorEntityId: string) => void;
+  // v1alpha2 combat (Wave 2.8)
+  /** Update an entity's HP from an EntityDamaged event's hp_after field. */
+  applyEntityDamaged: (event: EntityDamaged) => void;
+  /** Append (or replace by source ref) a status effect on an entity. */
+  applyStatusApplied: (event: StatusApplied) => void;
+  /** Update encounter mode from a ModeChanged event. */
+  applyModeChanged: (event: ModeChanged) => void;
+  /** Set active actor + round from a TurnStarted event. */
+  applyTurnStarted: (event: TurnStarted) => void;
+  /** Hook for TurnEnded (currently no-op; reserved for future per-turn UI). */
+  applyTurnEnded: () => void;
 }
 
 /**
@@ -328,6 +534,26 @@ export function useEncounterState(): UseEncounterStateResult {
     setState((prev) => applyDoorOpened(prev, doorEntityId));
   }, []);
 
+  const applyEntityDamagedCallback = useCallback((event: EntityDamaged) => {
+    setState((prev) => applyEntityDamaged(prev, event));
+  }, []);
+
+  const applyStatusAppliedCallback = useCallback((event: StatusApplied) => {
+    setState((prev) => applyStatusApplied(prev, event));
+  }, []);
+
+  const applyModeChangedCallback = useCallback((event: ModeChanged) => {
+    setState((prev) => applyModeChanged(prev, event));
+  }, []);
+
+  const applyTurnStartedCallback = useCallback((event: TurnStarted) => {
+    setState((prev) => applyTurnStarted(prev, event));
+  }, []);
+
+  const applyTurnEndedCallback = useCallback(() => {
+    setState((prev) => applyTurnEnded(prev));
+  }, []);
+
   return {
     state,
     applySnapshot,
@@ -339,5 +565,10 @@ export function useEncounterState(): UseEncounterStateResult {
     applyEntityAppeared: applyEntityAppearedCallback,
     applyEntityDisappeared: applyEntityDisappearedCallback,
     applyDoorOpened: applyDoorOpenedCallback,
+    applyEntityDamaged: applyEntityDamagedCallback,
+    applyStatusApplied: applyStatusAppliedCallback,
+    applyModeChanged: applyModeChangedCallback,
+    applyTurnStarted: applyTurnStartedCallback,
+    applyTurnEnded: applyTurnEndedCallback,
   };
 }


### PR DESCRIPTION
Closes #393. Wave 2.8 (Combat slice) web consumer half. Pairs with rpg-api#505 (TakeAction/EndTurn handlers + NPC dispatch) and rpg-toolkit#633 / PR #638 (NPC verb + combat events).

> **Base note:** This branch is opened against `feat/392-door-consumer` (PR #395) so the diff shows only the combat slice. Once #395 merges, GitHub will retarget this PR to `main` automatically.

Strictly additive, mirrors the slice-2 (#389) + Wave 2.7 (#395) patterns: two v2 verb hooks, five new dispatch arms, five new reducers (one no-op), and a harness combat section. Combat state (HP, statuses, mode, active actor, round) is v2-only delta and is preserved across same-encounter v1 snapshots per the #395 fix pattern; encounter switches reset everything.

## What ships

### v2 RPC hooks
- `src/api/useTakeActionV2.ts` — wraps `encounterClientV2.takeAction`. Accepts plain `{module,type,id}` ref + a proto-shaped `ActionTarget` (Wave 2.8 only exercises the `entityId` variant; `position`/`area`/`self` pass through).
- `src/api/useEndTurnV2.ts` — wraps `encounterClientV2.endTurn`.

Both follow the `useMoveEntityV2` / `useInteractV2` shape: loading/error state, promise rejects on RPC failure, error clears on next success.

### Stream dispatch
- `src/api/encounterStream2Dispatch.ts` — adds five arms: `onEntityDamaged`, `onStatusApplied`, `onModeChanged`, `onTurnStarted`, `onTurnEnded`. Inline doc notes the cause/effect split for combat: rpg-api drops `AttackResolved` (cause/narration) on the wire because `EntityDamaged` (effect) is the canonical proto event for HP-affecting outcomes — see [wave plan §toolkit verification findings](../../rpg-project/ideas/encounter/v1alpha2/plans/06-wave-2.8-combat-slice.md).

### State reducers
- `src/hooks/useEncounterState.ts` — adds five v2-only fields to `LocalEncounterState`: `entityHP: Map<string, EntityHP>`, `entityStatuses: Map<string, EntityStatus[]>`, `mode: EncounterMode`, `activeEntityId: string`, `round: number`.

  Reducers (all pure, immutable, with idempotency where meaningful):
  - `applyEntityDamaged` — writes `hp_after`; idempotent on identical hp; no-op when `hp_after` is missing (defensive).
  - `applyStatusApplied` — appends to entity status list; replaces any existing entry with the same source ref `{module,type,id}`; stacks distinct conditions; no-op when `status` is missing.
  - `applyModeChanged` — updates mode; idempotent.
  - `applyTurnStarted` — updates `activeEntityId` + `round`; idempotent.
  - `applyTurnEnded` — no-op (`TurnStarted` is authoritative for the next actor; clearing here would race the wire and flicker the harness UI).

  `applySnapshotToState` extends the #395 same-encounter preservation to cover all five new fields; encounter switch resets the whole combat state cleanly.

### Harness
- `src/components/playtest/PlaytestHarness.tsx` — header gets mode + active actor + round + HP. New **Combat** section: target-id input + **Attack** button (calls `useTakeActionV2` with `action_ref = {dnd5e, action, attack}` and entity-id target), **End turn** button (calls `useEndTurnV2`). Both buttons gated on `mode==TURN_BASED && activeEntityId==localPlayerId`. HP table renders all entities in `entityHP`. Statuses on local player rendered inline.
- **Cause/effect log lines:** every event type logs independently (no collapsing). On a single attack you'll see e.g. `EntityDamaged goblin-1 amount=5 hp_after=2/7` then `StatusApplied goblin-1 <- frightened` as two distinct lines.
- **Mode flip:** per the wave plan, Wave 2.8 ships the dev-only flip via `CreateEncounter(initial_mode=TURN_BASED)` on the rpg-api side (rpg-api#505 scope). The harness has no explicit mode-flip button; the mode indicator shows what the server set. Mid-encounter narrative-trigger flips are 2.10+.
- The harness is still slated for slice-3 deletion (#391); the combat section is dev-only verification scaffolding.

### Tests (vitest)

| File | Δ tests |
|------|--------:|
| `src/api/useTakeActionV2.test.ts` (new) | +5 |
| `src/api/useEndTurnV2.test.ts` (new) | +5 |
| `src/api/encounterStream2Dispatch.test.ts` | +5 |
| `src/api/useEncounterStream2.integration.test.tsx` | +1 |
| `src/hooks/useEncounterState.test.ts` | +24 |
| `src/components/playtest/PlaytestHarness.test.tsx` | +9 |
| **Total** | **+49** |

Suite: 462 passing (was 413 on `feat/392-door-consumer`).

The integration test threads the full `ModeChanged → TurnStarted → EntityDamaged → StatusApplied → TurnEnded → TurnStarted` sequence through `useEncounterStream2` into the unified state and verifies all five reducers ran correctly and accumulated as expected.

`npm run ci-check` green: format, lint, typecheck, build, vitest.

## Constraints honored

- **No business logic in the web.** The reducers consume server-emitted events; they don't compute hit/miss, damage, action validity. `EntityDamaged.hp_after` is authoritative — `amount` is informational only.
- **Cause/effect event split applies to combat too.** `AttackResolved` (cause) is dropped at the rpg-api translator per the wave plan; `EntityDamaged` (effect) and `StatusApplied` (effect) flow on the wire. The harness logs each event type independently.
- **Harness combat controls are throwaway.** No durable combat UI built; that's Wave 5 LobbyView migration territory.

## Test plan

- [x] CI green on all checks
- [x] New unit + integration tests cover dispatch, all five reducers, both new hooks, and harness combat controls
- [x] Cause/effect split preserved — every event type logs independently
- [x] v2-only combat delta state survives same-encounter v1 snapshot rebuild (regression test added)
- [ ] Two-browser playtest with rpg-api#505 once a goblin-1 monster is seeded in the dev encounter

## Cross-references

- Wave plan: `rpg-project/ideas/encounter/v1alpha2/plans/06-wave-2.8-combat-slice.md`
- Wave 2.8 tracker: rpg-project#23
- rpg-api server-side pair: rpg-api#505
- Toolkit pair: rpg-toolkit#633 (PR #638)
- Wave 2.7 web consumer (template): rpg-dnd5e-web#392 / PR #395
- Slice-2 walking skeleton: PR #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)