### PR TITLE
feat(playtest): useSubmitCheckV2 + prompt-modal + harness UI (Wave 2.9)

### DIFF
--- a/src/api/useSubmitCheckV2.test.ts
+++ b/src/api/useSubmitCheckV2.test.ts
@@ -1,0 +1,162 @@
+import type { SubmitCheckResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted lets us reference these before imports are evaluated
+const hoisted = vi.hoisted(() => ({
+  submitCheckFn: vi.fn<() => Promise<SubmitCheckResponse>>(),
+}));
+
+vi.mock('./client', () => ({
+  encounterClientV2: {
+    submitCheck: hoisted.submitCheckFn,
+  },
+}));
+
+// Import AFTER vi.mock so the mock is applied
+import { useSubmitCheckV2 } from './useSubmitCheckV2';
+
+beforeEach(() => {
+  hoisted.submitCheckFn.mockReset();
+});
+
+describe('useSubmitCheckV2', () => {
+  it('starts with loading=false, no error, and null lastResponse', () => {
+    const { result } = renderHook(() => useSubmitCheckV2());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastResponse).toBeNull();
+  });
+
+  it('calls encounterClientV2.submitCheck with correct request shape', async () => {
+    const fakeResponse: SubmitCheckResponse = {
+      success: true,
+      total: 18,
+    } as SubmitCheckResponse;
+    hoisted.submitCheckFn.mockResolvedValue(fakeResponse);
+
+    const { result } = renderHook(() => useSubmitCheckV2());
+
+    let response: SubmitCheckResponse | undefined;
+    await act(async () => {
+      response = await result.current.submitCheck({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 15,
+      });
+    });
+
+    expect(response).toBe(fakeResponse);
+    expect(hoisted.submitCheckFn).toHaveBeenCalledOnce();
+
+    expect(hoisted.submitCheckFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 15,
+      })
+    );
+  });
+
+  it('sets lastResponse on success', async () => {
+    const fakeResponse: SubmitCheckResponse = {
+      success: false,
+      total: 8,
+    } as SubmitCheckResponse;
+    hoisted.submitCheckFn.mockResolvedValue(fakeResponse);
+
+    const { result } = renderHook(() => useSubmitCheckV2());
+
+    await act(async () => {
+      await result.current.submitCheck({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 5,
+      });
+    });
+
+    expect(result.current.lastResponse).toBe(fakeResponse);
+    expect(result.current.lastResponse?.success).toBe(false);
+    expect(result.current.lastResponse?.total).toBe(8);
+  });
+
+  it('sets loading=true during the call and false after success', async () => {
+    let resolveRpc!: (v: SubmitCheckResponse) => void;
+    const pendingRpc = new Promise<SubmitCheckResponse>(
+      (resolve) => (resolveRpc = resolve)
+    );
+    hoisted.submitCheckFn.mockReturnValue(pendingRpc);
+
+    const { result } = renderHook(() => useSubmitCheckV2());
+
+    // Kick off submitCheck without awaiting
+    act(() => {
+      void result.current.submitCheck({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 12,
+      });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Resolve the RPC
+    act(() => resolveRpc({ success: true, total: 15 } as SubmitCheckResponse));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  it('sets error on RPC failure, loading=false, and promise rejects', async () => {
+    const rpcError = new Error('no pending prompt');
+    hoisted.submitCheckFn.mockRejectedValue(rpcError);
+
+    const { result } = renderHook(() => useSubmitCheckV2());
+
+    await act(async () => {
+      await expect(
+        result.current.submitCheck({
+          encounterId: 'enc-1',
+          entityId: 'char-alice',
+          roll: 10,
+        })
+      ).rejects.toThrow('no pending prompt');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(rpcError);
+    // lastResponse unchanged on failure
+    expect(result.current.lastResponse).toBeNull();
+  });
+
+  it('clears error on subsequent successful call', async () => {
+    hoisted.submitCheckFn
+      .mockRejectedValueOnce(new Error('first fail'))
+      .mockResolvedValue({ success: true, total: 18 } as SubmitCheckResponse);
+
+    const { result } = renderHook(() => useSubmitCheckV2());
+
+    // First call fails
+    await act(async () => {
+      await expect(
+        result.current.submitCheck({
+          encounterId: 'enc-1',
+          entityId: 'char-alice',
+          roll: 10,
+        })
+      ).rejects.toThrow('first fail');
+    });
+    expect(result.current.error).not.toBeNull();
+
+    // Second call succeeds
+    await act(async () => {
+      await result.current.submitCheck({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 15,
+      });
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.lastResponse).not.toBeNull();
+  });
+});

--- a/src/api/useSubmitCheckV2.ts
+++ b/src/api/useSubmitCheckV2.ts
@@ -1,0 +1,76 @@
+import { create } from '@bufbuild/protobuf';
+import type { SubmitCheckResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { SubmitCheckRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import { useCallback, useState } from 'react';
+import { encounterClientV2 } from './client';
+
+export interface UseSubmitCheckV2Result {
+  /**
+   * Calls the v1alpha2 SubmitCheck unary RPC. Resolves the caller's currently-pending
+   * InputRequired prompt (skill check). The server tracks the pending prompt as
+   * encounter state — no correlation id required. Returns FailedPrecondition if no
+   * prompt is pending.
+   *
+   * `lastResponse` is populated on success so the harness can render
+   * the outcome (rolled, total, success/fail) transiently before clearing the prompt.
+   */
+  submitCheck: (input: {
+    encounterId: string;
+    entityId: string;
+    roll: number;
+  }) => Promise<SubmitCheckResponse>;
+  loading: boolean;
+  error: Error | null;
+  lastResponse: SubmitCheckResponse | null;
+}
+
+/**
+ * Thin wrapper around the v1alpha2 SubmitCheck unary RPC.
+ *
+ * - loading=true while the RPC is in-flight, false on resolve/reject
+ * - error is set on failure, cleared on the next successful call
+ * - lastResponse holds the most recent successful response for transient display
+ * - The returned promise rejects on RPC error so callers can surface it
+ *
+ * Mirrors useInteractV2 — one file per v1alpha2 verb under src/api/.
+ */
+export function useSubmitCheckV2(): UseSubmitCheckV2Result {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastResponse, setLastResponse] = useState<SubmitCheckResponse | null>(
+    null
+  );
+
+  const submitCheck = useCallback(
+    async (input: {
+      encounterId: string;
+      entityId: string;
+      roll: number;
+    }): Promise<SubmitCheckResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(SubmitCheckRequestSchema, {
+        encounterId: input.encounterId,
+        entityId: input.entityId,
+        roll: input.roll,
+      });
+
+      try {
+        const response = await encounterClientV2.submitCheck(request);
+        setLastResponse(response);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('SubmitCheck RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { submitCheck, loading, error, lastResponse };
+}

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -4,6 +4,7 @@ import type {
   EndTurnResponse,
   InteractResponse,
   MoveEntityResponse,
+  SubmitCheckResponse,
   TakeActionResponse,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
@@ -31,6 +32,7 @@ const hoisted = vi.hoisted(() => ({
   interactFn: vi.fn<() => Promise<InteractResponse>>(),
   takeActionFn: vi.fn<() => Promise<TakeActionResponse>>(),
   endTurnFn: vi.fn<() => Promise<EndTurnResponse>>(),
+  submitCheckFn: vi.fn<() => Promise<SubmitCheckResponse>>(),
 }));
 
 vi.mock('../../api/client', () => ({
@@ -45,6 +47,7 @@ vi.mock('../../api/client', () => ({
     interact: hoisted.interactFn,
     takeAction: hoisted.takeActionFn,
     endTurn: hoisted.endTurnFn,
+    submitCheck: hoisted.submitCheckFn,
   },
 }));
 
@@ -64,6 +67,11 @@ beforeEach(() => {
   hoisted.takeActionFn.mockResolvedValue({} as TakeActionResponse);
   hoisted.endTurnFn.mockReset();
   hoisted.endTurnFn.mockResolvedValue({} as EndTurnResponse);
+  hoisted.submitCheckFn.mockReset();
+  hoisted.submitCheckFn.mockResolvedValue({
+    success: true,
+    total: 18,
+  } as SubmitCheckResponse);
 
   // Set up URL with both params
   window.history.pushState({}, '', '?encounterId=enc-1&playerId=alice');
@@ -845,5 +853,239 @@ describe('PlaytestHarness', () => {
     // No snapshot delivered — initiative order section should be absent
     const header = screen.getByTestId('harness-header');
     expect(header.textContent?.toLowerCase()).not.toContain('initiative:');
+  });
+
+  // ---------- Wave 2.9 prompt modal ----------------------------------------
+
+  it('renders skill-check prompt section when interact returns inputRequired', async () => {
+    const skillCheckPrompt = {
+      inputRequired: {
+        kind: {
+          case: 'skillCheck',
+          value: { dc: 12, ability: 'DEX', tool: undefined },
+        },
+      },
+    } as unknown as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(skillCheckPrompt);
+
+    render(<PlaytestHarness />);
+
+    const input = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'door-east' } });
+    });
+
+    const btn = screen.getByRole('button', {
+      name: /open door/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(btn.disabled).toBe(false));
+
+    act(() => fireEvent.click(btn));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy();
+    });
+
+    // Verify header text
+    expect(screen.getByText(/Skill check: DEX \(DC 12\)/)).toBeTruthy();
+    // Roll input and submit button are present
+    expect(screen.getByLabelText(/roll \(1-20\)/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /submit roll/i })).toBeTruthy();
+  });
+
+  it('calls submitCheck RPC with correct args on submit click', async () => {
+    const skillCheckPrompt = {
+      inputRequired: {
+        kind: {
+          case: 'skillCheck',
+          value: { dc: 15, ability: 'STR', tool: undefined },
+        },
+      },
+    } as unknown as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(skillCheckPrompt);
+
+    render(<PlaytestHarness />);
+
+    const doorInput = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(doorInput, { target: { value: 'door-east' } });
+    });
+    const openBtn = screen.getByRole('button', {
+      name: /open door/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(openBtn.disabled).toBe(false));
+    act(() => fireEvent.click(openBtn));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+
+    // Change the roll value
+    const rollInput = screen.getByLabelText(
+      /roll \(1-20\)/i
+    ) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(rollInput, { target: { value: '17' } });
+    });
+
+    const submitBtn = screen.getByRole('button', { name: /submit roll/i });
+    act(() => fireEvent.click(submitBtn));
+
+    await waitFor(() => {
+      expect(hoisted.submitCheckFn).toHaveBeenCalledOnce();
+    });
+
+    expect(hoisted.submitCheckFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 17,
+      })
+    );
+  });
+
+  it('shows transient result after submitCheck resolves', async () => {
+    const skillCheckPrompt = {
+      inputRequired: {
+        kind: {
+          case: 'skillCheck',
+          value: { dc: 12, ability: 'DEX', tool: undefined },
+        },
+      },
+    } as unknown as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(skillCheckPrompt);
+    hoisted.submitCheckFn.mockResolvedValue({
+      success: true,
+      total: 18,
+    } as SubmitCheckResponse);
+
+    render(<PlaytestHarness />);
+
+    const doorInput = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(doorInput, { target: { value: 'door-east' } });
+    });
+    const openBtn = screen.getByRole('button', { name: /open door/i });
+    await waitFor(() =>
+      expect((openBtn as HTMLButtonElement).disabled).toBe(false)
+    );
+    act(() => fireEvent.click(openBtn));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+
+    const submitBtn = screen.getByRole('button', { name: /submit roll/i });
+    act(() => fireEvent.click(submitBtn));
+
+    // Result appears immediately after resolve — the auto-clear timer fires 2s
+    // later; we just verify the result text is shown while still pending clear.
+    await waitFor(() => {
+      expect(screen.getByTestId('prompt-result')).toBeTruthy();
+    });
+    expect(screen.getByTestId('prompt-result').textContent).toContain(
+      'success!'
+    );
+  });
+
+  it('clears prompt when Dismiss button is clicked', async () => {
+    const skillCheckPrompt = {
+      inputRequired: {
+        kind: {
+          case: 'skillCheck',
+          value: { dc: 12, ability: 'DEX', tool: undefined },
+        },
+      },
+    } as unknown as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(skillCheckPrompt);
+
+    render(<PlaytestHarness />);
+
+    const doorInput = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(doorInput, { target: { value: 'door-east' } });
+    });
+    const openBtn = screen.getByRole('button', { name: /open door/i });
+    await waitFor(() =>
+      expect((openBtn as HTMLButtonElement).disabled).toBe(false)
+    );
+    act(() => fireEvent.click(openBtn));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+
+    // Click Dismiss — prompt should clear immediately
+    act(() =>
+      fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('skill-check-prompt')).toBeNull();
+    });
+  });
+
+  it('renders unsupported placeholder for dialogue prompt kind', async () => {
+    const dialoguePrompt = {
+      inputRequired: {
+        kind: {
+          case: 'dialogue',
+          value: { options: [] },
+        },
+      },
+    } as unknown as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(dialoguePrompt);
+
+    render(<PlaytestHarness />);
+
+    const doorInput = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(doorInput, { target: { value: 'door-east' } });
+    });
+    const openBtn = screen.getByRole('button', { name: /open door/i });
+    await waitFor(() =>
+      expect((openBtn as HTMLButtonElement).disabled).toBe(false)
+    );
+    act(() => fireEvent.click(openBtn));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('unsupported-prompt')).toBeTruthy();
+    });
+    expect(screen.getByTestId('unsupported-prompt').textContent).toContain(
+      '2.10+'
+    );
+  });
+
+  it('shows tool name in skill check prompt when tool is set', async () => {
+    const promptWithTool = {
+      inputRequired: {
+        kind: {
+          case: 'skillCheck',
+          value: {
+            dc: 12,
+            ability: 'DEX',
+            tool: { module: 'dnd5e', type: 'item', id: 'thieves-tools' },
+          },
+        },
+      },
+    } as unknown as InteractResponse;
+    hoisted.interactFn.mockResolvedValue(promptWithTool);
+
+    render(<PlaytestHarness />);
+
+    const doorInput = screen.getByLabelText(/door id/i) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(doorInput, { target: { value: 'door-east' } });
+    });
+    const openBtn = screen.getByRole('button', { name: /open door/i });
+    await waitFor(() =>
+      expect((openBtn as HTMLButtonElement).disabled).toBe(false)
+    );
+    act(() => fireEvent.click(openBtn));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy();
+    });
+    expect(screen.getByText(/thieves-tools/)).toBeTruthy();
   });
 });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -59,10 +59,18 @@ export function PlaytestHarness() {
   const [attackTargetId, setAttackTargetId] = useState('');
   // Wave 2.9: prompt roll input and transient result display
   const [rollValue, setRollValue] = useState(10);
-  const [promptResult, setPromptResult] = useState<string | null>(null);
+  // Structured result avoids string-sniffing for color/outcome logic.
+  const [promptResult, setPromptResult] = useState<{
+    success: boolean;
+    total: number;
+    roll: number;
+  } | null>(null);
+  // Ref to the prompt that is currently being auto-cleared; guards against
+  // clearing a newer prompt when the timer from a prior submit fires late.
   const clearResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
+  const clearingPromptRef = useRef<object | null>(null);
 
   const encounterState = useEncounterState();
   const {
@@ -276,6 +284,14 @@ export function PlaytestHarness() {
       const response = await interact(encounterId, id, 'open');
       addLog(`Interact(open) → ${id}`);
       if (response.inputRequired) {
+        // Cancel any in-progress auto-clear timer from a prior submit so it
+        // doesn't unexpectedly clear the new incoming prompt.
+        if (clearResultTimerRef.current) {
+          clearTimeout(clearResultTimerRef.current);
+          clearResultTimerRef.current = null;
+        }
+        clearingPromptRef.current = null;
+        setPromptResult(null);
         encounterState.setPendingPrompt(response.inputRequired);
         addLog(
           `InputRequired: ${response.inputRequired.kind?.case ?? 'unknown'}`
@@ -318,24 +334,37 @@ export function PlaytestHarness() {
   };
 
   const handleSubmitCheck = async () => {
+    // Capture the prompt being resolved. We pass this identity token to the
+    // auto-clear timer so a stale timer from a prior submit doesn't clear a
+    // newer prompt if the prompt changes before the 2s window expires.
+    const promptBeingResolved = encounterState.state.pendingPrompt;
     try {
       const response = await submitCheck({
         encounterId,
         entityId,
         roll: rollValue,
       });
-      const outcome = response.success ? 'success!' : 'failed.';
-      const resultMsg = `rolled ${rollValue.toString()}, total ${response.total.toString()}, ${outcome}`;
-      addLog(`SubmitCheck → ${resultMsg}`);
-      setPromptResult(resultMsg);
-      // Clear the result display after 2 s, then clear the prompt
+      addLog(
+        `SubmitCheck → rolled ${rollValue.toString()}, total ${response.total.toString()}, ${response.success ? 'success!' : 'failed.'}`
+      );
+      setPromptResult({
+        success: response.success,
+        total: response.total,
+        roll: rollValue,
+      });
+      // Clear any prior timer then start a new 2s window.
       if (clearResultTimerRef.current) {
         clearTimeout(clearResultTimerRef.current);
       }
+      clearingPromptRef.current = promptBeingResolved;
       clearResultTimerRef.current = setTimeout(() => {
-        setPromptResult(null);
-        encounterState.setPendingPrompt(null);
+        // Only clear the prompt if it hasn't changed since we started this timer.
+        if (clearingPromptRef.current === promptBeingResolved) {
+          setPromptResult(null);
+          encounterState.setPendingPrompt(null);
+        }
         clearResultTimerRef.current = null;
+        clearingPromptRef.current = null;
       }, 2000);
     } catch {
       // error is surfaced via submitCheckError state
@@ -690,14 +719,13 @@ export function PlaytestHarness() {
                       <div
                         data-testid="prompt-result"
                         style={{
-                          color: promptResult.includes('success')
-                            ? '#8f8'
-                            : '#f88',
+                          color: promptResult.success ? '#8f8' : '#f88',
                           fontWeight: 'bold',
                           fontSize: 13,
                         }}
                       >
-                        {promptResult}
+                        rolled {promptResult.roll}, total {promptResult.total},{' '}
+                        {promptResult.success ? 'success!' : 'failed.'}
                       </div>
                     ) : (
                       <div
@@ -713,13 +741,17 @@ export function PlaytestHarness() {
                             type="number"
                             min={1}
                             max={20}
+                            step={1}
                             value={rollValue}
                             aria-label="roll value"
                             onChange={(e) =>
                               setRollValue(
                                 Math.min(
                                   20,
-                                  Math.max(1, Number(e.target.value))
+                                  Math.max(
+                                    1,
+                                    Math.trunc(Number(e.target.value))
+                                  )
                                 )
                               )
                             }

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -5,13 +5,14 @@ import {
   EncounterMode,
   EntityType,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { v2PositionToV1 } from '../../api/positionConvert';
 import { useDevPlayerIdAuth } from '../../api/useDevPlayerIdAuth';
 import { useEncounterStream2 } from '../../api/useEncounterStream2';
 import { useEndTurnV2 } from '../../api/useEndTurnV2';
 import { useInteractV2 } from '../../api/useInteractV2';
 import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
+import { useSubmitCheckV2 } from '../../api/useSubmitCheckV2';
 import { useTakeActionV2 } from '../../api/useTakeActionV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
 import { protoPositionToHex } from '../../utils/hexCoord';
@@ -56,6 +57,12 @@ export function PlaytestHarness() {
   const [targetS, setTargetS] = useState(0);
   const [targetDoorId, setTargetDoorId] = useState('');
   const [attackTargetId, setAttackTargetId] = useState('');
+  // Wave 2.9: prompt roll input and transient result display
+  const [rollValue, setRollValue] = useState(10);
+  const [promptResult, setPromptResult] = useState<string | null>(null);
+  const clearResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   const encounterState = useEncounterState();
   const {
@@ -78,6 +85,11 @@ export function PlaytestHarness() {
     loading: endTurnLoading,
     error: endTurnError,
   } = useEndTurnV2();
+  const {
+    submitCheck,
+    loading: submitCheckLoading,
+    error: submitCheckError,
+  } = useSubmitCheckV2();
 
   const addLog = (msg: string) => {
     const entry = `[${formatTime(new Date())}] ${msg}`;
@@ -210,6 +222,16 @@ export function PlaytestHarness() {
     }
   );
 
+  // Clean up the auto-clear timer on unmount. Placed before the !playerId
+  // early return so this hook is always called unconditionally (Rules of Hooks).
+  useEffect(() => {
+    return () => {
+      if (clearResultTimerRef.current) {
+        clearTimeout(clearResultTimerRef.current);
+      }
+    };
+  }, []);
+
   if (!playerId) {
     return (
       <div style={{ padding: 16, color: 'red', fontFamily: 'monospace' }}>
@@ -251,8 +273,14 @@ export function PlaytestHarness() {
     const id = targetDoorId.trim();
     if (!id) return;
     try {
-      await interact(encounterId, id, 'open');
+      const response = await interact(encounterId, id, 'open');
       addLog(`Interact(open) → ${id}`);
+      if (response.inputRequired) {
+        encounterState.setPendingPrompt(response.inputRequired);
+        addLog(
+          `InputRequired: ${response.inputRequired.kind?.case ?? 'unknown'}`
+        );
+      }
     } catch {
       // error is surfaced via interactError state
     }
@@ -286,6 +314,31 @@ export function PlaytestHarness() {
       addLog(`EndTurn → ${entityId}`);
     } catch {
       // error is surfaced via endTurnError state
+    }
+  };
+
+  const handleSubmitCheck = async () => {
+    try {
+      const response = await submitCheck({
+        encounterId,
+        entityId,
+        roll: rollValue,
+      });
+      const outcome = response.success ? 'success!' : 'failed.';
+      const resultMsg = `rolled ${rollValue.toString()}, total ${response.total.toString()}, ${outcome}`;
+      addLog(`SubmitCheck → ${resultMsg}`);
+      setPromptResult(resultMsg);
+      // Clear the result display after 2 s, then clear the prompt
+      if (clearResultTimerRef.current) {
+        clearTimeout(clearResultTimerRef.current);
+      }
+      clearResultTimerRef.current = setTimeout(() => {
+        setPromptResult(null);
+        encounterState.setPendingPrompt(null);
+        clearResultTimerRef.current = null;
+      }, 2000);
+    } catch {
+      // error is surfaced via submitCheckError state
     }
   };
 
@@ -602,6 +655,142 @@ export function PlaytestHarness() {
               Interact error: {interactError.message}
             </div>
           )}
+
+          {/* Skill check prompt (Wave 2.9) */}
+          {encounterState.state.pendingPrompt !== null &&
+            (() => {
+              const prompt = encounterState.state.pendingPrompt;
+              if (prompt.kind?.case === 'skillCheck') {
+                const sc = prompt.kind.value;
+                return (
+                  <div
+                    data-testid="skill-check-prompt"
+                    style={{
+                      margin: '16px 0 8px',
+                      padding: '12px',
+                      background: '#1a1a2e',
+                      border: '1px solid #4a4aaa',
+                      borderRadius: 4,
+                    }}
+                  >
+                    <h3 style={{ margin: '0 0 8px', color: '#aaf' }}>
+                      Skill check prompt
+                    </h3>
+                    <div style={{ fontSize: 13, marginBottom: 8 }}>
+                      <strong>
+                        Skill check: {sc.ability} (DC {sc.dc})
+                      </strong>
+                      {sc.tool && (
+                        <span style={{ color: '#aaa', marginLeft: 8 }}>
+                          — requires: {sc.tool.id}
+                        </span>
+                      )}
+                    </div>
+                    {promptResult !== null ? (
+                      <div
+                        data-testid="prompt-result"
+                        style={{
+                          color: promptResult.includes('success')
+                            ? '#8f8'
+                            : '#f88',
+                          fontWeight: 'bold',
+                          fontSize: 13,
+                        }}
+                      >
+                        {promptResult}
+                      </div>
+                    ) : (
+                      <div
+                        style={{
+                          display: 'flex',
+                          gap: 8,
+                          alignItems: 'center',
+                        }}
+                      >
+                        <label style={{ fontSize: 12 }}>
+                          Roll (1-20){' '}
+                          <input
+                            type="number"
+                            min={1}
+                            max={20}
+                            value={rollValue}
+                            aria-label="roll value"
+                            onChange={(e) =>
+                              setRollValue(
+                                Math.min(
+                                  20,
+                                  Math.max(1, Number(e.target.value))
+                                )
+                              )
+                            }
+                            style={{
+                              width: 60,
+                              background: '#333',
+                              color: '#eee',
+                              border: '1px solid #555',
+                              padding: '2px 4px',
+                            }}
+                          />
+                        </label>
+                        <button
+                          onClick={() => void handleSubmitCheck()}
+                          disabled={submitCheckLoading}
+                          style={{
+                            padding: '4px 12px',
+                            background: '#2a2a4a',
+                            color: '#aaf',
+                            border: '1px solid #4a4aaa',
+                            cursor: submitCheckLoading
+                              ? 'not-allowed'
+                              : 'pointer',
+                          }}
+                        >
+                          {submitCheckLoading ? 'Submitting…' : 'Submit roll'}
+                        </button>
+                        <button
+                          onClick={() => encounterState.setPendingPrompt(null)}
+                          style={{
+                            padding: '4px 8px',
+                            background: '#2a2a2a',
+                            color: '#888',
+                            border: '1px solid #444',
+                            cursor: 'pointer',
+                            fontSize: 11,
+                          }}
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                    )}
+                    {submitCheckError && (
+                      <div
+                        style={{ color: '#f88', marginTop: 8, fontSize: 12 }}
+                      >
+                        SubmitCheck error: {submitCheckError.message}
+                      </div>
+                    )}
+                  </div>
+                );
+              }
+              // dialogue / targetSelect — Wave 2.10+
+              return (
+                <div
+                  data-testid="unsupported-prompt"
+                  style={{
+                    margin: '16px 0 8px',
+                    padding: '8px 12px',
+                    background: '#1a1a1a',
+                    border: '1px solid #555',
+                    borderRadius: 4,
+                    color: '#888',
+                    fontSize: 12,
+                  }}
+                >
+                  Prompt type {prompt.kind?.case ?? 'unknown'}: not yet
+                  supported (Wave 2.10+)
+                </div>
+              );
+            })()}
 
           {/* Combat controls (Wave 2.8 verification scaffold; deleted in slice 3) */}
           <h3 style={{ margin: '16px 0 8px', color: '#aaa' }}>Combat</h3>

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -32,6 +32,8 @@ import type {
 import {
   EncounterMode,
   EntityType as EntityTypeV2,
+  InputRequiredSchema,
+  SkillCheckPromptSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
 import { hexKey } from '../utils/hexCoord';
@@ -52,6 +54,7 @@ import {
   createEmptyEncounterState,
   mergeEntityPosition,
   mergeEntityUpdates,
+  setPendingPromptReducer,
   updateCombatState,
 } from './useEncounterState';
 
@@ -1524,5 +1527,104 @@ describe('applySnapshotToState — entityMeta + initiativeOrder delta preservati
 
     expect(switched.entityMeta.size).toBe(0);
     expect(switched.initiativeOrder).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 2.9 pending-prompt reducer
+// ---------------------------------------------------------------------------
+
+describe('Wave 2.9 setPendingPromptReducer', () => {
+  const makeSkillCheckPrompt = () =>
+    create(InputRequiredSchema, {
+      kind: {
+        case: 'skillCheck',
+        value: create(SkillCheckPromptSchema, {
+          dc: 12,
+          ability: 'DEX',
+        }),
+      },
+    });
+
+  it('starts with pendingPrompt=null in empty state', () => {
+    const state = createEmptyEncounterState();
+    expect(state.pendingPrompt).toBeNull();
+  });
+
+  it('sets pendingPrompt when passed a prompt', () => {
+    const prompt = makeSkillCheckPrompt();
+    const prev = createEmptyEncounterState();
+    const next = setPendingPromptReducer(prev, prompt);
+    expect(next.pendingPrompt).toBe(prompt);
+  });
+
+  it('clears pendingPrompt when passed null', () => {
+    const prompt = makeSkillCheckPrompt();
+    let state = createEmptyEncounterState();
+    state = setPendingPromptReducer(state, prompt);
+    expect(state.pendingPrompt).not.toBeNull();
+
+    const cleared = setPendingPromptReducer(state, null);
+    expect(cleared.pendingPrompt).toBeNull();
+  });
+
+  it('returns the same reference when prompt is unchanged (idempotent)', () => {
+    const prompt = makeSkillCheckPrompt();
+    const prev = setPendingPromptReducer(createEmptyEncounterState(), prompt);
+    const next = setPendingPromptReducer(prev, prompt);
+    expect(next).toBe(prev);
+  });
+
+  it('null → null also returns the same reference', () => {
+    const prev = createEmptyEncounterState();
+    const next = setPendingPromptReducer(prev, null);
+    expect(next).toBe(prev);
+  });
+
+  it('does not mutate the previous state', () => {
+    const prev = createEmptyEncounterState();
+    const prompt = makeSkillCheckPrompt();
+    setPendingPromptReducer(prev, prompt);
+    expect(prev.pendingPrompt).toBeNull();
+  });
+
+  it('does not touch unrelated state fields (entities, mode, round)', () => {
+    let state = createEmptyEncounterState();
+    state = applyTurnStarted(state, {
+      entityId: 'char-alice',
+      round: 2,
+    } as unknown as TurnStarted);
+    const prompt = makeSkillCheckPrompt();
+    const next = setPendingPromptReducer(state, prompt);
+    expect(next.activeEntityId).toBe('char-alice');
+    expect(next.round).toBe(2);
+    expect(next.pendingPrompt).toBe(prompt);
+  });
+
+  it('pendingPrompt is preserved across same-encounter snapshot', () => {
+    const prompt = makeSkillCheckPrompt();
+    let state = createEmptyEncounterState();
+    state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }), state);
+    state = setPendingPromptReducer(state, prompt);
+    expect(state.pendingPrompt).toBe(prompt);
+
+    const refreshed = applySnapshotToState(
+      makeSnapshot({ encounterId: 'enc-1' }),
+      state
+    );
+    expect(refreshed.pendingPrompt).toBe(prompt);
+  });
+
+  it('pendingPrompt is cleared on encounter switch', () => {
+    const prompt = makeSkillCheckPrompt();
+    let state = createEmptyEncounterState();
+    state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }), state);
+    state = setPendingPromptReducer(state, prompt);
+
+    const switched = applySnapshotToState(
+      makeSnapshot({ encounterId: 'enc-2' }),
+      state
+    );
+    expect(switched.pendingPrompt).toBeNull();
   });
 });

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -28,6 +28,7 @@ import type {
   StatusApplied,
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import type { InputRequired } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
   EntityType,
@@ -133,6 +134,13 @@ export interface LocalEncounterState {
   round: number;
   dungeonState: DungeonState;
   roomsCleared: number;
+  /**
+   * v1alpha2 pending prompt from Interact or TakeAction response. Callers set
+   * this explicitly via `setPendingPrompt(response.inputRequired)` after an RPC
+   * returns with inputRequired set, and clear it via `setPendingPrompt(null)`
+   * after SubmitCheck resolves. Never auto-set inside hooks — keeps hooks pure.
+   */
+  pendingPrompt: InputRequired | null;
 }
 
 /** Create an empty LocalEncounterState. Exported for testing. */
@@ -157,6 +165,7 @@ export function createEmptyEncounterState(): LocalEncounterState {
     round: 0,
     dungeonState: DungeonState.UNSPECIFIED,
     roomsCleared: 0,
+    pendingPrompt: null,
   };
 }
 
@@ -220,6 +229,10 @@ export function applySnapshotToState(
     round: sameEncounter ? prev.round : 0,
     dungeonState: proto.dungeonState,
     roomsCleared: proto.roomsCleared,
+    // pendingPrompt is caller-private; it doesn't flow through v1 snapshots.
+    // Preserve it across same-encounter syncs so a mid-session snapshot doesn't
+    // silently clear a prompt the player hasn't answered yet.
+    pendingPrompt: sameEncounter ? prev.pendingPrompt : null,
   };
 }
 
@@ -596,6 +609,20 @@ export function applyTurnEnded(prev: LocalEncounterState): LocalEncounterState {
 }
 
 /**
+ * Set or clear the pending prompt. Pass `null` to dismiss after SubmitCheck
+ * resolves; pass the InputRequired proto from an Interact/TakeAction response
+ * to surface it. Callers drive this explicitly — the hook never auto-sets it.
+ * Exported for testing.
+ */
+export function setPendingPromptReducer(
+  prev: LocalEncounterState,
+  prompt: InputRequired | null
+): LocalEncounterState {
+  if (prev.pendingPrompt === prompt) return prev;
+  return { ...prev, pendingPrompt: prompt };
+}
+
+/**
  * Replace combat state without touching entities or other fields.
  * Exported for testing.
  */
@@ -666,6 +693,13 @@ export interface UseEncounterStateResult {
       | { initiativeOrder: string[]; activeEntityId: string; round: number }
       | undefined
   ) => void;
+  // v1alpha2 prompts (Wave 2.9)
+  /**
+   * Set or clear the pending InputRequired prompt. Pass the proto from an
+   * Interact/TakeAction response to display the prompt; pass null to dismiss it
+   * after SubmitCheck resolves. Never called automatically inside hooks.
+   */
+  setPendingPrompt: (prompt: InputRequired | null) => void;
   // v1alpha2 combat (Wave 2.8)
   /** Update an entity's HP from an EntityDamaged event's hp_after field. */
   applyEntityDamaged: (event: EntityDamaged) => void;
@@ -782,6 +816,13 @@ export function useEncounterState(): UseEncounterStateResult {
     []
   );
 
+  const setPendingPromptCallback = useCallback(
+    (prompt: InputRequired | null) => {
+      setState((prev) => setPendingPromptReducer(prev, prompt));
+    },
+    []
+  );
+
   const applyEntityDamagedCallback = useCallback((event: EntityDamaged) => {
     setState((prev) => applyEntityDamaged(prev, event));
   }, []);
@@ -816,6 +857,7 @@ export function useEncounterState(): UseEncounterStateResult {
     applyEntityMeta: applyEntityMetaCallback,
     applyEntityAppearedBatch: applyEntityAppearedBatchCallback,
     applyV2SnapshotTurnState: applyV2SnapshotTurnStateCallback,
+    setPendingPrompt: setPendingPromptCallback,
     applyEntityDamaged: applyEntityDamagedCallback,
     applyStatusApplied: applyStatusAppliedCallback,
     applyModeChanged: applyModeChangedCallback,


### PR DESCRIPTION
## What shipped

- **`src/api/useSubmitCheckV2.ts`** — New v1alpha2 RPC hook wrapping `encounterClientV2.submitCheck`. Returns `{ submitCheck, loading, error, lastResponse }`. Mirrors `useInteractV2` shape exactly.
- **`src/hooks/useEncounterState.ts`** — Added `pendingPrompt: InputRequired | null` to `LocalEncounterState`, `setPendingPromptReducer` pure function, and `setPendingPrompt` hook callback. Prompt is preserved across same-encounter v1 snapshots; cleared on encounter switch.
- **`src/components/playtest/PlaytestHarness.tsx`** — Inline skill-check prompt section (not a `<dialog>` — an inline div beneath the Open Door controls):
  - Shows when `pendingPrompt.kind.case === 'skillCheck'`: header with ability + DC, optional tool name, number input (1-20), Submit Roll + Dismiss buttons.
  - On resolve: renders transient `rolled X, total Y, success!/failed.` for 2s via `setTimeout`, then auto-clears prompt via `setPendingPrompt(null)`.
  - For `dialogue`/`targetSelect`: renders "not yet supported (Wave 2.10+)" placeholder.
  - `handleOpenDoor` now calls `setPendingPrompt(response.inputRequired)` when Interact returns with a prompt.
  - `useEffect` cleanup for the auto-clear timer; placed before the `!playerId` early return to satisfy Rules of Hooks.

## Tests

- `useSubmitCheckV2.test.ts` — 6 cases: initial state, request shape, lastResponse on success, loading state, error on failure, error cleared on retry.
- `useEncounterState.test.ts` — +9 cases: set/clear/idempotent/no-mutate/unrelated-state-preserved/snapshot-preserve/encounter-switch-clears.
- `PlaytestHarness.test.tsx` — +5 cases: skill-check section renders on inputRequired, submit calls RPC with correct args, transient result shows, dismiss button clears, unsupported kind shows placeholder, tool name renders.

## UX choice: inline section vs `<dialog>`

Used an inline `<div>` section beneath the Open Door controls rather than a `<dialog>` element. This harness is a dev-only debug tool — inline is simpler, avoids focus-trap issues in tests, and matches the existing harness aesthetic.

## Seed note (manual end-to-end pending rpg-api#514)

End-to-end verification requires a locked-door Redis seed. When rpg-api#514 lands (or via local replace), seed `door-east` in the encounter with:
```python
"door-east": {
    "id": "door-east", "position": door_pos, "open": False,
    "locked": True, "lock_dc": 12, "lock_ability": "DEX",
    "lock_tool": "dnd5e:item:thieves-tools",
}
```
This can be done at manual verification time. The harness UI is ready to drive the flow end-to-end once the API ships the `inputRequired` payload on Interact.

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)