### PR TITLE
refactor(rendering): promote HEX_SIZE/SYNTY_SCALE/WALL_HEIGHT to shared homes

### DIFF
--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -31,7 +31,7 @@ import * as THREE from 'three';
 import { FrontierGroundHint } from './FrontierGroundHint';
 import { HexDoor } from './HexDoor';
 import { HexEntity } from './HexEntity';
-import { cubeToWorld, getHexLine, type CubeCoord } from './hexMath';
+import { cubeToWorld, getHexLine, HEX_SIZE, type CubeCoord } from './hexMath';
 import { MovementRangeBorder } from './MovementRangeBorder';
 import { PathPreview } from './PathPreview';
 import { ShadedHexFloor } from './ShadedHexFloor';
@@ -84,9 +84,6 @@ export interface HexGridProps {
    * layers (e.g. the playtest harness's Synty model showcase). */
   children?: React.ReactNode;
 }
-
-// Hex size constant - radius from center to vertex
-const HEX_SIZE = 1.0;
 
 // Ground plane size - large enough to cover the entire grid with plenty of margin
 const GROUND_PLANE_SIZE = 200;

--- a/src/components/hex-grid/HexWall.tsx
+++ b/src/components/hex-grid/HexWall.tsx
@@ -6,10 +6,10 @@
  * Uses shared hex geometry for visual consistency with tiles and doors.
  */
 
+import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import { WALL_HEIGHT } from '../../rendering/calibrationConstants';
 import { createHexPillarGeometry } from './hexGeometry';
 import { cubeToWorld, getHexLine, type CubeCoord } from './hexMath';
 

--- a/src/components/hex-grid/HexWall.tsx
+++ b/src/components/hex-grid/HexWall.tsx
@@ -9,6 +9,7 @@
 import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
+import { WALL_HEIGHT } from '../../rendering/calibrationConstants';
 import { createHexPillarGeometry } from './hexGeometry';
 import { cubeToWorld, getHexLine, type CubeCoord } from './hexMath';
 
@@ -16,9 +17,6 @@ export interface HexWallProps {
   wall: Wall;
   hexSize: number;
 }
-
-// Wall height in world space units (matches hex size scale)
-const WALL_HEIGHT = 0.8;
 
 // Color lookup by material type
 function getMaterialColor(material: string): string {

--- a/src/components/hex-grid/ShadedHexWall.tsx
+++ b/src/components/hex-grid/ShadedHexWall.tsx
@@ -16,6 +16,7 @@ import { useThree } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
+import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { WallBuilder, WallColors } from '@/rendering/WallBuilder';
 
 import { cubeToWorld, getHexLine, type CubeCoord } from './hexMath';
@@ -24,9 +25,6 @@ export interface ShadedHexWallProps {
   wall: Wall;
   hexSize: number;
 }
-
-// Wall height in world space units (matches HexWall's WALL_HEIGHT)
-const WALL_HEIGHT = 0.8;
 
 // Color lookup by wall kind. v1alpha2 Wall carries no material field (the
 // v1alpha1 room_common Wall this replaced did) — kind is the only semantic

--- a/src/components/hex-grid/hexMath.ts
+++ b/src/components/hex-grid/hexMath.ts
@@ -23,6 +23,17 @@ export interface WorldPos {
 const SQRT_3 = Math.sqrt(3);
 
 /**
+ * The game's standard hex radius (center to vertex), in world units. Every
+ * caller of cubeToWorld/worldToCube in the live game routes uses this value
+ * — until rpg-dnd5e-web#432's harness-parity gate, it was a private
+ * `const HEX_SIZE = 1.0` re-declared independently in HexGrid.tsx,
+ * SyntyShowcase.tsx, and SyntyRoomDemo.tsx (each with a "matches HEX_SIZE in
+ * HexGrid.tsx, not exported there" comment). Exported here so every
+ * consumer imports the same value instead of re-declaring it.
+ */
+export const HEX_SIZE = 1.0;
+
+/**
  * Direction vectors for the 6 hex neighbors
  * Order: E, NE, NW, W, SW, SE (clockwise from east)
  */

--- a/src/components/playtest/SyntyRoomDemo.tsx
+++ b/src/components/playtest/SyntyRoomDemo.tsx
@@ -10,9 +10,12 @@
  * hexes beyond the door — a fog-of-war edge prototype).
  *
  * This is the calibration surface the game dev lifts for real dungeon
- * rendering — see rpg-dnd5e-web#466. Game components (ShadedHexWall,
- * HexDoor, ShadedHexFloor, WallBuilder) are read here for constants only
- * and are never imported/modified.
+ * rendering — see rpg-dnd5e-web#466. WALL_HEIGHT/SYNTY_SCALE/HEX_SIZE come
+ * from the shared `rendering/calibrationConstants` + `hex-grid/hexMath`
+ * homes (rpg-dnd5e-web#432 harness-parity — previously three independent
+ * re-declarations); the game's wall/floor/door RENDERING components
+ * (ShadedHexWall, HexDoor, ShadedHexFloor, WallBuilder) are still never
+ * imported/modified here.
  *
  * The GLBs/textures live in public/models/synty/ which is gitignored —
  * Synty's license allows shipping them in the built game but not
@@ -23,10 +26,12 @@ import { useGLTF, useTexture } from '@react-three/drei';
 import { Suspense, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 
+import { SYNTY_SCALE, WALL_HEIGHT } from '../../rendering/calibrationConstants';
 import {
   coordToKey,
   cubeToWorld,
   HEX_DIRECTIONS,
+  HEX_SIZE,
   type CubeCoord,
   type WorldPos,
 } from '../hex-grid/hexMath';
@@ -34,17 +39,6 @@ import {
 const SYNTY_BASE = '/models/synty/';
 const ENV_BASE = SYNTY_BASE + 'env/';
 const TEX_BASE = SYNTY_BASE + 'textures/';
-
-// Matches HEX_SIZE in HexGrid.tsx / hexMath usage elsewhere (not exported).
-const HEX_SIZE = 1.0;
-
-// Matches WALL_HEIGHT in ShadedHexWall.tsx (world-space wall height used
-// by the existing game wall rendering / WallBuilder).
-const WALL_HEIGHT = 0.8;
-
-// Same uniform scale SyntyShowcase uses to land Synty's meter-scale assets
-// next to the game's ~1.5-unit-tall characters on HEX_SIZE=1 hexes.
-const SYNTY_SCALE = 0.75;
 
 // Raw (scale=1) local-space bounding sizes measured directly off the GLBs
 // with @gltf-transform/core (see PR description for the inspection

--- a/src/components/playtest/SyntyShowcase.tsx
+++ b/src/components/playtest/SyntyShowcase.tsx
@@ -13,17 +13,10 @@
 
 import { useGLTF } from '@react-three/drei';
 import { Suspense } from 'react';
-import { cubeToWorld, type CubeCoord } from '../hex-grid/hexMath';
+import { SYNTY_SCALE } from '../../rendering/calibrationConstants';
+import { cubeToWorld, HEX_SIZE, type CubeCoord } from '../hex-grid/hexMath';
 
 const SYNTY_BASE = '/models/synty/';
-
-// Synty assets are authored in meters (goblin ≈ 1.84 m tall). The game's
-// characters stand ~1.5 world units on HEX_SIZE=1 hexes, so ×0.75 lands a
-// goblin at ~1.4 units — believable next to the existing OBJ characters.
-const SYNTY_SCALE = 0.75;
-
-// Matches HEX_SIZE in HexGrid.tsx (not exported there).
-const HEX_SIZE = 1.0;
 
 interface PlacedModelProps {
   file: string;

--- a/src/rendering/calibrationConstants.ts
+++ b/src/rendering/calibrationConstants.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared rendering calibration constants for the hex-grid game routes and
+ * the Synty asset-integration surfaces (SyntyShowcase, SyntyRoomDemo). Both
+ * families of renderer place geometry against the SAME hex grid and the
+ * SAME wall height, so they must agree on these values rather than each
+ * re-declaring its own copy.
+ *
+ * Promoted here per rpg-dnd5e-web#432's harness-parity gate (PR #470's
+ * review already flagged this: "SYNTY_SCALE + the duplicated HEX_SIZE live
+ * private to the showcase — when assets move to game routes, promote the
+ * scale contract to a shared exported home — it becomes THE calibration
+ * constant"). That trigger point is now: EncounterMap/HexGrid consuming
+ * Synty pieces directly is the next slice in this wave.
+ */
+
+/**
+ * Uniform scale for placed Synty assets. Synty's POLYGON packs are authored
+ * in real-world meters; the game's existing OBJ characters stand ~1.5 world
+ * units tall on HEX_SIZE=1 hexes. 0.75 lands Synty's ~1.84m goblin at ~1.38
+ * units — verified against the game's characters and hex tile in the
+ * harness's `&synty=1` showcase (rpg-dnd5e-web#469/#470). Recommended as
+ * the standard for every Synty placement, not just characters.
+ */
+export const SYNTY_SCALE = 0.75;
+
+/**
+ * Wall height in world-space units for the game's procedural voxel walls
+ * (WallBuilder / ShadedHexWall) and, since rpg-dnd5e-web#472's Synty room
+ * demo, for calibrating Synty wall/door pieces to match — was independently
+ * re-declared as `const WALL_HEIGHT = 0.8` in ShadedHexWall.tsx,
+ * HexWall.tsx, and SyntyRoomDemo.tsx.
+ */
+export const WALL_HEIGHT = 0.8;


### PR DESCRIPTION
## Summary

Slice 4 of the harness-parity wave (#432). PR #470's gate flagged this explicitly: "SYNTY_SCALE + the duplicated HEX_SIZE live private to the showcase — when assets move to game routes, promote the scale contract to a shared exported home — it becomes THE calibration constant." That trigger point is this wave (slice 5 has EncounterMap/HexGrid consuming Synty pieces directly).

Before this commit:
- `HEX_SIZE = 1.0` was independently re-declared as a private const in `HexGrid.tsx`, `SyntyShowcase.tsx`, and `SyntyRoomDemo.tsx` (each with a "matches HEX_SIZE in HexGrid.tsx, not exported there" comment).
- `WALL_HEIGHT = 0.8` was independently re-declared in `ShadedHexWall.tsx`, `HexWall.tsx`, and `SyntyRoomDemo.tsx`.
- `SYNTY_SCALE = 0.75` lived only in `SyntyShowcase.tsx`.

Now:
- `HEX_SIZE` is exported from `hexMath.ts` — a hex-math concept, belongs with `cubeToWorld`/`HEX_DIRECTIONS`.
- `SYNTY_SCALE` and `WALL_HEIGHT` move to a new `src/rendering/calibrationConstants.ts` — rendering-calibration concepts, not hex-math, co-located with `WallBuilder.ts`/`FloorBuilder.ts` under `src/rendering/`.
- All 6 previously-duplicated declarations now import from one of these two homes. Every value is unchanged (`1.0`/`0.75`/`0.8`) — pure dedup, no behavior change intended.

## Scope-decisions

- `HexWall.tsx` (the pre-shader predecessor `ShadedHexWall.tsx` replaced) was dead code — re-exported from `hex-grid/index.ts` but never actually imported anywhere. This PR left it in place and just fixed its `WALL_HEIGHT` import for consistency. **Update: it's since been deleted in #477** (team-lead call — coherent to fold into the wall-rendering-area PR rather than a standalone chore), so the line above describes this PR's diff as written, not a still-open item.
- The broader hex-corner-angle math (`30 + 60*i` degree pattern) is duplicated across at least 8 files beyond what this PR touches (`HexTile.tsx`, `useMovementRange.ts`, `PathPreview.tsx`, `FrontierGroundHint.tsx`, `InstancedHexTiles.tsx`, `SyntyRoomDemo.tsx`, `hexGeometry.ts`, `ShadedHexFloor.tsx`) — flagged, not fixed. #477 extracts a narrow `hexCorners()`/`hexEdgeBetween()` into `hexMath.ts` for just the two call sites edge-derivation actually needs; consolidating the other 8 is a separate, larger cleanup this wave doesn't scope in.

## Load-bearing

Pure value-preserving dedup — no new abstractions, no changed constants. Every consumer imports the exact same numeric value it declared locally before.

## Test plan

- [x] `npm run ci-check` — format, lint, typecheck, build, tests all pass
- [x] `grep -rn "const HEX_SIZE\|const SYNTY_SCALE\|const WALL_HEIGHT" src/` confirms zero remaining duplicate declarations — each constant has exactly one definition now
- [x] **Behavior-preservation is provable by value-identity + green typecheck/build/tests** (stronger evidence than a pixel diff for a pure-dedup change): every promoted constant carries the exact literal value (`1.0`/`0.75`/`0.8`) it replaced, TypeScript's structural typing means every import site resolves to the identical number, and the build/test suite exercises every touched file. I did view the real game route live against this branch and it rendered as expected, but didn't save/attach that frame — retracting the earlier "confirmed by screenshot" wording since no image is actually on this PR; the value-identity argument above is the real evidence for this claim.
- [ ] The two dev-only Synty surfaces (`&synty=1`, `&syntyroom=1`) were NOT visually re-verified in this pass — their GLB assets aren't synced in this worktree (`assets:sync` is a separate opt-in step). Typecheck/build/lint all pass clean on their updated imports, and the promoted values are byte-identical to what they replaced, so there's no plausible regression path specific to them. Flagging honestly rather than claiming a check I didn't do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9
