### PR TITLE
feat(playtest): show AC in harness entity panel

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -30,6 +30,15 @@ let it rot.
 
 ## Recently landed (last 6 weeks, highlights)
 
+- **Chapter 2 Wave 2 — AC column in harness entity panel (PR #416, 2026-05-28)** —
+  `PlaytestHarness` entity table now shows an AC column alongside HP. AC is
+  stored in `entityAC: Map<string, number>` on `LocalEncounterState`, seeded
+  from v1alpha1 `EntityState.details` (character and monster) via
+  `applySnapshotToState` and `mergeEntityUpdates`. Note: the current v1alpha2
+  stream proto does not carry AC on `CharacterData`/`MonsterData` (filed as a
+  proto gap); the column reads '—' for entities that have not gone through the
+  v1alpha1 snapshot path.
+
 - **Chapter 2 Wave 1 (rogue) — Sneak Attack damage breakdown in combat log (PR #415, 2026-05-28)** —
   `PlaytestHarness` now renders per-source damage components from the v1alpha2
   `EntityDamaged.damage_breakdown` field (added in rpg-api-protos#161, populated by

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1112,6 +1112,7 @@ export function PlaytestHarness() {
                   <th style={{ padding: '4px 8px' }}>id</th>
                   <th style={{ padding: '4px 8px' }}>type</th>
                   <th style={{ padding: '4px 8px' }}>HP</th>
+                  <th style={{ padding: '4px 8px' }}>AC</th>
                   <th style={{ padding: '4px 8px' }}>x</th>
                   <th style={{ padding: '4px 8px' }}>y</th>
                   <th style={{ padding: '4px 8px' }}>z</th>
@@ -1129,6 +1130,7 @@ export function PlaytestHarness() {
                     id === encounterState.state.activeEntityId;
                   const meta = encounterState.state.entityMeta.get(id);
                   const hp = encounterState.state.entityHP.get(id);
+                  const ac = encounterState.state.entityAC.get(id);
                   // Row background: active actor (yellow/orange) takes priority over
                   // local player (green) so both states are distinguishable when
                   // it's the local player's turn.
@@ -1167,6 +1169,9 @@ export function PlaytestHarness() {
                         {hp ? `${hp.current}/${hp.max}` : '—'}
                       </td>
                       <td style={{ padding: '4px 8px' }}>
+                        {ac !== undefined ? ac : '—'}
+                      </td>
+                      <td style={{ padding: '4px 8px' }}>
                         {entity.position?.x ?? '—'}
                       </td>
                       <td style={{ padding: '4px 8px' }}>
@@ -1184,7 +1189,7 @@ export function PlaytestHarness() {
                 {entitiesArray.length === 0 && (
                   <tr>
                     <td
-                      colSpan={7}
+                      colSpan={8}
                       style={{ padding: '4px 8px', color: '#555' }}
                     >
                       (no entities yet)

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -11,11 +11,13 @@
 import { create } from '@bufbuild/protobuf';
 import { PositionSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import {
+  CharacterDetailsSchema,
   CombatStateSchema,
   DoorInfoSchema,
   EncounterStateDataSchema,
   type EntityState,
   EntityStateSchema,
+  MonsterDetailsSchema,
   RoomLayoutSchema,
   TurnStateSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
@@ -233,6 +235,35 @@ describe('applySnapshotToState', () => {
     expect(state.doors.size).toBe(0);
   });
 
+  it('seeds entityAC from character and monster details in snapshot entities', () => {
+    const snapshot = create(EncounterStateDataSchema, {
+      encounterId: 'enc-1',
+      dungeonId: 'dng-1',
+      dungeonState: DungeonState.ACTIVE,
+      entities: {
+        'char-1': create(EntityStateSchema, {
+          entityId: 'char-1',
+          entityType: EntityType.CHARACTER,
+          details: {
+            case: 'characterDetails',
+            value: create(CharacterDetailsSchema, { armorClass: 15 }),
+          },
+        }),
+        'goblin-1': create(EntityStateSchema, {
+          entityId: 'goblin-1',
+          entityType: EntityType.MONSTER,
+          details: {
+            case: 'monsterDetails',
+            value: create(MonsterDetailsSchema, { armorClass: 13 }),
+          },
+        }),
+      },
+    });
+    const state = applySnapshotToState(snapshot);
+    expect(state.entityAC.get('char-1')).toBe(15);
+    expect(state.entityAC.get('goblin-1')).toBe(13);
+  });
+
   it('produces independent state from previous calls (no shared references)', () => {
     const snapshot1 = makeSnapshot({
       encounterId: 'enc-1',
@@ -380,6 +411,34 @@ describe('mergeEntityUpdates', () => {
     expect(next.currentRoomId).toBe('room-1');
     expect(next.revealedRoomIds).toEqual(['room-1']);
     expect(next.roomsCleared).toBe(2);
+  });
+
+  it('extracts entityAC from character details', () => {
+    const prev = applySnapshotToState(makeSnapshot({}));
+    const charWithAC = create(EntityStateSchema, {
+      entityId: 'char-1',
+      entityType: EntityType.CHARACTER,
+      details: {
+        case: 'characterDetails',
+        value: create(CharacterDetailsSchema, { armorClass: 15 }),
+      },
+    });
+    const next = mergeEntityUpdates(prev, [charWithAC]);
+    expect(next.entityAC.get('char-1')).toBe(15);
+  });
+
+  it('extracts entityAC from monster details', () => {
+    const prev = applySnapshotToState(makeSnapshot({}));
+    const monster = create(EntityStateSchema, {
+      entityId: 'goblin-1',
+      entityType: EntityType.MONSTER,
+      details: {
+        case: 'monsterDetails',
+        value: create(MonsterDetailsSchema, { armorClass: 13 }),
+      },
+    });
+    const next = mergeEntityUpdates(prev, [monster]);
+    expect(next.entityAC.get('goblin-1')).toBe(13);
   });
 });
 

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -99,6 +99,14 @@ export interface LocalEncounterState {
    */
   entityHP: Map<string, EntityHP>;
   /**
+   * Per-entity armor class keyed by entity id. Populated by `mergeEntityUpdates`
+   * from EntityState.details (characterDetails.armorClass or
+   * monsterDetails.armorClass). Available when full v1alpha1 entity data flows
+   * through the state (snapshot path). Absent for v1alpha2-stub entities that
+   * have not yet received a full EntityState update.
+   */
+  entityAC: Map<string, number>;
+  /**
    * v1alpha2 active conditions per entity, keyed by entity id. Populated by
    * `applyStatusApplied`. Conditions with the same `source` ref replace each
    * other; multiple distinct conditions stack.
@@ -208,6 +216,7 @@ export function createEmptyEncounterState(): LocalEncounterState {
     doors: new Map(),
     openDoors: new Set(),
     entityHP: new Map(),
+    entityAC: new Map(),
     entityStatuses: new Map(),
     entityMeta: new Map(),
     initiativeOrder: [],
@@ -271,6 +280,25 @@ export function applySnapshotToState(
     // EntityDamaged / StatusApplied / ModeChanged / TurnStarted events;
     // preserve across same-encounter v1 snapshots (deltas aren't replayed).
     entityHP: sameEncounter ? prev.entityHP : new Map(),
+    // Seed entityAC from the v1alpha1 snapshot entities, which carry full details.
+    // Merge with any AC already tracked so that same-encounter delta events aren't lost.
+    entityAC: (() => {
+      const base = sameEncounter
+        ? new Map(prev.entityAC)
+        : new Map<string, number>();
+      for (const entity of Object.values(proto.entities ?? {})) {
+        const ac =
+          entity.details.case === 'characterDetails'
+            ? entity.details.value.armorClass
+            : entity.details.case === 'monsterDetails'
+              ? entity.details.value.armorClass
+              : undefined;
+        if (ac !== undefined && ac !== 0) {
+          base.set(entity.entityId, ac);
+        }
+      }
+      return base;
+    })(),
     entityStatuses: sameEncounter ? prev.entityStatuses : new Map(),
     // v2 entity identity metadata (type, monster ref) flows only via
     // EntityAppeared — not replayed on v1 snapshots. Preserve across same-encounter syncs.
@@ -309,10 +337,26 @@ export function mergeEntityUpdates(
   updates: EntityState[]
 ): LocalEncounterState {
   const newEntities = new Map(prev.entities);
+  const newAC = new Map(prev.entityAC);
+  let acChanged = false;
   for (const entity of updates) {
     newEntities.set(entity.entityId, entity);
+    const ac =
+      entity.details.case === 'characterDetails'
+        ? entity.details.value.armorClass
+        : entity.details.case === 'monsterDetails'
+          ? entity.details.value.armorClass
+          : undefined;
+    if (ac !== undefined && ac !== 0) {
+      newAC.set(entity.entityId, ac);
+      acChanged = true;
+    }
   }
-  return { ...prev, entities: newEntities };
+  return {
+    ...prev,
+    entities: newEntities,
+    entityAC: acChanged ? newAC : prev.entityAC,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds an AC column to the `PlaytestHarness` entity table alongside HP
- Introduces `entityAC: Map<string, number>` on `LocalEncounterState`, populated from v1alpha1 `EntityState.details` (character and monster `armorClass`) via `applySnapshotToState` and `mergeEntityUpdates`
- Tests added for both extraction paths (snapshot seed and entity delta update)
- `docs/status.md` updated with Wave 2 entry

**Proto gap noted**: The current v1alpha2 stream does not carry AC on `Entity.CharacterData` (the proto comment marks it as a future field). The AC column shows `—` for entities that have only flowed through the v1alpha2 path. When the proto gap is closed, `entityAC` will populate without further UI changes.

## Test plan

- [ ] `npm run ci-check` passes (format, lint, typecheck, build, tests — all green)
- [ ] New tests in `useEncounterState.test.ts`: AC seeded from character/monster details via snapshot and via `mergeEntityUpdates`
- [ ] Director verifies "charli reads AC 15" during MCP playtest against wave-2-monk fixture (end-to-end, not in this PR)

Closes #416
Part of KirkDiggler/rpg-api#558

🤖 Generated with [Claude Code](https://claude.com/claude-code)