### PR TITLE
fix(deploy): fail loud on deploy dispatch instead of swallowing errors

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,8 +99,7 @@ jobs:
             VITE_API_HOST=${{ secrets.VITE_API_HOST }}
 
       - name: Trigger deployment
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        continue-on-error: true
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
         with:
           workflow: deploy.yml


### PR DESCRIPTION
## Summary

Companion fix to KirkDiggler/rpg-api#662 — both repos' `docker.yml` trigger the same `rpg-deployment` `deploy.yml` via `benc-uk/workflow-dispatch`, and both had the same silent-failure shape.

`DEPLOYMENT_TOKEN` has been invalid (`Bad credentials`) since roughly February 2026 (see rpg-deployment#50 — https://github.com/KirkDiggler/rpg-deployment/issues/50). The "Trigger deployment" step had `continue-on-error: true`, so every push-to-main since then dispatched a failing deploy call and the workflow still reported green. Five months of merges looked deployed and weren't — this repo's images were current in ghcr (confirmed `web sha-4573404` pushed the night the rot was found), but nothing was actually redeploying the running service.

## Changes

- Removed `continue-on-error: true` from the "Trigger deployment" step — a failed dispatch now fails the workflow, so a dead token can't rot silently again.
- Widened the trigger gate from `github.event_name == 'push'` to `(github.event_name == 'push' || github.event_name == 'workflow_dispatch')` (still gated on `github.ref == 'refs/heads/main'`). This is deliberate: once Kirk rotates `DEPLOYMENT_TOKEN`, the plan is one manual `workflow_dispatch` rerun of this workflow to exercise the full chain end-to-end — that rerun *is* the new token's live test, and it needs the gate to actually let it through.

## Load-bearing

- `.github/workflows/docker.yml`'s "Trigger deployment" step — the only change. No app code touched; `npm run ci-check` is unaffected by a workflow-only diff but was run anyway per repo convention.

## Verification

- `npm run ci-check`: format, lint, typecheck, build, tests all pass.
- Workflow YAML is otherwise unchanged — same `benc-uk/workflow-dispatch` action pin, same inputs (`source`, `sha`), same target repo/workflow.

Part of the multi-repo fix for rpg-deployment#50 — https://github.com/KirkDiggler/rpg-deployment/issues/50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gA28TEYiq8UFMqbTZL3K9