### PR TITLE
feat(combat): render server-driven action menu + live economy (#426)

### DIFF
--- a/docs/architecture/components/combat-v2.md
+++ b/docs/architecture/components/combat-v2.md
@@ -1,7 +1,7 @@
 ---
 name: combat-v2 panels
 description: CombatPanel, ActionPanel/V2, CombatHistorySidebar, HoverInfoPanel — feature complete for Round 1, structurally growing
-updated: 2026-05-02
+updated: 2026-06-07
 confidence: high — verified by reading CombatPanel.tsx, CombatHistorySidebar.tsx, ActionPanel.tsx, ActionPanelV2.tsx, CharacterInfoSection.tsx
 ---
 
@@ -15,7 +15,7 @@ confidence: high — verified by reading CombatPanel.tsx, CombatHistorySidebar.t
 | ------------------------------------ | ------- | ----------------------------------------------------- |
 | `panels/CombatPanel.tsx`             | 243     | Top-level combat layout, routes to action/info panels |
 | `panels/CombatHistorySidebar.tsx`    | 484     | Scrolling combat event log                            |
-| `panels/ActionPanel.tsx`             | 335     | Original action UI                                    |
+| `panels/ActionPanel.tsx`             | ~290    | Original action UI (movement + features + end turn)   |
 | `panels/ActionPanelV2.tsx`           | 356     | Revised action UI (replacement? parallel?)            |
 | `panels/CharacterInfoSection.tsx`    | ~110    | HP bar, AC, ability scores, conditions                |
 | `panels/HoverInfoPanel.tsx`          | unknown | Entity hover tooltip                                  |
@@ -27,6 +27,23 @@ confidence: high — verified by reading CombatPanel.tsx, CombatHistorySidebar.t
 ## ActionPanel vs ActionPanelV2
 
 Both exist. Both are exported from `panels/index.ts`. The README in `combat-v2/` does not explain which to use or whether V2 supersedes the original. `LobbyView.tsx` imports from `./combat-v2` via the barrel export — which panel is actually rendered is unclear without reading the full render tree. This ambiguity should be resolved: deprecate one, document the decision.
+
+## TakeAction wave (#426): client-side attack gating removed
+
+`ActionPanel.tsx` previously computed attack legality in the web layer — an
+`isTargetAdjacent` hex-distance check (`~118–140`) feeding a `canAttack` gate on a
+hardcoded "Attack" button (`~244`). This was the one real rendering-rule violation
+in this panel (web deciding what's legal). It was **deleted** (decision D7): attack
+is now an entry in the server-authored action menu (`AvailableAction.available` +
+`unavailable_reason`), rendered by the v2 path's `ActionMenu` (in
+`components/playtest/`). `ActionPanel` keeps movement, class features, and end turn
+only. The server (toolkit → rpg-api) decides availability; the web renders the
+verdict.
+
+> Residual (NOT this wave): `LobbyView.tsx ~1315` still calls `hexDistance` when an
+> entity is clicked, but only for a `console.log` — it does not gate the attack on
+> the result. It's a logging artifact in the v1alpha1 path, not an active legality
+> gate. Clean up when the v1alpha1 combat path is retired.
 
 ## Architectural violation: ability modifier calculation
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-dnd5e-web status
 description: Where we are with the React/Discord Activity UI — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-05-28
+updated: 2026-06-07
 confidence: medium — seeded from full code read-through, git log, and open PRs; needs Kirk's correction pass on stream-bug details
 ---
 
@@ -11,6 +11,26 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't
 let it rot.
 
 ## Active work
+
+- **Chapter 2 TakeAction wave — server-driven action menu + live economy (#426)** —
+  The web now consumes the server-authored action menu instead of computing
+  attack legality. `useEncounterState` holds a `turnState` (economy +
+  `available_actions`), swapped in wholesale by the new `TurnStateChanged` stream
+  event (Invariant 12, no polling) and seeded from the v2 snapshot's `turnState`.
+  `PlaytestHarness` renders `<EconomyBar>` (live action/bonus/reaction/movement +
+  granted capacities) and `<ActionMenu>` (entries grouped by `economy_slot`,
+  disabled with the server's `unavailable_reason` when `available=false`, click
+  dispatches per `target_kind`: SINGLE_ENTITY prompts, SELF self-targets, NONE
+  fires untargeted). The stream dispatcher routes `ActionResolved` /
+  `AttackResolved` (the latter **fires on a MISS too** — #594; misses now show in
+  the combat log) / `TurnStateChanged`. **D7:** the hardcoded "Attack" button and
+  the client-side `isTargetAdjacent`/`canAttack` adjacency gating were DELETED
+  from `combat-v2/panels/ActionPanel.tsx` (the one real web-side legality
+  violation). Proto bumped to `@kirkdiggler/rpg-api-protos v0.1.100`.
+  **Server gap flagged (not web's lane):** the snapshot menu is unpopulated
+  server-side (rpg-api #601 — `ProjectFor` loads read-only, no held chars), so
+  whether the initial menu renders at turn start depends on the server emitting a
+  turn-start `TurnStateChanged` push. The web is ready for both paths.
 
 - **PR #377** (`fix/376-room-revealed-all-rooms`, open since 2026-04-06) — Fixes
   the bug where `onRoomRevealed` only added the current room to the dungeon map

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#99ba9c0608f79e8afae89b17195a3d428137dc40",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.100",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1390,8 +1390,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#99ba9c0608f79e8afae89b17195a3d428137dc40",
-      "integrity": "sha512-h1atjBJuP9n+7fxTdn8wz+B4z3zeBw52e8RPlJPMBnMveQqMTwyFry5Codylmlp1a/sa/cgPII4gojMw581d7g==",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#580a8321c43dc9527d8bf41b7afc9a366d68a8d6",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#99ba9c0608f79e8afae89b17195a3d428137dc40",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.100",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/api/encounterStream2Dispatch.test.ts
+++ b/src/api/encounterStream2Dispatch.test.ts
@@ -229,6 +229,51 @@ describe('dispatchEncounterStream2Event', () => {
     expect(arg.inputRequired?.kind?.case).toBe('reactionPrompt');
   });
 
+  // TakeAction wave (#426): the verb-resolution + live-menu spine.
+  it('routes actionResolved to onActionResolved', () => {
+    const onActionResolved = vi.fn();
+    const options: EncounterStream2Options = { onActionResolved };
+    const event = makeEvent('actionResolved', {
+      actorEntityId: 'char-alice',
+      actionRef: { module: 'dnd5e', type: 'combat_abilities', id: 'attack' },
+      targetEntityId: 'goblin-1',
+      economyConsumed: { actions: 1 },
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onActionResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes attackResolved to onAttackResolved (including a miss)', () => {
+    const onAttackResolved = vi.fn();
+    const options: EncounterStream2Options = { onAttackResolved };
+    const event = makeEvent('attackResolved', {
+      attackerEntityId: 'char-alice',
+      targetEntityId: 'goblin-1',
+      hit: false, // #594: a miss must still dispatch
+      critical: false,
+      attackRoll: 4,
+      attackBonus: 5,
+      targetAc: 13,
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onAttackResolved).toHaveBeenCalledTimes(1);
+    const arg = onAttackResolved.mock.calls[0]?.[0] as { hit?: boolean };
+    expect(arg.hit).toBe(false);
+  });
+
+  it('routes turnStateChanged to onTurnStateChanged', () => {
+    const onTurnStateChanged = vi.fn();
+    const options: EncounterStream2Options = { onTurnStateChanged };
+    const event = makeEvent('turnStateChanged', {
+      turnState: {
+        economy: { actionsRemaining: 1, bonusActionsRemaining: 1 },
+        availableActions: [],
+      },
+    });
+    dispatchEncounterStream2Event(event, options);
+    expect(onTurnStateChanged).toHaveBeenCalledTimes(1);
+  });
+
   it('logs a warning for unknown event cases without throwing', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const event = makeEvent('someUnknownCase' as 'snapshotDelivered', {});

--- a/src/api/encounterStream2Dispatch.ts
+++ b/src/api/encounterStream2Dispatch.ts
@@ -1,4 +1,6 @@
 import type {
+  ActionResolved,
+  AttackResolved,
   DoorOpened,
   EncounterEnded,
   EncounterEvent,
@@ -15,6 +17,7 @@ import type {
   StatusApplied,
   TurnEnded,
   TurnStarted,
+  TurnStateChanged,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 
 /**
@@ -30,10 +33,12 @@ import type {
  * GeometryRevealed (effect) event from the toolkit's deliberate two-phase
  * emission. Consumers should subscribe to BOTH; do not try to combine them.
  *
- * The same cause/effect split applies in Wave 2.8 for combat: the toolkit
- * emits its `AttackResolvedEvent` (cause/narration) but the rpg-api translator
- * drops it on the wire (no proto event for cause-only attacks); HP changes
- * arrive as `EntityDamaged` (effect) and conditions as `StatusApplied` (effect).
+ * The same cause/effect split applies for combat: an action emits an umbrella
+ * `ActionResolved` (what + economy cost) correlated via the envelope
+ * `correlation_id` to its `AttackResolved` (roll, hit/miss/crit — fires on a
+ * MISS too, the #594 fix), and any `EntityDamaged` (HP, hit only) /
+ * `StatusApplied` (conditions). The live action menu + economy ride
+ * `TurnStateChanged` (TakeAction wave #426).
  */
 export interface EncounterStream2Options {
   /** slice-1: encounter field is empty; treat as connect-confirm only. */
@@ -59,6 +64,28 @@ export interface EncounterStream2Options {
   onTurnStarted?: (event: TurnStarted) => void;
   /** Active actor finished; the next TurnStarted is authoritative for who's next. */
   onTurnEnded?: (event: TurnEnded) => void;
+  // TakeAction wave (#426): the verb-resolution + live-menu spine.
+  /**
+   * Umbrella beat for any action a character takes (attack, dodge, dash, …).
+   * Carries the action ref + the economy it consumed. The roll/hit/miss detail
+   * of an attack rides the correlated AttackResolved; damage rides the
+   * correlated EntityDamaged. Web renders this as a combat-log line — server is
+   * authoritative, web computes nothing.
+   */
+  onActionResolved?: (event: ActionResolved) => void;
+  /**
+   * Per-attack roll detail. CRUCIAL: fires on a MISS too (`hit=false`) — the
+   * #594 fix. Web renders the hit OR miss in the combat log so a whiff is no
+   * longer silent.
+   */
+  onAttackResolved?: (event: AttackResolved) => void;
+  /**
+   * The live menu/economy push (Invariant 12, no polling). Carries the
+   * recomputed TurnState (economy + available_actions). The web swaps it in
+   * wholesale and re-renders the action menu — it never recomputes availability
+   * client-side. This is the event that drives the server-authored action menu.
+   */
+  onTurnStateChanged?: (event: TurnStateChanged) => void;
   // Wave 2.10: death + encounter resolution events.
   /**
    * Entity HP reached 0. The entity remains in the entities map until
@@ -133,6 +160,15 @@ export function dispatchEncounterStream2Event(
     case 'turnEnded':
       options.onTurnEnded?.(payload.value);
       break;
+    case 'actionResolved':
+      options.onActionResolved?.(payload.value);
+      break;
+    case 'attackResolved':
+      options.onAttackResolved?.(payload.value);
+      break;
+    case 'turnStateChanged':
+      options.onTurnStateChanged?.(payload.value);
+      break;
     case 'entityDied':
       options.onEntityDied?.(payload.value);
       break;
@@ -148,7 +184,7 @@ export function dispatchEncounterStream2Event(
     default:
       // Either out-of-current-scope but known to the proto (entityHealed,
       // dialogue, etc. — the proto defines 20+ event cases;
-      // we currently handle 14) OR a genuinely unknown case from a proto
+      // we currently handle 17) OR a genuinely unknown case from a proto
       // version mismatch. Either way: warn + continue so the stream doesn't
       // tear down. Add a case arm + callback when the feature lands.
       // The cast strips the narrowed-to-undefined `case` so we can log it.

--- a/src/components/combat-v2/panels/ActionPanel.tsx
+++ b/src/components/combat-v2/panels/ActionPanel.tsx
@@ -4,12 +4,9 @@ import {
   EquipmentSlots,
   FeatureActions,
 } from '@/components/features';
-import { hexDistance, type CubeCoord } from '@/utils/hexUtils';
+import { type CubeCoord } from '@/utils/hexUtils';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import type {
-  CombatState,
-  Room,
-} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type { CombatState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { FeatureId } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -20,10 +17,7 @@ export interface ActionPanelProps {
   combatState: CombatState | null;
   encounterId: string | null;
   selectedCharacters: Character[];
-  room: Room | null;
-  attackTarget?: string | null;
   onMoveAction?: () => void;
-  onAttackAction?: () => void;
   onActivateFeature?: (featureId: FeatureId) => void;
   onCombatStateUpdate?: (combatState: CombatState) => void;
   movementMode?: boolean;
@@ -51,10 +45,7 @@ export function ActionPanel({
   combatState,
   encounterId,
   selectedCharacters,
-  room,
-  attackTarget,
   onMoveAction,
-  onAttackAction,
   onActivateFeature,
   onCombatStateUpdate,
   movementMode = false,
@@ -115,33 +106,12 @@ export function ActionPanel({
     }
   };
 
-  // Check if attack target is adjacent (for melee attacks)
-  // Server provides cube coordinates in position.x, position.y, position.z
-  const isTargetAdjacent = (() => {
-    if (!attackTarget || !room || !currentTurn.entityId) return false;
-
-    const currentEntity = room.entities[currentTurn.entityId];
-    const targetEntity = room.entities[attackTarget];
-
-    if (!currentEntity?.position || !targetEntity?.position) return false;
-
-    const distance = hexDistance(
-      currentEntity.position.x,
-      currentEntity.position.y,
-      currentEntity.position.z,
-      targetEntity.position.x,
-      targetEntity.position.y,
-      targetEntity.position.z
-    );
-
-    return distance === 1;
-  })();
-
-  // Attack button should be enabled if:
-  // 1. Has action available
-  // 2. Has a target selected
-  // 3. Target is adjacent (for now, only melee)
-  const canAttack = resources.hasAction && attackTarget && isTargetAdjacent;
+  // TakeAction wave (#426, D7): the client-side adjacency/range gating that used
+  // to live here (isTargetAdjacent + canAttack) was REMOVED. Web must not compute
+  // attack legality — that was the one real boundary violation in this panel.
+  // The server now authors the action menu (AvailableAction.available +
+  // unavailable_reason); the menu is rendered by the v2 path (PlaytestHarness's
+  // ActionMenu). This panel keeps movement + class features + end turn only.
 
   const panelContent = (
     <div
@@ -241,30 +211,10 @@ export function ActionPanel({
 
         {/* Actions Section */}
         <div className={styles.actionsSection}>
-          {/* Attack Button */}
-          <button
-            onClick={onAttackAction}
-            disabled={!canAttack}
-            className={`${styles.actionButton} ${styles.attack} ${
-              !canAttack ? styles.disabled : ''
-            }`}
-            title={
-              !resources.hasAction
-                ? 'No action available'
-                : !attackTarget
-                  ? 'Select a target'
-                  : !isTargetAdjacent
-                    ? 'Target not adjacent'
-                    : 'Attack target'
-            }
-          >
-            ⚔️ Attack
-            {attackTarget && !isTargetAdjacent && (
-              <span style={{ fontSize: '10px', marginLeft: '4px' }}>
-                (too far)
-              </span>
-            )}
-          </button>
+          {/* TakeAction wave (#426, D7): the hardcoded Attack button was REMOVED.
+              Attack is now an entry in the server-authored action menu
+              (AvailableAction) rendered by the v2 path, with availability +
+              unavailable_reason decided server-side. */}
 
           {/* Move Button */}
           <button

--- a/src/components/playtest/ActionMenu.test.tsx
+++ b/src/components/playtest/ActionMenu.test.tsx
@@ -1,0 +1,121 @@
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  EconomySlot,
+  TargetKind,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionMenu } from './ActionMenu';
+
+function action(
+  partial: Partial<AvailableAction> & { id: string }
+): AvailableAction {
+  return {
+    ref: { module: 'dnd5e', type: 'combat_abilities', id: partial.id },
+    displayName: partial.displayName ?? partial.id,
+    available: partial.available ?? true,
+    unavailableReason: partial.unavailableReason ?? '',
+    economySlot: partial.economySlot ?? EconomySlot.ACTION,
+    targetKind: partial.targetKind ?? TargetKind.SINGLE_ENTITY,
+  } as unknown as AvailableAction;
+}
+
+describe('ActionMenu', () => {
+  it('renders the empty state when there are no actions', () => {
+    render(
+      <ActionMenu
+        actions={[]}
+        enabled
+        loading={false}
+        onSelectAction={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('action-menu-empty')).toBeTruthy();
+  });
+
+  it('renders actions grouped by economy slot', () => {
+    render(
+      <ActionMenu
+        actions={[
+          action({
+            id: 'attack',
+            displayName: 'Attack',
+            economySlot: EconomySlot.ACTION,
+          }),
+          action({
+            id: 'martial-arts',
+            displayName: 'Martial Arts',
+            economySlot: EconomySlot.BONUS_ACTION,
+          }),
+        ]}
+        enabled
+        loading={false}
+        onSelectAction={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Action')).toBeTruthy();
+    expect(screen.getByText('Bonus Action')).toBeTruthy();
+    expect(screen.getByText('Attack')).toBeTruthy();
+    expect(screen.getByText('Martial Arts')).toBeTruthy();
+  });
+
+  it('disables an unavailable action and shows the server unavailable_reason', () => {
+    render(
+      <ActionMenu
+        actions={[
+          action({
+            id: 'move',
+            displayName: 'Move',
+            available: false,
+            unavailableReason: 'movement lands in Beat-2',
+            economySlot: EconomySlot.MOVEMENT,
+            targetKind: TargetKind.POSITION,
+          }),
+        ]}
+        enabled
+        loading={false}
+        onSelectAction={vi.fn()}
+      />
+    );
+    const btn = screen.getByTestId(
+      'action-dnd5e:combat_abilities:move'
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('data-available')).toBe('false');
+    expect(
+      screen.getByTestId('action-reason-dnd5e:combat_abilities:move')
+        .textContent
+    ).toContain('movement lands in Beat-2');
+  });
+
+  it('fires onSelectAction with the chosen action when available + enabled', () => {
+    const onSelectAction = vi.fn();
+    const attack = action({ id: 'attack', displayName: 'Attack' });
+    render(
+      <ActionMenu
+        actions={[attack]}
+        enabled
+        loading={false}
+        onSelectAction={onSelectAction}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-dnd5e:combat_abilities:attack'));
+    expect(onSelectAction).toHaveBeenCalledTimes(1);
+    expect(onSelectAction.mock.calls[0]?.[0]).toBe(attack);
+  });
+
+  it('disables all actions when not enabled (not the local turn)', () => {
+    render(
+      <ActionMenu
+        actions={[action({ id: 'attack', available: true })]}
+        enabled={false}
+        loading={false}
+        onSelectAction={vi.fn()}
+      />
+    );
+    const btn = screen.getByTestId(
+      'action-dnd5e:combat_abilities:attack'
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/src/components/playtest/ActionMenu.tsx
+++ b/src/components/playtest/ActionMenu.tsx
@@ -1,0 +1,157 @@
+/**
+ * ActionMenu — renders the server-authored action menu (TakeAction wave #426).
+ *
+ * Consumes the `available_actions` list from the server-pushed TurnState
+ * (TurnStateChanged event / snapshot). It:
+ *   - groups entries by `economy_slot` (Action / Bonus Action / Reaction /
+ *     Movement / Free),
+ *   - DISABLES entries where `available === false` and shows the server's
+ *     `unavailable_reason` (no client-side legality check — D7 / no-logic-in-web),
+ *   - on click, hands the chosen action back to the harness which raises the
+ *     targeting prompt per `target_kind` and dispatches TakeAction.
+ *
+ * The web computes NOTHING here — availability, reasons, slots, and target
+ * kinds are all the server's verdict, rendered verbatim.
+ */
+
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  actionKey,
+  economySlotLabel,
+  groupActionsBySlot,
+  targetKindLabel,
+} from './actionMenuHelpers';
+
+export interface ActionMenuProps {
+  /** The server-authored available actions (from TurnState.available_actions). */
+  actions: AvailableAction[];
+  /** Whether the menu is interactive (TURN_BASED + local player's turn, not loading). */
+  enabled: boolean;
+  /** Whether a TakeAction RPC is currently in flight. */
+  loading: boolean;
+  /**
+   * Invoked when an available action is clicked. The harness decides what to do
+   * per the action's `target_kind` (raise a prompt or dispatch directly) — the
+   * menu never inspects targeting rules itself.
+   */
+  onSelectAction: (action: AvailableAction) => void;
+}
+
+export function ActionMenu({
+  actions,
+  enabled,
+  loading,
+  onSelectAction,
+}: ActionMenuProps) {
+  const groups = groupActionsBySlot(actions);
+
+  if (actions.length === 0) {
+    return (
+      <div
+        data-testid="action-menu-empty"
+        style={{ color: '#666', fontSize: 12, marginBottom: 8 }}
+      >
+        (no actions available — waiting for the server menu)
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="action-menu" style={{ marginBottom: 8 }}>
+      {groups.map(({ slot, actions: slotActions }) => (
+        <div key={slot} style={{ marginBottom: 8 }}>
+          <div
+            style={{
+              fontSize: 11,
+              color: '#888',
+              textTransform: 'uppercase',
+              letterSpacing: 0.5,
+              marginBottom: 4,
+            }}
+          >
+            {economySlotLabel(slot)}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 6,
+              flexWrap: 'wrap',
+            }}
+          >
+            {slotActions.map((action) => (
+              <ActionMenuButton
+                key={actionKey(action)}
+                action={action}
+                enabled={enabled}
+                loading={loading}
+                onSelectAction={onSelectAction}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface ActionMenuButtonProps {
+  action: AvailableAction;
+  enabled: boolean;
+  loading: boolean;
+  onSelectAction: (action: AvailableAction) => void;
+}
+
+function ActionMenuButton({
+  action,
+  enabled,
+  loading,
+  onSelectAction,
+}: ActionMenuButtonProps) {
+  // Disabled when the server says unavailable OR the turn/loading gate is off.
+  // The unavailable_reason is the SERVER's string — rendered verbatim, never
+  // composed client-side.
+  const serverUnavailable = !action.available;
+  const disabled = !enabled || loading || serverUnavailable;
+  const title = serverUnavailable
+    ? action.unavailableReason || 'unavailable'
+    : `Take action (${targetKindLabel(action.targetKind)})`;
+
+  return (
+    <button
+      type="button"
+      data-testid={`action-${actionKey(action)}`}
+      data-available={String(action.available)}
+      onClick={() => onSelectAction(action)}
+      disabled={disabled}
+      title={title}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        padding: '4px 10px',
+        background: serverUnavailable
+          ? '#2a2a2a'
+          : enabled
+            ? '#2a3a4a'
+            : '#262626',
+        color: serverUnavailable ? '#777' : enabled ? '#9cf' : '#666',
+        border: `1px solid ${serverUnavailable ? '#444' : '#3a5a7a'}`,
+        borderRadius: 4,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        fontFamily: 'monospace',
+        fontSize: 12,
+        opacity: serverUnavailable ? 0.7 : 1,
+      }}
+    >
+      <span>{action.displayName || actionKey(action)}</span>
+      {serverUnavailable && action.unavailableReason && (
+        <span
+          data-testid={`action-reason-${actionKey(action)}`}
+          style={{ fontSize: 10, color: '#a66', marginTop: 2 }}
+        >
+          {action.unavailableReason}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/playtest/EconomyBar.test.tsx
+++ b/src/components/playtest/EconomyBar.test.tsx
@@ -1,0 +1,39 @@
+import { create } from '@bufbuild/protobuf';
+import { ActionEconomySchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EconomyBar } from './EconomyBar';
+
+describe('EconomyBar', () => {
+  it('renders the empty state when economy is null', () => {
+    render(<EconomyBar economy={null} />);
+    expect(screen.getByTestId('economy-bar-empty')).toBeTruthy();
+  });
+
+  it('renders the server-authored economy values verbatim', () => {
+    const economy = create(ActionEconomySchema, {
+      actionsRemaining: 1,
+      bonusActionsRemaining: 0,
+      reactionsRemaining: 1,
+      movementRemaining: 30,
+    });
+    render(<EconomyBar economy={economy} />);
+    const bar = screen.getByTestId('economy-bar');
+    expect(bar.textContent).toContain('Action');
+    expect(bar.textContent).toContain('Bonus');
+    expect(bar.textContent).toContain('Reaction');
+    expect(bar.textContent).toContain('Movement');
+    expect(bar.textContent).toContain('30');
+  });
+
+  it('renders granted-capacity counts from the two-level economy', () => {
+    const economy = create(ActionEconomySchema, {
+      actionsRemaining: 1,
+      capacities: { attacks: 1, martial_arts_bonus: 1 },
+    });
+    render(<EconomyBar economy={economy} />);
+    const bar = screen.getByTestId('economy-bar');
+    expect(bar.textContent).toContain('attacks');
+    expect(bar.textContent).toContain('martial_arts_bonus');
+  });
+});

--- a/src/components/playtest/EconomyBar.tsx
+++ b/src/components/playtest/EconomyBar.tsx
@@ -1,0 +1,70 @@
+/**
+ * EconomyBar — live action-economy display (TakeAction wave #426).
+ *
+ * Renders the server-authored ActionEconomy from the pushed TurnState
+ * (TurnStateChanged event, Invariant 12 — no polling). Every value is the
+ * server's count; the web subtracts nothing and computes nothing.
+ */
+
+import type { ActionEconomy } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+
+export interface EconomyBarProps {
+  /** The server-authored economy from TurnState.economy (null until pushed). */
+  economy: ActionEconomy | null | undefined;
+}
+
+function Slot({ label, value }: { label: string; value: number }) {
+  const spent = value <= 0;
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        gap: 4,
+        alignItems: 'baseline',
+        color: spent ? '#666' : '#9c9',
+      }}
+    >
+      <span style={{ fontSize: 11, color: '#888' }}>{label}:</span>
+      <strong>{value}</strong>
+    </span>
+  );
+}
+
+export function EconomyBar({ economy }: EconomyBarProps) {
+  if (!economy) {
+    return (
+      <div
+        data-testid="economy-bar-empty"
+        style={{ color: '#666', fontSize: 12, marginBottom: 8 }}
+      >
+        (economy: waiting for the server)
+      </div>
+    );
+  }
+
+  // Surface any granted-capacity counts (e.g. "attacks", "martial_arts_bonus")
+  // the toolkit's two-level economy carries — rendered verbatim.
+  const capacities = Object.entries(economy.capacities ?? {});
+
+  return (
+    <div
+      data-testid="economy-bar"
+      style={{
+        display: 'flex',
+        gap: 16,
+        flexWrap: 'wrap',
+        alignItems: 'baseline',
+        marginBottom: 8,
+        fontSize: 12,
+      }}
+    >
+      <Slot label="Action" value={economy.actionsRemaining} />
+      <Slot label="Bonus" value={economy.bonusActionsRemaining} />
+      <Slot label="Reaction" value={economy.reactionsRemaining} />
+      <Slot label="Movement" value={economy.movementRemaining} />
+      {capacities.map(([key, value]) => (
+        <Slot key={key} label={key} value={value} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -8,7 +8,11 @@ import type {
   SubmitCheckResponse,
   TakeActionResponse,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
-import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  EconomySlot,
+  EncounterMode,
+  TargetKind,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   act,
   fireEvent,
@@ -1928,6 +1932,161 @@ describe('PlaytestHarness', () => {
         expect(
           screen.getByText(/Selected goblin-1 \(encounter ended/)
         ).toBeTruthy();
+      });
+    });
+  });
+
+  // TakeAction wave (#426): the server-authored action menu + live economy +
+  // attack-miss visibility, driven off the stream's TurnStateChanged /
+  // AttackResolved events.
+  describe('server-driven action menu (#426)', () => {
+    function enterTurn() {
+      act(() => fake.push(makeEvent('snapshotDelivered', {})));
+      act(() =>
+        fake.push(
+          makeEvent('modeChanged', {
+            from: EncounterMode.FREE_ROAM,
+            to: EncounterMode.TURN_BASED,
+            reason: '',
+          })
+        )
+      );
+      act(() =>
+        fake.push(
+          makeEvent('turnStarted', { entityId: 'char-alice', round: 1 })
+        )
+      );
+    }
+
+    it('renders the pushed menu grouped by slot and the live economy', async () => {
+      render(<PlaytestHarness />);
+      enterTurn();
+
+      act(() =>
+        fake.push(
+          makeEvent('turnStateChanged', {
+            turnState: {
+              economy: {
+                actionsRemaining: 1,
+                bonusActionsRemaining: 1,
+                reactionsRemaining: 1,
+                movementRemaining: 30,
+              },
+              availableActions: [
+                {
+                  ref: {
+                    module: 'dnd5e',
+                    type: 'combat_abilities',
+                    id: 'attack',
+                  },
+                  displayName: 'Attack',
+                  available: true,
+                  unavailableReason: '',
+                  economySlot: EconomySlot.ACTION,
+                  targetKind: TargetKind.SINGLE_ENTITY,
+                },
+                {
+                  ref: {
+                    module: 'dnd5e',
+                    type: 'combat_abilities',
+                    id: 'move',
+                  },
+                  displayName: 'Move',
+                  available: false,
+                  unavailableReason: 'movement lands in Beat-2',
+                  economySlot: EconomySlot.MOVEMENT,
+                  targetKind: TargetKind.POSITION,
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('action-menu')).toBeTruthy();
+      });
+      // Attack entry available; Move entry disabled with the server reason.
+      const attackBtn = screen.getByTestId(
+        'action-dnd5e:combat_abilities:attack'
+      ) as HTMLButtonElement;
+      const moveBtn = screen.getByTestId(
+        'action-dnd5e:combat_abilities:move'
+      ) as HTMLButtonElement;
+      expect(attackBtn.disabled).toBe(false);
+      expect(moveBtn.disabled).toBe(true);
+      expect(
+        screen.getByTestId('action-reason-dnd5e:combat_abilities:move')
+          .textContent
+      ).toContain('movement lands in Beat-2');
+      expect(screen.getByTestId('economy-bar').textContent).toContain('30');
+    });
+
+    it('dispatches a SELF action with no prompt (Dodge)', async () => {
+      render(<PlaytestHarness />);
+      enterTurn();
+      act(() =>
+        fake.push(
+          makeEvent('turnStateChanged', {
+            turnState: {
+              economy: { actionsRemaining: 1 },
+              availableActions: [
+                {
+                  ref: {
+                    module: 'dnd5e',
+                    type: 'combat_abilities',
+                    id: 'dodge',
+                  },
+                  displayName: 'Dodge',
+                  available: true,
+                  unavailableReason: '',
+                  economySlot: EconomySlot.ACTION,
+                  targetKind: TargetKind.SELF,
+                },
+              ],
+            },
+          })
+        )
+      );
+
+      const dodgeBtn = await screen.findByTestId(
+        'action-dnd5e:combat_abilities:dodge'
+      );
+      await waitFor(() =>
+        expect((dodgeBtn as HTMLButtonElement).disabled).toBe(false)
+      );
+      act(() => fireEvent.click(dodgeBtn));
+
+      await waitFor(() => expect(hoisted.takeActionFn).toHaveBeenCalledOnce());
+      expect(hoisted.takeActionFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorEntityId: 'char-alice',
+          actionRef: expect.objectContaining({ id: 'dodge' }),
+          target: expect.objectContaining({
+            kind: expect.objectContaining({ case: 'self' }),
+          }),
+        })
+      );
+    });
+
+    it('shows an attack MISS in the combat log (#594)', async () => {
+      render(<PlaytestHarness />);
+      enterTurn();
+      act(() =>
+        fake.push(
+          makeEvent('attackResolved', {
+            attackerEntityId: 'char-alice',
+            targetEntityId: 'goblin-1',
+            hit: false,
+            critical: false,
+            attackRoll: 4,
+            attackBonus: 5,
+            targetAc: 13,
+          })
+        )
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/AttackResolved.*MISS/)).toBeTruthy();
       });
     });
   });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,9 +1,11 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
   EntityType,
+  TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useEffect, useRef, useState } from 'react';
 import { v2PositionToV1 } from '../../api/positionConvert';
@@ -18,6 +20,9 @@ import { useSubmitCheckV2 } from '../../api/useSubmitCheckV2';
 import { useTakeActionV2 } from '../../api/useTakeActionV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
 import { protoPositionToHex } from '../../utils/hexCoord';
+import { ActionMenu } from './ActionMenu';
+import { actionKey, targetKindNeedsPrompt } from './actionMenuHelpers';
+import { EconomyBar } from './EconomyBar';
 import { PlaytestMap } from './PlaytestMap';
 
 /**
@@ -286,6 +291,34 @@ export function PlaytestHarness() {
         encounterState.applyTurnEnded();
         addLog(`TurnEnded ${e.entityId}`);
       },
+      // TakeAction wave (#426): the live menu/economy push. Swap in the
+      // server-authored TurnState wholesale (Invariant 12, no polling). The
+      // action menu + economy bar re-render off this — web computes nothing.
+      onTurnStateChanged: (e) => {
+        encounterState.applyTurnStateChanged(e.turnState);
+        const n = e.turnState?.availableActions.length ?? 0;
+        addLog(`TurnStateChanged (${n} action(s) in menu)`);
+      },
+      // TakeAction wave (#426): umbrella resolution beat for any action. Render
+      // it as a combat-log line. The roll/hit/miss detail rides AttackResolved;
+      // damage rides EntityDamaged.
+      onActionResolved: (e) => {
+        const refStr = e.actionRef
+          ? `${e.actionRef.module}:${e.actionRef.type}:${e.actionRef.id}`
+          : '(no ref)';
+        const targetPart = e.targetEntityId ? ` → ${e.targetEntityId}` : '';
+        addLog(`ActionResolved ${e.actorEntityId} ${refStr}${targetPart}`);
+      },
+      // TakeAction wave (#426 / #594): per-attack roll detail. CRUCIAL — this
+      // fires on a MISS too (hit=false). Render the miss in the combat log so a
+      // whiff is no longer silent.
+      onAttackResolved: (e) => {
+        const outcome = e.critical ? 'CRIT' : e.hit ? 'HIT' : 'MISS';
+        addLog(
+          `AttackResolved ${e.attackerEntityId} → ${e.targetEntityId}: ${outcome} ` +
+            `(roll ${e.attackRoll}+${e.attackBonus} vs AC ${e.targetAc})`
+        );
+      },
       onEntityDied: (e) => {
         encounterState.applyEntityDied(e);
         const killerPart = e.killerEntityId ? ` by ${e.killerEntityId}` : '';
@@ -440,6 +473,73 @@ export function PlaytestHarness() {
     }
   };
 
+  // TakeAction wave (#426): dispatch a server-menu action. The web does NOT
+  // decide what's legal — it reads target_kind off the menu entry (the server's
+  // verdict) to raise the right targeting prompt, then sends the action ref +
+  // ActionTarget. The server gates availability/legality and pushes the
+  // refreshed menu/economy back via TurnStateChanged.
+  const handleSelectAction = async (action: AvailableAction) => {
+    if (!action.ref) {
+      addLog('SelectAction: menu entry missing ref (server defect)');
+      return;
+    }
+    const refStr = actionKey(action);
+
+    // Targeted kinds need a target chosen first. The dev panel's "Target id"
+    // input drives SINGLE_ENTITY for verification; POSITION/AREA prompting is a
+    // later wave (no L1 action this beat uses them). If a target is required but
+    // none is selected, tell the player rather than guessing one.
+    if (targetKindNeedsPrompt(action.targetKind)) {
+      if (action.targetKind === TargetKind.SINGLE_ENTITY) {
+        const id = attackTargetId.trim();
+        if (!id) {
+          addLog(`${refStr}: select a target id first (single-entity action)`);
+          return;
+        }
+        await dispatchAction(action.ref, {
+          kind: { case: 'entityId', value: id },
+        } as unknown as ActionTarget);
+        return;
+      }
+      // POSITION / AREA — no L1 action this beat reaches here; surface clearly.
+      addLog(
+        `${refStr}: ${action.targetKind === TargetKind.POSITION ? 'position' : 'area'}-targeted actions not yet wired in the harness`
+      );
+      return;
+    }
+
+    // SELF → target the actor; NONE → untargeted (no prompt). Both fire with no
+    // user prompt; the difference is whether an ActionTarget is attached.
+    if (action.targetKind === TargetKind.SELF) {
+      await dispatchAction(action.ref, {
+        kind: { case: 'self', value: {} },
+      } as unknown as ActionTarget);
+      return;
+    }
+    // NONE (e.g. Dash) or UNSPECIFIED defect: fire with no target; the server
+    // accepts NONE untargeted and rejects a true defect.
+    await dispatchAction(action.ref, undefined);
+  };
+
+  const dispatchAction = async (
+    actionRef: { module: string; type: string; id: string },
+    target: ActionTarget | undefined
+  ) => {
+    try {
+      await takeAction({
+        encounterId,
+        actorEntityId: entityId,
+        actionRef,
+        // The proto target field is required by the request schema; an
+        // untargeted (NONE) action sends an empty ActionTarget oneof.
+        target: target ?? ({ kind: { case: undefined } } as ActionTarget),
+      });
+      addLog(`TakeAction(${actionRef.id})`);
+    } catch {
+      // error is surfaced via takeActionError state
+    }
+  };
+
   const handleSubmitCheck = async () => {
     // Capture the prompt being resolved. We pass this identity token to the
     // auto-clear timer so a stale timer from a prior submit doesn't clear a
@@ -572,6 +672,13 @@ export function PlaytestHarness() {
     !encounterEnded &&
     encounterState.state.mode === EncounterMode.TURN_BASED &&
     isMyTurn;
+
+  // TakeAction wave (#426): the server-authored menu + economy. Rendered
+  // verbatim — the web never recomputes availability or cost. NULL until the
+  // first TurnStateChanged / snapshot turnState arrives.
+  const turnState = encounterState.state.turnState;
+  const availableActions = turnState?.availableActions ?? [];
+  const economy = turnState?.economy ?? null;
 
   // Visual map handlers. The map's hex click hands back the full computed
   // path; we forward to moveEntity as the existing handleMove does. Entity
@@ -1406,6 +1513,26 @@ export function PlaytestHarness() {
                 ? '(none)'
                 : myStatuses.map((s) => s.source.id).join(', ')}
             </div>
+
+            {/* TakeAction wave (#426): server-authored economy + action menu.
+                The menu drives the UI (Invariant 11/12) — entries are grouped by
+                economy_slot, disabled with the server's unavailable_reason when
+                available=false, and clicking dispatches per target_kind. The web
+                computes NO availability/legality/cost (no-logic-in-web, D7). */}
+            <h4 style={{ margin: '8px 0 4px', color: '#888' }}>
+              Action economy (live)
+            </h4>
+            <EconomyBar economy={economy} />
+            <h4 style={{ margin: '8px 0 4px', color: '#888' }}>
+              Action menu (server-driven)
+            </h4>
+            <ActionMenu
+              actions={availableActions}
+              enabled={combatEnabled}
+              loading={takeActionLoading}
+              onSelectAction={(a) => void handleSelectAction(a)}
+            />
+
             {/* HP is now shown inline in the entities table above. */}
             {!isMyTurn &&
               encounterState.state.mode === EncounterMode.TURN_BASED && (
@@ -1419,6 +1546,10 @@ export function PlaytestHarness() {
                 (combat actions enabled only in TURN_BASED mode)
               </div>
             )}
+            {/* Manual target picker + raw Attack — a dev verification scaffold.
+                The server-driven Action menu above is the real UI; this stays so
+                a tester can pick a single-entity target id and drive a raw
+                attack while debugging. */}
             <div
               style={{
                 display: 'flex',

--- a/src/components/playtest/actionMenuHelpers.test.ts
+++ b/src/components/playtest/actionMenuHelpers.test.ts
@@ -1,0 +1,101 @@
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  EconomySlot,
+  TargetKind,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  actionKey,
+  economySlotLabel,
+  groupActionsBySlot,
+  targetKindLabel,
+  targetKindNeedsPrompt,
+} from './actionMenuHelpers';
+
+function action(
+  partial: Partial<AvailableAction> & { id: string }
+): AvailableAction {
+  return {
+    ref: { module: 'dnd5e', type: 'combat_abilities', id: partial.id },
+    displayName: partial.displayName ?? partial.id,
+    available: partial.available ?? true,
+    unavailableReason: partial.unavailableReason ?? '',
+    economySlot: partial.economySlot ?? EconomySlot.ACTION,
+    targetKind: partial.targetKind ?? TargetKind.SINGLE_ENTITY,
+  } as unknown as AvailableAction;
+}
+
+describe('groupActionsBySlot', () => {
+  it('groups actions by economy slot in display order', () => {
+    const actions = [
+      action({ id: 'attack', economySlot: EconomySlot.ACTION }),
+      action({ id: 'martial-arts', economySlot: EconomySlot.BONUS_ACTION }),
+      action({ id: 'dodge', economySlot: EconomySlot.ACTION }),
+      action({ id: 'move', economySlot: EconomySlot.MOVEMENT }),
+    ];
+    const groups = groupActionsBySlot(actions);
+    expect(groups.map((g) => g.slot)).toEqual([
+      EconomySlot.ACTION,
+      EconomySlot.BONUS_ACTION,
+      EconomySlot.MOVEMENT,
+    ]);
+    // ACTION group preserves server order (attack before dodge).
+    expect(groups[0]?.actions.map((a) => a.ref?.id)).toEqual([
+      'attack',
+      'dodge',
+    ]);
+  });
+
+  it('omits empty groups and returns [] for no actions', () => {
+    expect(groupActionsBySlot([])).toEqual([]);
+  });
+});
+
+describe('targetKindNeedsPrompt', () => {
+  it('requires a prompt only for entity/position/area targets', () => {
+    expect(targetKindNeedsPrompt(TargetKind.SINGLE_ENTITY)).toBe(true);
+    expect(targetKindNeedsPrompt(TargetKind.POSITION)).toBe(true);
+    expect(targetKindNeedsPrompt(TargetKind.AREA)).toBe(true);
+  });
+
+  it('does not prompt for SELF or NONE (SELF != NONE, both promptless)', () => {
+    expect(targetKindNeedsPrompt(TargetKind.SELF)).toBe(false);
+    expect(targetKindNeedsPrompt(TargetKind.NONE)).toBe(false);
+    expect(targetKindNeedsPrompt(TargetKind.UNSPECIFIED)).toBe(false);
+  });
+});
+
+describe('economySlotLabel', () => {
+  it('labels each slot', () => {
+    expect(economySlotLabel(EconomySlot.ACTION)).toBe('Action');
+    expect(economySlotLabel(EconomySlot.BONUS_ACTION)).toBe('Bonus Action');
+    expect(economySlotLabel(EconomySlot.REACTION)).toBe('Reaction');
+    expect(economySlotLabel(EconomySlot.MOVEMENT)).toBe('Movement');
+    expect(economySlotLabel(EconomySlot.FREE)).toBe('Free');
+    expect(economySlotLabel(EconomySlot.UNSPECIFIED)).toBe('Other');
+  });
+});
+
+describe('targetKindLabel', () => {
+  it('labels each kind', () => {
+    expect(targetKindLabel(TargetKind.SELF)).toBe('self');
+    expect(targetKindLabel(TargetKind.SINGLE_ENTITY)).toBe('single target');
+    expect(targetKindLabel(TargetKind.NONE)).toBe('no target');
+  });
+});
+
+describe('actionKey', () => {
+  it('builds module:type:id key from the ref', () => {
+    expect(actionKey(action({ id: 'attack' }))).toBe(
+      'dnd5e:combat_abilities:attack'
+    );
+  });
+
+  it('falls back to displayName when ref is missing', () => {
+    const a = {
+      ref: undefined,
+      displayName: 'Mystery',
+    } as unknown as AvailableAction;
+    expect(actionKey(a)).toBe('Mystery');
+  });
+});

--- a/src/components/playtest/actionMenuHelpers.ts
+++ b/src/components/playtest/actionMenuHelpers.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure display helpers for the server-authored action menu (TakeAction wave
+ * #426). These format the server's verdict for the UI — they NEVER compute
+ * availability, legality, targeting rules, or economy cost. The server
+ * (toolkit → rpg-api) decides all of that; the web only renders it.
+ */
+
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  EconomySlot,
+  TargetKind,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+
+/** Display order for the economy-slot groups in the menu. */
+export const ECONOMY_SLOT_ORDER: EconomySlot[] = [
+  EconomySlot.ACTION,
+  EconomySlot.BONUS_ACTION,
+  EconomySlot.REACTION,
+  EconomySlot.MOVEMENT,
+  EconomySlot.FREE,
+  EconomySlot.UNSPECIFIED,
+];
+
+/** Human-readable group heading for an economy slot. */
+export function economySlotLabel(slot: EconomySlot): string {
+  switch (slot) {
+    case EconomySlot.ACTION:
+      return 'Action';
+    case EconomySlot.BONUS_ACTION:
+      return 'Bonus Action';
+    case EconomySlot.REACTION:
+      return 'Reaction';
+    case EconomySlot.MOVEMENT:
+      return 'Movement';
+    case EconomySlot.FREE:
+      return 'Free';
+    case EconomySlot.UNSPECIFIED:
+    default:
+      // UNSPECIFIED is a server defect (toolkit should always set a slot); we
+      // surface it rather than hide it so the gap is visible in a playtest.
+      return 'Other';
+  }
+}
+
+/**
+ * Group available actions by economy slot, preserving the server's order within
+ * each group. Returns only non-empty groups, in ECONOMY_SLOT_ORDER. Pure — the
+ * server already decided the menu; this is layout only.
+ */
+export function groupActionsBySlot(
+  actions: AvailableAction[]
+): Array<{ slot: EconomySlot; actions: AvailableAction[] }> {
+  const bySlot = new Map<EconomySlot, AvailableAction[]>();
+  for (const action of actions) {
+    const list = bySlot.get(action.economySlot);
+    if (list) {
+      list.push(action);
+    } else {
+      bySlot.set(action.economySlot, [action]);
+    }
+  }
+  return ECONOMY_SLOT_ORDER.filter((slot) => bySlot.has(slot)).map((slot) => ({
+    slot,
+    actions: bySlot.get(slot)!,
+  }));
+}
+
+/**
+ * Whether the UI must raise a targeting prompt before dispatching this action.
+ * Driven entirely by the server's target_kind — the web does not know which
+ * actions need a target, it asks the menu entry.
+ *  - SINGLE_ENTITY / POSITION / AREA → prompt for a target
+ *  - SELF → no prompt (targets the actor); dispatch with a self ActionTarget
+ *  - NONE → no prompt (untargeted, e.g. Dash); dispatch with no target
+ *  - UNSPECIFIED → server defect; treat as "no prompt" and let the server reject
+ */
+export function targetKindNeedsPrompt(kind: TargetKind): boolean {
+  return (
+    kind === TargetKind.SINGLE_ENTITY ||
+    kind === TargetKind.POSITION ||
+    kind === TargetKind.AREA
+  );
+}
+
+/** Short human label for a target kind (debug / tooltip surface). */
+export function targetKindLabel(kind: TargetKind): string {
+  switch (kind) {
+    case TargetKind.SELF:
+      return 'self';
+    case TargetKind.SINGLE_ENTITY:
+      return 'single target';
+    case TargetKind.POSITION:
+      return 'position';
+    case TargetKind.AREA:
+      return 'area';
+    case TargetKind.NONE:
+      return 'no target';
+    case TargetKind.UNSPECIFIED:
+    default:
+      return 'unspecified';
+  }
+}
+
+/** Stable key for an action menu entry (the ref triple). */
+export function actionKey(action: AvailableAction): string {
+  const r = action.ref;
+  return r ? `${r.module}:${r.type}:${r.id}` : action.displayName;
+}

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -35,10 +35,14 @@ import type {
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import {
+  AvailableActionSchema,
+  EconomySlot,
   EncounterMode,
   EntityType as EntityTypeV2,
   InputRequiredSchema,
   SkillCheckPromptSchema,
+  TargetKind,
+  TurnStateSchema as TurnStateSchemaV2,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
 import { hexKey } from '../utils/hexCoord';
@@ -58,6 +62,7 @@ import {
   applyStatusApplied,
   applyTurnEnded,
   applyTurnStarted,
+  applyTurnStateChanged,
   applyV2SnapshotTurnState,
   createEmptyEncounterState,
   mergeEntityPosition,
@@ -1407,11 +1412,15 @@ describe('applyEntityMetaFromAppeared', () => {
 describe('applyV2SnapshotTurnState', () => {
   it('sets initiativeOrder, activeEntityId, round, and mode from snapshot turn state', () => {
     const prev = createEmptyEncounterState();
-    const after = applyV2SnapshotTurnState(prev, EncounterMode.TURN_BASED, {
-      initiativeOrder: ['char-alice', 'goblin-1'],
-      activeEntityId: 'char-alice',
-      round: 1,
-    });
+    const after = applyV2SnapshotTurnState(
+      prev,
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        initiativeOrder: ['char-alice', 'goblin-1'],
+        activeEntityId: 'char-alice',
+        round: 1,
+      })
+    );
     expect(after.initiativeOrder).toEqual(['char-alice', 'goblin-1']);
     expect(after.activeEntityId).toBe('char-alice');
     expect(after.round).toBe(1);
@@ -1437,11 +1446,15 @@ describe('applyV2SnapshotTurnState', () => {
     // Regression guard: a prior combat session sets initiative/active/round;
     // a FREE_ROAM snapshot must clear those so the UI does not show old data.
     let state = createEmptyEncounterState();
-    state = applyV2SnapshotTurnState(state, EncounterMode.TURN_BASED, {
-      initiativeOrder: ['char-alice', 'goblin-1'],
-      activeEntityId: 'char-alice',
-      round: 2,
-    });
+    state = applyV2SnapshotTurnState(
+      state,
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        initiativeOrder: ['char-alice', 'goblin-1'],
+        activeEntityId: 'char-alice',
+        round: 2,
+      })
+    );
     const after = applyV2SnapshotTurnState(
       state,
       EncounterMode.FREE_ROAM,
@@ -1471,24 +1484,119 @@ describe('applyV2SnapshotTurnState', () => {
       prev,
       makeStatusApplied('char-alice', 'dnd5e', 'condition', 'poisoned')
     );
-    const after = applyV2SnapshotTurnState(prev, EncounterMode.TURN_BASED, {
-      initiativeOrder: ['char-alice', 'goblin-1'],
-      activeEntityId: 'char-alice',
-      round: 1,
-    });
+    const after = applyV2SnapshotTurnState(
+      prev,
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        initiativeOrder: ['char-alice', 'goblin-1'],
+        activeEntityId: 'char-alice',
+        round: 1,
+      })
+    );
     expect(after.entityHP.get('goblin-1')).toEqual({ current: 5, max: 7 });
     expect(after.entityStatuses.get('char-alice')).toHaveLength(1);
   });
 
   it('does not mutate the previous state', () => {
     const prev = createEmptyEncounterState();
-    applyV2SnapshotTurnState(prev, EncounterMode.TURN_BASED, {
-      initiativeOrder: ['goblin-1'],
-      activeEntityId: 'goblin-1',
-      round: 1,
-    });
+    applyV2SnapshotTurnState(
+      prev,
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        initiativeOrder: ['goblin-1'],
+        activeEntityId: 'goblin-1',
+        round: 1,
+      })
+    );
     expect(prev.initiativeOrder).toEqual([]);
     expect(prev.mode).toBe(EncounterMode.UNSPECIFIED);
+  });
+
+  // TakeAction wave (#426): the snapshot seeds the server-authored menu/economy
+  // so it renders at turn start, before the first TurnStateChanged push.
+  it('seeds turnState (menu + economy) from the snapshot turn state', () => {
+    const prev = createEmptyEncounterState();
+    const turnState = create(TurnStateSchemaV2, {
+      initiativeOrder: ['char-alice'],
+      activeEntityId: 'char-alice',
+      round: 1,
+      economy: { actionsRemaining: 1, bonusActionsRemaining: 1 },
+      availableActions: [
+        create(AvailableActionSchema, {
+          ref: { module: 'dnd5e', type: 'combat_abilities', id: 'attack' },
+          displayName: 'Attack',
+          available: true,
+          economySlot: EconomySlot.ACTION,
+          targetKind: TargetKind.SINGLE_ENTITY,
+        }),
+      ],
+    });
+    const after = applyV2SnapshotTurnState(
+      prev,
+      EncounterMode.TURN_BASED,
+      turnState
+    );
+    expect(after.turnState?.availableActions).toHaveLength(1);
+    expect(after.turnState?.economy?.actionsRemaining).toBe(1);
+  });
+
+  it('clears turnState when leaving TURN_BASED', () => {
+    const seeded = applyV2SnapshotTurnState(
+      createEmptyEncounterState(),
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        activeEntityId: 'char-alice',
+        round: 1,
+        availableActions: [],
+      })
+    );
+    const after = applyV2SnapshotTurnState(
+      seeded,
+      EncounterMode.FREE_ROAM,
+      undefined
+    );
+    expect(after.turnState).toBeNull();
+  });
+});
+
+describe('applyTurnStateChanged', () => {
+  it('swaps in the server-authored TurnState wholesale', () => {
+    const prev = createEmptyEncounterState();
+    const turnState = create(TurnStateSchemaV2, {
+      activeEntityId: 'char-alice',
+      round: 2,
+      economy: { actionsRemaining: 0, bonusActionsRemaining: 1 },
+      availableActions: [
+        create(AvailableActionSchema, {
+          ref: { module: 'dnd5e', type: 'combat_abilities', id: 'attack' },
+          displayName: 'Attack',
+          available: false,
+          unavailableReason: 'no action remaining',
+          economySlot: EconomySlot.ACTION,
+          targetKind: TargetKind.SINGLE_ENTITY,
+        }),
+      ],
+    });
+    const after = applyTurnStateChanged(prev, turnState);
+    expect(after.turnState?.economy?.actionsRemaining).toBe(0);
+    expect(after.turnState?.availableActions[0]?.available).toBe(false);
+    expect(after.turnState?.availableActions[0]?.unavailableReason).toBe(
+      'no action remaining'
+    );
+  });
+
+  it('is a no-op (returns prev) when turnState is undefined', () => {
+    const prev = createEmptyEncounterState();
+    expect(applyTurnStateChanged(prev, undefined)).toBe(prev);
+  });
+
+  it('does not mutate the previous state', () => {
+    const prev = createEmptyEncounterState();
+    applyTurnStateChanged(
+      prev,
+      create(TurnStateSchemaV2, { availableActions: [] })
+    );
+    expect(prev.turnState).toBeNull();
   });
 });
 
@@ -1619,11 +1727,15 @@ describe('applySnapshotToState — entityMeta + initiativeOrder delta preservati
 
   it('preserves initiativeOrder across same-encounter v1 snapshot', () => {
     let state = applySnapshotToState(makeSnapshot({ encounterId: 'enc-1' }));
-    state = applyV2SnapshotTurnState(state, EncounterMode.TURN_BASED, {
-      initiativeOrder: ['char-alice', 'goblin-1'],
-      activeEntityId: 'char-alice',
-      round: 1,
-    });
+    state = applyV2SnapshotTurnState(
+      state,
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        initiativeOrder: ['char-alice', 'goblin-1'],
+        activeEntityId: 'char-alice',
+        round: 1,
+      })
+    );
 
     const refreshed = applySnapshotToState(
       makeSnapshot({ encounterId: 'enc-1' }),
@@ -1643,11 +1755,15 @@ describe('applySnapshotToState — entityMeta + initiativeOrder delta preservati
       undefined,
       undefined
     );
-    state = applyV2SnapshotTurnState(state, EncounterMode.TURN_BASED, {
-      initiativeOrder: ['char-alice', 'goblin-1'],
-      activeEntityId: 'char-alice',
-      round: 1,
-    });
+    state = applyV2SnapshotTurnState(
+      state,
+      EncounterMode.TURN_BASED,
+      create(TurnStateSchemaV2, {
+        initiativeOrder: ['char-alice', 'goblin-1'],
+        activeEntityId: 'char-alice',
+        round: 1,
+      })
+    );
 
     const switched = applySnapshotToState(
       makeSnapshot({ encounterId: 'enc-2' }),

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -31,7 +31,10 @@ import type {
   StatusApplied,
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
-import type { InputRequired } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import type {
+  InputRequired,
+  TurnState,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
   EntityType,
@@ -143,6 +146,19 @@ export interface LocalEncounterState {
    * turns of the same round.
    */
   round: number;
+  /**
+   * TakeAction wave (#426): the server-authored live turn state — economy
+   * (actions / bonus / reaction / movement remaining) + the available_actions
+   * menu. Pushed wholesale on the stream via TurnStateChanged (Invariant 12, no
+   * polling); the active actor's snapshot also seeds it. NULL until the first
+   * TurnStateChanged / snapshot carrying it arrives.
+   *
+   * The web renders this verbatim — it groups available_actions by economy_slot,
+   * disables entries where available=false (showing unavailable_reason), and
+   * raises the targeting prompt per target_kind. NO availability / legality /
+   * cost is computed client-side; the server's verdict is the only source.
+   */
+  turnState: TurnState | null;
   dungeonState: DungeonState;
   roomsCleared: number;
   /**
@@ -223,6 +239,7 @@ export function createEmptyEncounterState(): LocalEncounterState {
     mode: EncounterMode.UNSPECIFIED,
     activeEntityId: '',
     round: 0,
+    turnState: null,
     dungeonState: DungeonState.UNSPECIFIED,
     roomsCleared: 0,
     pendingPrompt: null,
@@ -309,6 +326,11 @@ export function applySnapshotToState(
     mode: sameEncounter ? prev.mode : EncounterMode.UNSPECIFIED,
     activeEntityId: sameEncounter ? prev.activeEntityId : '',
     round: sameEncounter ? prev.round : 0,
+    // TakeAction wave (#426): the server-authored menu/economy flows only via
+    // the v2 stream's TurnStateChanged (or the v2 SnapshotDelivered turnState),
+    // never the v1 snapshot path. Preserve across same-encounter v1 syncs so a
+    // v1 state-sync doesn't wipe the live menu the player is acting from.
+    turnState: sameEncounter ? prev.turnState : null,
     dungeonState: proto.dungeonState,
     roomsCleared: proto.roomsCleared,
     // pendingPrompt is caller-private; it doesn't flow through v1 snapshots.
@@ -522,9 +544,7 @@ export function applyEntityMetaFromAppeared(
 export function applyV2SnapshotTurnState(
   prev: LocalEncounterState,
   encounterMode: EncounterMode,
-  turnState:
-    | { initiativeOrder: string[]; activeEntityId: string; round: number }
-    | undefined
+  turnState: TurnState | undefined
 ): LocalEncounterState {
   const modeChanged = prev.mode !== encounterMode;
   const inTurnBased = encounterMode === EncounterMode.TURN_BASED;
@@ -537,7 +557,8 @@ export function applyV2SnapshotTurnState(
       !modeChanged &&
       prev.initiativeOrder.length === 0 &&
       prev.activeEntityId === '' &&
-      prev.round === 0;
+      prev.round === 0 &&
+      prev.turnState === null;
     if (nothingChanged) return prev;
     return {
       ...prev,
@@ -545,6 +566,9 @@ export function applyV2SnapshotTurnState(
       initiativeOrder: [],
       activeEntityId: '',
       round: 0,
+      // Clear the menu/economy too when leaving TURN_BASED — a stale menu from a
+      // prior combat must not linger.
+      turnState: null,
     };
   }
   return {
@@ -553,6 +577,10 @@ export function applyV2SnapshotTurnState(
     initiativeOrder: turnState.initiativeOrder,
     activeEntityId: turnState.activeEntityId,
     round: turnState.round,
+    // TakeAction wave (#426): seed the server-authored menu/economy from the
+    // snapshot so the menu renders at turn start, before the first
+    // TurnStateChanged push. Stored verbatim; web computes nothing.
+    turnState,
   };
 }
 
@@ -711,6 +739,24 @@ export function applyTurnStarted(
     activeEntityId: event.entityId,
     round: event.round,
   };
+}
+
+/**
+ * Apply a TurnStateChanged event (TakeAction wave #426): swaps in the
+ * server-authored TurnState (economy + available_actions menu) wholesale.
+ *
+ * The toolkit computes it, rpg-api projects it field-for-field, the web renders
+ * it. No availability is recomputed client-side. If `turnState` is missing
+ * (defensive — proto field is optional) the call is a no-op so a malformed wire
+ * frame doesn't blank out the menu the player is acting from.
+ * Exported for testing.
+ */
+export function applyTurnStateChanged(
+  prev: LocalEncounterState,
+  turnState: TurnState | undefined
+): LocalEncounterState {
+  if (!turnState) return prev;
+  return { ...prev, turnState };
 }
 
 /**
@@ -891,13 +937,13 @@ export interface UseEncounterStateResult {
   /**
    * Apply v1alpha2 turn state from a SnapshotDelivered event.
    * Updates initiativeOrder, activeEntityId, round, and mode without touching
-   * HP / statuses / doors (those flow only via delta events).
+   * HP / statuses / doors (those flow only via delta events). Also seeds the
+   * server-authored menu/economy (turnState) so the menu renders at turn start
+   * before the first TurnStateChanged push (TakeAction wave #426).
    */
   applyV2SnapshotTurnState: (
     encounterMode: EncounterMode,
-    turnState:
-      | { initiativeOrder: string[]; activeEntityId: string; round: number }
-      | undefined
+    turnState: TurnState | undefined
   ) => void;
   // v1alpha2 prompts (Wave 2.9)
   /**
@@ -929,6 +975,11 @@ export interface UseEncounterStateResult {
   applyTurnStarted: (event: TurnStarted) => void;
   /** Hook for TurnEnded (currently no-op; reserved for future per-turn UI). */
   applyTurnEnded: () => void;
+  /**
+   * TakeAction wave (#426): swap in the server-authored TurnState (economy +
+   * available_actions menu) from a TurnStateChanged event. No-op if undefined.
+   */
+  applyTurnStateChanged: (turnState: TurnState | undefined) => void;
   // v1alpha2 death + resolution (Wave 2.10)
   /**
    * No-op state reducer for EntityDied — entity stays rendered until
@@ -1040,15 +1091,17 @@ export function useEncounterState(): UseEncounterStateResult {
   );
 
   const applyV2SnapshotTurnStateCallback = useCallback(
-    (
-      encounterMode: EncounterMode,
-      turnState:
-        | { initiativeOrder: string[]; activeEntityId: string; round: number }
-        | undefined
-    ) => {
+    (encounterMode: EncounterMode, turnState: TurnState | undefined) => {
       setState((prev) =>
         applyV2SnapshotTurnState(prev, encounterMode, turnState)
       );
+    },
+    []
+  );
+
+  const applyTurnStateChangedCallback = useCallback(
+    (turnState: TurnState | undefined) => {
+      setState((prev) => applyTurnStateChanged(prev, turnState));
     },
     []
   );
@@ -1122,6 +1175,7 @@ export function useEncounterState(): UseEncounterStateResult {
     applyModeChanged: applyModeChangedCallback,
     applyTurnStarted: applyTurnStartedCallback,
     applyTurnEnded: applyTurnEndedCallback,
+    applyTurnStateChanged: applyTurnStateChangedCallback,
     applyEntityDied: applyEntityDiedCallback,
     applyEntityRemoved: applyEntityRemovedCallback,
     applyEncounterEnded: applyEncounterEndedCallback,


### PR DESCRIPTION
## What

The web lane of the **TakeAction wave** (Chapter 2, umbrella rpg-project #54). The web now renders the server-authored action menu and economy verbatim, and the one real web-side legality violation is deleted. **The web computes nothing** — availability, legality, targeting, and cost are all the server's verdict, rendered as-is (no-logic-in-web, D7).

## Rendered (server data, zero game logic)

- **Action menu** (`ActionMenu`, in `PlaytestHarness`): consumes `TurnState.available_actions`, **grouped by `economy_slot`** (Action / Bonus Action / Reaction / Movement / Free). Entries where `available=false` are **disabled and show the server's `unavailable_reason`** (e.g. Move → "movement lands in Beat-2", D17). Clicking dispatches per **`target_kind`**: SINGLE_ENTITY raises the target prompt, SELF self-targets (D15: SELF ≠ NONE), NONE fires untargeted (e.g. Dash, no prompt).
- **Live economy** (`EconomyBar`): action / bonus / reaction / movement remaining + granted-capacity counts (two-level economy), driven by the **`TurnStateChanged`** push off the stream (Invariant 12, **no polling**).
- **Resolved beats incl. MISSES**: stream dispatcher routes `ActionResolved` / `AttackResolved` / `TurnStateChanged`. `AttackResolved` **fires on a miss too** (`hit=false`) — the **#594** fix; misses now appear in the combat log (`AttackResolved … MISS (roll N+M vs AC K)`).
- **State**: `useEncounterState` holds a server-authored `turnState` (economy + menu), swapped in **wholesale** on `TurnStateChanged` and **seeded from the v2 snapshot `turnState`** so the menu can render at turn start.

## Deleted (D7)

- The **hardcoded "Attack" button** and the **client-side `isTargetAdjacent` / `canAttack` adjacency-range gating** in `combat-v2/panels/ActionPanel.tsx` — the one real web-side legality computation. Attack is now a server menu entry.

## Proto

- Bumped `@kirkdiggler/rpg-api-protos` → **v0.1.100** (lock regenerated; commit `580a8321` = the v0.1.100 tag).

## Tests / CI

- New: dispatcher routes (incl. miss), `turnState` reducer + snapshot seeding, `ActionMenu` grouping/disable/dispatch, `EconomyBar`, pure helpers, harness menu integration.
- `npm run ci-check` **green** (format, lint, typecheck, build, tests — 630 pass).

## ⚠️ Server-side gap flagged (NOT this lane)

The **initial menu at turn start** depends on the server emitting a turn-start `TurnStateChanged` push. The **snapshot menu is unpopulated server-side** (rpg-api **#601** — `ProjectFor` loads read-only, no held characters / DataJSON). The LIVE push (PR #600) is the primary menu contract and works; the web is ready for **both** paths (it seeds from snapshot turnState when present and swaps on the push). If the MCP playtest shows no menu until the player acts, the fix is **#601**, not here.

## Verification note

Vercel previews can't reach the backend — real end-to-end is the **MCP playtest** next.

Part of #54 · refs #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)