### PR TITLE
feat(map): walls flow from the stream to the hexes

### DIFF
--- a/docs/architecture/components/playtest-harness.md
+++ b/docs/architecture/components/playtest-harness.md
@@ -1,7 +1,7 @@
 ---
 name: PlaytestHarness
 description: Dev-only verification harness for the v1alpha2 encounter stream — now with a clickable hex grid alongside the raw dev panel
-updated: 2026-07-04
+updated: 2026-07-13
 confidence: high — verified by reading PlaytestHarness.tsx + PlaytestMap.tsx and the vitest suite
 ---
 
@@ -33,7 +33,8 @@ The choice is local component state; no URL persistence. Switching modes does no
 
 1. **Floor tiles from per-hex reveals.** The playtest accumulates v1alpha2 `revealedHexes: Set<string>` via the `GeometryRevealed` event; production game routes accumulate v1alpha1 `Room`-shaped `floorTiles` via `useDungeonMap`. `synthesizeFloorTiles` joins reveals + every entity's cell into the `Map<string, AbsoluteFloorTile>` HexGrid expects, with `roomId: ''` (the playtest does not track room-level reveal aggregation).
 2. **RenderableEntity[] from v2 state.** v2 `EntityState` stubs carry only `entityId` + `position`; identity (CHARACTER/MONSTER + monsterRefId) and HP live in separate stores (`entityMeta`, `entityHP`). `buildRenderableEntities` joins all three.
