### PR TITLE
feat(playtest): render status effects + attack advantage/disadvantage (#430)

### DIFF
--- a/docs/architecture/components/playtest-harness.md
+++ b/docs/architecture/components/playtest-harness.md
@@ -1,8 +1,8 @@
 ---
 name: PlaytestHarness
 description: Dev-only verification harness for the v1alpha2 encounter stream — now with a clickable hex grid alongside the raw dev panel
-updated: 2026-05-18
-confidence: high — verified by reading PlaytestHarness.tsx + PlaytestMap.tsx and the 55-test vitest suite
+updated: 2026-07-04
+confidence: high — verified by reading PlaytestHarness.tsx + PlaytestMap.tsx and the vitest suite
 ---
 
 # PlaytestHarness
@@ -65,15 +65,33 @@ The `attackTargetId` state is shared with the dev panel's existing "Target id" i
 
 When `showDev` is true, the harness renders the pre-visual layout below the map:
 
-- Entities table (id, type, HP, x/y/z, ghost flag) — populated from `useEncounterState`
+- Entities table (id, type, HP, AC, x/y/z, ghost flag, **status**) — populated from `useEncounterState`
 - Revealed hexes summary
 - Move controls (Q/R/S spinbuttons + Move button) — still functional, useful for exact-coordinate verification
 - Open door input + button
 - Skill check prompt modal (Wave 2.9)
-- Combat controls (Attack target id + Attack/End turn buttons)
+- Combat controls (Attack target id + Attack/End turn buttons; "Statuses (N)" summary for the local player)
 - Recent events log (right column)
 
 Both layers consume the same hooks; switching mode is a render-only toggle.
+
+### Status effects + attack advantage/disadvantage (Beat 2, #430)
+
+The entities table's **status** column renders every entity's active conditions (from
+`useEncounterState`'s `entityStatuses`, populated by `StatusApplied` events) as icon+label badges,
+e.g. `🏃 Dodging`, `🫥 Hidden`, `🙌 Helped`. Display metadata is resolved entirely web-side via
+`src/utils/conditionIcons.ts`'s `getConditionDisplay(refId)` — keyed by the condition ref's `id`
+string (e.g. `"dodging"`), never the wire's `StatusEffect.display_name`/`icon_hint`, which may be
+empty (rpg-api does not author display strings — Invariant 2). This is the same lookup table
+`onStatusApplied`'s log line and the `AttackResolved` combat-log line below both use — a single
+ref-keyed source of truth, not three parallel ones.
+
+The combat log's `AttackResolved` line appends `[advantage: <names>]` / `[disadvantage: <names>]`
+when `has_advantage`/`has_disadvantage` are true, naming the granting/imposing condition(s) from
+`advantage_sources`/`disadvantage_sources` (both `repeated Ref`, resolved through the same
+`getConditionDisplay` lookup). These booleans and refs are copied verbatim from the toolkit's
+resolved `AttackResult` at every hop (toolkit → rpg-api → wire) — the web never recomputes or infers
+advantage/disadvantage from other fields (Invariant 1: web computes nothing).
 
 ## Test coverage
 

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -9,7 +9,7 @@ confidence: high — verified by reading encounterHooks.ts, useEncounterState.ts
 
 ## Proto packages consumed
 
-All types flow in from `@kirkdiggler/rpg-api-protos` (currently v0.1.86). The web layer consumes two proto namespaces:
+All types flow in from `@kirkdiggler/rpg-api-protos` (currently v0.1.102). The web layer consumes two proto namespaces:
 
 | Proto package        | Generated path                           | What we use                                                                                                      |
 | -------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
@@ -93,4 +93,4 @@ These are justified. They are UI concerns not representable in proto. They shoul
 
 ## Proto version discipline
 
-`@kirkdiggler/rpg-api-protos` is installed from GitHub (`github:KirkDiggler/rpg-api-protos#v0.1.86`). Version bumps require regenerating the lock file: `rm -rf node_modules package-lock.json && npm install`. The `CLAUDE.md` documents this. Failure to regenerate can cause CI to use stale proto code despite `package.json` being updated.
+`@kirkdiggler/rpg-api-protos` is installed from GitHub (`github:KirkDiggler/rpg-api-protos#v0.1.102`). Version bumps require regenerating the lock file: `rm -rf node_modules package-lock.json && npm install`. The `CLAUDE.md` documents this. Failure to regenerate can cause CI to use stale proto code despite `package.json` being updated.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,7 +1,7 @@
 ---
 name: rpg-dnd5e-web status
 description: Where we are with the React/Discord Activity UI — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-06-07
+updated: 2026-07-04
 confidence: medium — seeded from full code read-through, git log, and open PRs; needs Kirk's correction pass on stream-bug details
 ---
 
@@ -11,6 +11,27 @@ This is a living doc. Edit it in the same PR that invalidates a line. Don't
 let it rot.
 
 ## Active work
+
+- **Chapter 2 Beat 2 — status effects + attack advantage/disadvantage (#430, wave rpg-project#75)** —
+  `PlaytestHarness`'s entities table gains a **status** column rendering every
+  entity's active conditions (Dodging/Hidden/Helped, plus whatever else the
+  stream applies) as icon+label badges, and the `AttackResolved` combat-log
+  line now appends `[advantage: <names>]` / `[disadvantage: <names>]` sourced
+  from the new `has_advantage`/`has_disadvantage`/`advantage_sources`/
+  `disadvantage_sources` fields (rpg-api-protos#173, fields 8-11 on
+  `AttackResolved`). Display resolution for all condition refs (both the
+  status column and the advantage/disadvantage source names) is unified
+  through `src/utils/conditionIcons.ts`'s `getConditionDisplay(refId)` —
+  a pre-existing string-keyed lookup table that was written but never wired
+  into any component until this wave; extended with `dodging`/`hidden`/`helped`
+  entries rather than adding a second lookup table (R5: display metadata
+  stays web-side, keyed by the `Ref.id` string, never the wire's
+  `StatusEffect.display_name`/`icon_hint`, which may be empty). Proto bumped
+  to `@kirkdiggler/rpg-api-protos v0.1.102`.
+  **Note:** `enumDisplays.ts`'s `CONDITION_DISPLAY` (keyed by the v1alpha1
+  `ConditionId` enum, used by `ConditionsDisplay`/`activeConditions` on the
+  static character sheet) is a _different, unrelated_ lookup — don't confuse
+  the two; the v2 stream's `StatusEffect.source` is a bare `Ref`, not that enum.
 
 - **Chapter 2 TakeAction wave — server-driven action menu + live economy (#426)** —
   The web now consumes the server-authored action menu instead of computing

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.100",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.102",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1390,7 +1390,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#580a8321c43dc9527d8bf41b7afc9a366d68a8d6",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#f224488c38b431332628d56cd6f7e57fd5269b76",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.100",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.102",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -2148,5 +2148,133 @@ describe('PlaytestHarness', () => {
         expect(screen.getByText(/AttackResolved.*MISS/)).toBeTruthy();
       });
     });
