### PR TITLE
fix(stream): reconnect when encounter stream is aborted before first snapshot

### DIFF
--- a/src/api/useEncounterStream2.test.ts
+++ b/src/api/useEncounterStream2.test.ts
@@ -2,9 +2,14 @@ import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/ap
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeStream, type FakeStream } from './fakeEncounterStream2';
+import { RECONNECT_CONFIG } from './streamReconnect';
 
 function makeEvent(caseName: string, value: unknown): EncounterEvent {
   return { event: { case: caseName, value } } as unknown as EncounterEvent;
+}
+
+function abortError(message = 'signal is aborted without reason'): Error {
+  return Object.assign(new Error(message), { name: 'AbortError' });
 }
 
 // vi.hoisted allows the mock factory to use these refs even though hoisting
@@ -13,6 +18,11 @@ function makeEvent(caseName: string, value: unknown): EncounterEvent {
 const hoisted = vi.hoisted(() => {
   return {
     fakeRef: { current: null as FakeStream | null },
+    // Consumed in FIFO order before falling back to fakeRef.current — lets a
+    // test hand distinct streams to successive streamEncounter() calls (e.g.
+    // simulating mount-churn where a second connect attempt starts before
+    // the first one has torn down).
+    streamQueue: [] as FakeStream[],
   };
 });
 
@@ -20,6 +30,9 @@ vi.mock('./client', () => {
   return {
     encounterClientV2: {
       streamEncounter: vi.fn(() => {
+        if (hoisted.streamQueue.length > 0) {
+          return hoisted.streamQueue.shift()!.iterator;
+        }
         if (!hoisted.fakeRef.current) {
           throw new Error(
             'fakeRef.current is null — test forgot to set it in beforeEach'
@@ -32,6 +45,7 @@ vi.mock('./client', () => {
 });
 
 // Import the hook AFTER vi.mock so the mock is applied
+import { encounterClientV2 } from './client';
 import { useEncounterStream2 } from './useEncounterStream2';
 
 let fake: FakeStream;
@@ -39,10 +53,13 @@ let fake: FakeStream;
 beforeEach(() => {
   fake = createFakeStream();
   hoisted.fakeRef.current = fake;
+  hoisted.streamQueue = [];
+  vi.mocked(encounterClientV2.streamEncounter).mockClear();
 });
 
 afterEach(() => {
   hoisted.fakeRef.current = null;
+  hoisted.streamQueue = [];
   // Defensive: ensure fake timers don't bleed into the next test if the
   // reconnect test fails before reaching its inline vi.useRealTimers() call.
   vi.useRealTimers();
@@ -166,6 +183,112 @@ describe('useEncounterStream2', () => {
     await vi.waitFor(() =>
       expect(result.current.connectionState).toBe('connecting')
     );
+
+    vi.useRealTimers();
+  });
+
+  // #442 regression coverage: an abort landing before the consumer has
+  // intentionally torn the hook down must be a reconnect case, not a
+  // terminal one — and the reverse (a real unmount) must never reconnect.
+
+  it('schedules a reconnect when the stream aborts before the first snapshot arrives', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', {})
+    );
+    expect(result.current.connectionState).toBe('connecting');
+
+    // The transport aborts (AbortError/[canceled] shape from the issue)
+    // without us ever having called AbortController.abort() ourselves — the
+    // hook is still mounted and still wants this encounter.
+    await act(async () => {
+      fake.error(abortError());
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await vi.waitFor(() =>
+      expect(result.current.connectionState).toBe('disconnected')
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RECONNECT_CONFIG.initialDelayMs);
+    });
+    await vi.waitFor(() => {
+      expect(result.current.connectionState).toBe('connecting');
+    });
+    expect(
+      vi.mocked(encounterClientV2.streamEncounter).mock.calls
+    ).toHaveLength(2);
+
+    vi.useRealTimers();
+  });
+
+  it('does not schedule a reconnect when unmounted before the first snapshot arrives', async () => {
+    vi.useFakeTimers();
+    const { unmount, result } = renderHook(() =>
+      useEncounterStream2('enc-1', 'alice', {})
+    );
+    expect(result.current.connectionState).toBe('connecting');
+
+    unmount();
+
+    // The transport notices our own teardown abort() and rejects — this
+    // must resolve as "nobody wants this anymore," not a reconnect.
+    await act(async () => {
+      fake.error(abortError());
+      await vi.advanceTimersByTimeAsync(RECONNECT_CONFIG.maxDelayMs + 1000);
+    });
+
+    expect(
+      vi.mocked(encounterClientV2.streamEncounter).mock.calls
+    ).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  it('a superseded connection from mount-churn never re-arms its own reconnect and does not disrupt the live one', async () => {
+    // Models the actual #442 race on the same hook instance (shared refs):
+    // an effect re-run tears the first connect() attempt down and starts a
+    // second one immediately — the same shape React StrictMode's dev
+    // double-invoke produces on mount. The first attempt's underlying
+    // transport notices the abort and rejects *after* the second attempt is
+    // already live, so any handler reading the shared abortControllerRef at
+    // that point sees the second attempt's controller, not its own.
+    vi.useFakeTimers();
+    const first = createFakeStream();
+    const second = createFakeStream();
+    hoisted.streamQueue = [first, second];
+
+    const { result, rerender } = renderHook(
+      ({ playerId }: { playerId: string }) =>
+        useEncounterStream2('enc-1', playerId, {}),
+      { initialProps: { playerId: 'alice' } }
+    );
+    rerender({ playerId: 'bob' });
+
+    // Both connect() attempts fired synchronously (churn), and only the
+    // second is still live.
+    expect(hoisted.streamQueue).toHaveLength(0);
+    expect(
+      vi.mocked(encounterClientV2.streamEncounter).mock.calls
+    ).toHaveLength(2);
+
+    // The stale first attempt's belated rejection must not touch state or
+    // arm a zombie reconnect that would clobber the live (second) stream.
+    await act(async () => {
+      first.error(abortError());
+      await vi.advanceTimersByTimeAsync(RECONNECT_CONFIG.maxDelayMs + 1000);
+    });
+    expect(
+      vi.mocked(encounterClientV2.streamEncounter).mock.calls
+    ).toHaveLength(2); // no 3rd, zombie call from the stale attempt
+
+    // The live (second) attempt is unaffected and still reaches 'connected'.
+    act(() => {
+      second.push(makeEvent('snapshotDelivered', {}));
+    });
+    await vi.waitFor(() => {
+      expect(result.current.connectionState).toBe('connected');
+    });
 
     vi.useRealTimers();
   });

--- a/src/api/useEncounterStream2.ts
+++ b/src/api/useEncounterStream2.ts
@@ -36,6 +36,24 @@ interface UseEncounterStream2Result {
  * Treat as a stream-up sync barrier.
  *
  * Reconnect: shared RECONNECT_CONFIG with v1 hook (1s → 30s, 10 attempts).
+ *
+ * Mount-churn resilience (#442): a mount can tear its effect down and set it
+ * back up again in quick succession (React StrictMode's dev double-invoke is
+ * the common trigger, but any deps-driven re-run shapes the same race) —
+ * the first connect() attempt's underlying transport can notice the
+ * teardown's abort() and reject *after* the second attempt has already
+ * replaced `abortControllerRef.current`. A catch handler that reads that
+ * shared ref to decide "was I the one who got aborted" is reading a value
+ * that may belong to a newer, unrelated attempt by then. Each connect()
+ * attempt is tagged with a `generationRef` value at the moment it starts;
+ * every side effect it performs (state updates, scheduling a reconnect,
+ * touching the shared refs) is gated on still being the current generation,
+ * and "was this abort mine" is decided from the attempt's own locally
+ * captured AbortController, never the shared ref. That keeps a stale
+ * attempt's belated rejection from silently no-op'ing (false intentional
+ * read) *and* from re-arming its own zombie reconnect that clobbers the
+ * live connection (false error read) — both were on the table with the old
+ * shared-ref check depending on timing, which is why the bug was flaky.
  */
 export function useEncounterStream2(
   encounterId: string | null,
@@ -54,6 +72,11 @@ export function useEncounterStream2(
     undefined
   );
   const abortControllerRef = useRef<AbortController | undefined>(undefined);
+  // Bumped at the start of every connect() attempt (initial, StrictMode-churn
+  // replay, and scheduled retries alike) so a superseded attempt's async
+  // continuations can recognize they're stale and no-op instead of touching
+  // shared state on a newer attempt's behalf.
+  const generationRef = useRef(0);
 
   useEffect(() => {
     if (!encounterId) {
@@ -61,26 +84,32 @@ export function useEncounterStream2(
       return;
     }
 
-    const scheduleReconnect = () => {
-      if (retryCountRef.current >= RECONNECT_CONFIG.maxAttempts) {
-        setConnectionState('error');
-        setError(new Error('Max reconnection attempts reached'));
-        return;
-      }
-      setConnectionState('disconnected');
-      const delay = Math.min(
-        RECONNECT_CONFIG.initialDelayMs *
-          Math.pow(RECONNECT_CONFIG.backoffMultiplier, retryCountRef.current),
-        RECONNECT_CONFIG.maxDelayMs
-      );
-      retryCountRef.current++;
-      retryTimeoutRef.current = setTimeout(connect, delay);
-    };
-
     const connect = async () => {
+      const myGeneration = ++generationRef.current;
+      const isCurrent = () => generationRef.current === myGeneration;
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
       setConnectionState('connecting');
       setError(null);
-      abortControllerRef.current = new AbortController();
+
+      const scheduleReconnect = () => {
+        if (!isCurrent()) return; // a newer attempt already owns the hook
+
+        if (retryCountRef.current >= RECONNECT_CONFIG.maxAttempts) {
+          setConnectionState('error');
+          setError(new Error('Max reconnection attempts reached'));
+          return;
+        }
+        setConnectionState('disconnected');
+        const delay = Math.min(
+          RECONNECT_CONFIG.initialDelayMs *
+            Math.pow(RECONNECT_CONFIG.backoffMultiplier, retryCountRef.current),
+          RECONNECT_CONFIG.maxDelayMs
+        );
+        retryCountRef.current++;
+        retryTimeoutRef.current = setTimeout(connect, delay);
+      };
 
       try {
         const request = create(StreamEncounterRequestSchema, {
@@ -88,11 +117,13 @@ export function useEncounterStream2(
           playerId,
         });
         const stream = encounterClientV2.streamEncounter(request, {
-          signal: abortControllerRef.current.signal,
+          signal: controller.signal,
         });
 
         let sawFirstSnapshot = false;
         for await (const event of stream as AsyncIterable<EncounterEvent>) {
+          if (!isCurrent()) return; // superseded mid-stream; a newer attempt owns state now
+
           if (!sawFirstSnapshot) {
             // Broker contract: first message is always SnapshotDelivered. We
             // don't validate the case here — a violation is a server-side bug
@@ -110,8 +141,9 @@ export function useEncounterStream2(
         // Stream closed by server — schedule reconnect
         scheduleReconnect();
       } catch (err) {
-        if (abortControllerRef.current?.signal.aborted) {
-          return; // intentional abort, not an error
+        if (!isCurrent()) return; // superseded — a newer attempt is already running
+        if (controller.signal.aborted) {
+          return; // our own cleanup tore this attempt down; nothing wants it anymore
         }
         console.error('[useEncounterStream2] stream error:', err);
         scheduleReconnect();


### PR DESCRIPTION
## Summary

Closes #442. Fixes the LobbyFlow→EncounterView transition race where the encounter stream's first connection is sometimes aborted mid-mount and the page gets stuck on "connecting" forever, with no reconnect ever observed.

Related: KirkDiggler/rpg-project#81

## Root cause

The transition itself isn't buggy — `GameView` mounts `EncounterView` once, with no remount on `encounterId` changes (it's a prop, not a key). The actual churn is React StrictMode's dev double-invoke of `EncounterView`'s effect: mount → cleanup → mount, synchronously, on every dev-mode mount. That's deterministic, but whether it actually *breaks* the stream is not — it depends on whether the first `connect()` attempt's underlying transport rejects (`AbortError`/`[canceled]`) before or after the second attempt has already replaced the shared `abortControllerRef.current`. That's the source of the reported 2-of-4-browsers nondeterminism.

`useEncounterStream2`'s catch handler decided "was this abort intentional" by reading `abortControllerRef.current?.signal.aborted` — a **shared, mutable ref** — at catch time, which can by then point to a **different, newer** connect attempt:

- If the newer attempt's controller isn't aborted, the stale attempt's catch falls through to `scheduleReconnect()`, arming a `setTimeout(connect, delay)` against **its own dead closure**. When that zombie timer later fires, it creates yet another `AbortController`, overwrites the ref again (orphaning the live connection), and resets state back to `'connecting'` — which is exactly the "stuck connecting forever" symptom, since nothing then observes or repairs the orphaned live stream.
- The reverse false-positive (a live attempt's real error getting silently swallowed because the ref happens to look aborted) was also on the table depending on timing.

## Fix

Tag every `connect()` attempt with a generation counter (`generationRef`) at the moment it starts. Every side effect a connect attempt performs — state updates, writing `abortControllerRef`/`retryTimeoutRef`, and `scheduleReconnect()` itself — is gated on `generationRef.current === myGeneration`. "Was this abort mine" is now decided from the attempt's own **locally captured** `AbortController`, never the shared ref. A superseded attempt's belated rejection is now a guaranteed no-op instead of a coin flip.

This tolerates StrictMode's double-invoke (and any future deps-driven churn) rather than working around or disabling it, per the harness's existing dev-mode guidance.

## Load-bearing

- The race lives entirely in `useEncounterStream2`'s per-attempt bookkeeping, not in `EncounterView`/`GameView`/`LobbyFlow` — no changes needed there. `GameView` mounts `EncounterView` exactly once (prop, not key), so the only churn is the hook's own effect double-invoking.
- `useLobbyStream` (`src/api/useLobbyStream.ts`) has the **identical** shared-ref pattern and is exposed to the same class of race on any future churn of `LobbyFlow`'s mount — it isn't touched here (out of scope for #442, which is specific to the lobby→encounter transition), but it's worth a follow-up if lobby-mount churn is ever observed.
- The harness (`/playtest`) mounts `useEncounterStream2` once from a URL with no in-app transition, so it never exercised this path — its 656-test suite is unaffected and stays green (now 659 with the 3 new regression tests).

## Regression tests (`src/api/useEncounterStream2.test.ts`)

1. `schedules a reconnect when the stream aborts before the first snapshot arrives` — a transport-level abort while the hook is still mounted and still wants the connection must reconnect, not swallow the error.
2. `does not schedule a reconnect when unmounted before the first snapshot arrives` — a real unmount's own abort must never reconnect.
3. `a superseded connection from mount-churn never re-arms its own reconnect and does not disrupt the live one` — the actual #442 regression: reproduces the shared-ref race on a single hook instance (via a `rerender`-driven effect churn) and asserts the stale attempt never fires a 3rd, zombie `streamEncounter()` call. **Verified this test fails against the pre-fix code** (caught the exact bug: a 3rd zombie call from the stale generation) before confirming it passes with the fix.

## Four-question gate

- **Goal**: encounter stream reconnects reliably across the lobby→encounter mount transition, regardless of StrictMode/effect churn timing. Met — the fix removes the timing dependency entirely (generation gating, not luck).
- **Pattern**: matches the existing `RECONNECT_CONFIG`/backoff shared with `useEncounterStream` (v1) and `useLobbyStream`; no new abstractions, just closing the per-attempt identity gap in the existing connect/reconnect closure shape.
- **Test**: `npm run ci-check` green (format, lint, typecheck, build, tests — 659/659). New regression test independently verified to fail on the old code and pass on the fix.
- **Pushback**: `useLobbyStream` carries the same latent bug (noted above, left out of scope). Also flagging: I did not spin up dev servers/browsers to re-run the original 4-browser MCP playtest myself per the no-browser/no-dev-server constraint — this PR's evidence is the isolated regression test reproducing the exact race mechanism, not a fresh playtest capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)