-3. **Click routing.** HexGrid's `onMoveComplete` / `onEntityClick` callbacks are forwarded to the harness, which translates to `moveEntity` / `takeAction` RPCs.
+3. **Walls straight from the store.** `useEncounterState.walls: Map<string, Wall>` (The Dungeon wave 1, rpg-dnd5e-web#451) is handed to `HexGrid` as `Array.from(walls.values())` — no adapter-level transform needed since the store already keys by `wallKey`. Degrades to `[]` (no walls render) until rpg-api#644 populates `Space.Walls`/`GeometryRevealed.walls` on the wire.
+4. **Click routing.** HexGrid's `onMoveComplete` / `onEntityClick` callbacks are forwarded to the harness, which translates to `moveEntity` / `takeAction` RPCs.
 
 ### PlaytestMap uses HexGrid directly
 

--- a/docs/architecture/components/use-encounter-state.md
+++ b/docs/architecture/components/use-encounter-state.md
@@ -1,7 +1,7 @@
 ---
 name: useEncounterState
 description: Single authoritative entity/turn/prompt store, populated exclusively from the v1alpha2 stream — trimmed of its v1alpha1 snapshot-replace path in slice 3
-updated: 2026-07-12
+updated: 2026-07-13
 confidence: high — verified by reading useEncounterState.ts and useEncounterState.test.ts in full
 ---
 
@@ -50,19 +50,20 @@ Map<string, EntityState>` uses the v1alpha1 `EntityState` proto as its
 
 ## State shape
 
-| Field                                                             | Populated by                                                                              |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `entities`                                                        | `applyEntityAppeared(Batch)`, delta reducers                                              |
-| `revealedHexes`                                                   | `applyHexRevealed` (`GeometryRevealed`)                                                   |
-| `openDoors`                                                       | `applyDoorOpened` (`DoorOpened`)                                                          |
-| `entityHP`                                                        | `applyEntityDamaged`, entity-appear seeding                                               |
-| `entityAC`                                                        | Entity-appear seeding (initial AC)                                                        |
-| `entityStatuses`                                                  | `applyStatusApplied`/`applyStatusRemoved`                                                 |
-| `entityMeta`                                                      | `applyEntityMetaFromAppeared`/batch                                                       |
-| `initiativeOrder`, `activeEntityId`, `round`, `mode`, `turnState` | `applySnapshotTurnState`, `applyTurnStarted`, `applyTurnStateChanged`, `applyModeChanged` |
-| `pendingPrompt`                                                   | `setPendingPromptReducer` (caller-driven, never auto-set)                                 |
-| `encounterStatus`, `encounterEndedReason`                         | `applyEncounterEnded`                                                                     |
-| `reactionReadiness`                                               | `setReactionReadyLocalReducer` (optimistic mirror after `SetReactionReady` RPC)           |
+| Field                                                             | Populated by                                                                                                                                                                          |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entities`                                                        | `applyEntityAppeared(Batch)`, delta reducers                                                                                                                                          |
+| `revealedHexes`                                                   | `applyHexRevealed` (`GeometryRevealed`)                                                                                                                                               |
+| `walls`                                                           | `applyWallsRevealed` (snapshot's `Space.walls`, `GeometryRevealed.walls`) — sticky `Map<wallKey, Wall>`; overwrites an entry when `kind` changes (e.g. a door opening), never removes |
+| `openDoors`                                                       | `applyDoorOpened` (`DoorOpened`)                                                                                                                                                      |
+| `entityHP`                                                        | `applyEntityDamaged`, entity-appear seeding                                                                                                                                           |
+| `entityAC`                                                        | Entity-appear seeding (initial AC)                                                                                                                                                    |
+| `entityStatuses`                                                  | `applyStatusApplied`/`applyStatusRemoved`                                                                                                                                             |
+| `entityMeta`                                                      | `applyEntityMetaFromAppeared`/batch                                                                                                                                                   |
+| `initiativeOrder`, `activeEntityId`, `round`, `mode`, `turnState` | `applySnapshotTurnState`, `applyTurnStarted`, `applyTurnStateChanged`, `applyModeChanged`                                                                                             |
+| `pendingPrompt`                                                   | `setPendingPromptReducer` (caller-driven, never auto-set)                                                                                                                             |
+| `encounterStatus`, `encounterEndedReason`                         | `applyEncounterEnded`                                                                                                                                                                 |
+| `reactionReadiness`                                               | `setReactionReadyLocalReducer` (optimistic mirror after `SetReactionReady` RPC)                                                                                                       |
 
 `applyEntityPositionUpdate`/`mergeEntityPosition` and `reset` round out
 the public API — the former is the `MovementCompletedEvent` fallback when

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -72,10 +72,13 @@ state-free helpers `hex-grid/*` and the playtest map still depend on:
 `AbsoluteFloorTile` (tile shape), `wallKey` (canonical wall-dedup key),
 `openDoorWalkableKeys` (open-door cube keys for pathfinding). No proto
 mutation, no accumulated multi-room state — that's future work (slice 4).
-`wallKey` has two call sites: `HexGrid`'s render loop (deduplicating a
-wall reported by both adjacent hexes into one `ShadedHexWall`) and
-`useEncounterState.applyWallsRevealed` (the same direction-normalized key,
-now also the sticky store's `Map` key).
+`wallKey` has two call sites: `useEncounterState.applyWallsRevealed`, where
+it's the sticky store's `Map` key and does the actual dedup (a wall
+reported from either adjacent hex collapses to one entry before
+`Array.from(walls.values())` ever reaches `HexGrid`), and `HexGrid`'s
+render loop, which reuses the same direction-normalized string only as the
+React `key` for each `ShadedHexWall` — it does not itself dedupe the
+`walls` array it's given.
 Full detail: [use-dungeon-map.md](components/use-dungeon-map.md).
 
 ## Transform functions: deleted with LobbyView

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-dnd5e-web data model
 description: Proto types consumed, transform layer, derived UI state
-updated: 2026-07-12
-confidence: medium — proto packages table, snapshot, and transform sections refreshed for slice 3 (rpg-dnd5e-web#447, LobbyView deletion); hand-rolled-interfaces and proto-version-discipline sections not independently re-verified this pass
+updated: 2026-07-13
+confidence: medium — proto packages table, snapshot, walls, and transform sections refreshed for The Dungeon wave 1 (rpg-dnd5e-web#451) and slice 3 (rpg-dnd5e-web#447, LobbyView deletion); hand-rolled-interfaces and proto-version-discipline sections not independently re-verified this pass
 ---
 
 # Data model
@@ -13,12 +13,12 @@ All types flow in from `@kirkdiggler/rpg-api-protos`. The web layer consumes sev
 
 | Proto package                    | Generated path                             | What we use                                                                                                                                                                                                                                     |
 | -------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dnd5e.api.v1alpha2` (encounter) | `gen/ts/dnd5e/api/v1alpha2/encounter/*_pb` | `StreamEncounter`, all v2 event types, `TurnState`, `AvailableAction`, `InputRequired` — the live game/harness stream                                                                                                                           |
+| `dnd5e.api.v1alpha2` (encounter) | `gen/ts/dnd5e/api/v1alpha2/encounter/*_pb` | `StreamEncounter`, all v2 event types, `TurnState`, `AvailableAction`, `InputRequired`, `Space` (`hexes`/`walls`/`entities`/`zones`), `Wall`/`WallKind` — the live game/harness stream                                                          |
 | `dnd5e.api.v1alpha1` (encounter) | `gen/ts/dnd5e/api/v1alpha1/encounter_pb`   | `EntityState`, `RoomLayout`, `DoorInfo`, `EntityPlacement`, `Room` — entity/geometry **shapes**, deliberately reused by the v2 stream's event payloads (not a legacy holdover; see [use-encounter-state.md](components/use-encounter-state.md)) |
 | `dnd5e.api.lobby.v1alpha1`       | `gen/ts/dnd5e/api/lobby/v1alpha1/*_pb`     | `LobbyService`, `LobbyEvent`/`StreamLobby` — party assembly (slice 1, rpg-api#630)                                                                                                                                                              |
 | `dnd5e.api.v1alpha1` (character) | `gen/ts/dnd5e/api/v1alpha1/character_pb`   | `Character`, `CharacterService` — the character creation/sheet subsystem, unaffected by and never in scope for the game-screen rebuild                                                                                                          |
 | `dnd5e.api.v1alpha1` (enums)     | `gen/ts/dnd5e/api/v1alpha1/enums_pb`       | `Ability`, `EntityType`, `MonsterType`, `ConditionType`, `FeatureType`                                                                                                                                                                          |
-| `api.v1alpha1`                   | `gen/ts/api/v1alpha1/room_common_pb`       | `Wall`, `Position`, `GridType`                                                                                                                                                                                                                  |
+| `api.v1alpha1`                   | `gen/ts/api/v1alpha1/room_common_pb`       | `Position`, `GridType` — `Wall` moved off this package to the v1alpha2 encounter type in rpg-dnd5e-web#450; only the dead, unexported-from-anywhere-live `HexWall.tsx` (superseded by `ShadedHexWall`) still imports the old one                |
 | `api.v1alpha1`                   | `gen/ts/api/v1alpha1/dice_pb`              | `DiceService`                                                                                                                                                                                                                                   |
 
 The old v1alpha1 `EncounterService`'s request/response lobby/combat RPCs
@@ -45,6 +45,16 @@ distinguishing `characterDetails`/`monsterDetails`. The v2 stream's
 `EntityAppeared` event carries one; `useEncounterState.entities` is a
 `Map<entityId, EntityState>` built up one appearance at a time.
 
+Walls follow the same seed-then-delta shape as entities, mirroring
+`revealedHexes`: `SnapshotDelivered.encounter.space?.walls` seeds the sticky
+`walls` store via `applyWallsRevealed`, and each `GeometryRevealed.walls`
+merges in newly-explored segments (or an updated `kind`, e.g. a door
+transitioning `DOOR_CLOSED` -> `DOOR_OPEN`) the same way. `EncounterMap` and
+`PlaytestMap` both thread the store's `walls: Map<string, Wall>` through to
+`HexGrid`'s `walls?: Wall[]` prop (`Array.from(walls.values())`); an empty
+map — today's api, until rpg-api#644 lands `Space.Walls` population — is
+just an empty `walls` prop, not an error path.
+
 ## useEncounterState: unified entity/turn/prompt store
 
 `hooks/useEncounterState.ts` maintains entity, turn, and prompt state
@@ -62,6 +72,10 @@ state-free helpers `hex-grid/*` and the playtest map still depend on:
 `AbsoluteFloorTile` (tile shape), `wallKey` (canonical wall-dedup key),
 `openDoorWalkableKeys` (open-door cube keys for pathfinding). No proto
 mutation, no accumulated multi-room state — that's future work (slice 4).
+`wallKey` has two call sites: `HexGrid`'s render loop (deduplicating a
+wall reported by both adjacent hexes into one `ShadedHexWall`) and
+`useEncounterState.applyWallsRevealed` (the same direction-normalized key,
+now also the sticky store's `Map` key).
 Full detail: [use-dungeon-map.md](components/use-dungeon-map.md).
 
 ## Transform functions: deleted with LobbyView

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -12,6 +12,7 @@
  */
 
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useMemo } from 'react';
 import type { EntityMeta } from '../../hooks/useEncounterState';
 import { HexGrid } from '../hex-grid';
@@ -29,6 +30,8 @@ export interface EncounterMapProps {
   entityMeta: Map<string, EntityMeta>;
   /** Per-hex reveal set ("x,y,z" cube-coord keys) from GeometryRevealed events. */
   revealedHexes: Set<string>;
+  /** Sticky revealed walls, keyed by wallKey, from Space.walls/GeometryRevealed.walls. Renders as [] when the server sends none. */
+  walls: Map<string, Wall>;
   /** Per-entity HP — marks monsters dead (HP <= 0) so HexGrid renders their corpse. */
   entityHP: Map<string, { current: number; max: number }>;
   /** v1alpha2 initiative order (entity ids) — drives the TurnOrderOverlay. Empty outside TURN_BASED. */
@@ -55,6 +58,7 @@ export function EncounterMap({
   entities,
   entityMeta,
   revealedHexes,
+  walls,
   entityHP,
   initiativeOrder,
   activeEntityId,
@@ -69,6 +73,8 @@ export function EncounterMap({
     () => synthesizeFloorTiles(revealedHexes, entities.values()),
     [revealedHexes, entities]
   );
+
+  const wallList = useMemo(() => Array.from(walls.values()), [walls]);
 
   const renderableEntities = useMemo(
     () => buildRenderableEntities(entities, entityMeta, entityHP),
@@ -102,6 +108,7 @@ export function EncounterMap({
       <HexGrid
         floorTiles={floorTiles}
         entities={renderableEntities}
+        walls={wallList}
         selectedEntityId={myEntityId}
         currentEntityId={myEntityId}
         movementRemaining={movementRemaining}

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -126,6 +126,10 @@ export function EncounterView({
         if (entityEntries.length > 0) {
           encounterState.applyEntityAppearedBatch(entityEntries);
         }
+        const walls = e.encounter.space?.walls ?? [];
+        if (walls.length > 0) {
+          encounterState.applyWallsRevealed(walls);
+        }
       }
     },
     onEntityMoved: (e) => {
@@ -142,6 +146,10 @@ export function EncounterView({
         .map((h) => h.position)
         .filter((p): p is NonNullable<typeof p> => p !== undefined);
       encounterState.applyHexRevealed(positions.map(protoPositionToHex));
+      const walls = e.walls ?? [];
+      if (walls.length > 0) {
+        encounterState.applyWallsRevealed(walls);
+      }
     },
     onEntityAppeared: (e) => {
       if (!e.entity || !e.entity.position) return;
@@ -376,6 +384,7 @@ export function EncounterView({
           entities={encounterState.state.entities}
           entityMeta={encounterState.state.entityMeta}
           revealedHexes={encounterState.state.revealedHexes}
+          walls={encounterState.state.walls}
           entityHP={encounterState.state.entityHP}
           // Gate by mode: applyModeChanged only flips `mode`, it doesn't
           // clear initiativeOrder/activeEntityId (only the next snapshot's

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -201,6 +201,10 @@ export function PlaytestHarness() {
           if (entityEntries.length > 0) {
             encounterState.applyEntityAppearedBatch(entityEntries);
           }
+          const walls = e.encounter.space?.walls ?? [];
+          if (walls.length > 0) {
+            encounterState.applyWallsRevealed(walls);
+          }
         }
         addLog('SnapshotDelivered (stream up)');
       },
@@ -220,6 +224,10 @@ export function PlaytestHarness() {
           .map((h) => h.position)
           .filter((p): p is NonNullable<typeof p> => p !== undefined);
         encounterState.applyHexRevealed(positions.map(protoPositionToHex));
+        const walls = e.walls ?? [];
+        if (walls.length > 0) {
+          encounterState.applyWallsRevealed(walls);
+        }
         addLog(`GeometryRevealed ${positions.length} hex(es)`);
       },
       onEntityAppeared: (e) => {
@@ -990,6 +998,7 @@ export function PlaytestHarness() {
             entities={encounterState.state.entities}
             entityMeta={encounterState.state.entityMeta}
             revealedHexes={encounterState.state.revealedHexes}
+            walls={encounterState.state.walls}
             entityHP={encounterState.state.entityHP}
             myEntityId={entityId}
             fallbackPosition={fallback}

--- a/src/components/playtest/PlaytestMap.tsx
+++ b/src/components/playtest/PlaytestMap.tsx
@@ -37,6 +37,7 @@
  */
 
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useMemo } from 'react';
 import type { EntityMeta } from '../../hooks/useEncounterState';
 import { HexGrid } from '../hex-grid';
@@ -63,6 +64,12 @@ export interface PlaytestMapProps {
    * becomes a synthesized floor tile so HexGrid can render and pathfind.
    */
   revealedHexes: Set<string>;
+  /**
+   * Sticky revealed walls, keyed by `wallKey`, from `Space.walls` (snapshot)
+   * merged with `GeometryRevealed.walls` (delta). Degrades to an empty map
+   * — and no walls render — when the server sends none.
+   */
+  walls: Map<string, Wall>;
   /**
    * v1alpha2 per-entity HP. Used to mark monsters as dead (HP <= 0) so
    * HexGrid renders their corpse and excludes them from blocking checks.
@@ -115,6 +122,7 @@ export function PlaytestMap({
   entities,
   entityMeta,
   revealedHexes,
+  walls,
   entityHP,
   myEntityId,
   fallbackPosition,
@@ -128,6 +136,8 @@ export function PlaytestMap({
       synthesizeFloorTiles(revealedHexes, entities.values(), fallbackPosition),
     [revealedHexes, entities, fallbackPosition]
   );
+
+  const wallList = useMemo(() => Array.from(walls.values()), [walls]);
 
   const renderableEntities = useMemo(
     () => buildRenderableEntities(entities, entityMeta, entityHP),
@@ -153,6 +163,7 @@ export function PlaytestMap({
       <HexGrid
         floorTiles={floorTiles}
         entities={renderableEntities}
+        walls={wallList}
         selectedEntityId={myEntityId}
         currentEntityId={myEntityId}
         movementRemaining={movementRemaining}

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -36,9 +36,14 @@ import {
   SkillCheckPromptSchema,
   TargetKind,
   TurnStateSchema,
+  PositionSchema as V2PositionSchema,
+  type Wall,
+  WallKind,
+  WallSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
 import { hexKey } from '../utils/hexCoord';
+import { wallKey } from './dungeonMapGeometry';
 import {
   applyDoorOpened,
   applyEncounterEnded,
@@ -57,11 +62,24 @@ import {
   applyTurnEnded,
   applyTurnStarted,
   applyTurnStateChanged,
+  applyWallsRevealed,
   createEmptyEncounterState,
   mergeEntityPosition,
   setPendingPromptReducer,
   setReactionReadyLocalReducer,
 } from './useEncounterState';
+
+function makeTestWall(
+  from: { x: number; y: number; z: number },
+  to: { x: number; y: number; z: number },
+  kind: WallKind = WallKind.SOLID
+): Wall {
+  return create(WallSchema, {
+    from: create(V2PositionSchema, from),
+    to: create(V2PositionSchema, to),
+    kind,
+  });
+}
 
 describe('createEmptyEncounterState', () => {
   it('returns empty state with Maps and default values', () => {
@@ -73,6 +91,8 @@ describe('createEmptyEncounterState', () => {
     expect(state.entities.size).toBe(0);
     expect(state.revealedHexes).toBeInstanceOf(Set);
     expect(state.revealedHexes.size).toBe(0);
+    expect(state.walls).toBeInstanceOf(Map);
+    expect(state.walls.size).toBe(0);
     expect(state.openDoors).toBeInstanceOf(Set);
     expect(state.openDoors.size).toBe(0);
     expect(state.entityHP).toBeInstanceOf(Map);
@@ -241,6 +261,75 @@ describe('v1alpha2 reducer additions', () => {
       ]);
       const after = applyHexRevealed(prev, [{ q: 2, r: -1, s: -1 }]);
       expect(after.revealedHexes.size).toBe(1);
+    });
+  });
+
+  describe('applyWallsRevealed', () => {
+    it('adds walls to the sticky map without dropping existing ones', () => {
+      const wallA = makeTestWall({ x: 0, y: 0, z: 0 }, { x: 1, y: -1, z: 0 });
+      const wallB = makeTestWall(
+        { x: 2, y: -1, z: -1 },
+        { x: 3, y: -2, z: -1 }
+      );
+
+      const after1 = applyWallsRevealed(createEmptyEncounterState(), [wallA]);
+      expect(after1.walls.get(wallKey(wallA))).toEqual(wallA);
+
+      const after2 = applyWallsRevealed(after1, [wallB]);
+      expect(after2.walls.get(wallKey(wallA))).toEqual(wallA);
+      expect(after2.walls.get(wallKey(wallB))).toEqual(wallB);
+      expect(after2.walls.size).toBe(2);
+    });
+
+    it('is idempotent (same reference) on a re-delivered wall with unchanged kind', () => {
+      const wall = makeTestWall({ x: 0, y: 0, z: 0 }, { x: 1, y: -1, z: 0 });
+      const prev = applyWallsRevealed(createEmptyEncounterState(), [wall]);
+      const after = applyWallsRevealed(prev, [wall]);
+      expect(after).toBe(prev);
+    });
+
+    it('overwrites an entry whose kind changed (door open/close transitions)', () => {
+      const closed = makeTestWall(
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+        WallKind.DOOR_CLOSED
+      );
+      const opened = makeTestWall(
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+        WallKind.DOOR_OPEN
+      );
+
+      const prev = applyWallsRevealed(createEmptyEncounterState(), [closed]);
+      const after = applyWallsRevealed(prev, [opened]);
+      expect(after).not.toBe(prev);
+      expect(after.walls.get(wallKey(closed))?.kind).toBe(WallKind.DOOR_OPEN);
+      expect(after.walls.size).toBe(1);
+    });
+
+    it('collapses a wall reported in either direction to the same key', () => {
+      const forward = makeTestWall({ x: 0, y: 0, z: 0 }, { x: 1, y: -1, z: 0 });
+      const reverse = makeTestWall({ x: 1, y: -1, z: 0 }, { x: 0, y: 0, z: 0 });
+
+      const after = applyWallsRevealed(createEmptyEncounterState(), [
+        forward,
+        reverse,
+      ]);
+      expect(after.walls.size).toBe(1);
+    });
+
+    it('skips walls missing from/to (defensive)', () => {
+      const malformed = create(WallSchema, { kind: WallKind.SOLID });
+      const after = applyWallsRevealed(createEmptyEncounterState(), [
+        malformed,
+      ]);
+      expect(after.walls.size).toBe(0);
+    });
+
+    it('is a no-op on an empty walls array', () => {
+      const prev = createEmptyEncounterState();
+      const after = applyWallsRevealed(prev, []);
+      expect(after).toBe(prev);
     });
   });
 

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -32,6 +32,7 @@ import type {
 import type {
   InputRequired,
   TurnState,
+  Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
@@ -39,6 +40,7 @@ import {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useCallback, useState } from 'react';
 import { hexKey, type CubeHexCoord } from '../utils/hexCoord';
+import { wallKey } from './dungeonMapGeometry';
 
 /** v1alpha2 per-entity HP, populated from EntityDamaged.hp_after. */
 export interface EntityHP {
@@ -79,6 +81,15 @@ export interface LocalEncounterState {
   entities: Map<string, EntityState & { ghost?: boolean }>;
   /** v1alpha2-revealed hexes (per-hex granularity). */
   revealedHexes: Set<string>;
+  /**
+   * v1alpha2 revealed walls, keyed by `wallKey` (canonical, direction-
+   * normalized). Sticky like `revealedHexes` — populated from the
+   * snapshot's `Space.walls` and merged from `GeometryRevealed.walls`,
+   * never removed. Unlike `revealedHexes` (a bare position `Set`), this
+   * keeps the full `Wall` (including `kind`) since renderers need it to
+   * distinguish solid/door/window segments.
+   */
+  walls: Map<string, Wall>;
   /**
    * v1alpha2 open-door entity IDs. Populated by `applyDoorOpened` from the
    * DoorOpened event, keyed by the proto's `door_entity_id`. Renderers
@@ -211,6 +222,7 @@ export function createEmptyEncounterState(): LocalEncounterState {
     dungeonId: '',
     entities: new Map(),
     revealedHexes: new Set(),
+    walls: new Map(),
     openDoors: new Set(),
     entityHP: new Map(),
     entityAC: new Map(),
@@ -269,6 +281,33 @@ export function applyHexRevealed(
     next.add(hexKey(h));
   }
   return { ...prev, revealedHexes: next };
+}
+
+/**
+ * Add walls to the sticky wall map without dropping previously revealed
+ * walls. Keyed by `wallKey` (direction-normalized), so a wall reported from
+ * either adjacent hex collapses to one entry. A re-delivered wall with an
+ * unchanged `kind` is a no-op; a changed `kind` (e.g. a door segment
+ * transitioning `DOOR_CLOSED` -> `DOOR_OPEN`) overwrites the entry — the
+ * wall list carries state transitions, not just first-reveal. Walls missing
+ * `from`/`to` (defensive — proto fields are optional) are skipped, same
+ * guard HexGrid/ShadedHexWall apply before rendering.
+ * Exported for testing.
+ */
+export function applyWallsRevealed(
+  prev: LocalEncounterState,
+  walls: Wall[]
+): LocalEncounterState {
+  let next: Map<string, Wall> | undefined;
+  for (const wall of walls) {
+    if (!wall.from || !wall.to) continue;
+    const key = wallKey(wall);
+    const existing = (next ?? prev.walls).get(key);
+    if (existing && existing.kind === wall.kind) continue;
+    if (!next) next = new Map(prev.walls);
+    next.set(key, wall);
+  }
+  return next ? { ...prev, walls: next } : prev;
 }
 
 /**
@@ -772,6 +811,8 @@ export interface UseEncounterStateResult {
   // v1alpha2 additions
   /** Add hexes to the per-hex reveal set (additive, idempotent) */
   applyHexRevealed: (hexes: CubeHexCoord[]) => void;
+  /** Add walls to the sticky wall map, keyed by `wallKey` (additive, idempotent) */
+  applyWallsRevealed: (walls: Wall[]) => void;
   /** Add or revive an entity at its first-visible position, clearing ghost */
   applyEntityAppeared: (entity: EntityState) => void;
   /** Mark entity as ghosted at last known position; no-op if not tracked */
@@ -892,6 +933,10 @@ export function useEncounterState(): UseEncounterStateResult {
 
   const applyHexRevealedCallback = useCallback((hexes: CubeHexCoord[]) => {
     setState((prev) => applyHexRevealed(prev, hexes));
+  }, []);
+
+  const applyWallsRevealedCallback = useCallback((walls: Wall[]) => {
+    setState((prev) => applyWallsRevealed(prev, walls));
   }, []);
 
   const applyEntityAppearedCallback = useCallback((entity: EntityState) => {
@@ -1019,6 +1064,7 @@ export function useEncounterState(): UseEncounterStateResult {
     applyEntityPositionUpdate,
     reset,
     applyHexRevealed: applyHexRevealedCallback,
+    applyWallsRevealed: applyWallsRevealedCallback,
     applyEntityAppeared: applyEntityAppearedCallback,
     applyEntityDisappeared: applyEntityDisappearedCallback,
     applyDoorOpened: applyDoorOpenedCallback,


### PR DESCRIPTION
## Summary

Closes #451 — pure plumbing (design: [The Dungeon](https://github.com/KirkDiggler/rpg-project/blob/main/ideas/the-dungeon/design.md), step 9; board [#19](https://github.com/users/KirkDiggler/projects/19), The Dungeon leg). The type half landed in #450 (HexGrid already imports the v1alpha2 `Wall`); this PR threads the actual wall data from the encounter stream into the map.

- **`useEncounterState`** gains a sticky `walls: Map<string, Wall>` store (keyed by `wallKey`, same normalized key `HexGrid` already uses to dedupe a wall reported from both adjacent hexes) and a new `applyWallsRevealed` reducer. Mirrors `revealedHexes`'s seed-then-delta shape, but keeps the full `Wall` (not just a position key) since renderers need `kind` to distinguish solid/door/window segments. A re-delivered wall with an unchanged `kind` is a no-op; a changed `kind` (e.g. `DOOR_CLOSED` → `DOOR_OPEN`) overwrites the entry — the wall list carries state transitions, not just first-reveal.
- **`EncounterView`/`PlaytestHarness`** seed the store from `SnapshotDelivered.encounter.space?.walls` and merge from each `GeometryRevealed.walls`, same pattern as the existing entity/hex handling.
- **`EncounterMap`/`PlaytestMap`** take the new `walls` prop and pass `Array.from(walls.values())` straight through to `HexGrid`'s existing `walls?: Wall[]` prop — `ShadedHexWall` rendering was already built and waiting (per #450's load-bearing note).
- **Docs close the loop**: `data-model.md` (proto table + a new walls-flow paragraph, plus fixing a stale row that still said `Wall` lives in `room_common_pb` — that moved in #450), `use-encounter-state.md` (state-shape table), `playtest-harness.md` (adapter responsibilities list).

Both routes degrade gracefully to no walls when the server sends none — today's api, until rpg-api#644 lands `Space.Walls` population. No client-side wall inference anywhere; every wall rendered is server data verbatim.

## Load-bearing

- The store keeps the full `Wall` proto (not a bare position `Set` like `revealedHexes`) because `kind` (SOLID/DOOR_CLOSED/DOOR_OPEN/WINDOW) is load-bearing for rendering — `ShadedHexWall` picks wall color from it.
- `applyWallsRevealed` overwrites-on-kind-change rather than skip-if-present, so a door's `DOOR_CLOSED` → `DOOR_OPEN` transition (delivered as a re-sent `Wall` on a later `GeometryRevealed`, per the design doc's "the segment stays in the wall list with a different kind" note) actually updates the stored entry.
- Final verification (walled room renders on both routes, with rpg-api#644 running locally) is the orchestrator's full MCP playtest — this PR's own verification is `npm run ci-check` green plus reasoning through the two SnapshotDelivered/GeometryRevealed call sites; I did not stand up a local api build.

## Test plan

- [x] `npm run ci-check` green (format, lint, typecheck, build, 575/575 tests)
- [x] New `applyWallsRevealed` reducer tests: sticky accumulation, idempotency on unchanged `kind`, overwrite on `kind` change (door open), direction-normalized dedup, defensive skip on missing `from`/`to`, no-op on empty input
- [x] `createEmptyEncounterState` asserts the new `walls` field
- [x] Fixed a latent crash surfaced by the new `onGeometryRevealed` wall-length check: `PlaytestHarness.test.tsx`'s cause/effect-split test builds a partial `GeometryRevealed` fixture with no `walls` field, so the handler now guards with `e.walls ?? []` (also applied in `EncounterView`) rather than assuming the field is always populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)