### PR TITLE
fix(sheet): render real character features instead of hardcoded empty stub

### DIFF
--- a/src/character/sheet/components/DnDFeatures.test.tsx
+++ b/src/character/sheet/components/DnDFeatures.test.tsx
@@ -1,0 +1,56 @@
+import { create, type MessageInitShape } from '@bufbuild/protobuf';
+import {
+  CharacterSchema,
+  type Character,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DnDFeatures } from './DnDFeatures';
+
+function makeCharacter(
+  overrides: MessageInitShape<typeof CharacterSchema> = {}
+): Character {
+  return create(CharacterSchema, {
+    id: 'char-1',
+    features: [
+      {
+        name: 'Rage',
+        description: 'Enter a battle fury.',
+        source: 'dnd5e:classes:barbarian',
+        level: 1,
+      },
+    ],
+    ...overrides,
+  });
+}
+
+describe('DnDFeatures', () => {
+  it("renders the character's real features instead of the empty stub", () => {
+    render(<DnDFeatures character={makeCharacter()} />);
+    expect(screen.getByText('Rage')).toBeTruthy();
+    expect(screen.getByText('1 features')).toBeTruthy();
+  });
+
+  it('shows an empty state when the character has no features', () => {
+    render(<DnDFeatures character={makeCharacter({ features: [] })} />);
+    expect(screen.getByText(/No features available yet/)).toBeTruthy();
+    expect(screen.getByText('0 features')).toBeTruthy();
+  });
+
+  it('opens the modal with the same feature data on click', () => {
+    const onShowModal = vi.fn();
+    render(
+      <DnDFeatures character={makeCharacter()} onShowModal={onShowModal} />
+    );
+
+    fireEvent.click(screen.getByText('FEATURES & TRAITS'));
+
+    expect(onShowModal).toHaveBeenCalledTimes(1);
+    const [title, content] = onShowModal.mock.calls[0];
+    expect(title).toBe('Features & Traits');
+
+    const modal = document.createElement('div');
+    render(<>{content}</>, { container: modal });
+    expect(within(modal).getByText('Rage')).toBeTruthy();
+  });
+});

