### PR TITLE
fix(character-creation): wire Rogue Expertise picker into class selection

### DIFF
--- a/src/character/creation/ClassSelectionModal.tsx
+++ b/src/character/creation/ClassSelectionModal.tsx
@@ -403,6 +403,25 @@ export function ClassSelectionModal({
       }
     }
 
+    // Validate expertise choices
+    const expertiseChoices =
+      choicesSource?.filter(
+        (choice) => choice.choiceType === ChoiceCategory.EXPERTISE
+      ) || [];
+
+    for (const choice of expertiseChoices) {
+      const expertiseChoice = currentClassChoices.expertise?.find(
+        (ec) => ec.choiceId === choice.id
+      );
+      const selected = expertiseChoice?.skills || [];
+      if (selected.length !== choice.chooseCount) {
+        setErrorMessage(
+          `Please select ${choice.chooseCount} skill${choice.chooseCount > 1 ? 's' : ''} for expertise: ${choice.description}`
+        );
+        return;
+      }
+    }
+
     // For now, we'll skip validation of other choice types that don't use enums yet
     // TODO: Add validation for weapon proficiencies, armor proficiencies, feats, features
     // when they are updated to use structured types
@@ -1380,6 +1399,85 @@ export function ClassSelectionModal({
                       );
                     })()}
 