+
+    // Beat 2 (#430): has_disadvantage/has_advantage + *_sources ride the
+    // same AttackResolved event, copied verbatim from the toolkit — the
+    // combat log must surface the source condition's display name, not just
+    // the raw boolean.
+    it('shows disadvantage with the source condition name in the combat log (#430)', async () => {
+      render(<PlaytestHarness />);
+      enterTurn();
+      act(() =>
+        fake.push(
+          makeEvent('attackResolved', {
+            attackerEntityId: 'goblin-1',
+            targetEntityId: 'char-alice',
+            hit: false,
+            critical: false,
+            attackRoll: 8,
+            attackBonus: 4,
+            targetAc: 16,
+            hasDisadvantage: true,
+            disadvantageSources: [
+              { module: 'dnd5e', type: 'conditions', id: 'dodging' },
+            ],
+          })
+        )
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText(/AttackResolved.*disadvantage: Dodging/)
+        ).toBeTruthy();
+      });
+    });
+
+    it('shows advantage with the source condition name in the combat log (#430)', async () => {
+      render(<PlaytestHarness />);
+      enterTurn();
+      act(() =>
+        fake.push(
+          makeEvent('attackResolved', {
+            attackerEntityId: 'char-alice',
+            targetEntityId: 'goblin-1',
+            hit: true,
+            critical: false,
+            attackRoll: 17,
+            attackBonus: 5,
+            targetAc: 13,
+            hasAdvantage: true,
+            advantageSources: [
+              { module: 'dnd5e', type: 'conditions', id: 'hidden' },
+            ],
+          })
+        )
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText(/AttackResolved.*advantage: Hidden/)
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  // Beat 2 (#430): Hidden/Helped status icons on entities, driven entirely by
+  // server-sent StatusApplied events (Invariant 1: web computes nothing).
+  describe('status effect rendering (#430)', () => {
+    it('renders a Hidden status badge on the entity table row after StatusApplied', async () => {
+      render(<PlaytestHarness />);
+      act(() => fake.push(makeEvent('snapshotDelivered', {})));
+      act(() =>
+        fake.push(
+          makeEvent('entityAppeared', {
+            entity: { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
+          })
+        )
+      );
+      act(() =>
+        fake.push(
+          makeEvent('statusApplied', {
+            entityId: 'char-alice',
+            status: {
+              source: { module: 'dnd5e', type: 'conditions', id: 'hidden' },
+              displayName: '',
+            },
+          })
+        )
+      );
+
+      await waitFor(() => {
+        const cell = screen.getByTestId('entity-status-char-alice');
+        expect(cell.textContent).toContain('Hidden');
+      });
+    });
+
+    // Regression coverage for the Help condition's target-label fix
+    // (design.md R1): the condition must render on the TARGET entity, not
+    // whoever applied it — a third-party viewer (a different entity than
+    // either the helper or the helped ally) must see it too.
+    it('renders a Helped status badge on a non-local-player entity (third-party visibility)', async () => {
+      render(<PlaytestHarness />);
+      act(() => fake.push(makeEvent('snapshotDelivered', {})));
+      act(() =>
+        fake.push(
+          makeEvent('entityAppeared', {
+            entity: { id: 'char-fighter', position: { x: 1, y: 0, z: -1 } },
+          })
+        )
+      );
+      act(() =>
+        fake.push(
+          makeEvent('statusApplied', {
+            entityId: 'char-fighter',
+            sourceEntityId: 'char-monk',
+            status: {
+              source: { module: 'dnd5e', type: 'conditions', id: 'helped' },
+              displayName: '',
+            },
+          })
+        )
+      );
+
+      await waitFor(() => {
+        const cell = screen.getByTestId('entity-status-char-fighter');
+        expect(cell.textContent).toContain('Helped');
+      });
+    });
+
+    it('shows "(none)" in the my-statuses summary when no conditions are active', () => {
+      render(<PlaytestHarness />);
+      expect(screen.getByTestId('my-statuses').textContent).toContain('(none)');
+    });
   });
 });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -19,6 +19,7 @@ import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useSubmitCheckV2 } from '../../api/useSubmitCheckV2';
 import { useTakeActionV2 } from '../../api/useTakeActionV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
+import { getConditionDisplay } from '../../utils/conditionIcons';
 import { protoPositionToHex } from '../../utils/hexCoord';
 import { ActionMenu } from './ActionMenu';
 import { actionKey, targetKindNeedsPrompt } from './actionMenuHelpers';
@@ -58,6 +59,30 @@ const MODE_LABEL: Record<EncounterMode, string> = {
 
 function formatTime(d: Date): string {
   return d.toTimeString().slice(0, 8);
+}
+
+/** Comma-joined display labels for a list of condition source refs (e.g.
+ * `AttackResolved`'s `advantage_sources`), resolved via the web's existing
+ * ref-keyed lookup (`conditionIcons.ts`) — never the server's
+ * `display_name`, which "may be empty" per `StatusEffect`'s doc comment
+ * (R5: display resolution stays web-side). */
+function formatSourceRefs(refs: Array<{ id: string }>): string {
+  return refs.map((r) => getConditionDisplay(r.id).label).join(', ');
+}
+
+/** Icon + label badge text for one entity's status list, e.g. "🏃 Dodging,
+ * 🫥 Hidden". Resolved the same way as `formatSourceRefs` — by `source.id`
+ * through the web's lookup table, never the (possibly empty) wire
+ * `display_name`. */
+function formatStatusBadges(
+  statuses: Array<{ source: { id: string } }>
+): string {
+  return statuses
+    .map((s) => {
+      const d = getConditionDisplay(s.source.id);
+      return `${d.icon} ${d.label}`;
+    })
+    .join(', ');
 }
 
 /** Extract a readable message from a caught RPC rejection. ConnectError's
@@ -313,7 +338,10 @@ export function PlaytestHarness() {
       onStatusApplied: (e) => {
         encounterState.applyStatusApplied(e);
         const id = e.status?.source?.id ?? '?';
-        addLog(`StatusApplied ${e.entityId} <- ${id}`);
+        const display = getConditionDisplay(id);
+        addLog(
+          `StatusApplied ${e.entityId} <- ${id} (${display.icon} ${display.label})`
+        );
       },
       onModeChanged: (e) => {
         encounterState.applyModeChanged(e);
@@ -350,11 +378,20 @@ export function PlaytestHarness() {
       // TakeAction wave (#426 / #594): per-attack roll detail. CRUCIAL — this
       // fires on a MISS too (hit=false). Render the miss in the combat log so a
       // whiff is no longer silent.
+      // Beat 2 (#430): has_advantage/has_disadvantage + *_sources are copied
+      // verbatim from the toolkit's AttackResult — rendered as-is, never
+      // recomputed from other fields (Invariant 1: web computes nothing).
       onAttackResolved: (e) => {
         const outcome = e.critical ? 'CRIT' : e.hit ? 'HIT' : 'MISS';
+        const advPart = e.hasAdvantage
+          ? ` [advantage: ${formatSourceRefs(e.advantageSources) || '?'}]`
+          : '';
+        const disadvPart = e.hasDisadvantage
+          ? ` [disadvantage: ${formatSourceRefs(e.disadvantageSources) || '?'}]`
+          : '';
         addLog(
           `AttackResolved ${e.attackerEntityId} → ${e.targetEntityId}: ${outcome} ` +
-            `(roll ${e.attackRoll}+${e.attackBonus} vs AC ${e.targetAc})`
+            `(roll ${e.attackRoll}+${e.attackBonus} vs AC ${e.targetAc})${advPart}${disadvPart}`
         );
       },
       onEntityDied: (e) => {
@@ -1315,6 +1352,7 @@ export function PlaytestHarness() {
                   <th style={{ padding: '4px 8px' }}>y</th>
                   <th style={{ padding: '4px 8px' }}>z</th>
                   <th style={{ padding: '4px 8px' }}>ghost?</th>
+                  <th style={{ padding: '4px 8px' }}>status</th>
                 </tr>
               </thead>
               <tbody>
@@ -1329,6 +1367,14 @@ export function PlaytestHarness() {
                   const meta = encounterState.state.entityMeta.get(id);
                   const hp = encounterState.state.entityHP.get(id);
                   const ac = encounterState.state.entityAC.get(id);
+                  // Beat 2 (#430): status icons on ANY entity, not just the
+                  // local player — the Help/Hide playtest beats specifically
+                  // need a third party to observe a condition on someone
+                  // else (e.g. the Fighter's Helped condition, or the
+                  // goblin's Dodging). Driven entirely by server-sent
+                  // StatusApplied events (Invariant 1: web computes nothing).
+                  const statuses =
+                    encounterState.state.entityStatuses.get(id) ?? [];
                   // Row background: active actor (yellow/orange) takes priority over
                   // local player (green) so both states are distinguishable when
                   // it's the local player's turn.
@@ -1381,13 +1427,21 @@ export function PlaytestHarness() {
                       <td style={{ padding: '4px 8px' }}>
                         {entity.ghost ? 'yes' : ''}
                       </td>
+                      <td
+                        data-testid={`entity-status-${id}`}
+                        style={{ padding: '4px 8px', color: '#ccc' }}
+                      >
+                        {statuses.length === 0
+                          ? '—'
+                          : formatStatusBadges(statuses)}
+                      </td>
                     </tr>
                   );
                 })}
                 {entitiesArray.length === 0 && (
                   <tr>
                     <td
-                      colSpan={8}
+                      colSpan={9}
                       style={{ padding: '4px 8px', color: '#555' }}
                     >
                       (no entities yet)
@@ -1553,11 +1607,14 @@ export function PlaytestHarness() {
 
             {/* Combat controls (Wave 2.8 verification scaffold; deleted in slice 3) */}
             <h3 style={{ margin: '16px 0 8px', color: '#aaa' }}>Combat</h3>
-            <div style={{ fontSize: 12, color: '#777', marginBottom: 8 }}>
+            <div
+              data-testid="my-statuses"
+              style={{ fontSize: 12, color: '#777', marginBottom: 8 }}
+            >
               Statuses ({myStatuses.length}):{' '}
               {myStatuses.length === 0
                 ? '(none)'
-                : myStatuses.map((s) => s.source.id).join(', ')}
+                : formatStatusBadges(myStatuses)}
             </div>
 
             {/* TakeAction wave (#426): server-authored economy + action menu.

--- a/src/utils/conditionIcons.ts
+++ b/src/utils/conditionIcons.ts
@@ -173,6 +173,36 @@ const BUFF_CONDITIONS: Record<string, ConditionDisplay> = {
 };
 
 /**
+ * Combat-ability action states.
+ * Temporary conditions granted by taking a combat action (Dodge/Hide/Help),
+ * as opposed to a class feature or spell. Beat 2 (#430) is the first wave
+ * to populate real StatusApplied data for these three refs on the v1alpha2
+ * encounter stream.
+ */
+const ACTION_STATE_CONDITIONS: Record<string, ConditionDisplay> = {
+  dodging: {
+    icon: '🏃',
+    label: 'Dodging',
+    color: '#3b82f6', // blue - positive (for the holder)
+    description:
+      'Attacks against you have disadvantage; advantage on DEX saves',
+  },
+  hidden: {
+    icon: '🫥',
+    label: 'Hidden',
+    color: '#3b82f6', // blue - positive (for the holder)
+    description:
+      'Your attacks have advantage; attacks against you have disadvantage',
+  },
+  helped: {
+    icon: '🙌',
+    label: 'Helped',
+    color: '#3b82f6', // blue - positive (for the holder)
+    description: 'Advantage on your next attack roll',
+  },
+};
+
+/**
  * Combat state conditions.
  * These represent special combat states like dying or dead.
  */
@@ -242,6 +272,11 @@ export function getConditionDisplay(conditionName: string): ConditionDisplay {
     return COMBAT_STATE_CONDITIONS[normalized];
   }
 
+  // Check combat-ability action states (Dodge/Hide/Help)
+  if (ACTION_STATE_CONDITIONS[normalized]) {
+    return ACTION_STATE_CONDITIONS[normalized];
+  }
+
   // Return default for unknown conditions
   // Use the original (non-normalized) name for the label, but capitalize it
   return {
@@ -261,6 +296,7 @@ export function getAllConditions(): ConditionDisplay[] {
     ...Object.values(STANDARD_CONDITIONS),
     ...Object.values(BUFF_CONDITIONS),
     ...Object.values(COMBAT_STATE_CONDITIONS),
+    ...Object.values(ACTION_STATE_CONDITIONS),
   ];
 }
 


### PR DESCRIPTION
## Summary
- Bumps `@kirkdiggler/rpg-api-protos` to `v0.1.102`, picking up the `AttackResolved` fields 8-11 (`has_advantage`, `has_disadvantage`, `advantage_sources`, `disadvantage_sources`) added in rpg-api-protos#173/#174.
- `PlaytestHarness`'s entities table gains a **status** column rendering every entity's active conditions (Dodging/Hidden/Helped, and anything else the stream applies) as icon+label badges — driven entirely by `StatusApplied` events, not local player only, so a third-party viewer can observe conditions on any entity (needed for the Help beat's audience regression check).
- The `AttackResolved` combat-log line now appends `[advantage: <names>]` / `[disadvantage: <names>]`, naming the granting/imposing condition(s) via the new source-ref fields. These booleans/refs are rendered as-is — never recomputed (Invariant 1: web computes nothing).
- The "Statuses (N)" local-player summary line and the `StatusApplied` log line are upgraded to show resolved icon+label instead of the raw ref id.

Closes #430
Refs KirkDiggler/rpg-project#75

## Load-bearing changes

- **Reused an existing lookup table instead of adding a new one.** I found `src/utils/conditionIcons.ts` (`getConditionDisplay(name): ConditionDisplay`, string-keyed, case-insensitive) already existed with exactly the shape the wave design doc's R5 decision describes ("the web resolves display_name/icon_hint from its own lookup table") — but it wasn't imported by any component anywhere in the repo. I extended it with `dodging`/`hidden`/`helped` entries (new `ACTION_STATE_CONDITIONS` category) and wired it into `PlaytestHarness`, rather than building a second, parallel ref-keyed table. Note there's an unrelated same-named `getConditionDisplay` in `src/utils/enumDisplays.ts`, keyed by the v1alpha1 `ConditionId` *enum* (used by the static character sheet's `ConditionsDisplay`/`activeConditions`) — a different mechanism for a different proto surface (v1alpha1 character state vs. v1alpha2 encounter stream). Don't conflate the two; this PR only touches the v1alpha2 path.
- **Display resolution never trusts the wire's `display_name`/`icon_hint`.** `StatusEffect.display_name` "may be empty" per its own doc comment, and `useEncounterState.ts` already just passes it through raw. All three render sites (status badges, `AttackResolved`'s advantage/disadvantage names, `StatusApplied` log line) resolve via `getConditionDisplay(ref.id)` — keyed by `id` alone (ignoring `type`, which varies between `"condition"`/`"conditions"` across call sites in the actual proto, not load-bearing for display).
- **`advantage_sources`/`disadvantage_sources`/status booleans are rendered verbatim, never recomputed.** Matches the toolkit/protos contract ("consumers must never recompute advantage/disadvantage from other fields").

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run ci-check` — format, lint, typecheck, build, tests all green
- [x] New vitest cases in `PlaytestHarness.test.tsx`: disadvantage-with-source-name and advantage-with-source-name in the combat log; Hidden status badge on the local player's own entity row; Helped status badge on a **different** (non-local-player) entity row — regression coverage for the Help condition's target-label fix in the design; "(none)" empty-state for the statuses summary.
- [x] Full suite: 636 tests passing across 36 files.

## Blockers / notes for whoever plays this through
- I did not touch `docs/architecture/data-model.md` beyond bumping the stale proto version number (it referenced v0.1.86, already stale before this PR, and doesn't document the v1alpha2 namespace at all) — a full rewrite of that doc is out of scope for this PR.
- Nothing here depends on unmerged toolkit/rpg-api work landing later — the proto fields are already live at v0.1.102, and Hidden/Helped will render correctly the moment rpg-toolkit#716 actually emits `StatusApplied` for those refs (this PR only adds the display layer, per the wave's stated web scope).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01E2xgbzQbNgFvkhBkmB3xQE