--- a/src/character/sheet/components/DnDFeatures.tsx
+++ b/src/character/sheet/components/DnDFeatures.tsx
@@ -1,5 +1,6 @@
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { useState } from 'react';
+import { FeaturesPanel } from '../../../components/features';
 import { Card } from '../../../components/ui/Card';
 
 interface DnDFeaturesProps {
@@ -7,261 +8,26 @@ interface DnDFeaturesProps {
   onShowModal?: (title: string, content: React.ReactNode) => void;
 }
 
-// Feature data structure for consistent typing
-interface FeatureData {
-  name: string;
-  source: string;
-  level: number;
-  description: string;
-}
-
 export function DnDFeatures({ character, onShowModal }: DnDFeaturesProps) {
   const [expanded, setExpanded] = useState(false);
 
-  // Extract features from character data
-  // Note: The protobuf Character type doesn't yet have features, fightingStyles, racialTraits, backgroundFeature fields
-  // This implementation provides structure for when those fields are added
-  const extractFeatures = (): FeatureData[] => {
-    const features: FeatureData[] = [];
+  const features = character.features || [];
 
-    // TODO: When protobuf is updated, replace with:
-    // - character.features?.map(f => ({ name: f.name, source: 'Class', level: f.level, description: f.description })) || []
-    // - character.fightingStyles?.map(style => ({ name: style, source: 'Fighting Style', level: 1, description: '' })) || []
-    // - character.racialTraits?.map(trait => ({ name: trait, source: getRaceDisplayName(character.race), level: 1, description: '' })) || []
-    // - character.backgroundFeature ? [{ name: character.backgroundFeature, source: 'Background', level: 1, description: '' }] : []
-
-    // For now, we have no feature data available in the current character structure
-    // Acknowledge the character parameter for future use
-    void character;
-    // Return empty array to show graceful empty state
-    return features;
-  };
-
-  const allFeatures = extractFeatures();
-
-  // Group features by source type
-  const classFeatures = allFeatures.filter(
-    (f) =>
-      f.source !== 'Racial Trait' &&
-      f.source !== 'Background' &&
-      f.source !== 'Fighting Style'
-  );
-  const racialTraits = allFeatures.filter((f) => f.source === 'Racial Trait');
-  const fightingStyles = allFeatures.filter(
-    (f) => f.source === 'Fighting Style'
-  );
-  const backgroundFeatures = allFeatures.filter(
-    (f) => f.source === 'Background'
-  );
-
-  const handleShowDetails = () => {
-    const content = (
-      <div className="space-y-6">
-        {allFeatures.length === 0 && (
-          <div
-            className="text-center py-8"
-            style={{ color: 'var(--text-muted)' }}
-          >
-            <p className="text-sm">
-              No features available yet. Features will appear here as your
-              character gains class abilities, racial traits, and other special
-              abilities.
-            </p>
-          </div>
-        )}
-
-        {classFeatures.length > 0 && (
-          <div>
-            <h5
-              className="text-lg font-bold mb-3 pb-2 border-b"
-              style={{
-                color: 'var(--text-primary)',
-                borderColor: 'var(--border-primary)',
-              }}
-            >
-              Class Features
-            </h5>
-            <div className="space-y-4">
-              {classFeatures.map((feature, index) => (
-                <div
-                  key={index}
-                  className="p-3 rounded"
-                  style={{ backgroundColor: 'var(--bg-secondary)' }}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h6
-                      className="font-bold"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {feature.name}
-                    </h6>
-                    <div
-                      className="text-xs px-2 py-1 rounded"
-                      style={{
-                        backgroundColor: 'var(--rare)',
-                        color: 'var(--text-button)',
-                      }}
-                    >
-                      {feature.source} {feature.level}
-                    </div>
-                  </div>
-                  <p
-                    className="text-sm leading-relaxed"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {feature.description}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {fightingStyles.length > 0 && (
-          <div>
-            <h5
-              className="text-lg font-bold mb-3 pb-2 border-b"
-              style={{
-                color: 'var(--text-primary)',
-                borderColor: 'var(--border-primary)',
-              }}
-            >
-              Fighting Styles
-            </h5>
-            <div className="space-y-4">
-              {fightingStyles.map((style, index) => (
-                <div
-                  key={index}
-                  className="p-3 rounded"
-                  style={{ backgroundColor: 'var(--bg-secondary)' }}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h6
-                      className="font-bold"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {style.name}
-                    </h6>
-                    <div
-                      className="text-xs px-2 py-1 rounded"
-                      style={{
-                        backgroundColor: 'var(--epic)',
-                        color: 'var(--text-button)',
-                      }}
-                    >
-                      {style.source}
-                    </div>
-                  </div>
-                  <p
-                    className="text-sm leading-relaxed"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {style.description}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {racialTraits.length > 0 && (
-          <div>
-            <h5
-              className="text-lg font-bold mb-3 pb-2 border-b"
-              style={{
-                color: 'var(--text-primary)',
-                borderColor: 'var(--border-primary)',
-              }}
-            >
-              Racial Traits
-            </h5>
-            <div className="space-y-4">
-              {racialTraits.map((trait, index) => (
-                <div
-                  key={index}
-                  className="p-3 rounded"
-                  style={{ backgroundColor: 'var(--bg-secondary)' }}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h6
-                      className="font-bold"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {trait.name}
-                    </h6>
-                    <div
-                      className="text-xs px-2 py-1 rounded"
-                      style={{
-                        backgroundColor: 'var(--uncommon)',
-                        color: 'var(--text-button)',
-                      }}
-                    >
-                      {trait.source}
-                    </div>
-                  </div>
-                  <p
-                    className="text-sm leading-relaxed"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {trait.description}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {backgroundFeatures.length > 0 && (
-          <div>
-            <h5
-              className="text-lg font-bold mb-3 pb-2 border-b"
-              style={{
-                color: 'var(--text-primary)',
-                borderColor: 'var(--border-primary)',
-              }}
-            >
-              Background Features
-            </h5>
-            <div className="space-y-4">
-              {backgroundFeatures.map((feature, index) => (
-                <div
-                  key={index}
-                  className="p-3 rounded"
-                  style={{ backgroundColor: 'var(--bg-secondary)' }}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h6
-                      className="font-bold"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {feature.name}
-                    </h6>
-                    <div
-                      className="text-xs px-2 py-1 rounded"
-                      style={{
-                        backgroundColor: 'var(--legendary)',
-                        color: 'var(--text-button)',
-                      }}
-                    >
-                      {feature.source}
-                    </div>
-                  </div>
-                  <p
-                    className="text-sm leading-relaxed"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {feature.description}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+  const renderFeatures = () =>
+    features.length === 0 ? (
+      <div className="text-center py-6" style={{ color: 'var(--text-muted)' }}>
+        <p className="text-sm">
+          No features available yet. Features will appear here as your character
+          gains class abilities, racial traits, and other special abilities.
+        </p>
       </div>
+    ) : (
+      <FeaturesPanel character={character} />
     );
 
+  const handleShowDetails = () => {
     if (onShowModal) {
-      onShowModal('Features & Traits', content);
+      onShowModal('Features & Traits', renderFeatures());
     } else {
       setExpanded(!expanded);
     }
@@ -289,93 +55,12 @@ export function DnDFeatures({ character, onShowModal }: DnDFeaturesProps) {
             color: 'var(--text-button)',
           }}
         >
-          {allFeatures.length} features
+          {features.length} features
         </div>
       </div>
 
-      {/* Preview - show first few features or empty state */}
-      <div className="mt-3 space-y-3">
-        {allFeatures.length === 0 ? (
-          <div
-            className="text-center py-6"
-            style={{ color: 'var(--text-muted)' }}
-          >
-            <p className="text-sm">No features available yet</p>
-            <p className="text-xs mt-1" style={{ color: 'var(--text-subtle)' }}>
-              Features will appear as your character develops
-            </p>
-          </div>
-        ) : (
-          <>
-            {allFeatures.slice(0, 3).map((feature, index) => {
-              // Determine color based on feature source
-              const getBorderColor = (source: string) => {
-                if (source.includes('Class') || source === 'Class')
-                  return 'var(--rare)';
-                if (source === 'Fighting Style') return 'var(--epic)';
-                if (source === 'Racial Trait') return 'var(--uncommon)';
-                if (source === 'Background') return 'var(--legendary)';
-                return 'var(--uncommon)';
-              };
-
-              const getBackgroundColor = (source: string) => {
-                if (source.includes('Class') || source === 'Class')
-                  return 'var(--rare)';
-                if (source === 'Fighting Style') return 'var(--epic)';
-                if (source === 'Racial Trait') return 'var(--uncommon)';
-                if (source === 'Background') return 'var(--legendary)';
-                return 'var(--uncommon)';
-              };
-
-              return (
-                <div
-                  key={index}
-                  className="p-2 rounded border-l-4"
-                  style={{
-                    backgroundColor: 'var(--bg-secondary)',
-                    borderColor: getBorderColor(feature.source),
-                  }}
-                >
-                  <div className="flex items-center justify-between mb-1">
-                    <h6
-                      className="font-bold text-sm"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {feature.name}
-                    </h6>
-                    <span
-                      className="text-xs px-1 py-0.5 rounded"
-                      style={{
-                        backgroundColor: getBackgroundColor(feature.source),
-                        color: 'var(--text-button)',
-                      }}
-                    >
-                      {feature.source}
-                    </span>
-                  </div>
-                  <p
-                    className="text-xs line-clamp-2"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {feature.description.length > 100
-                      ? feature.description.substring(0, 100) + '...'
-                      : feature.description}
-                  </p>
-                </div>
-              );
-            })}
-
-            {allFeatures.length > 3 && (
-              <div
-                className="text-sm italic text-center"
-                style={{ color: 'var(--text-subtle)' }}
-              >
-                ...and {allFeatures.length - 3} more features
-              </div>
-            )}
-          </>
-        )}
-      </div>
+      {/* Preview */}
+      <div className="mt-3">{renderFeatures()}</div>
 
       {/* Click indicator */}
       <div
@@ -388,64 +73,10 @@ export function DnDFeatures({ character, onShowModal }: DnDFeaturesProps) {
       {/* Expanded content (if modal not used) */}
       {expanded && !onShowModal && (
         <div
-          className="mt-4 pt-4 border-t space-y-4"
+          className="mt-4 pt-4 border-t"
           style={{ borderColor: 'var(--border-primary)' }}
         >
-          {allFeatures.length === 0 ? (
-            <div
-              className="text-center py-4"
-              style={{ color: 'var(--text-muted)' }}
-            >
-              <p className="text-sm">
-                No features available yet. Features will appear here as your
-                character gains class abilities, racial traits, and other
-                special abilities.
-              </p>
-            </div>
-          ) : (
-            allFeatures.map((feature, index) => {
-              const getBackgroundColor = (source: string) => {
-                if (source.includes('Class') || source === 'Class')
-                  return 'var(--rare)';
-                if (source === 'Fighting Style') return 'var(--epic)';
-                if (source === 'Racial Trait') return 'var(--uncommon)';
-                if (source === 'Background') return 'var(--legendary)';
-                return 'var(--uncommon)';
-              };
-
-              return (
-                <div
-                  key={index}
-                  className="p-3 rounded"
-                  style={{ backgroundColor: 'var(--bg-secondary)' }}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h6
-                      className="font-bold"
-                      style={{ color: 'var(--text-primary)' }}
-                    >
-                      {feature.name}
-                    </h6>
-                    <div
-                      className="text-xs px-2 py-1 rounded"
-                      style={{
-                        backgroundColor: getBackgroundColor(feature.source),
-                        color: 'var(--text-button)',
-                      }}
-                    >
-                      {feature.source} {feature.level}
-                    </div>
-                  </div>
-                  <p
-                    className="text-sm leading-relaxed"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {feature.description}
-                  </p>
-                </div>
-              );
-            })
-          )}
+          {renderFeatures()}
         </div>
       )}
     </Card>

--- a/src/character/sheet/components/DnDFeatures.tsx
+++ b/src/character/sheet/components/DnDFeatures.tsx
@@ -59,8 +59,10 @@ export function DnDFeatures({ character, onShowModal }: DnDFeaturesProps) {
         </div>
       </div>
 
-      {/* Preview */}
-      <div className="mt-3">{renderFeatures()}</div>
+      {/* Preview - hidden once expanded inline (no modal) so the panel isn't rendered twice */}
+      {(onShowModal || !expanded) && (
+        <div className="mt-3">{renderFeatures()}</div>
+      )}
 
       {/* Click indicator */}
       <div


### PR DESCRIPTION
## Summary

`DnDFeatures.tsx` hardcoded `extractFeatures()` → `[]` with a stale comment claiming the proto lacked `features`/`fightingStyles`/`racialTraits`/`backgroundFeature` fields. That claim was false: `character.features` and `character.activeConditions` are populated by the API and already rendered correctly in combat by `FeaturesPanel`/`FeatureBadge` (used in `HoverInfoPanel`, `ActionPanel`).

This PR deletes the dead stub and the ~370 lines of duplicate accordion-style rendering that consumed it, and instead reuses `FeaturesPanel` directly for both the card preview and the expanded modal/inline view. Net effect: a freshly created character's Fighting Style / Rage / Martial Arts / Sneak Attack / Second Wind / Unarmored Defense etc. are now visible on the character sheet, sourced from the same `character.features` + `character.activeConditions` data combat already uses — no new extraction or display logic was written.

Closes #436

## Load-bearing

None — this is a pure rendering fix. No new game logic was added to the client; empty-state fallback and click-to-modal are UI-only. `character.fightingStyles` / `character.racialTraits` / `character.backgroundFeature` (separate proto fields, currently unconsumed anywhere in the codebase) were intentionally left untouched since nothing indicates the API currently populates them independently of `character.features`.

## Test plan

- [x] `npm run ci-check` (format, lint, typecheck, build, tests) — all green, including via the pre-push hook
- [x] Added `src/character/sheet/components/DnDFeatures.test.tsx` (vitest + Testing Library, following the `characterMerge.test.ts` proto-fixture pattern):
  - renders a real feature (`Rage`) from `character.features` instead of the empty stub
  - shows the empty state when `character.features` is `[]`
  - clicking the card header opens the modal with the same feature data

```
npm run ci-check
npx vitest run src/character/sheet/components/DnDFeatures.test.tsx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2