### PR TITLE
feat(playtest): render damage_breakdown components in combat log (#414)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#cdd9e0e3945d60ee1148599bc4663c5dfb083ba7",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#3a5e2bc47447",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1356,8 +1356,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#cdd9e0e3945d60ee1148599bc4663c5dfb083ba7",
-      "integrity": "sha512-yQ+OGhztRwPuzqpQqKTTyVHCdwxIpydRldGWhsy+AV2iNCTwQD8AVcyTWA/KlPV5s2yj3GCW6AnEZG+pjCVYOA==",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#3a5e2bc47447ce81ad02bfb5d4735a584c47ba68",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#cdd9e0e3945d60ee1148599bc4663c5dfb083ba7",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#3a5e2bc47447",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/api/encounterStream2Dispatch.test.ts
+++ b/src/api/encounterStream2Dispatch.test.ts
@@ -92,6 +92,29 @@ describe('dispatchEncounterStream2Event', () => {
     expect(onEntityDamaged).toHaveBeenCalledTimes(1);
   });
 
+  it('passes damageBreakdown components to onEntityDamaged when present', () => {
+    const onEntityDamaged = vi.fn();
+    const options: EncounterStream2Options = { onEntityDamaged };
+    const event = makeEvent('entityDamaged', {
+      entityId: 'goblin-1',
+      amount: 10,
+      hpAfter: { current: 90, max: 100 },
+      damageBreakdown: [
+        { source: 'dnd5e:weapons:shortsword', amount: 6, isCritical: false },
+        { source: 'dnd5e:abilities:dex', amount: 3, isCritical: false },
+        { source: 'dnd5e:features:sneak_attack', amount: 1, isCritical: false },
+      ],
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onEntityDamaged).toHaveBeenCalledTimes(1);
+    const received = onEntityDamaged.mock.calls[0][0];
+    expect(received.damageBreakdown).toHaveLength(3);
+    expect(received.damageBreakdown[0].source).toBe('dnd5e:weapons:shortsword');
+    expect(received.damageBreakdown[2].source).toBe(
+      'dnd5e:features:sneak_attack'
+    );
+  });
+
   it('routes statusApplied to onStatusApplied', () => {
     const onStatusApplied = vi.fn();
     const options: EncounterStream2Options = { onStatusApplied };

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -237,7 +237,20 @@ export function PlaytestHarness() {
         encounterState.applyEntityDamaged(e);
         const hp = e.hpAfter;
         const hpStr = hp ? ` hp_after=${hp.current}/${hp.max}` : '';
-        addLog(`EntityDamaged ${e.entityId} amount=${e.amount}${hpStr}`);
+        const breakdownStr =
+          e.damageBreakdown && e.damageBreakdown.length > 0
+            ? ' [' +
+              e.damageBreakdown
+                .map(
+                  (c) =>
+                    `${c.source}:${c.amount}${c.isCritical ? '(crit)' : ''}`
+                )
+                .join(', ') +
+              ']'
+            : '';
+        addLog(
+          `EntityDamaged ${e.entityId} amount=${e.amount}${hpStr}${breakdownStr}`
+        );
       },
       onStatusApplied: (e) => {
         encounterState.applyStatusApplied(e);


### PR DESCRIPTION
## Summary

- Extends `PlaytestHarness.tsx` `onEntityDamaged` handler to append a `[source:amount, ...]` suffix when `v2` stream events carry `damageBreakdown` components
- Adds `encounterStream2Dispatch.test.ts` coverage for `damageBreakdown` pass-through to `onEntityDamaged`
- Guards the breakdown rendering with `e.damageBreakdown &&` so old/missing breakdown is a no-op

Rolls up to: rpg-api#550 (Wave 1 Rogue damage breakdown)

## Dependencies

This PR depends on:
- rpg-api-protos#161: adds `DamageComponent` message + `damage_breakdown` field to `EntityDamaged`
- rpg-toolkit#682: wires `DamageComponent` through broker JSON round-trip
- rpg-api#556: populates `damage_breakdown` from toolkit breakdown

**CI typecheck will fail** until `package.json` is updated to the proto commit after rpg-api-protos#161 merges (CI needs the new generated TS for the `damageBreakdown` field).

## Test plan

- [ ] CI passes after proto #161 merges and package.json is updated to new generated commit
- [ ] `encounterStream2Dispatch.test.ts` — new test verifies breakdown components flow through dispatch
- [ ] MCP playtest: alice attacks goblin, combat log shows `[dnd5e:weapons:shortsword:6, dnd5e:abilities:dex:3, dnd5e:features:sneak_attack:N]` in the EntityDamaged line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #414
Part of KirkDiggler/rpg-api#550 (Chapter 2 Wave 1)