### PR TITLE
feat(game): GameView — LobbyFlow + EncounterView on the shared harness architecture

### DIFF
--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -1,0 +1,57 @@
+---
+name: GameView
+description: The live game path's successor to LobbyView — party assembly (LobbyFlow) then a live encounter (EncounterView), built entirely on the shared harness stack
+updated: 2026-07-08
+confidence: high — verified by reading every new file in full, running the full vitest suite (656 passing), and cross-checking rpg-api's start_encounter.go entity-id claim
+---
+
+# GameView
+
+`src/components/game/GameView.tsx` — mounted by `App.tsx` on the route `LobbyView` used to occupy. Slice 2 of the [game screen rebuild](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/design.md) (rpg-dnd5e-web#440). `LobbyView.tsx` itself is untouched and now unreferenced — its deletion is slice 3, not this one.
+
+GameView is a two-state switch, nothing more:
+
+```
+GameView
+├── LobbyFlow        (no encounterId yet)
+└── EncounterView     (encounterId set, from LobbyFlow's onEncounterStarted)
+```
+
+## LobbyFlow — party assembly
+
+`src/components/game/LobbyFlow.tsx`, backed by the new `dnd5e.api.lobby.v1alpha1` `LobbyService` (rpg-api-protos#177, rpg-api#630 — [lobby-surface.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/lobby-surface.md)). This is a distinct proto package and client (`lobbyClient` in `src/api/client.ts`) from the v1alpha1 `EncounterService`'s legacy `CreateEncounter`/`JoinEncounter`/`SetReady` RPCs, which `LobbyView` still uses until slice 3.
+
+- **Create**: `useCreateLobby` — caller becomes host, binds `characterId`.
+- **Join**: `useJoinLobby` — takes the opaque `join_ref` minted at create. Idempotent and rebinding (a second call re-binds `characterId` rather than erroring).
+- **Dev join-ref carrier**: `LobbyFlow` reads a `?joinRef=` URL param once on mount and auto-joins — the dev/playtest equivalent of the Discord Activity's automatic instance carrier (lobby-surface.md Decision 2). This is what keeps multi-browser MCP playtest joins trivial without Discord.
+- **Ready / start**: `useSetLobbyReady` toggles the caller's flag; `useStartLobbyEncounter` is host-only and gated all-ready server-side. On success `LobbyFlow` drives off both the RPC response _and_ the stream's `encounter_started` (belt-and-suspenders — see `useLobbyStream`'s docstring).
+- **Roster**: `useLobbyStream` (`StreamLobby`, snapshot-then-deltas — the same pattern as `useEncounterStream2`) feeds `PartyRoster`, which renders `is_host`/`is_ready`/`is_connected` verbatim, never inferred.
+
+`useLobbyStream` and its event dispatcher (`src/api/lobbyStreamDispatch.ts`) are a deliberate sibling of `useEncounterStream2`/`encounterStream2Dispatch.ts` — same reconnect config (`streamReconnect.ts`), same snapshot-first contract, but no envelope (the lobby has no causation chain to reassemble) and a short-lived stream that ends the moment `encounter_started` fires.
+
+## EncounterView — the shared harness stack
+
+`src/components/game/EncounterView.tsx`. Per design.md's "Already shared or generic" survey, this slice does not build a new combat engine — it composes the pieces `PlaytestHarness` already proved out:
+
+| Piece          | Source                                                                                 | Notes                                                                                                                                                                                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stream + state | `useEncounterStream2` + `useEncounterState`                                            | Same hooks, same dispatch. Zero harness assumptions in either.                                                                                                                                                                                                                                       |
+| Action menu    | `ActionMenu` / `EconomyBar` (`components/playtest/`)                                   | Rendered verbatim off server-pushed `TurnState` — no client legality logic. Slice 2 renders these directly; a game-grade `ActionPanel` wrapper is a later slice, per #440's scope.                                                                                                                   |
+| Map            | `EncounterMap` (new, `components/game/`)                                               | Thin HexGrid adapter, generalized from `PlaytestMap` — both now import `synthesizeFloorTiles`/`buildRenderableEntities` from the pre-existing shared `components/playtest/playtestMapHelpers.ts`. Single room only; multi-room accumulation is slice 4.                                              |
+| Prompts        | `PromptModal` (new, `components/game/`)                                                | Extracted from `PlaytestHarness` (Wave 2.9/2.11d inline JSX) so both surfaces dispatch `SubmitCheck` through one component instead of two copies drifting apart. `PlaytestHarness` now renders this component too — same testids, same behavior, verified by its existing (unmodified) vitest suite. |
+| Formatting     | `errorMessage`, `formatStatusBadges`, `formatSourceRefs` (`src/utils/combatFormat.ts`) | Also extracted out of `PlaytestHarness` for the same reason.                                                                                                                                                                                                                                         |
+
+### entityId is `characterId`, not `char-<playerId>`
+
+The local player's `entityId` in an `EncounterView` is the `characterId` bound at lobby create/join — **not** `char-<playerId>`, the shortcut `PlaytestHarness` uses (which only works there because devseed happens to name characters that way). This is because `StartEncounter` seeds the toolkit encounter with `EntityID: core.EntityID(m.CharacterID)` per ready member (rpg-api `internal/orchestrators/lobby/start_encounter.go`) — confirmed by reading that file directly, not inferred.
+
+### Scope explicitly excluded this slice
+
+Equipment modal, dungeon result overlay, and multi-room accumulation are not built here — see design.md's slice breakdown (2 vs 4) and #440's issue body. `EncounterMap` also does not wire door interaction: `HexGrid`'s door-click surface needs a `DoorInfo[]` the v2 stream doesn't accumulate yet, the same gap documented in `playtest-harness.md`'s known limitations.
+
+## Related references
+
+- [design.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/design.md) — parent design, target shape, deletion list, slice breakdown
+- [lobby-surface.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/lobby-surface.md) — LobbyService contract, decisions, edge cases
+- [playtest-harness.md](playtest-harness.md) — the harness `EncounterView` shares its stack with
+- rpg-dnd5e-web#440 (this slice), #432 (umbrella), rpg-project#81 (wave umbrella)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.103",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.104",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1390,7 +1390,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#6fc5a23bd29ddc09569fe9bddb2287db1257b39d",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#e1dbc19e727494a1e3c36e67becee5b6aad2a0bd",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.103",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.104",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,8 @@ import { CharacterDraftProvider } from './character/creation/CharacterDraftConte
 import { InteractiveCharacterSheet } from './character/creation/InteractiveCharacterSheet';
 import { useCharacterDraft } from './character/creation/useCharacterDraft';
 import { CharacterSheet } from './character/sheet/CharacterSheet';
+import { GameView } from './components/game/GameView';
 import { CharacterCarousel, SelectedCharacterPanel } from './components/home';
-import { LobbyView } from './components/LobbyView';
 import { PlaytestHarness } from './components/playtest/PlaytestHarness';
 import { ThemeSelector } from './components/ThemeSelector';
 import { ConceptsView } from './concepts/ConceptsView';
@@ -214,8 +214,12 @@ function AppContent() {
               <p className="mt-4 text-red-500">{discord.error}</p>
             )}
           </motion.div>
-        ) : currentView === 'lobby' ? (
-          <LobbyView characterId={lobbyCharacterId} onBack={handleBackToHome} />
+        ) : currentView === 'lobby' && lobbyCharacterId ? (
+          <GameView
+            characterId={lobbyCharacterId}
+            playerId={playerId || 'test-player'}
+            onBack={handleBackToHome}
+          />
         ) : currentView === 'concepts' ? (
           <ConceptsView onBack={handleBackToHome} />
         ) : currentView === 'home' ? (

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,7 @@ import type { Interceptor } from '@connectrpc/connect';
 import { createClient } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { DiceService } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/dice_pb';
+import { LobbyService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
 import { CharacterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { EncounterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import { EncounterService as EncounterServiceV2 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
@@ -88,3 +89,9 @@ export const encounterClient = createClient(EncounterService, transport);
 
 // Create the v1alpha2 encounter service client
 export const encounterClientV2 = createClient(EncounterServiceV2, transport);
+
+// Create the lobby service client (dnd5e.api.lobby.v1alpha1 — party assembly,
+// GameView slice 2). Separate service from v1alpha1 EncounterService's old
+// CreateEncounter/JoinEncounter/SetReady lobby RPCs, which LobbyView still
+// uses until slice 3's deletion.
+export const lobbyClient = createClient(LobbyService, transport);

--- a/src/api/lobbyStreamDispatch.ts
+++ b/src/api/lobbyStreamDispatch.ts
@@ -1,0 +1,80 @@
+import type {
+  EncounterStarted,
+  HostChanged,
+  LobbyEvent,
+  LobbySnapshot,
+  MemberConnectionChanged,
+  MemberJoined,
+  MemberLeft,
+  MemberReady,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/events_pb';
+
+/**
+ * Per-event-type callbacks for the lobby stream. Mirrors
+ * encounterStream2Dispatch's shape — one optional callback per oneof case.
+ *
+ * Unlike EncounterEvent, LobbyEvent carries no envelope (sequence,
+ * timestamp, correlation_id) — the lobby has no causation chains to
+ * reassemble and the stream is short-lived, ending the moment
+ * encounter_started fires (lobby-surface.md's LobbyEvent doc comment).
+ */
+export interface LobbyStreamOptions {
+  /** Always the first event delivered on a new StreamLobby subscription. */
+  onSnapshot?: (event: LobbySnapshot) => void;
+  onMemberJoined?: (event: MemberJoined) => void;
+  onMemberLeft?: (event: MemberLeft) => void;
+  onMemberReady?: (event: MemberReady) => void;
+  /**
+   * Presence, not membership: a dropped StreamLobby subscription flips
+   * is_connected false but keeps the seat. Only memberLeft removes a member.
+   */
+  onMemberConnectionChanged?: (event: MemberConnectionChanged) => void;
+  /** Host role migrated (host left) to the oldest remaining member. */
+  onHostChanged?: (event: HostChanged) => void;
+  /**
+   * Terminal event — WAITING -> STARTED. No further LobbyEvent follows on
+   * this stream; consumers drop the lobby stream and subscribe
+   * StreamEncounter(encounter_id) instead.
+   */
+  onEncounterStarted?: (event: EncounterStarted) => void;
+}
+
+/**
+ * Dispatches a typed LobbyEvent to the appropriate callback. Pure function;
+ * no side effects beyond callback invocation + a console.warn on an unknown
+ * event case (gap to file as a proto version mismatch).
+ */
+export function dispatchLobbyStreamEvent(
+  event: LobbyEvent,
+  options: LobbyStreamOptions
+): void {
+  const payload = event.event;
+  switch (payload.case) {
+    case 'snapshot':
+      options.onSnapshot?.(payload.value);
+      break;
+    case 'memberJoined':
+      options.onMemberJoined?.(payload.value);
+      break;
+    case 'memberLeft':
+      options.onMemberLeft?.(payload.value);
+      break;
+    case 'memberReady':
+      options.onMemberReady?.(payload.value);
+      break;
+    case 'memberConnectionChanged':
+      options.onMemberConnectionChanged?.(payload.value);
+      break;
+    case 'hostChanged':
+      options.onHostChanged?.(payload.value);
+      break;
+    case 'encounterStarted':
+      options.onEncounterStarted?.(payload.value);
+      break;
+    default:
+      console.warn(
+        '[useLobbyStream] unhandled event case:',
+        (payload as { case?: string }).case
+      );
+  }
+}

--- a/src/api/useCreateLobby.ts
+++ b/src/api/useCreateLobby.ts
@@ -1,0 +1,55 @@
+import { create } from '@bufbuild/protobuf';
+import type { CreateLobbyResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { CreateLobbyRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { useCallback, useState } from 'react';
+import { lobbyClient } from './client';
+
+export interface UseCreateLobbyInput {
+  campaignId: string;
+  characterId: string;
+}
+
+export interface UseCreateLobbyResult {
+  /**
+   * Calls CreateLobby. The caller becomes host and binds characterId as
+   * their seat. Returns {lobbyId, joinRef, hostPlayerId} — joinRef is the
+   * opaque dev-carrier value other players supply to JoinLobby (URL param
+   * or displayed short code).
+   */
+  createLobby: (input: UseCreateLobbyInput) => Promise<CreateLobbyResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/** Thin wrapper around the LobbyService CreateLobby unary RPC. */
+export function useCreateLobby(): UseCreateLobbyResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const createLobby = useCallback(
+    async (input: UseCreateLobbyInput): Promise<CreateLobbyResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(CreateLobbyRequestSchema, {
+        campaignId: input.campaignId,
+        characterId: input.characterId,
+      });
+
+      try {
+        const response = await lobbyClient.createLobby(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('CreateLobby RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { createLobby, loading, error };
+}

--- a/src/api/useJoinLobby.ts
+++ b/src/api/useJoinLobby.ts
@@ -1,0 +1,56 @@
+import { create } from '@bufbuild/protobuf';
+import type { JoinLobbyResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { JoinLobbyRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { useCallback, useState } from 'react';
+import { lobbyClient } from './client';
+
+export interface UseJoinLobbyInput {
+  /** Opaque ref minted at CreateLobby — the dev carrier is a URL param or entered short code. */
+  joinRef: string;
+  characterId: string;
+}
+
+export interface UseJoinLobbyResult {
+  /**
+   * Calls JoinLobby. Idempotent and rebinding — a player already in the
+   * lobby who calls again (reconnect, second tab, re-pick character) has
+   * characterId rebound rather than erroring. Returns FailedPrecondition
+   * if the lobby already STARTED or the party is at cap.
+   */
+  joinLobby: (input: UseJoinLobbyInput) => Promise<JoinLobbyResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/** Thin wrapper around the LobbyService JoinLobby unary RPC. */
+export function useJoinLobby(): UseJoinLobbyResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const joinLobby = useCallback(
+    async (input: UseJoinLobbyInput): Promise<JoinLobbyResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(JoinLobbyRequestSchema, {
+        joinRef: input.joinRef,
+        characterId: input.characterId,
+      });
+
+      try {
+        const response = await lobbyClient.joinLobby(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('JoinLobby RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { joinLobby, loading, error };
+}

--- a/src/api/useLobbyStream.ts
+++ b/src/api/useLobbyStream.ts
@@ -1,0 +1,129 @@
+import { create } from '@bufbuild/protobuf';
+import type { LobbyEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/events_pb';
+import { StreamLobbyRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { useEffect, useRef, useState } from 'react';
+import { lobbyClient } from './client';
+import {
+  dispatchLobbyStreamEvent,
+  type LobbyStreamOptions,
+} from './lobbyStreamDispatch';
+import { RECONNECT_CONFIG } from './streamReconnect';
+
+type ConnectionState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnected'
+  | 'error';
+
+interface UseLobbyStreamResult {
+  connectionState: ConnectionState;
+  error: Error | null;
+}
+
+/**
+ * Subscribes to the LobbyService StreamLobby RPC. Sibling of
+ * useEncounterStream2 — same snapshot-then-deltas contract, same reconnect
+ * config, but no envelope and no playerId request field (StreamLobbyRequest
+ * takes only lobby_id; the subscriber's identity for presence tracking
+ * comes from the authenticated context — see StreamLobbyRequest's doc
+ * comment in service.proto).
+ *
+ * Lifecycle:
+ *   1. lobbyId set -> open stream, state='connecting'
+ *   2. First message is always LobbySnapshot -> state='connected'
+ *   3. Subsequent events dispatched via dispatchLobbyStreamEvent
+ *   4. encounter_started is terminal — the server closes the stream after
+ *      publishing it; callers unmount this hook (by clearing lobbyId) once
+ *      onEncounterStarted fires rather than waiting for the close to
+ *      trigger a reconnect loop against a lobby that no longer accepts
+ *      subscribers.
+ *   5. Stream end / error otherwise -> state='disconnected' -> exponential
+ *      backoff reconnect (shared RECONNECT_CONFIG with the encounter hooks).
+ */
+export function useLobbyStream(
+  lobbyId: string | null,
+  options: LobbyStreamOptions
+): UseLobbyStreamResult {
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>('idle');
+  const [error, setError] = useState<Error | null>(null);
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const retryCountRef = useRef(0);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const abortControllerRef = useRef<AbortController | undefined>(undefined);
+
+  useEffect(() => {
+    if (!lobbyId) {
+      setConnectionState('idle');
+      return;
+    }
+
+    const scheduleReconnect = () => {
+      if (retryCountRef.current >= RECONNECT_CONFIG.maxAttempts) {
+        setConnectionState('error');
+        setError(new Error('Max reconnection attempts reached'));
+        return;
+      }
+      setConnectionState('disconnected');
+      const delay = Math.min(
+        RECONNECT_CONFIG.initialDelayMs *
+          Math.pow(RECONNECT_CONFIG.backoffMultiplier, retryCountRef.current),
+        RECONNECT_CONFIG.maxDelayMs
+      );
+      retryCountRef.current++;
+      retryTimeoutRef.current = setTimeout(connect, delay);
+    };
+
+    const connect = async () => {
+      setConnectionState('connecting');
+      setError(null);
+      abortControllerRef.current = new AbortController();
+
+      try {
+        const request = create(StreamLobbyRequestSchema, { lobbyId });
+        const stream = lobbyClient.streamLobby(request, {
+          signal: abortControllerRef.current.signal,
+        });
+
+        let sawFirstSnapshot = false;
+        for await (const event of stream as AsyncIterable<LobbyEvent>) {
+          if (!sawFirstSnapshot) {
+            dispatchLobbyStreamEvent(event, optionsRef.current);
+            sawFirstSnapshot = true;
+            setConnectionState('connected');
+            retryCountRef.current = 0;
+            continue;
+          }
+          dispatchLobbyStreamEvent(event, optionsRef.current);
+        }
+
+        // Stream closed by server — expected on encounter_started (terminal);
+        // the caller clears lobbyId in response to onEncounterStarted, which
+        // tears this effect down before scheduleReconnect would fire again
+        // for the same lobby.
+        scheduleReconnect();
+      } catch (err) {
+        if (abortControllerRef.current?.signal.aborted) {
+          return; // intentional abort, not an error
+        }
+        console.error('[useLobbyStream] stream error:', err);
+        scheduleReconnect();
+      }
+    };
+
+    connect();
+
+    return () => {
+      abortControllerRef.current?.abort();
+      clearTimeout(retryTimeoutRef.current);
+    };
+  }, [lobbyId]);
+
+  return { connectionState, error };
+}

--- a/src/api/useSetLobbyReady.ts
+++ b/src/api/useSetLobbyReady.ts
@@ -1,0 +1,58 @@
+import { create } from '@bufbuild/protobuf';
+import type { SetReadyResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { SetReadyRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { useCallback, useState } from 'react';
+import { lobbyClient } from './client';
+
+export interface UseSetLobbyReadyInput {
+  lobbyId: string;
+  ready: boolean;
+}
+
+export interface UseSetLobbyReadyResult {
+  /**
+   * Calls SetReady. Toggles the caller's ready flag; the server broadcasts
+   * member_ready on StreamLobby — the response itself is a lean ack, so
+   * callers read the new state back off the stream, not this return value.
+   */
+  setReady: (input: UseSetLobbyReadyInput) => Promise<SetReadyResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Thin wrapper around the LobbyService SetReady unary RPC. Named
+ * useSetLobbyReady (not useSetReady) to stay distinguishable from the
+ * v1alpha1 useSetReady in lobbyHooks.ts, which LobbyView still uses.
+ */
+export function useSetLobbyReady(): UseSetLobbyReadyResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const setReady = useCallback(
+    async (input: UseSetLobbyReadyInput): Promise<SetReadyResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(SetReadyRequestSchema, {
+        lobbyId: input.lobbyId,
+        ready: input.ready,
+      });
+
+      try {
+        const response = await lobbyClient.setReady(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('SetReady RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { setReady, loading, error };
+}

--- a/src/api/useStartLobbyEncounter.ts
+++ b/src/api/useStartLobbyEncounter.ts
@@ -1,0 +1,58 @@
+import { create } from '@bufbuild/protobuf';
+import type { StartEncounterResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { StartEncounterRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { useCallback, useState } from 'react';
+import { lobbyClient } from './client';
+
+export interface UseStartLobbyEncounterInput {
+  lobbyId: string;
+}
+
+export interface UseStartLobbyEncounterResult {
+  /**
+   * Calls StartEncounter. Host-only and all-ready gated server-side —
+   * returns PermissionDenied / FailedPrecondition if the caller isn't the
+   * host or a member isn't ready yet. Returns the new encounterId; the
+   * server also broadcasts encounter_started on StreamLobby so every
+   * member (not just the caller) switches to StreamEncounter.
+   */
+  startEncounter: (
+    input: UseStartLobbyEncounterInput
+  ) => Promise<StartEncounterResponse>;
+  loading: boolean;
+  error: Error | null;
+}
+
+/** Thin wrapper around the LobbyService StartEncounter unary RPC. */
+export function useStartLobbyEncounter(): UseStartLobbyEncounterResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const startEncounter = useCallback(
+    async (
+      input: UseStartLobbyEncounterInput
+    ): Promise<StartEncounterResponse> => {
+      setLoading(true);
+      setError(null);
+
+      const request = create(StartEncounterRequestSchema, {
+        lobbyId: input.lobbyId,
+      });
+
+      try {
+        const response = await lobbyClient.startEncounter(request);
+        return response;
+      } catch (err) {
+        const wrapped =
+          err instanceof Error ? err : new Error('StartEncounter RPC failed');
+        setError(wrapped);
+        throw wrapped;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return { startEncounter, loading, error };
+}

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -1,0 +1,101 @@
+/**
+ * EncounterMap — the game route's hex-grid adapter, generalized from
+ * PlaytestMap (see rpg-project's design.md: "harness-specific — generalize,
+ * don't lift"). Same wrapping pattern as PlaytestMap — thin props-to-HexGrid
+ * translation, with all real logic (floor-tile synthesis, renderable-entity
+ * construction) staying in the shared `playtestMapHelpers.ts` both
+ * components import. HexGrid itself is already shared (design.md: "Already
+ * shared or generic").
+ *
+ * Single room this slice (GameView slice 2, #440) — multi-room accumulation
+ * is slice 4, scheduled with The Dungeon leg's multi-room trailblazer.
+ */
+
+import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import { useMemo } from 'react';
+import type { EntityMeta } from '../../hooks/useEncounterState';
+import { HexGrid } from '../hex-grid';
+import type { CubeCoord } from '../hex-grid/hexMath';
+import {
+  buildRenderableEntities,
+  synthesizeFloorTiles,
+} from '../playtest/playtestMapHelpers';
+
+export interface EncounterMapProps {
+  /** Unified entity store from useEncounterState (v1alpha1 EntityState stubs, entityId + position). */
+  entities: Map<string, EntityState & { ghost?: boolean }>;
+  /** v1alpha2 identity metadata (type, monsterRefId) keyed by entityId. */
+  entityMeta: Map<string, EntityMeta>;
+  /** Per-hex reveal set ("x,y,z" cube-coord keys) from GeometryRevealed events. */
+  revealedHexes: Set<string>;
+  /** Per-entity HP — marks monsters dead (HP <= 0) so HexGrid renders their corpse. */
+  entityHP: Map<string, { current: number; max: number }>;
+  /** Local player's entity id — the character bound at lobby create/join, not derived from playerId. */
+  myEntityId: string;
+  /** True when the local player can act this turn; forced true outside TURN_BASED so clicks still dispatch. */
+  isMyTurn: boolean;
+  /** Movement budget for the path-preview overlay only — the server enforces the real budget. */
+  movementRemaining?: number;
+  /** Full computed path (start + intermediates + end) when a hex click lands a move. */
+  onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
+  /** Clicked entity id — caller dispatches attack for monsters or selects for characters. */
+  onEntityClick: (entityId: string) => void;
+}
+
+const DEFAULT_MOVEMENT_FEET = 30;
+
+export function EncounterMap({
+  entities,
+  entityMeta,
+  revealedHexes,
+  entityHP,
+  myEntityId,
+  isMyTurn,
+  movementRemaining = DEFAULT_MOVEMENT_FEET,
+  onMove,
+  onEntityClick,
+}: EncounterMapProps) {
+  const floorTiles = useMemo(
+    () => synthesizeFloorTiles(revealedHexes, entities.values()),
+    [revealedHexes, entities]
+  );
+
+  const renderableEntities = useMemo(
+    () => buildRenderableEntities(entities, entityMeta, entityHP),
+    [entities, entityMeta, entityHP]
+  );
+
+  return (
+    <div
+      data-testid="encounter-map"
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        minHeight: 360,
+        background: '#0a0a0a',
+        border: '1px solid #333',
+        borderRadius: 4,
+      }}
+    >
+      <HexGrid
+        floorTiles={floorTiles}
+        entities={renderableEntities}
+        selectedEntityId={myEntityId}
+        currentEntityId={myEntityId}
+        movementRemaining={movementRemaining}
+        isPlayerTurn={isMyTurn}
+        combatState={null}
+        onMoveComplete={(path: CubeCoord[]) => {
+          onMove(path.map((c) => ({ x: c.x, y: c.y, z: c.z })));
+        }}
+        onEntityClick={(targetId: string) => {
+          onEntityClick(targetId);
+        }}
+        // Deliberately not wired — see PlaytestMap's identical note: HexGrid
+        // fires both onAttackComplete AND onEntityClick for an attackable
+        // monster click, so wiring both here would double-dispatch.
+      />
+    </div>
+  );
+}

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -1,0 +1,411 @@
+/**
+ * EncounterView — GameView slice 2's live-combat surface (#440). Mounts when
+ * LobbyFlow's StreamLobby delivers encounter_started. Built entirely on the
+ * shared harness stack (design.md: "Already shared or generic"):
+ * useEncounterStream2 + useEncounterState for the SnapshotDelivered-first
+ * flow, ActionMenu/EconomyBar rendered verbatim off the server-pushed
+ * TurnState, EncounterMap (HexGrid) for movement/targeting, and PromptModal
+ * for skill-check/reaction prompts — the same component PlaytestHarness
+ * renders, not a copy.
+ *
+ * The local player's entityId is the bound `characterId` (what
+ * StartEncounter used as the toolkit AddPlayer EntityID — see
+ * rpg-api's lobby orchestrator start_encounter.go), NOT `char-<playerId>`.
+ * That shortcut only works in the harness because devseed happens to name
+ * characters that way; GameView threads the real characterId through
+ * instead (see GameView/LobbyFlow props).
+ *
+ * Single room this slice — multi-room accumulation is slice 4. Door
+ * interaction is out of scope here too: HexGrid's door-click surface needs a
+ * DoorInfo[] the v2 stream doesn't accumulate yet (the same documented gap
+ * PlaytestMap has — see docs/architecture/components/playtest-harness.md
+ * "Known limitations"), and devseed's single-room fixture has no door to
+ * exercise it against.
+ */
+
+import { create } from '@bufbuild/protobuf';
+import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  EncounterMode,
+  EntityType,
+  TargetKind,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { useState } from 'react';
+import { v2PositionToV1 } from '../../api/positionConvert';
+import { useEncounterStream2 } from '../../api/useEncounterStream2';
+import { useEndTurnV2 } from '../../api/useEndTurnV2';
+import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
+import { useTakeActionV2 } from '../../api/useTakeActionV2';
+import { useEncounterState } from '../../hooks/useEncounterState';
+import { errorMessage, formatStatusBadges } from '../../utils/combatFormat';
+import { protoPositionToHex } from '../../utils/hexCoord';
+import { ActionMenu } from '../playtest/ActionMenu';
+import { targetKindNeedsPrompt } from '../playtest/actionMenuHelpers';
+import { EconomyBar } from '../playtest/EconomyBar';
+import { EncounterMap } from './EncounterMap';
+import { PromptModal } from './PromptModal';
+
+const ATTACK_ACTION_REF = {
+  module: 'dnd5e',
+  type: 'action',
+  id: 'attack',
+} as const;
+
+const MODE_LABEL: Record<EncounterMode, string> = {
+  [EncounterMode.UNSPECIFIED]: 'UNSPECIFIED',
+  [EncounterMode.FREE_ROAM]: 'FREE_ROAM',
+  [EncounterMode.TURN_BASED]: 'TURN_BASED',
+};
+
+export interface EncounterViewProps {
+  encounterId: string;
+  /** The character bound at lobby create/join — the entity id in this encounter. */
+  characterId: string;
+  /** The authenticated player id — carried on the stream request for viewer identity. */
+  playerId: string;
+  onBack: () => void;
+}
+
+export function EncounterView({
+  encounterId,
+  characterId,
+  playerId,
+  onBack,
+}: EncounterViewProps) {
+  const entityId = characterId;
+  const encounterState = useEncounterState();
+  // Set by clicking any entity on the map — feeds SINGLE_ENTITY-targeted
+  // menu actions (e.g. a spell chosen after the player clicks its target).
+  // Clicking a monster additionally fires an immediate basic attack, the
+  // same primary-loop shortcut PlaytestMap's VisualAttack click gives the
+  // harness.
+  const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null);
+  const { moveEntity, error: moveError } = useMoveEntityV2();
+  const {
+    takeAction,
+    loading: takeActionLoading,
+    error: takeActionError,
+  } = useTakeActionV2();
+  const {
+    endTurn,
+    loading: endTurnLoading,
+    error: endTurnError,
+  } = useEndTurnV2();
+
+  const stream = useEncounterStream2(encounterId, playerId, {
+    onSnapshotDelivered: (e) => {
+      if (e.encounter) {
+        encounterState.applyV2SnapshotTurnState(
+          e.encounter.mode,
+          e.encounter.turnState
+        );
+        const entityEntries = (e.encounter.space?.entities ?? [])
+          .filter((entity) => entity.position !== undefined)
+          .map((entity) => ({
+            entity: create(EntityStateSchema, {
+              entityId: entity.id,
+              position: v2PositionToV1(entity.position!),
+            }),
+            type: entity.type,
+            monsterRefId:
+              entity.data?.case === 'monster'
+                ? entity.data.value.monsterRef?.id
+                : undefined,
+            initialHP: entity.hp
+              ? { current: entity.hp.current, max: entity.hp.max }
+              : undefined,
+            initialAC: entity.armorClass,
+          }));
+        if (entityEntries.length > 0) {
+          encounterState.applyEntityAppearedBatch(entityEntries);
+        }
+      }
+    },
+    onEntityMoved: (e) => {
+      const last = e.actualPath[e.actualPath.length - 1];
+      if (last) {
+        encounterState.applyEntityPositionUpdate(
+          e.entityId,
+          v2PositionToV1(last)
+        );
+      }
+    },
+    onGeometryRevealed: (e) => {
+      const positions = e.hexes
+        .map((h) => h.position)
+        .filter((p): p is NonNullable<typeof p> => p !== undefined);
+      encounterState.applyHexRevealed(positions.map(protoPositionToHex));
+    },
+    onEntityAppeared: (e) => {
+      if (!e.entity || !e.entity.position) return;
+      const stub = create(EntityStateSchema, {
+        entityId: e.entity.id,
+        position: v2PositionToV1(e.entity.position),
+      });
+      encounterState.applyEntityAppeared(stub);
+      const monsterRefId =
+        e.entity.data?.case === 'monster'
+          ? e.entity.data.value.monsterRef?.id
+          : undefined;
+      const initialHP = e.entity.hp
+        ? { current: e.entity.hp.current, max: e.entity.hp.max }
+        : undefined;
+      encounterState.applyEntityMeta(
+        e.entity.id,
+        e.entity.type,
+        monsterRefId,
+        initialHP,
+        e.entity.armorClass
+      );
+    },
+    onEntityDisappeared: (e) => {
+      if (e.lastKnownPosition) {
+        encounterState.applyEntityDisappeared(
+          e.entityId,
+          protoPositionToHex(e.lastKnownPosition)
+        );
+      }
+    },
+    onEntityDamaged: (e) => {
+      encounterState.applyEntityDamaged(e);
+    },
+    onStatusApplied: (e) => {
+      encounterState.applyStatusApplied(e);
+    },
+    onStatusRemoved: (e) => {
+      encounterState.applyStatusRemoved(e);
+    },
+    onModeChanged: (e) => {
+      encounterState.applyModeChanged(e);
+    },
+    onTurnStarted: (e) => {
+      encounterState.applyTurnStarted(e);
+    },
+    onTurnEnded: () => {
+      encounterState.applyTurnEnded();
+    },
+    onTurnStateChanged: (e) => {
+      encounterState.applyTurnStateChanged(e.turnState);
+    },
+    onEntityDied: (e) => {
+      encounterState.applyEntityDied(e);
+    },
+    onEntityRemoved: (e) => {
+      encounterState.applyEntityRemoved(e);
+    },
+    onEncounterEnded: (e) => {
+      encounterState.applyEncounterEnded(e);
+    },
+    onInputRequiredDelivered: (e) => {
+      if (!e.inputRequired) return;
+      encounterState.setPendingPrompt(e.inputRequired);
+    },
+  });
+
+  const myPosition = encounterState.state.entities.get(entityId)?.position;
+  const myHP = encounterState.state.entityHP.get(entityId);
+  const myStatuses = encounterState.state.entityStatuses.get(entityId) ?? [];
+  const encounterEnded = encounterState.state.encounterStatus === 'ended';
+  const isMyTurn =
+    encounterState.state.mode === EncounterMode.TURN_BASED &&
+    encounterState.state.activeEntityId === entityId;
+  const combatEnabled =
+    !encounterEnded &&
+    encounterState.state.mode === EncounterMode.TURN_BASED &&
+    isMyTurn;
+
+  const turnState = encounterState.state.turnState;
+  const availableActions = turnState?.availableActions ?? [];
+  const economy = turnState?.economy ?? null;
+
+  const dispatchAction = async (
+    actionRef: { module: string; type: string; id: string },
+    target: ActionTarget | undefined
+  ) => {
+    try {
+      await takeAction({
+        encounterId,
+        actorEntityId: entityId,
+        actionRef,
+        target: target ?? ({ kind: { case: undefined } } as ActionTarget),
+      });
+    } catch {
+      // error surfaced via takeActionError below
+    }
+  };
+
+  // TakeAction wave (#426): the server-menu drives what's dispatchable — the
+  // web reads target_kind off the menu entry (the server's verdict) and
+  // raises a target prompt only when required. Mirrors
+  // PlaytestHarness.handleSelectAction (design.md: "Already shared or
+  // generic" pattern), adapted for this view's targeting source: the
+  // harness reads a dev-panel target-id input, this view reads the map's
+  // click-to-select state (selectedTargetId) instead.
+  const handleSelectAction = async (action: AvailableAction) => {
+    if (!action.ref) return;
+    if (targetKindNeedsPrompt(action.targetKind)) {
+      if (action.targetKind === TargetKind.SINGLE_ENTITY && selectedTargetId) {
+        await dispatchAction(action.ref, {
+          kind: { case: 'entityId', value: selectedTargetId },
+        } as unknown as ActionTarget);
+      }
+      // POSITION / AREA, and SINGLE_ENTITY with nothing selected yet: no-op.
+      // No L1 action needs POSITION/AREA (matches the harness's current
+      // scope); SINGLE_ENTITY needs the player to click a target first.
+      return;
+    }
+    if (action.targetKind === TargetKind.SELF) {
+      await dispatchAction(action.ref, {
+        kind: { case: 'self', value: {} },
+      } as unknown as ActionTarget);
+      return;
+    }
+    await dispatchAction(action.ref, undefined);
+  };
+
+  const handleVisualMove = async (
+    path: Array<{ x: number; y: number; z: number }>
+  ) => {
+    if (encounterEnded || path.length === 0) return;
+    try {
+      await moveEntity(encounterId, entityId, path);
+    } catch {
+      // error surfaced via moveError below
+    }
+  };
+
+  const handleVisualEntityClick = (targetId: string) => {
+    if (targetId === entityId) return;
+    setSelectedTargetId(targetId);
+    if (encounterEnded) return;
+    const targetMeta = encounterState.state.entityMeta.get(targetId);
+    const isMonster = targetMeta?.type === EntityType.MONSTER;
+    if (!isMonster) return;
+    void dispatchAction(ATTACK_ACTION_REF, {
+      kind: { case: 'entityId', value: targetId },
+    } as unknown as ActionTarget);
+  };
+
+  const handleEndTurn = async () => {
+    try {
+      await endTurn(encounterId, entityId);
+    } catch {
+      // error surfaced via endTurnError below
+    }
+  };
+
+  return (
+    <div
+      data-testid="encounter-view"
+      style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+    >
+      <div
+        data-testid="encounter-header"
+        className="flex flex-wrap items-center gap-4 rounded-lg px-4 py-2"
+        style={{ background: 'var(--bg-secondary, #1a1a1a)' }}
+      >
+        <span>
+          mode: <strong>{MODE_LABEL[encounterState.state.mode]}</strong>
+        </span>
+        <span>
+          round: <strong>{encounterState.state.round}</strong>
+        </span>
+        <span>
+          active:{' '}
+          <strong>{encounterState.state.activeEntityId || '(none)'}</strong>
+        </span>
+        <span>
+          HP: <strong>{myHP ? `${myHP.current}/${myHP.max}` : '—'}</strong>
+        </span>
+        {myStatuses.length > 0 && (
+          <span data-testid="my-status-badges">
+            {formatStatusBadges(myStatuses)}
+          </span>
+        )}
+        <span style={{ marginLeft: 'auto', opacity: 0.6, fontSize: 12 }}>
+          {stream.connectionState}
+        </span>
+        <button onClick={onBack} style={{ fontSize: 12 }}>
+          Leave
+        </button>
+      </div>
+
+      {encounterEnded && (
+        <div
+          data-testid="encounter-ended-banner"
+          className="rounded-lg px-4 py-3 font-bold"
+          style={{ background: '#2a1a00', color: '#ffcc66' }}
+        >
+          Encounter ended
+          {encounterState.state.encounterEndedReason
+            ? `: ${encounterState.state.encounterEndedReason}`
+            : ''}
+        </div>
+      )}
+
+      <PromptModal
+        encounterId={encounterId}
+        entityId={entityId}
+        prompt={encounterState.state.pendingPrompt}
+        onDismiss={() => encounterState.setPendingPrompt(null)}
+      />
+
+      <div style={{ height: 480 }}>
+        <EncounterMap
+          entities={encounterState.state.entities}
+          entityMeta={encounterState.state.entityMeta}
+          revealedHexes={encounterState.state.revealedHexes}
+          entityHP={encounterState.state.entityHP}
+          myEntityId={entityId}
+          isMyTurn={
+            encounterState.state.mode === EncounterMode.TURN_BASED
+              ? isMyTurn
+              : true
+          }
+          onMove={(path) => void handleVisualMove(path)}
+          onEntityClick={handleVisualEntityClick}
+        />
+      </div>
+
+      {!myPosition && (
+        <div style={{ fontSize: 12, opacity: 0.6 }}>
+          Waiting for your position…
+        </div>
+      )}
+
+      <EconomyBar economy={economy} />
+      <ActionMenu
+        actions={availableActions}
+        enabled={combatEnabled}
+        loading={takeActionLoading}
+        onSelectAction={(a) => void handleSelectAction(a)}
+      />
+      <div>
+        <button
+          onClick={() => void handleEndTurn()}
+          disabled={!combatEnabled || endTurnLoading}
+        >
+          {endTurnLoading ? 'Ending…' : 'End turn'}
+        </button>
+      </div>
+
+      {moveError && (
+        <div style={{ color: '#f88', fontSize: 12 }}>
+          Move error: {errorMessage(moveError)}
+        </div>
+      )}
+      {takeActionError && (
+        <div style={{ color: '#f88', fontSize: 12 }}>
+          Action error: {errorMessage(takeActionError)}
+        </div>
+      )}
+      {endTurnError && (
+        <div style={{ color: '#f88', fontSize: 12 }}>
+          End turn error: {errorMessage(endTurnError)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/game/GameView.tsx
+++ b/src/components/game/GameView.tsx
@@ -1,0 +1,47 @@
+/**
+ * GameView — the live game path's successor to LobbyView (design.md's
+ * Target Shape). Slice 2 (#440) builds the two pieces that exist today:
+ * LobbyFlow (party assembly on the new LobbyService) and EncounterView (the
+ * shared harness stack). Equipment, the result overlay, and multi-room are
+ * later slices; this component's job is just the state machine between the
+ * two: lobby until `encounter_started`, then the encounter.
+ *
+ * LobbyView.tsx stays untouched and unreferenced — App.tsx now mounts
+ * GameView on the same route LobbyView used to occupy. Deleting LobbyView
+ * itself is slice 3, not this one.
+ */
+
+import { useState } from 'react';
+import { EncounterView } from './EncounterView';
+import { LobbyFlow } from './LobbyFlow';
+
+export interface GameViewProps {
+  /** The character selected on the home screen. */
+  characterId: string;
+  playerId: string;
+  onBack: () => void;
+}
+
+export function GameView({ characterId, playerId, onBack }: GameViewProps) {
+  const [encounterId, setEncounterId] = useState<string | null>(null);
+
+  if (encounterId) {
+    return (
+      <EncounterView
+        encounterId={encounterId}
+        characterId={characterId}
+        playerId={playerId}
+        onBack={onBack}
+      />
+    );
+  }
+
+  return (
+    <LobbyFlow
+      characterId={characterId}
+      playerId={playerId}
+      onEncounterStarted={setEncounterId}
+      onBack={onBack}
+    />
+  );
+}

--- a/src/components/game/LobbyFlow.tsx
+++ b/src/components/game/LobbyFlow.tsx
@@ -1,0 +1,256 @@
+/**
+ * LobbyFlow — GameView slice 2's party-assembly front end (#440), built on
+ * the new `dnd5e.api.lobby.v1alpha1` LobbyService (rpg-api-protos#177,
+ * rpg-api#630 — slice 1, merged). Create/join/ready/host-start on the
+ * lobby's own StreamLobby snapshot-then-deltas, mirroring StreamEncounter's
+ * proven pattern. On `encounter_started`, hands the encounterId up to
+ * GameView and unmounts — no lobby state survives the handoff
+ * (lobby-surface.md).
+ *
+ * This is a NEW component on a NEW proto package — distinct from the
+ * v1alpha1 LobbyScreen/WaitingRoom in src/components/lobby/, which
+ * LobbyView still uses and which this slice does not touch or reuse
+ * (design.md: clean-slate rebuild, no shim).
+ */
+
+import type { LobbyMember } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/types_pb';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCreateLobby } from '../../api/useCreateLobby';
+import { useJoinLobby } from '../../api/useJoinLobby';
+import { useLobbyStream } from '../../api/useLobbyStream';
+import { useSetLobbyReady } from '../../api/useSetLobbyReady';
+import { useStartLobbyEncounter } from '../../api/useStartLobbyEncounter';
+import { errorMessage } from '../../utils/combatFormat';
+import { PartyRoster } from './PartyRoster';
+
+/**
+ * Placeholder campaign scope — CreateLobbyRequest.campaign_id is
+ * validated-but-otherwise-opaque today (lobby-surface.md: "mirrors
+ * CreateEncounterRequest's campaign_id, unused"). No campaign concept
+ * exists in the UI yet; a single constant keeps every dev lobby in the same
+ * (currently meaningless) scope until one does.
+ */
+const DEV_CAMPAIGN_ID = 'default-campaign';
+
+export interface LobbyFlowProps {
+  /** The character selected on the home screen — bound to this player's lobby seat. */
+  characterId: string;
+  playerId: string;
+  onEncounterStarted: (encounterId: string) => void;
+  onBack: () => void;
+}
+
+export function LobbyFlow({
+  characterId,
+  playerId,
+  onEncounterStarted,
+  onBack,
+}: LobbyFlowProps) {
+  const [lobbyId, setLobbyId] = useState<string | null>(null);
+  const [joinRef, setJoinRef] = useState<string | null>(null);
+  const [hostPlayerId, setHostPlayerId] = useState<string | null>(null);
+  const [members, setMembers] = useState<LobbyMember[]>([]);
+  const [joinCodeInput, setJoinCodeInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const { createLobby, loading: createLoading } = useCreateLobby();
+  const { joinLobby, loading: joinLoading } = useJoinLobby();
+  const { setReady, loading: readyLoading } = useSetLobbyReady();
+  const { startEncounter, loading: startLoading } = useStartLobbyEncounter();
+
+  // Dev join-ref carrier (lobby-surface.md Decision 2): a URL param supplies
+  // the same opaque join_ref the Discord Activity carrier will supply
+  // automatically later. Read once — this component doesn't react to the
+  // URL changing after mount.
+  const urlJoinRef = useMemo(
+    () => new URLSearchParams(window.location.search).get('joinRef'),
+    []
+  );
+  const attemptedAutoJoinRef = useRef(false);
+
+  const handleJoin = async (ref: string) => {
+    const trimmed = ref.trim();
+    if (!trimmed) return;
+    setError(null);
+    try {
+      const resp = await joinLobby({ joinRef: trimmed, characterId });
+      setLobbyId(resp.lobbyId);
+      setMembers(resp.members);
+      setJoinRef(trimmed);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  useEffect(() => {
+    if (urlJoinRef && !lobbyId && !attemptedAutoJoinRef.current) {
+      attemptedAutoJoinRef.current = true;
+      void handleJoin(urlJoinRef);
+    }
+    // handleJoin is stable enough for this one-shot mount effect; including
+    // it would re-run on every render since it's not memoized.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlJoinRef, lobbyId]);
+
+  const stream = useLobbyStream(lobbyId, {
+    onSnapshot: (e) => setMembers(e.members),
+    onMemberJoined: (e) => {
+      if (!e.member) return;
+      const joined = e.member;
+      setMembers((prev) => [
+        ...prev.filter((m) => m.playerId !== joined.playerId),
+        joined,
+      ]);
+    },
+    onMemberLeft: (e) =>
+      setMembers((prev) => prev.filter((m) => m.playerId !== e.playerId)),
+    onMemberReady: (e) =>
+      setMembers((prev) =>
+        prev.map((m) =>
+          m.playerId === e.playerId ? { ...m, isReady: e.ready } : m
+        )
+      ),
+    onMemberConnectionChanged: (e) =>
+      setMembers((prev) =>
+        prev.map((m) =>
+          m.playerId === e.playerId ? { ...m, isConnected: e.connected } : m
+        )
+      ),
+    onHostChanged: (e) => {
+      setHostPlayerId(e.playerId);
+      setMembers((prev) =>
+        prev.map((m) => ({ ...m, isHost: m.playerId === e.playerId }))
+      );
+    },
+    onEncounterStarted: (e) => {
+      setLobbyId(null); // drop the lobby stream — encounter_started is terminal
+      onEncounterStarted(e.encounterId);
+    },
+  });
+
+  const handleCreate = async () => {
+    setError(null);
+    try {
+      const resp = await createLobby({
+        campaignId: DEV_CAMPAIGN_ID,
+        characterId,
+      });
+      setLobbyId(resp.lobbyId);
+      setJoinRef(resp.joinRef);
+      setHostPlayerId(resp.hostPlayerId);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const handleToggleReady = async () => {
+    if (!lobbyId) return;
+    const me = members.find((m) => m.playerId === playerId);
+    const nextReady = !(me?.isReady ?? false);
+    setError(null);
+    try {
+      await setReady({ lobbyId, ready: nextReady });
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const handleStart = async () => {
+    if (!lobbyId) return;
+    setError(null);
+    try {
+      const resp = await startEncounter({ lobbyId });
+      // Belt-and-suspenders: also drive off the RPC response directly in
+      // case the caller's own StreamLobby delta races the response (the
+      // broadcast should reach every member including the host, but the
+      // host doesn't need to wait for its own echo).
+      setLobbyId(null);
+      onEncounterStarted(resp.encounterId);
+    } catch (err) {
+      setError(errorMessage(err));
+    }
+  };
+
+  const isHost =
+    members.length > 0
+      ? members.some((m) => m.playerId === playerId && m.isHost)
+      : hostPlayerId === playerId;
+  const allReady = members.length > 0 && members.every((m) => m.isReady);
+  const me = members.find((m) => m.playerId === playerId);
+
+  if (!lobbyId) {
+    return (
+      <div
+        data-testid="lobby-flow-entry"
+        style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+      >
+        <h2>Party up</h2>
+        <button onClick={() => void handleCreate()} disabled={createLoading}>
+          {createLoading ? 'Creating…' : 'Create lobby'}
+        </button>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <label>
+            Join code{' '}
+            <input
+              type="text"
+              value={joinCodeInput}
+              onChange={(e) => setJoinCodeInput(e.target.value)}
+              placeholder="paste a join code"
+              aria-label="join code"
+            />
+          </label>
+          <button
+            onClick={() => void handleJoin(joinCodeInput)}
+            disabled={joinLoading || !joinCodeInput.trim()}
+          >
+            {joinLoading ? 'Joining…' : 'Join'}
+          </button>
+        </div>
+        {error && <div style={{ color: '#f88' }}>{error}</div>}
+        <button onClick={onBack}>Back</button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="lobby-flow-roster"
+      style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+    >
+      <h2>Lobby</h2>
+      <div style={{ fontSize: 12, opacity: 0.6 }}>
+        connection: {stream.connectionState}
+      </div>
+      {joinRef && (
+        <div data-testid="join-code-display" style={{ fontSize: 13 }}>
+          Join code: <code>{joinRef}</code>
+        </div>
+      )}
+      <PartyRoster members={members} />
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          onClick={() => void handleToggleReady()}
+          disabled={readyLoading}
+        >
+          {me?.isReady ? 'Unready' : 'Ready up'}
+        </button>
+        {isHost && (
+          <button
+            data-testid="start-encounter-button"
+            onClick={() => void handleStart()}
+            disabled={!allReady || startLoading}
+            title={
+              allReady
+                ? 'Start the encounter'
+                : 'Waiting for everyone to ready up'
+            }
+          >
+            {startLoading ? 'Starting…' : 'Start'}
+          </button>
+        )}
+      </div>
+      {error && <div style={{ color: '#f88' }}>{error}</div>}
+      <button onClick={onBack}>Back</button>
+    </div>
+  );
+}

--- a/src/components/game/PartyRoster.tsx
+++ b/src/components/game/PartyRoster.tsx
@@ -1,0 +1,61 @@
+/**
+ * PartyRoster — renders LobbyFlow's member list. Presence (is_host /
+ * is_ready / is_connected) is rendered exactly as the server sends it, never
+ * inferred — the roster comes from StreamLobby's snapshot-then-deltas
+ * (lobby-surface.md's LobbyMember contract).
+ */
+
+import type { LobbyMember } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/types_pb';
+
+export interface PartyRosterProps {
+  members: LobbyMember[];
+}
+
+export function PartyRoster({ members }: PartyRosterProps) {
+  if (members.length === 0) {
+    return (
+      <div data-testid="party-roster-empty" style={{ opacity: 0.6 }}>
+        (waiting for the party roster…)
+      </div>
+    );
+  }
+
+  return (
+    <ul data-testid="party-roster" style={{ listStyle: 'none', padding: 0 }}>
+      {members.map((member) => (
+        <li
+          key={member.playerId}
+          data-testid={`party-member-${member.playerId}`}
+          className="flex items-center gap-3 rounded-md px-3 py-2"
+          style={{
+            background: 'var(--bg-secondary, #1a1a1a)',
+            opacity: member.isConnected ? 1 : 0.5,
+            marginBottom: 6,
+          }}
+        >
+          <span
+            data-testid={`party-member-connected-${member.playerId}`}
+            title={member.isConnected ? 'connected' : 'disconnected'}
+            style={{ color: member.isConnected ? '#8f8' : '#666' }}
+          >
+            {member.isConnected ? '●' : '○'}
+          </span>
+          <span style={{ flex: 1 }}>
+            {member.characterName || member.characterId}
+            {member.isHost && (
+              <span style={{ marginLeft: 6, fontSize: 11, opacity: 0.7 }}>
+                (host)
+              </span>
+            )}
+          </span>
+          <span
+            data-testid={`party-member-ready-${member.playerId}`}
+            style={{ color: member.isReady ? '#8f8' : '#888', fontSize: 12 }}
+          >
+            {member.isReady ? 'ready' : 'not ready'}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/game/PromptModal.tsx
+++ b/src/components/game/PromptModal.tsx
@@ -1,0 +1,336 @@
+/**
+ * PromptModal — the skill-check / reaction InputRequired prompt, lifted out
+ * of PlaytestHarness (Wave 2.9 / 2.11d) so PlaytestHarness and EncounterView
+ * render the exact same modal off the exact same dispatch logic rather than
+ * two copies drifting apart. GameView slice 2 (#440).
+ *
+ * Owns its own RPC dispatch (useSubmitCheckV2), roll input, transient
+ * post-submit result display, and auto-clear timer — callers only pass the
+ * current prompt (from useEncounterState) and a dismiss callback. This is a
+ * behavior-preserving extraction: testids (skill-check-prompt, prompt-result,
+ * reaction-prompt, reaction-take-btn, reaction-skip-btn, unsupported-prompt)
+ * and copy match the original harness markup exactly so PlaytestHarness's
+ * existing test suite continues to assert through it unchanged.
+ */
+
+import type { InputRequired } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { useEffect, useRef, useState } from 'react';
+import { useSubmitCheckV2 } from '../../api/useSubmitCheckV2';
+
+export interface PromptModalProps {
+  encounterId: string;
+  /** The local player's entity id — the character the check/reaction resolves for. */
+  entityId: string;
+  /** The current pending prompt (null renders nothing). */
+  prompt: InputRequired | null;
+  /** Called to clear the prompt — on Dismiss, or after the 2s post-submit result window. */
+  onDismiss: () => void;
+  /** Optional event-log sink (PlaytestHarness's Recent-events log). */
+  onLog?: (message: string) => void;
+}
+
+export function PromptModal({
+  encounterId,
+  entityId,
+  prompt,
+  onDismiss,
+  onLog,
+}: PromptModalProps) {
+  const {
+    submitCheck,
+    loading: submitCheckLoading,
+    error: submitCheckError,
+  } = useSubmitCheckV2();
+  const [rollValue, setRollValue] = useState(10);
+  const [promptResult, setPromptResult] = useState<{
+    success: boolean;
+    total: number;
+    roll: number;
+  } | null>(null);
+
+  // Ref to the prompt that is currently being auto-cleared; guards against
+  // clearing a newer prompt when the timer from a prior submit fires late.
+  const clearResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const clearingPromptRef = useRef<InputRequired | null>(null);
+  // Always-fresh mirror of the current prompt prop. handleSubmitReaction
+  // compares the prompt-at-await-start to the freshest prompt after the
+  // await so a newer prompt arriving during the RPC isn't clobbered.
+  const latestPromptRef = useRef<InputRequired | null>(prompt);
+  useEffect(() => {
+    latestPromptRef.current = prompt;
+  }, [prompt]);
+
+  // Reset transient result state whenever a NEW prompt identity arrives —
+  // generalizes what the harness previously did at each call site that
+  // published a prompt (the stream's onInputRequiredDelivered and
+  // handleOpenDoor's inline RPC response). Doing it here means every
+  // pendingPrompt change is covered from one place regardless of source.
+  const promptIdentityRef = useRef<InputRequired | null>(null);
+  useEffect(() => {
+    if (prompt !== promptIdentityRef.current) {
+      promptIdentityRef.current = prompt;
+      if (clearResultTimerRef.current) {
+        clearTimeout(clearResultTimerRef.current);
+        clearResultTimerRef.current = null;
+      }
+      clearingPromptRef.current = null;
+      setPromptResult(null);
+    }
+  }, [prompt]);
+
+  useEffect(() => {
+    return () => {
+      if (clearResultTimerRef.current) {
+        clearTimeout(clearResultTimerRef.current);
+      }
+    };
+  }, []);
+
+  if (prompt === null) {
+    return null;
+  }
+
+  const handleSubmitCheck = async () => {
+    const promptBeingResolved = prompt;
+    try {
+      const response = await submitCheck({
+        encounterId,
+        entityId,
+        roll: rollValue,
+      });
+      onLog?.(
+        `SubmitCheck → rolled ${rollValue.toString()}, total ${response.total.toString()}, ${response.success ? 'success!' : 'failed.'}`
+      );
+      setPromptResult({
+        success: response.success,
+        total: response.total,
+        roll: rollValue,
+      });
+      if (clearResultTimerRef.current) {
+        clearTimeout(clearResultTimerRef.current);
+      }
+      clearingPromptRef.current = promptBeingResolved;
+      clearResultTimerRef.current = setTimeout(() => {
+        if (clearingPromptRef.current === promptBeingResolved) {
+          setPromptResult(null);
+          onDismiss();
+        }
+        clearResultTimerRef.current = null;
+        clearingPromptRef.current = null;
+      }, 2000);
+    } catch {
+      // error is surfaced via submitCheckError state below
+    }
+  };
+
+  const handleSubmitReaction = async (takeReaction: boolean) => {
+    const promptBeingResolved = prompt;
+    try {
+      await submitCheck({
+        encounterId,
+        entityId,
+        roll: 0, // ignored for reaction prompts
+        takeReaction,
+      });
+      onLog?.(
+        `SubmitCheck{take_reaction:${takeReaction.toString()}} → reaction ${takeReaction ? 'taken' : 'skipped'}`
+      );
+      if (latestPromptRef.current === promptBeingResolved) {
+        onDismiss();
+      }
+    } catch {
+      // error is surfaced via submitCheckError state below
+    }
+  };
+
+  if (prompt.kind?.case === 'skillCheck') {
+    const sc = prompt.kind.value;
+    return (
+      <div
+        data-testid="skill-check-prompt"
+        style={{
+          margin: '16px 0 8px',
+          padding: '12px',
+          background: '#1a1a2e',
+          border: '1px solid #4a4aaa',
+          borderRadius: 4,
+        }}
+      >
+        <h3 style={{ margin: '0 0 8px', color: '#aaf' }}>Skill check prompt</h3>
+        <div style={{ fontSize: 13, marginBottom: 8 }}>
+          <strong>
+            Skill check: {sc.ability} (DC {sc.dc})
+          </strong>
+          {sc.tool && (
+            <span style={{ color: '#aaa', marginLeft: 8 }}>
+              — requires: {sc.tool.id}
+            </span>
+          )}
+        </div>
+        {promptResult !== null ? (
+          <div
+            data-testid="prompt-result"
+            style={{
+              color: promptResult.success ? '#8f8' : '#f88',
+              fontWeight: 'bold',
+              fontSize: 13,
+            }}
+          >
+            rolled {promptResult.roll}, total {promptResult.total},{' '}
+            {promptResult.success ? 'success!' : 'failed.'}
+          </div>
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+            }}
+          >
+            <label style={{ fontSize: 12 }}>
+              Roll (1-20){' '}
+              <input
+                type="number"
+                min={1}
+                max={20}
+                step={1}
+                value={rollValue}
+                aria-label="roll value"
+                onChange={(e) =>
+                  setRollValue(
+                    Math.min(
+                      20,
+                      Math.max(1, Math.trunc(Number(e.target.value)))
+                    )
+                  )
+                }
+                style={{
+                  width: 60,
+                  background: '#333',
+                  color: '#eee',
+                  border: '1px solid #555',
+                  padding: '2px 4px',
+                }}
+              />
+            </label>
+            <button
+              onClick={() => void handleSubmitCheck()}
+              disabled={submitCheckLoading}
+              style={{
+                padding: '4px 12px',
+                background: '#2a2a4a',
+                color: '#aaf',
+                border: '1px solid #4a4aaa',
+                cursor: submitCheckLoading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              {submitCheckLoading ? 'Submitting…' : 'Submit roll'}
+            </button>
+            <button
+              onClick={onDismiss}
+              style={{
+                padding: '4px 8px',
+                background: '#2a2a2a',
+                color: '#888',
+                border: '1px solid #444',
+                cursor: 'pointer',
+                fontSize: 11,
+              }}
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+        {submitCheckError && (
+          <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
+            SubmitCheck error: {submitCheckError.message}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (prompt.kind?.case === 'reactionPrompt') {
+    const rp = prompt.kind.value;
+    const refStr = rp.reactionRef
+      ? `${rp.reactionRef.module}:${rp.reactionRef.type}:${rp.reactionRef.id}`
+      : 'unknown reaction';
+    const description =
+      rp.displayText !== ''
+        ? rp.displayText
+        : `${rp.triggerKind} reaction from ${rp.triggerSourceEntityId}`;
+    return (
+      <div
+        data-testid="reaction-prompt"
+        style={{
+          margin: '16px 0 8px',
+          padding: '12px',
+          background: '#2a1a1a',
+          border: '1px solid #aa4a4a',
+          borderRadius: 4,
+        }}
+      >
+        <h3 style={{ margin: '0 0 8px', color: '#faa' }}>
+          Reaction prompt: {refStr}
+        </h3>
+        <div style={{ fontSize: 13, marginBottom: 8 }}>{description}</div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <button
+            data-testid="reaction-take-btn"
+            onClick={() => void handleSubmitReaction(true)}
+            disabled={submitCheckLoading}
+            style={{
+              padding: '4px 12px',
+              background: '#3a2a2a',
+              color: '#faa',
+              border: '1px solid #aa4a4a',
+              cursor: submitCheckLoading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {submitCheckLoading ? 'Submitting…' : 'Take'}
+          </button>
+          <button
+            data-testid="reaction-skip-btn"
+            onClick={() => void handleSubmitReaction(false)}
+            disabled={submitCheckLoading}
+            style={{
+              padding: '4px 12px',
+              background: '#2a2a2a',
+              color: '#bbb',
+              border: '1px solid #555',
+              cursor: submitCheckLoading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Skip
+          </button>
+        </div>
+        {submitCheckError && (
+          <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
+            SubmitCheck error: {submitCheckError.message}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // dialogue / targetSelect — Wave 2.10+
+  return (
+    <div
+      data-testid="unsupported-prompt"
+      style={{
+        margin: '16px 0 8px',
+        padding: '8px 12px',
+        background: '#1a1a1a',
+        border: '1px solid #555',
+        borderRadius: 4,
+        color: '#888',
+        fontSize: 12,
+      }}
+    >
+      Prompt type {prompt.kind?.case ?? 'unknown'}: not yet supported (Wave
+      2.10+)
+    </div>
+  );
+}

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -7,7 +7,7 @@ import {
   EntityType,
   TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { v2PositionToV1 } from '../../api/positionConvert';
 import { useActivateFeatureV2 } from '../../api/useActivateFeatureV2';
 import { useDevPlayerIdAuth } from '../../api/useDevPlayerIdAuth';
@@ -16,11 +16,16 @@ import { useEndTurnV2 } from '../../api/useEndTurnV2';
 import { useInteractV2 } from '../../api/useInteractV2';
 import { useMoveEntityV2 } from '../../api/useMoveEntityV2';
 import { useSetReactionReady } from '../../api/useSetReactionReady';
-import { useSubmitCheckV2 } from '../../api/useSubmitCheckV2';
 import { useTakeActionV2 } from '../../api/useTakeActionV2';
 import { useEncounterState } from '../../hooks/useEncounterState';
+import {
+  errorMessage,
+  formatSourceRefs,
+  formatStatusBadges,
+} from '../../utils/combatFormat';
 import { getConditionDisplay } from '../../utils/conditionIcons';
 import { protoPositionToHex } from '../../utils/hexCoord';
+import { PromptModal } from '../game/PromptModal';
 import { ActionMenu } from './ActionMenu';
 import { actionKey, targetKindNeedsPrompt } from './actionMenuHelpers';
 import { EconomyBar } from './EconomyBar';
@@ -59,38 +64,6 @@ const MODE_LABEL: Record<EncounterMode, string> = {
 
 function formatTime(d: Date): string {
   return d.toTimeString().slice(0, 8);
-}
-
-/** Comma-joined display labels for a list of condition source refs (e.g.
- * `AttackResolved`'s `advantage_sources`), resolved via the web's existing
- * ref-keyed lookup (`conditionIcons.ts`) — never the server's
- * `display_name`, which "may be empty" per `StatusEffect`'s doc comment
- * (R5: display resolution stays web-side). */
-function formatSourceRefs(refs: Array<{ id: string }>): string {
-  return refs.map((r) => getConditionDisplay(r.id).label).join(', ');
-}
-
-/** Icon + label badge text for one entity's status list, e.g. "🏃 Dodging,
- * 🫥 Hidden". Resolved the same way as `formatSourceRefs` — by `source.id`
- * through the web's lookup table, never the (possibly empty) wire
- * `display_name`. */
-function formatStatusBadges(
-  statuses: Array<{ source: { id: string } }>
-): string {
-  return statuses
-    .map((s) => {
-      const d = getConditionDisplay(s.source.id);
-      return `${d.icon} ${d.label}`;
-    })
-    .join(', ');
-}
-
-/** Extract a readable message from a caught RPC rejection. ConnectError's
- * `.message` is already prefixed with the status code (e.g.
- * `[invalid_argument] target.entity_id is required`), so this doubles as
- * "code + message" without the harness needing to know about ConnectError. */
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 /** Short, log-friendly descriptor of an ActionTarget for the Recent-events
@@ -144,25 +117,6 @@ export function PlaytestHarness() {
   // stated need: clickable map for intuitive driving without losing the
   // event log / entity table he uses for backend verification mid-playtest.
   const [viewMode, setViewMode] = useState<ViewMode>('both');
-  // Wave 2.9: prompt roll input and transient result display
-  const [rollValue, setRollValue] = useState(10);
-  // Structured result avoids string-sniffing for color/outcome logic.
-  const [promptResult, setPromptResult] = useState<{
-    success: boolean;
-    total: number;
-    roll: number;
-  } | null>(null);
-  // Ref to the prompt that is currently being auto-cleared; guards against
-  // clearing a newer prompt when the timer from a prior submit fires late.
-  const clearResultTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-  const clearingPromptRef = useRef<object | null>(null);
-  // Always-fresh mirror of the current pending prompt. Used by async
-  // handlers (handleSubmitReaction) that must compare the prompt-at-await-
-  // start to the freshest prompt after the await — the React state captured
-  // via the handler's closure is the render-time snapshot, not the latest.
-  const latestPendingPromptRef = useRef<object | null>(null);
 
   const encounterState = useEncounterState();
   const {
@@ -185,11 +139,6 @@ export function PlaytestHarness() {
     loading: endTurnLoading,
     error: endTurnError,
   } = useEndTurnV2();
-  const {
-    submitCheck,
-    loading: submitCheckLoading,
-    error: submitCheckError,
-  } = useSubmitCheckV2();
   // Wave 2.11d: per-character per-reaction readiness toggle. The panel below
   // the prompt section uses this to arm/unarm reactions like Shield + OA.
   const {
@@ -448,15 +397,8 @@ export function PlaytestHarness() {
           addLog('InputRequiredDelivered: (no payload)');
           return;
         }
-        // Cancel any in-progress auto-clear timer from a prior skill-check
-        // submit so it doesn't unexpectedly clear the incoming prompt while
-        // the player is mid-reaction. Mirrors handleOpenDoor.
-        if (clearResultTimerRef.current) {
-          clearTimeout(clearResultTimerRef.current);
-          clearResultTimerRef.current = null;
-        }
-        clearingPromptRef.current = null;
-        setPromptResult(null);
+        // PromptModal resets its own transient result/timer state whenever
+        // the prompt object identity changes — no reset needed here.
         encounterState.setPendingPrompt(e.inputRequired);
         addLog(
           `InputRequiredDelivered: ${e.inputRequired.kind?.case ?? 'unknown'}`
@@ -464,23 +406,6 @@ export function PlaytestHarness() {
       },
     }
   );
-
-  // Clean up the auto-clear timer on unmount. Placed before the !playerId
-  // early return so this hook is always called unconditionally (Rules of Hooks).
-  useEffect(() => {
-    return () => {
-      if (clearResultTimerRef.current) {
-        clearTimeout(clearResultTimerRef.current);
-      }
-    };
-  }, []);
-
-  // Keep latestPendingPromptRef in sync with the freshest pendingPrompt so
-  // handleSubmitReaction's post-await check sees the current value, not the
-  // closure-captured render snapshot. See handleSubmitReaction for rationale.
-  useEffect(() => {
-    latestPendingPromptRef.current = encounterState.state.pendingPrompt;
-  }, [encounterState.state.pendingPrompt]);
 
   if (!playerId) {
     return (
@@ -526,14 +451,8 @@ export function PlaytestHarness() {
       const response = await interact(encounterId, id, 'open');
       addLog(`Interact(open) → ${id}`);
       if (response.inputRequired) {
-        // Cancel any in-progress auto-clear timer from a prior submit so it
-        // doesn't unexpectedly clear the new incoming prompt.
-        if (clearResultTimerRef.current) {
-          clearTimeout(clearResultTimerRef.current);
-          clearResultTimerRef.current = null;
-        }
-        clearingPromptRef.current = null;
-        setPromptResult(null);
+        // PromptModal resets its own transient result/timer state whenever
+        // the prompt object identity changes — no reset needed here.
         encounterState.setPendingPrompt(response.inputRequired);
         addLog(
           `InputRequired: ${response.inputRequired.kind?.case ?? 'unknown'}`
@@ -646,78 +565,6 @@ export function PlaytestHarness() {
         `TakeAction(${actionRef.id})${describeActionTarget(target)} REJECTED: ${errorMessage(err)}`,
         true
       );
-    }
-  };
-
-  const handleSubmitCheck = async () => {
-    // Capture the prompt being resolved. We pass this identity token to the
-    // auto-clear timer so a stale timer from a prior submit doesn't clear a
-    // newer prompt if the prompt changes before the 2s window expires.
-    const promptBeingResolved = encounterState.state.pendingPrompt;
-    try {
-      const response = await submitCheck({
-        encounterId,
-        entityId,
-        roll: rollValue,
-      });
-      addLog(
-        `SubmitCheck → rolled ${rollValue.toString()}, total ${response.total.toString()}, ${response.success ? 'success!' : 'failed.'}`
-      );
-      setPromptResult({
-        success: response.success,
-        total: response.total,
-        roll: rollValue,
-      });
-      // Clear any prior timer then start a new 2s window.
-      if (clearResultTimerRef.current) {
-        clearTimeout(clearResultTimerRef.current);
-      }
-      clearingPromptRef.current = promptBeingResolved;
-      clearResultTimerRef.current = setTimeout(() => {
-        // Only clear the prompt if it hasn't changed since we started this timer.
-        if (clearingPromptRef.current === promptBeingResolved) {
-          setPromptResult(null);
-          encounterState.setPendingPrompt(null);
-        }
-        clearResultTimerRef.current = null;
-        clearingPromptRef.current = null;
-      }, 2000);
-    } catch {
-      // error is surfaced via submitCheckError state
-    }
-  };
-
-  // Wave 2.11d: dispatch SubmitCheck{take_reaction} for the active reaction
-  // prompt. take=true sends the reaction; take=false skips. On success the
-  // prompt is cleared immediately — the resume flow's outcome events arrive
-  // separately on the stream and update HP/AC via the reducer.
-  const handleSubmitReaction = async (takeReaction: boolean) => {
-    // Capture the in-flight prompt by reference. We compare against the
-    // freshest state value AFTER the await so that a newer prompt arriving
-    // during the RPC isn't accidentally cleared. Use the ref pattern via
-    // the setter's functional form below.
-    const promptBeingResolved = encounterState.state.pendingPrompt;
-    try {
-      await submitCheck({
-        encounterId,
-        entityId,
-        roll: 0, // ignored for reaction prompts
-        takeReaction,
-      });
-      addLog(
-        `SubmitCheck{take_reaction:${takeReaction.toString()}} → reaction ${takeReaction ? 'taken' : 'skipped'}`
-      );
-      // Clear the prompt only if it's still the one we resolved. Reaction
-      // prompts don't show a post-submit result panel (unlike skill checks
-      // which show rolled/total/success transiently). Outcome events arrive
-      // via the stream and the reducer updates HP/AC/etc. Reading
-      // encounterState.state here would still be the stale render snapshot,
-      // so we use latestPendingPromptRef to peek the freshest value.
-      if (latestPendingPromptRef.current === promptBeingResolved) {
-        encounterState.setPendingPrompt(null);
-      }
-    } catch {
-      // error is surfaced via submitCheckError state
     }
   };
 
@@ -991,202 +838,15 @@ export function PlaytestHarness() {
           (`skill-check-prompt`, `reaction-prompt`, `unsupported-prompt`,
           `ready-reactions-panel`) are preserved so existing tests
           continue to query at top level. */}
-      {/* Skill check prompt (Wave 2.9) */}
-      {encounterState.state.pendingPrompt !== null &&
-        (() => {
-          const prompt = encounterState.state.pendingPrompt;
-          if (prompt.kind?.case === 'skillCheck') {
-            const sc = prompt.kind.value;
-            return (
-              <div
-                data-testid="skill-check-prompt"
-                style={{
-                  margin: '16px 0 8px',
-                  padding: '12px',
-                  background: '#1a1a2e',
-                  border: '1px solid #4a4aaa',
-                  borderRadius: 4,
-                }}
-              >
-                <h3 style={{ margin: '0 0 8px', color: '#aaf' }}>
-                  Skill check prompt
-                </h3>
-                <div style={{ fontSize: 13, marginBottom: 8 }}>
-                  <strong>
-                    Skill check: {sc.ability} (DC {sc.dc})
-                  </strong>
-                  {sc.tool && (
-                    <span style={{ color: '#aaa', marginLeft: 8 }}>
-                      — requires: {sc.tool.id}
-                    </span>
-                  )}
-                </div>
-                {promptResult !== null ? (
-                  <div
-                    data-testid="prompt-result"
-                    style={{
-                      color: promptResult.success ? '#8f8' : '#f88',
-                      fontWeight: 'bold',
-                      fontSize: 13,
-                    }}
-                  >
-                    rolled {promptResult.roll}, total {promptResult.total},{' '}
-                    {promptResult.success ? 'success!' : 'failed.'}
-                  </div>
-                ) : (
-                  <div
-                    style={{
-                      display: 'flex',
-                      gap: 8,
-                      alignItems: 'center',
-                    }}
-                  >
-                    <label style={{ fontSize: 12 }}>
-                      Roll (1-20){' '}
-                      <input
-                        type="number"
-                        min={1}
-                        max={20}
-                        step={1}
-                        value={rollValue}
-                        aria-label="roll value"
-                        onChange={(e) =>
-                          setRollValue(
-                            Math.min(
-                              20,
-                              Math.max(1, Math.trunc(Number(e.target.value)))
-                            )
-                          )
-                        }
-                        style={{
-                          width: 60,
-                          background: '#333',
-                          color: '#eee',
-                          border: '1px solid #555',
-                          padding: '2px 4px',
-                        }}
-                      />
-                    </label>
-                    <button
-                      onClick={() => void handleSubmitCheck()}
-                      disabled={submitCheckLoading}
-                      style={{
-                        padding: '4px 12px',
-                        background: '#2a2a4a',
-                        color: '#aaf',
-                        border: '1px solid #4a4aaa',
-                        cursor: submitCheckLoading ? 'not-allowed' : 'pointer',
-                      }}
-                    >
-                      {submitCheckLoading ? 'Submitting…' : 'Submit roll'}
-                    </button>
-                    <button
-                      onClick={() => encounterState.setPendingPrompt(null)}
-                      style={{
-                        padding: '4px 8px',
-                        background: '#2a2a2a',
-                        color: '#888',
-                        border: '1px solid #444',
-                        cursor: 'pointer',
-                        fontSize: 11,
-                      }}
-                    >
-                      Dismiss
-                    </button>
-                  </div>
-                )}
-                {submitCheckError && (
-                  <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
-                    SubmitCheck error: {submitCheckError.message}
-                  </div>
-                )}
-              </div>
-            );
-          }
-          // Wave 2.11d reaction prompt: Take / Skip → SubmitCheck{take_reaction}.
-          if (prompt.kind?.case === 'reactionPrompt') {
-            const rp = prompt.kind.value;
-            const refStr = rp.reactionRef
-              ? `${rp.reactionRef.module}:${rp.reactionRef.type}:${rp.reactionRef.id}`
-              : 'unknown reaction';
-            const description =
-              rp.displayText !== ''
-                ? rp.displayText
-                : `${rp.triggerKind} reaction from ${rp.triggerSourceEntityId}`;
-            return (
-              <div
-                data-testid="reaction-prompt"
-                style={{
-                  margin: '16px 0 8px',
-                  padding: '12px',
-                  background: '#2a1a1a',
-                  border: '1px solid #aa4a4a',
-                  borderRadius: 4,
-                }}
-              >
-                <h3 style={{ margin: '0 0 8px', color: '#faa' }}>
-                  Reaction prompt: {refStr}
-                </h3>
-                <div style={{ fontSize: 13, marginBottom: 8 }}>
-                  {description}
-                </div>
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <button
-                    data-testid="reaction-take-btn"
-                    onClick={() => void handleSubmitReaction(true)}
-                    disabled={submitCheckLoading}
-                    style={{
-                      padding: '4px 12px',
-                      background: '#3a2a2a',
-                      color: '#faa',
-                      border: '1px solid #aa4a4a',
-                      cursor: submitCheckLoading ? 'not-allowed' : 'pointer',
-                    }}
-                  >
-                    {submitCheckLoading ? 'Submitting…' : 'Take'}
-                  </button>
-                  <button
-                    data-testid="reaction-skip-btn"
-                    onClick={() => void handleSubmitReaction(false)}
-                    disabled={submitCheckLoading}
-                    style={{
-                      padding: '4px 12px',
-                      background: '#2a2a2a',
-                      color: '#bbb',
-                      border: '1px solid #555',
-                      cursor: submitCheckLoading ? 'not-allowed' : 'pointer',
-                    }}
-                  >
-                    Skip
-                  </button>
-                </div>
-                {submitCheckError && (
-                  <div style={{ color: '#f88', marginTop: 8, fontSize: 12 }}>
-                    SubmitCheck error: {submitCheckError.message}
-                  </div>
-                )}
-              </div>
-            );
-          }
-          // dialogue / targetSelect — Wave 2.10+
-          return (
-            <div
-              data-testid="unsupported-prompt"
-              style={{
-                margin: '16px 0 8px',
-                padding: '8px 12px',
-                background: '#1a1a1a',
-                border: '1px solid #555',
-                borderRadius: 4,
-                color: '#888',
-                fontSize: 12,
-              }}
-            >
-              Prompt type {prompt.kind?.case ?? 'unknown'}: not yet supported
-              (Wave 2.10+)
-            </div>
-          );
-        })()}
+      {/* Skill check / reaction prompt (Wave 2.9 / 2.11d) — shared with
+          GameView's EncounterView via PromptModal (#440). */}
+      <PromptModal
+        encounterId={encounterId}
+        entityId={entityId}
+        prompt={encounterState.state.pendingPrompt}
+        onDismiss={() => encounterState.setPendingPrompt(null)}
+        onLog={addLog}
+      />
 
       {/* Wave 2.11d ready-reactions panel: per-character per-reaction toggles.
           Server is source of truth (reactionReadiness map flows from

--- a/src/utils/combatFormat.ts
+++ b/src/utils/combatFormat.ts
@@ -1,0 +1,37 @@
+/**
+ * Small pure formatting helpers shared by the v1alpha2 combat surfaces
+ * (PlaytestHarness and GameView's EncounterView, #440) so both render
+ * server-pushed state through the same lookup — never two copies drifting
+ * apart. Display resolution stays web-side (never the wire's possibly-empty
+ * display_name), keyed by the condition/ref's `id` through
+ * `conditionIcons.ts`'s `getConditionDisplay`.
+ */
+
+import { getConditionDisplay } from './conditionIcons';
+
+/** Icon + label badge text for one entity's status list, e.g. "🏃 Dodging, 🫥 Hidden". */
+export function formatStatusBadges(
+  statuses: Array<{ source: { id: string } }>
+): string {
+  return statuses
+    .map((s) => {
+      const d = getConditionDisplay(s.source.id);
+      return `${d.icon} ${d.label}`;
+    })
+    .join(', ');
+}
+
+/** Comma-joined display labels for a list of condition source refs (e.g. `advantage_sources`). */
+export function formatSourceRefs(refs: Array<{ id: string }>): string {
+  return refs.map((r) => getConditionDisplay(r.id).label).join(', ');
+}
+
+/**
+ * Extract a readable message from a caught RPC rejection. ConnectError's
+ * `.message` is already prefixed with the status code (e.g.
+ * `[invalid_argument] target.entity_id is required`), so this doubles as
+ * "code + message" without callers needing to know about ConnectError.
+ */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}


### PR DESCRIPTION
## Summary

Builds `GameView` — the live game path's successor to `LobbyView` — as slice 2 of the [game screen rebuild](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/design.md). Two pieces:

- **LobbyFlow**: create/join/ready/host-start party assembly on the new `dnd5e.api.lobby.v1alpha1` `LobbyService` (slice 1, merged: rpg-api-protos#177 + rpg-api#630). `StreamLobby` snapshot-then-deltas feeds `PartyRoster`, rendering `is_host`/`is_ready`/`is_connected` verbatim. Dev join-ref carrier via `?joinRef=` URL param keeps multi-browser MCP playtest joins trivial without Discord.
- **EncounterView**: mounts on `encounter_started`, built entirely on the shared harness stack — `useEncounterStream2` + `useEncounterState`, `ActionMenu`/`EconomyBar` rendered verbatim off the server-pushed `TurnState` (zero client legality logic), a generalized `EncounterMap` (HexGrid adapter), and `PromptModal` for skill-check/reaction prompts. Single room this slice.

Closes #440. Umbrella: #432. Wave umbrella: KirkDiggler/rpg-project#81. Design: [design.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/design.md), [lobby-surface.md](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/game-screen-rebuild/lobby-surface.md).

## Load-bearing

- **New components take unsuffixed names** (`GameView`, `LobbyFlow`, `PartyRoster`, `EncounterView`, `EncounterMap`, `PromptModal`); no existing shared hook was renamed (`useEncounterStream2`, `useMoveEntityV2`, etc. unchanged) — that rename pass is slice 3, alongside `LobbyView`'s deletion. `LobbyView.tsx` is untouched and now unreferenced from `App.tsx`.
- **`PromptModal` is a real extraction, not a copy.** It was lifted out of `PlaytestHarness`'s inline skill-check/reaction JSX so both surfaces dispatch `SubmitCheck` through one component. `PlaytestHarness` now renders `PromptModal` too; its existing (unmodified) vitest suite still passes against the same testids, proving the extraction is behavior-preserving. Same treatment for `errorMessage`/`formatStatusBadges`/`formatSourceRefs`, pulled into `src/utils/combatFormat.ts`.
- **`entityId` is `characterId`, not `char-<playerId>`.** `EncounterView`'s local player identity is the character bound at lobby create/join. Verified directly against rpg-api: `StartEncounter` seeds `EntityID: core.EntityID(m.CharacterID)` per ready member (`internal/orchestrators/lobby/start_encounter.go`) — this is not the `char-<playerId>` shortcut `PlaytestHarness` gets away with only because devseed happens to name characters that way.
- **`EncounterMap` generalizes, doesn't duplicate, `PlaytestMap`.** Both now import `synthesizeFloorTiles`/`buildRenderableEntities` from the pre-existing shared `playtestMapHelpers.ts`; `HexGrid` itself was already shared.
- Explicitly out of scope this slice (per #440 and design.md's slice breakdown): Equipment modal, dungeon result overlay, multi-room accumulation, and door interaction on the map (the v2 stream doesn't accumulate `DoorInfo[]` yet — same gap `PlaytestMap` already has).

## Verification

Browser/MCP playtest verification was **deliberately deferred** to the orchestrator's end-to-end drive against a running stack — this PR was built and verified in an isolated worktree without launching dev servers, browsers, or Docker. Verified locally:

- `npm run ci-check` — format, lint, typecheck, build, and the full vitest suite (656 tests / 38 files, including `PlaytestHarness.test.tsx` unmodified) all pass.
- Proto bump to `@kirkdiggler/rpg-api-protos#v0.1.104` confirmed installed (`node_modules/@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/` present) and lockfile-pinned to a real commit.
- The `characterId`-as-`entityId` claim above cross-checked against rpg-api source, not assumed.

Also adds `docs/architecture/components/game-view.md` documenting the new component tree, per the repo's docs-close-the-loop convention — `docs/status.md`/`quality.md` refresh is **not** included here (both are already fairly stale relative to current chapter framing) and is flagged as a follow-up rather than attempted blind in this PR.

## Test plan

- [x] `npm run ci-check` passes (format, lint, typecheck, build, 656 tests)
- [ ] MCP playtest: create lobby → second browser joins via join-ref → both ready → host starts → both land in the same encounter and can fight (orchestrator, post-merge-readiness)
- [ ] Copilot review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9