+                    {/* Expertise Choices */}
+                    {(() => {
+                      const expertiseChoices =
+                        choicesSource?.filter(
+                          (choice) =>
+                            choice.choiceType === ChoiceCategory.EXPERTISE
+                        ) || [];
+
+                      if (expertiseChoices.length === 0) return null;
+
+                      return (
+                        <div>
+                          <h4
+                            style={{
+                              color: textPrimary,
+                              fontSize: '18px',
+                              fontWeight: 'bold',
+                              marginBottom: '12px',
+                              fontFamily: 'Cinzel, serif',
+                            }}
+                          >
+                            Choose Your Expertise{' '}
+                            <span
+                              style={{ color: '#ef4444', fontSize: '16px' }}
+                            >
+                              *
+                            </span>
+                          </h4>
+                          {expertiseChoices.map((choice) => (
+                            <div
+                              key={choice.id}
+                              style={{ marginBottom: '16px' }}
+                            >
+                              <ChoiceRenderer
+                                choice={choice}
+                                currentSelections={
+                                  currentClassChoices.expertise?.find(
+                                    (ec) => ec.choiceId === choice.id
+                                  )?.skills || []
+                                }
+                                onSelectionChange={(_choiceId, selections) => {
+                                  // selections are Skill enums directly
+                                  const skillEnums = selections as Skill[];
+
+                                  setClassChoicesMap((prev) => {
+                                    const currentChoices = prev[choiceKey] || {
+                                      skills: [],
+                                      equipment: [],
+                                      features: [],
+                                      expertise: [],
+                                    };
+                                    const updatedExpertise =
+                                      currentChoices.expertise?.filter(
+                                        (ec) => ec.choiceId !== choice.id
+                                      ) || [];
+
+                                    if (skillEnums.length > 0) {
+                                      updatedExpertise.push({
+                                        choiceId: choice.id,
+                                        skills: skillEnums,
+                                      });
+                                    }
+
+                                    return {
+                                      ...prev,
+                                      [choiceKey]: {
+                                        ...currentChoices,
+                                        expertise: updatedExpertise,
+                                      },
+                                    };
+                                  });
+                                }}
+                              />
+                            </div>
+                          ))}
+                        </div>
+                      );
+                    })()}
+
                     {/* Class Features */}
                     {(() => {
                       const featureChoices =
@@ -1697,7 +1795,9 @@ export function ClassSelectionModal({
                             choice.choiceType !== ChoiceCategory.LANGUAGES &&
                             choice.choiceType !== ChoiceCategory.TOOLS &&
                             choice.choiceType !== ChoiceCategory.EQUIPMENT &&
-                            choice.choiceType !== ChoiceCategory.FIGHTING_STYLE
+                            choice.choiceType !==
+                              ChoiceCategory.FIGHTING_STYLE &&
+                            choice.choiceType !== ChoiceCategory.EXPERTISE
                         ) || [];
 
                       if (otherChoices.length === 0) return null;

--- a/src/components/ChoiceRenderer.test.tsx
+++ b/src/components/ChoiceRenderer.test.tsx
@@ -1,0 +1,80 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  ChoiceCategory,
+  ChoiceSchema,
+  ExpertiseOptionsSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import { Skill } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChoiceRenderer } from './ChoiceRenderer';
+
+describe('ChoiceRenderer - EXPERTISE', () => {
+  const expertiseChoice = create(ChoiceSchema, {
+    id: 'rogue-expertise-1',
+    description: 'Choose 2 skills or thieves’ tools for expertise',
+    chooseCount: 2,
+    choiceType: ChoiceCategory.EXPERTISE,
+    options: {
+      case: 'expertiseOptions',
+      value: create(ExpertiseOptionsSchema, {
+        availableSkills: [
+          Skill.STEALTH,
+          Skill.PERCEPTION,
+          Skill.SLEIGHT_OF_HAND,
+        ],
+      }),
+    },
+  });
+
+  it('renders expertise skill options instead of falling back to SimpleChoice', () => {
+    render(
+      <ChoiceRenderer
+        choice={expertiseChoice}
+        currentSelections={[]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Stealth')).toBeTruthy();
+    expect(screen.getByText('Perception')).toBeTruthy();
+    expect(screen.getByText('Sleight of Hand')).toBeTruthy();
+  });
+
+  it('reports selected skills as Skill enum values via onSelectionChange', () => {
+    const onSelectionChange = vi.fn();
+
+    render(
+      <ChoiceRenderer
+        choice={expertiseChoice}
+        currentSelections={[]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Stealth'));
+
+    expect(onSelectionChange).toHaveBeenCalledWith('rogue-expertise-1', [
+      Skill.STEALTH,
+    ]);
+  });
+
+  it('allows choosing up to chooseCount skills', () => {
+    const onSelectionChange = vi.fn();
+
+    render(
+      <ChoiceRenderer
+        choice={expertiseChoice}
+        currentSelections={[Skill.STEALTH]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Perception'));
+
+    expect(onSelectionChange).toHaveBeenCalledWith('rogue-expertise-1', [
+      Skill.STEALTH,
+      Skill.PERCEPTION,
+    ]);
+  });
+});

--- a/src/components/ChoiceRenderer.tsx
+++ b/src/components/ChoiceRenderer.tsx
@@ -128,6 +128,32 @@ export function ChoiceRenderer({
     );
   }
 
+  // Expertise - use EnumChoice, grouped like Skills
+  // (only skill-based expertise is advertised today; see ExpertiseOptions)
+  if (
+    choice.choiceType === ChoiceCategory.EXPERTISE &&
+    choice.options?.case === 'expertiseOptions'
+  ) {
+    return (
+      <EnumChoice
+        choice={choice}
+        available={choice.options.value.availableSkills}
+        currentSelections={currentSelections}
+        getDisplayInfo={getSkillInfo}
+        getGroup={getSkillAbility}
+        groupOrder={[
+          'Strength',
+          'Dexterity',
+          'Constitution',
+          'Intelligence',
+          'Wisdom',
+          'Charisma',
+        ]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+  }
+
   // Fighting Styles - use EnumChoice
   if (
     choice.choiceType === ChoiceCategory.FIGHTING_STYLE &&

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -42,7 +42,7 @@ export interface FeatureChoice {
 
 export interface ExpertiseChoice {
   choiceId: string;
-  skills: string[];
+  skills: Skill[];
 }
 
 export interface TraitChoice {

--- a/src/utils/choiceConverter.ts
+++ b/src/utils/choiceConverter.ts
@@ -136,22 +136,9 @@ export function convertFeatureChoiceToProto(
 
 export function convertExpertiseChoiceToProto(
   choiceId: string,
-  selectedSkills: string[],
+  selectedSkills: Skill[],
   source: ChoiceSource
 ): ChoiceData {
-  // Convert string skill names to Skill enum values
-  const skillEnums = selectedSkills
-    .map((skillStr) => {
-      // Try to find the enum value for this skill string
-      const enumValue = Object.entries(Skill).find(
-        ([key, val]) =>
-          typeof val === 'number' &&
-          key.toLowerCase() === skillStr.toLowerCase().replace(/[^a-z]/g, '')
-      )?.[1] as Skill | undefined;
-      return enumValue || Skill.UNSPECIFIED;
-    })
-    .filter((s) => s !== Skill.UNSPECIFIED);
-
   return create(ChoiceDataSchema, {
     choiceId,
     category: ChoiceCategory.EXPERTISE,
@@ -159,7 +146,7 @@ export function convertExpertiseChoiceToProto(
     selection: {
       case: 'expertise',
       value: create(ExpertiseSelectionSchema, {
-        skills: skillEnums,
+        skills: selectedSkills.filter((s) => s !== Skill.UNSPECIFIED),
       }),
     },
   });


### PR DESCRIPTION
## Summary

Closes #437. Pairs with KirkDiggler/rpg-api#626 (advertises the Expertise requirement this depends on).

- `ChoiceRenderer` had no `EXPERTISE` case and fell through to `SimpleChoice`, which cannot select anything. Added a case mirroring `FIGHTING_STYLE`/`SKILLS`: `EnumChoice` grouped by ability, backed by `choice.options.value.availableSkills` (`ExpertiseOptions`).
- `ClassSelectionModal`'s catch-all ("Other Choices") was storing EXPERTISE selections into `choices.proficiencies` (a dead end) instead of `choices.expertise`, which the already-existing downstream wiring (`utils/choiceConverter.ts` `convertExpertiseChoiceToProto`, `InteractiveCharacterSheet.tsx`) expects. Added a dedicated Expertise block (same pattern as the Skills block) plus validation in `handleSelect()`, and excluded EXPERTISE from the catch-all filter.
- Found and fixed a real bug in `convertExpertiseChoiceToProto` while wiring this up: it matched a regex-stripped selection string (`skillStr.toLowerCase().replace(/[^a-z]/g, '')`) against the *raw* Skill enum key (`key.toLowerCase()`, underscore intact), so it could never match any multi-word skill name — verified with a standalone repro of the exact regex before touching it (`stealth` matches, `sleight-of-hand` never does, regardless of format). Changed `ExpertiseChoice.skills` from `string[]` to `Skill[]` (enum values) and simplified the converter to match its siblings (`convertSkillChoiceToProto`, `convertToolChoiceToProto`), which the file's own header comment already describes as the intended pattern ("no string manipulation, no guessing - just direct enum usage").

`CharacterSheetFooter.tsx` (orphaned `ValidateDraft` UI) was in scope to consider but not touched — wiring it in is a separate, non-trivial change (new error-surface pattern across the whole finalize flow) and would have diluted this fix; leaving it for a follow-up rather than half-wiring it.

## Load-bearing

Verified live end-to-end via Chrome DevTools MCP: ran `rpg-api` (branch `fix/advertise-expertise`) + envoy grpc-web proxy + this build's `npm run dev` locally, drove the full character creation flow in a real browser — name, Rogue class with 4 skills + **2 expertise skills including "Sleight of Hand"** (deliberately chosen to prove the multi-word-skill bug fix), equipment, Human race with a language choice, Criminal background, ability scores — and finalized. Character "Shadow" was created successfully and appears on the character list / sheet.

One real gap found and scoped out, not fixed here: the finalized character (fetched via `GetCharacter`) shows Stealth and Sleight of Hand both at +4 — identical to a plain proficient skill, not the +6 that doubled proficiency would produce.

**Correction**: an earlier version of this note incorrectly blamed rpg-toolkit for this. Re-traced with the pinned toolkit version and the toolkit is correct end to end (expertise correctly compiles to a `shared.Expert` proficiency level and `GetSkillModifier` doubles it). The actual break is in rpg-api's `ConvertCharacterDataToProto`, which flattens proficiency level into a boolean list before it ever reaches the wire — `DnDSkills.tsx` here is doing the only thing it can with what the API gives it (`abilityModifier + proficiencyBonus` for every skill in the flat list); it has no way to know a skill has expertise. Full trace, evidence, and recommended fix shape (expose the already-computed modifier per skill rather than a raw level, per the render-never-calculate boundary) filed as KirkDiggler/rpg-api#627 — needs a proto schema change plus rpg-api and this repo's `DnDSkills.tsx`, genuinely separate from this PR.

## Test plan

- `npx vitest run` — 653/653 tests pass across 37 files, including 3 new tests in `src/components/ChoiceRenderer.test.tsx` proving EXPERTISE renders via `EnumChoice` (not `SimpleChoice`) and reports selections as `Skill[]` via `onSelectionChange`
- `npm run typecheck` — clean
- `npm run lint` — clean (0 errors; 2 pre-existing warnings in unrelated `LobbyView.tsx`)
- `npm run format:check` — clean
- `npm run ci-check` — all checks pass (format, lint, typecheck, build, tests)
- Full browser e2e verification as described above (Load-bearing section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpYTxv1QkBQx98n34AL9w2
