### PR TITLE
fix: surface rejected TakeAction as a visible Recent-events entry

### DIFF
--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -19,6 +19,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -736,9 +737,67 @@ describe('PlaytestHarness', () => {
 
     act(() => fireEvent.click(attackBtn));
 
+    // The message now appears twice: the standing takeActionError panel
+    // (below the combat controls) and the new Recent-events log entry
+    // (#428, asserted separately below) — both are "visible", so allow
+    // either/both matches rather than asserting a single element.
     await waitFor(() => {
-      expect(screen.getByText(/not your turn/i)).toBeTruthy();
+      expect(screen.getAllByText(/not your turn/i).length).toBeGreaterThan(0);
     });
+  });
+
+  // #428: a rejected TakeAction previously produced NO entry in the
+  // Recent-events log — the harness's primary verification surface — and was
+  // only visible in the browser console via the standing error panel. This
+  // proves the rejection now shows up as a visible, error-styled log line
+  // carrying the action ref + the server's message.
+  it('logs a rejected TakeAction as a visible error entry in the event log (#428)', async () => {
+    hoisted.takeActionFn.mockRejectedValue(
+      new Error('[invalid_argument] target.entity_id is required')
+    );
+
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(makeEvent('snapshotDelivered', {})));
+    act(() =>
+      fake.push(
+        makeEvent('modeChanged', {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+          reason: '',
+        })
+      )
+    );
+    act(() =>
+      fake.push(makeEvent('turnStarted', { entityId: 'char-alice', round: 1 }))
+    );
+
+    const input = screen.getByLabelText(
+      /attack target id/i
+    ) as HTMLInputElement;
+    act(() => {
+      fireEvent.change(input, { target: { value: 'goblin-1' } });
+    });
+
+    const attackBtn = screen.getByRole('button', {
+      name: /^attack$/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(attackBtn.disabled).toBe(false));
+
+    act(() => fireEvent.click(attackBtn));
+
+    const eventLog = screen.getByTestId('event-log');
+    await waitFor(() => {
+      expect(
+        within(eventLog).getByTestId('event-log-entry-error')
+      ).toBeTruthy();
+    });
+    const errorEntry = within(eventLog).getByTestId('event-log-entry-error');
+    expect(errorEntry.textContent).toContain('TakeAction(attack)');
+    expect(errorEntry.textContent).toContain('REJECTED');
+    expect(errorEntry.textContent).toContain(
+      '[invalid_argument] target.entity_id is required'
+    );
   });
 
   it('shows endTurn error when RPC fails', async () => {

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -60,6 +60,14 @@ function formatTime(d: Date): string {
   return d.toTimeString().slice(0, 8);
 }
 
+/** Extract a readable message from a caught RPC rejection. ConnectError's
+ * `.message` is already prefixed with the status code (e.g.
+ * `[invalid_argument] target.entity_id is required`), so this doubles as
+ * "code + message" without the harness needing to know about ConnectError. */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /**
  * Dev-only playtest verification harness for wave-2.5 slice 2.
  * Renders at ?encounterId=<id>&playerId=<id> in development mode.
@@ -78,7 +86,7 @@ export function PlaytestHarness() {
 
   const entityId = playerId ? `char-${playerId}` : '';
 
-  const [log, setLog] = useState<string[]>([]);
+  const [log, setLog] = useState<Array<{ text: string; isError: boolean }>>([]);
   const [targetQ, setTargetQ] = useState(0);
   const [targetR, setTargetR] = useState(0);
   const [targetS, setTargetS] = useState(0);
@@ -148,8 +156,11 @@ export function PlaytestHarness() {
     error: activateFeatureError,
   } = useActivateFeatureV2();
 
-  const addLog = (msg: string) => {
-    const entry = `[${formatTime(new Date())}] ${msg}`;
+  // isError styles the entry red in the Recent-events log — used for rejected
+  // RPCs (currently TakeAction, #428) so a server rejection is visible in the
+  // harness's primary verification surface, not just the console.
+  const addLog = (msg: string, isError = false) => {
+    const entry = { text: `[${formatTime(new Date())}] ${msg}`, isError };
     setLog((prev) => [entry, ...prev].slice(0, 30));
   };
 
@@ -459,8 +470,11 @@ export function PlaytestHarness() {
         target,
       });
       addLog(`TakeAction(attack) → ${id}`);
-    } catch {
-      // error is surfaced via takeActionError state
+    } catch (err) {
+      // #428: a rejected TakeAction was previously console-only. Log it here
+      // (in addition to the takeActionError panel below) so it's visible in
+      // the harness's Recent-events log — the verification surface.
+      addLog(`TakeAction(attack) → ${id} REJECTED: ${errorMessage(err)}`, true);
     }
   };
 
@@ -535,8 +549,12 @@ export function PlaytestHarness() {
         target: target ?? ({ kind: { case: undefined } } as ActionTarget),
       });
       addLog(`TakeAction(${actionRef.id})`);
-    } catch {
-      // error is surfaced via takeActionError state
+    } catch (err) {
+      // #428: surface the rejection in the Recent-events log, not just console.
+      addLog(
+        `TakeAction(${actionRef.id}) REJECTED: ${errorMessage(err)}`,
+        true
+      );
     }
   };
 
@@ -737,8 +755,9 @@ export function PlaytestHarness() {
         target,
       });
       addLog(`VisualAttack → ${targetId}`);
-    } catch {
-      // error surfaced via takeActionError state
+    } catch (err) {
+      // #428: surface the rejection in the Recent-events log, not just console.
+      addLog(`VisualAttack → ${targetId} REJECTED: ${errorMessage(err)}`, true);
     }
   };
 
@@ -1687,6 +1706,7 @@ export function PlaytestHarness() {
               Recent events ({log.length})
             </h3>
             <div
+              data-testid="event-log"
               style={{
                 background: '#0a0a0a',
                 border: '1px solid #333',
@@ -1700,8 +1720,17 @@ export function PlaytestHarness() {
                 <span style={{ color: '#555' }}>(waiting for events…)</span>
               )}
               {log.map((entry, i) => (
-                <div key={i} style={{ color: '#9d9', marginBottom: 2 }}>
-                  {entry}
+                <div
+                  key={i}
+                  data-testid={
+                    entry.isError ? 'event-log-entry-error' : 'event-log-entry'
+                  }
+                  style={{
+                    color: entry.isError ? '#f88' : '#9d9',
+                    marginBottom: 2,
+                  }}
+                >
+                  {entry.text}
                 </div>
               ))}
             </div>

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -68,6 +68,23 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** Short, log-friendly descriptor of an ActionTarget for the Recent-events
+ * log (e.g. ` → goblin-1`, ` → self`, or `` for an untargeted NONE action).
+ * Read-only formatting of the oneof the harness already constructed — no
+ * targeting logic. */
+function describeActionTarget(target: ActionTarget | undefined): string {
+  const kind = target?.kind;
+  if (!kind || kind.case === undefined) return '';
+  switch (kind.case) {
+    case 'entityId':
+      return ` → ${String(kind.value)}`;
+    case 'self':
+      return ' → self';
+    default:
+      return ` → ${kind.case}`;
+  }
+}
+
 /**
  * Dev-only playtest verification harness for wave-2.5 slice 2.
  * Renders at ?encounterId=<id>&playerId=<id> in development mode.
@@ -86,7 +103,13 @@ export function PlaytestHarness() {
 
   const entityId = playerId ? `char-${playerId}` : '';
 
-  const [log, setLog] = useState<Array<{ text: string; isError: boolean }>>([]);
+  const [log, setLog] = useState<
+    Array<{ id: number; text: string; isError: boolean }>
+  >([]);
+  // Monotonic id for log entries. Entries are prepended, so the array index is
+  // an unstable React key (it re-associates DOM nodes as the log shifts); a
+  // per-entry id keyed off this counter stays stable across prepends.
+  const logIdRef = useRef(0);
   const [targetQ, setTargetQ] = useState(0);
   const [targetR, setTargetR] = useState(0);
   const [targetS, setTargetS] = useState(0);
@@ -160,7 +183,11 @@ export function PlaytestHarness() {
   // RPCs (currently TakeAction, #428) so a server rejection is visible in the
   // harness's primary verification surface, not just the console.
   const addLog = (msg: string, isError = false) => {
-    const entry = { text: `[${formatTime(new Date())}] ${msg}`, isError };
+    const entry = {
+      id: logIdRef.current++,
+      text: `[${formatTime(new Date())}] ${msg}`,
+      isError,
+    };
     setLog((prev) => [entry, ...prev].slice(0, 30));
   };
 
@@ -548,11 +575,11 @@ export function PlaytestHarness() {
         // untargeted (NONE) action sends an empty ActionTarget oneof.
         target: target ?? ({ kind: { case: undefined } } as ActionTarget),
       });
-      addLog(`TakeAction(${actionRef.id})`);
+      addLog(`TakeAction(${actionRef.id})${describeActionTarget(target)}`);
     } catch (err) {
       // #428: surface the rejection in the Recent-events log, not just console.
       addLog(
-        `TakeAction(${actionRef.id}) REJECTED: ${errorMessage(err)}`,
+        `TakeAction(${actionRef.id})${describeActionTarget(target)} REJECTED: ${errorMessage(err)}`,
         true
       );
     }
@@ -1719,9 +1746,9 @@ export function PlaytestHarness() {
               {log.length === 0 && (
                 <span style={{ color: '#555' }}>(waiting for events…)</span>
               )}
-              {log.map((entry, i) => (
+              {log.map((entry) => (
                 <div
-                  key={i}
+                  key={entry.id}
                   data-testid={
                     entry.isError ? 'event-log-entry-error' : 'event-log-entry'
                   }


### PR DESCRIPTION
## Bug

From a live playtest: a Hide attempt rejected by the API with `InvalidArgument` produced **no entry** in the playtest harness's Recent-events log — the rejection was only visible in the browser console. `PlaytestHarness.tsx` sends the TakeAction correctly; the rejection just wasn't surfaced into the on-screen event log (only into a separate `takeActionError` panel below the combat controls). Since the harness is the verification instrument for playtest-driven waves, a silent rejection was indistinguishable from a swallowed request.

## Fix

Web-only, render layer — no game logic added, per the boundary rule.

- `log` state changed from `string[]` to `Array<{ text: string; isError: boolean }>`; `addLog` takes an optional `isError` flag.
- Recent-events entries render red (`#f88`, matching the existing error-panel color) when `isError` is true, green otherwise. Container gets `data-testid="event-log"`; entries get `data-testid="event-log-entry"` / `"event-log-entry-error"`.
- All three TakeAction call sites (`handleAttack`, `dispatchAction` — the server-driven Action menu path, and `handleVisualEntityClick`) now log an error entry on rejection: `TakeAction(<id>) → <target> REJECTED: <message>`. The message comes straight from the caught `Error`/`ConnectError` — ConnectError's `.message` is already prefixed with the status code (e.g. `[invalid_argument] target.entity_id is required`), so this is "code + message" with no interpretation added.
- The existing `takeActionError` panel is unchanged/left in place; the log entry is additive.

## Tests

Added `logs a rejected TakeAction as a visible error entry in the event log (#428)` to `PlaytestHarness.test.tsx`, asserting the event-log gets an `event-log-entry-error` node containing the action ref, "REJECTED", and the server message. Adjusted the pre-existing `shows takeAction error when RPC fails` test (`getByText` → `getAllByText`) since the message now legitimately appears in two places on screen.

`npm run ci-check` passes locally (format, lint, typecheck, build, all 71 tests).

Closes #428
Part of KirkDiggler/rpg-project#54

Relates to playtest-as-spec (#425) — the harness is the verification instrument, so a rejection needs to be as visible as any other event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umo5u8DPWgF624fF6tNmsm