### PR TITLE
feat(perf): dev perf probe on real route + committed sweep + baseline (#537)

### DIFF
--- a/docs/perf/baseline-2026-07-20.md
+++ b/docs/perf/baseline-2026-07-20.md
@@ -1,0 +1,248 @@
+# Runtime performance baseline — real game route (rpg-dnd5e-web#537)
+
+First committed baseline for the DevPerfProbe (`src/dev/DevPerfProbe.tsx`)
+and its sweep driver scripts. Future asset PRs should re-run the sweep and
+diff their numbers against this file rather than guessing at impact.
+
+Captured against `main` at `b133064` (feat(hex-grid): wall corner/end
+fittings for dungeon walls (#536 phase 2) (#539)) — **after** #536 phase 2
+landed, so the wall draw-call analysis below already accounts for the new
+corner/end fitting pieces, not the pre-#539 wall set.
+
+## Methodology
+
+- **Real route only**, never `/playtest`: Home → real character-creation
+  wizard → Create/Join lobby → Ready up → Start → live `EncounterView`.
+  Same convention as `docs/evidence/idle-anim-506-real-route-reverify.md`.
+- **Real characters**, not devseed fixtures: every character in this sweep
+  was created through the actual creation wizard (name → race → class →
+  background → abilities → appearance → Begin Adventure), driven by
+  `scripts/perf/mkchar_full.mjs`. All are Tiefling/Halfling/Human/
+  Dwarf/Elf/Dragonborn/Gnome/Half-Orc **Barbarians** — see "Judgment
+  calls" for why the roster isn't class-varied.
+- **Stack**: the same from-source, no-Docker, no-root stack as the
+  idle-anim-506 doc (Go 1.25.3, Redis 7.4.1 compiled from source, `rpg-api`
+  built from `main` with `AUTH_DEV_MODE=true`, `grpcwebproxy` standing in
+  for Envoy's grpc-web translation), already running in this sandbox
+  ahead of this work. `npm run dev` (Vite) against it, `public/models/
+synty/` synced fresh from `rpg-game-assets` `main` (post rpg-game-assets
+  PR #15/#16 — mesh-stats + the floor-snap fix) via `rsync`.
+- **Probe**: `?perfProbe&perfProbeLabel=<stage>&perfProbeMs=<window>` on
+  the real `EncounterMap` route. Samples `renderer.info` and wall-clock
+  frame deltas every frame for the window, forcing the demand-frameloop
+  canvas to keep rendering via `invalidate()` (same trick
+  `ClassCharacterModel.tsx`'s idle-clip playback already uses). Full
+  schema in `src/dev/DevPerfProbe.tsx`.
+- **Why reload-per-stage, not one continuous capture**: the probe reads
+  its query flag via `useMemo(...,[])` — once, at mount — matching this
+  codebase's existing `?syntyDungeon` convention. Revealed-hex/wall state
+  is server-side (`GeometryRevealed`/`StreamEncounter` snapshot), so
+  reloading the page **resumes** the same encounter with whatever's
+  already revealed (the same mechanism this repo's "resume-after-refresh"
+  #444 relies on) — each stage is a fresh page load with that stage's
+  query params, not a live query-string mutation.
+- **Dev build, not production**: unminified React + Three.js, React
+  StrictMode double-mounting, and a shared sandbox box also running
+  several other agents' dev servers/Chromium instances concurrently. The
+  absolute frame-time numbers below are **not** representative of a
+  production build's real FPS — treat them as a same-methodology,
+  same-machine baseline for **relative** comparison across sweeps, which
+  is exactly what #537 asked for ("so asset PRs can diff against
+  baseline"), not an absolute perf claim.
+- Driver scripts (committed, `npm`-runnable): `scripts/perf/mkchar_full.mjs`
+  (character creation), `scripts/perf/sweep_solo.mjs` (empty/walls/props
+  stages, one character), `scripts/perf/sweep_party.mjs` (4-character
+  stage, full lobby join flow -- creates its own 4 characters via
+  `mkchar_full.mjs`, so it's a single re-runnable command). See "How to
+  re-run" below. Raw per-stage JSON + screenshots: `playtest-evidence/
+asset-pipeline/pr-537-perf/` (evidence branch, this PR's evidence link).
+
+## Results
+
+| stage                                          | frames | mean ms | p50 ms | p95 ms | p99 ms | fps (mean) | draw calls (mean) | draw calls (max) | triangles (mean) | triangles (max) | geometries | textures | programs |
+| ---------------------------------------------- | ------ | ------- | ------ | ------ | ------ | ---------- | ----------------- | ---------------- | ---------------- | --------------- | ---------- | -------- | -------- |
+| empty (solo, free-roam, pre-combat)            | 99     | 81.88   | 72.30  | 95.74  | 383.43 | 12.21      | 229.8             | 250              | 57,807           | 67,918          | 150        | 12       | 7        |
+| walls (solo, turn-based, 2 goblins engaged)    | 119    | 68.19   | 61.90  | 66.21  | 430.01 | 14.66      | 217.8             | 237              | 45,463           | 55,432          | 189        | 12       | 7        |
+| +props (solo, same combat + 6 devPropDemoKeys) | 110    | 73.80   | 65.90  | 73.10  | 382.60 | 13.55      | 217.1             | 241              | 47,598           | 60,252          | 194        | 18       | 7        |
+| +4 characters (cold load, party just joined)   | 83     | 185.11  | 187.75 | 247.02 | 695.86 | 5.40       | 289.1             | 345              | 103,161          | 133,376         | 141        | 18       | 7        |
+| +4 characters (warm, second load)              | 46     | 179.88  | 180.40 | 247.24 | 734.36 | 5.56       | 271.0             | 345              | 91,890           | 133,376         | 126        | 18       | 7        |
+
+Full precision + `frameTimeMs.min/max`, per-frame `rendererInfo` arrays'
+summary stats, `startedAt`/`url` per stage: `solo-sweep-results.json` /
+`party-sweep-results.json` in the evidence branch.
+
+### What each stage actually shows (read before citing a number)
+
+- **empty**: real solo `EncounterView`, `FREE_ROAM` mode, right after
+  Start — `solo-01-empty.png`. The room's full wall layout was already
+  visible (this single-room slice reveals its whole layout at encounter
+  start, not progressively per-hex) — "empty" here means "before combat,"
+  not "no geometry."
+- **walls**: same encounter, after a few movement clicks — which,
+  unexpectedly, pulled 2 nearby goblins into `TURN_BASED` combat
+  (`solo-03-walls-combat.png`). The wall layout is visually unchanged from
+  "empty"; the triangle/call **decrease** here is the 2 goblins' small
+  footprint plus a tighter camera view, not "fewer walls." Take the
+  empty→walls delta with a grain of salt for that reason — it is not an
+  isolated wall-count variable.
+- **+props**: same combat scene + `devPropDemoKeys=barrel,pillar,rock-
+pile,crate,tomb,barricade` — `solo-04-props.png` clearly shows all 6
+  real prop GLBs rendered next to the character. This delta (+2,135
+  triangles / -0.7 draw calls vs. "walls") is the closest thing to an
+  isolated single-variable comparison in this sweep.
+- **+4 characters**: a separate real lobby with 4 distinct real, finalized
+  Barbarian characters (`party-03-four-characters.png`, `party-02-all-
+ready.png`), same devseed-default room, no `devPropDemoKeys`. "cold" is
+  the first page load after all 4 joined (still Suspense-loading 4 GLB
+  rigs + baked weapons); "warm" is a second reload once everything's in
+  the browser's HTTP cache. Both post ~180ms mean frame time (~5.5fps) —
+  a real, significant drop from the ~70-95ms single-character stages,
+  even accounting for the shared-sandbox dev-build caveat above.
+
+## Top optimization opportunities, ranked by impact
+
+### 1. Weapon standalone-prop texture bloat (asset-side, already flagged in rpg-game-assets#15)
+
+Every one of the 17 standalone weapon GLBs (`characters/weapons/*.glb`)
+embeds a full 2048×2048 (16MB) or 4096×4096 (64MB) atlas for a mesh with
+40–1,110 triangles — `arrow-01.glb` (40 triangles) costs 64MB of
+decoded GPU texture, 1.6MB per triangle. **~792MB of estimated decoded
+texture memory** across the 17 files that a correctly-sized/shared
+texture would eliminate almost entirely. Not exercised directly in this
+sweep (none of these weapons are equipped/socketed yet), but it's the
+single highest-ROI fix found across both halves of #537 — see
+rpg-game-assets PR #15's "Top optimization opportunity" section for the
+full breakdown.
+
+### 2. Walls: N segments = N draw calls, zero instancing (feeds #536)
+
+`SyntyHexWall.tsx`'s `GlbInstance` (lines ~73–90) renders **one
+`scene.clone(true)`'d GLB `<primitive>` per wall/door edge segment** —
+confirmed directly from source, not inferred from behavior:
+
+```tsx
+function GlbInstance({ file, position, rotationY, scale }: GlbInstanceProps) {
+  const { scene } = useGLTF(ENV_BASE + file);
+  const cloned = useMemo(() => scene.clone(true), [scene]);
+  return (
+    <primitive object={cloned} position={...} rotation={...} scale={scale} />
+  );
+}
+```
+
+Every segment is a fully separate `Object3D` clone with its own draw
+call(s) — no batching, no `InstancedMesh`, regardless of how many
+segments share the exact same GLB (e.g. 8 "plain" wall segments around a
+room's perimeter are 8 separate draw calls today, not 1). This sweep's
+own numbers corroborate it: total draw calls per frame sit at 217-290
+across every stage measured, for a **single small room** with one
+character (or four) and, at most, 6 synthetic props — most of that has
+to be floor tiles + wall segments, since neither model-count nor prop-
+count comes close to explaining 217+ draws on their own. #536 landed
+wall corner/end fittings (PR #539) on top of this same
+one-clone-per-segment approach, which only grows the per-room segment
+count (more distinct fitting pieces at each bend) — worth fixing before
+that count grows further with multi-room (#440 slice 4).
+
+**What InstancedMesh would save**: group wall segments by
+`(file, scale)` — the classic/shaded renderer already proves this
+pattern works in this exact codebase (`ShadedHexFloor` →
+`InstancedHexTiles.tsx` batches every floor tile into a single
+`THREE.InstancedMesh` draw call). Applying the same grouping to
+`SyntyHexWall` would collapse wall+door draw calls from
+O(segments) to O(distinct file+scale combinations) — for the
+`WALL_VARIANTS` set (plain/broken/alcove + door/door-frame), that's a
+small, bounded number of instanced draw calls regardless of room size,
+instead of scaling linearly with perimeter length.
+
+### 3. Floor tiles: the SAME non-instancing gap, and likely the bigger contributor
+
+`SyntyHexFloor.tsx`'s own module docstring already names this as a
+"Known MVP limitation": **one `<mesh>` per tile**, explicitly contrasted
+with `ShadedHexFloor`'s `InstancedMesh`. A single-room floor easily runs
+into the hundreds of tiles (the checkerboard floor pattern fills the
+entire visible play area in every screenshot in this sweep) — each one
+its own draw call, identical geometry/material every time. This is not
+new to #536/#539, but it compounds with the wall-instancing gap above
+(both non-instanced renderers live side-by-side in the same
+`syntyDungeon` path) and is at least as large a contributor to the 217-290
+draw calls measured here. Recommend scoping both fixes together: the
+`InstancedHexTiles.tsx` pattern this repo already has for the shaded
+floor renderer is a direct template for both.
+
+### 4. 4-character load cost (measured directly, this sweep)
+
+Going from 1 to 4 real characters raised mean frame time from ~70-95ms to
+~180ms and draw calls from ~218-230 to ~271-289 (see Results table) — each
+class GLB is its own `useGLTF` + `SkeletonUtils.clone()` per
+`ClassCharacterModel.tsx`, one draw call (plus baked-in weapon) per
+character, which is reasonable at party-of-4 scale but won't stay cheap
+if monster counts grow independently, especially once instancing closes
+the walls/floor gap and characters become a proportionally larger share
+of the draw-call budget.
+
+## How to re-run this sweep
+
+Requires a running backend (`rpg-api` + Redis + a grpc-web proxy, `AUTH_DEV_MODE=true`)
+and `npm run dev` pointed at it -- see `docs/evidence/idle-anim-506-real-route-reverify.md`
+for the full from-source stack recipe. Requires `npx playwright install chromium`
+once (Playwright is a devDependency; browser binaries are a separate download).
+
+```bash
+# Solo-character stages (empty / walls / +props) -- creates 1 character:
+node scripts/perf/mkchar_full.mjs http://localhost:3001 sweep1 "Sweep Hero"
+node scripts/perf/sweep_solo.mjs http://localhost:3001 sweep1 "Sweep Hero" /tmp/perf-solo-out
+
+# +4 characters stage -- creates its own 4 fresh characters, joins one lobby:
+node scripts/perf/sweep_party.mjs http://localhost:3001 /tmp/perf-party-out
+```
+
+Each run prints every stage's `PERF_PROBE_RESULT:` JSON line to stdout and
+writes it to `<outDir>/*-sweep-results.json`, plus a screenshot per stage.
+Diff the new `*-sweep-results.json` against this file's Results table (or
+the raw JSON in `playtest-evidence/asset-pipeline/pr-537-perf/`) to see
+what an asset change actually did to draw calls/triangles/frame time.
+
+## Judgment calls
+
+- **All 4 sweep characters are Barbarians**, not one-of-each-class. Two
+  real app gaps made the other 3 classes unreliable within this task's
+  time budget, found incidentally while driving the real character wizard
+  (not asset-side bugs, but worth filing separately):
+  - **Fighter**: `ListClasses` is called with `includeFeatures: false`,
+    so the creation wizard never fetches or renders a "fighting style"
+    picker — but `CreateCharacter`'s server-side validation requires one
+    for Fighter. Every Fighter draft's "Begin Adventure" 400s with
+    `"Choose a fighting style required"`, with no UI path to satisfy it.
+  - **Monk**: needs one more proficiency choice (an artisan's-tools-or-
+    musical-instrument pick) beyond skills/equipment; clicking a specific
+    instrument option didn't reliably clear the validation banner within
+    a few automated attempts.
+  - **Rogue**: reliably got through race/class/skill/equipment picks but
+    then failed at the background step in every attempt during this
+    sweep; root cause not isolated (ran out of time budget to chase it
+    down given Barbarian was already a clean, reliable path).
+  - Barbarian was the one class that created cleanly and reliably every
+    time, so the roster standardized on it once that was clear. Character
+    class doesn't materially change what's being measured here (each is
+    still one real GLB + baked weapon, one `useGLTF`/clone, one draw
+    call) — the class-variety gap is cosmetic for this baseline's
+    purposes, not a measurement-validity concern.
+- **The race picker's carousel** (`VisualCarousel.tsx`) renders all 9
+  races in the DOM but visually clips the ones far from the centered
+  selection — clicking a specific named race tile (e.g. always picking
+  Tiefling, to dodge Human's extra-language / Dwarf's extra-tool-
+  proficiency sub-choices) was flaky for that reason. `mkchar_full.mjs`
+  instead accepts whichever race the modal defaults to, and generically
+  detects+rerolls only when that race turns out to need an unhandled
+  sub-choice (validated by checking whether "Select `<race>`" actually
+  closed the modal) — see the script's own comments for the full
+  reasoning trail.
+- **"walls" stage isn't an isolated wall-count measurement** — see the
+  per-stage notes above; movement clicks incidentally triggered combat
+  with 2 goblins. Re-running the sweep to get a cleaner isolated
+  empty-vs-walls comparison (e.g. by moving without approaching any
+  monster) is a good next refinement, not done here given time budget.
+- **Absolute frame-time numbers are dev-build, shared-sandbox numbers**,
+  not production performance — see Methodology. Use them for relative,
+  same-methodology comparison only.

--- a/docs/perf/baseline-2026-07-20.md
+++ b/docs/perf/baseline-2026-07-20.md
@@ -106,13 +106,14 @@ ready.png`), same devseed-default room, no `devPropDemoKeys`. "cold" is
 Every one of the 17 standalone weapon GLBs (`characters/weapons/*.glb`)
 embeds a full 2048×2048 (16MB) or 4096×4096 (64MB) atlas for a mesh with
 40–1,110 triangles — `arrow-01.glb` (40 triangles) costs 64MB of
-decoded GPU texture, 1.6MB per triangle. **~792MB of estimated decoded
-texture memory** across the 17 files that a correctly-sized/shared
-texture would eliminate almost entirely. Not exercised directly in this
-sweep (none of these weapons are equipped/socketed yet), but it's the
-single highest-ROI fix found across both halves of #537 — see
-rpg-game-assets PR #15's "Top optimization opportunity" section for the
-full breakdown.
+decoded GPU texture, 1.6MB per triangle. **~896MB of estimated decoded
+texture memory** across the 17 files (summed `estGpuMB` across all 17
+weapon-`budgetClass` entries in the merged mesh-stats.json) that a
+correctly-sized/shared texture would eliminate almost entirely. Not
+exercised directly in this sweep (none of these weapons are equipped/
+socketed yet), but it's the single highest-ROI fix found across both
+halves of #537 — see rpg-game-assets PR #15's "Top optimization
+opportunity" section for the full breakdown.
 
 ### 2. Walls: N segments = N draw calls, zero instancing (feeds #536)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "husky": "^9.1.7",
         "jsdom": "^27.3.0",
         "lint-staged": "^16.2.6",
+        "playwright": "^1.61.1",
         "prettier": "^3.6.2",
         "prettier-plugin-organize-imports": "^4.1.0",
         "typescript": "~5.8.3",
@@ -5837,6 +5838,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "pre-commit": "npm run format && npm run lint && npm run typecheck",
     "ci-check": "./scripts/ci-check.sh",
     "ci-fix": "npm run format && npm run lint --fix && npm run typecheck && npm run build",
-    "assets:sync": "sh scripts/sync-synty-assets.sh"
+    "assets:sync": "sh scripts/sync-synty-assets.sh",
+    "perf:sweep-solo": "node scripts/perf/sweep_solo.mjs",
+    "perf:sweep-party": "node scripts/perf/sweep_party.mjs"
   },
   "dependencies": {
     "@connectrpc/connect": "^2.0.2",
@@ -64,6 +66,7 @@
     "husky": "^9.1.7",
     "jsdom": "^27.3.0",
     "lint-staged": "^16.2.6",
+    "playwright": "^1.61.1",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "~5.8.3",

--- a/scripts/perf/mkchar_full.mjs
+++ b/scripts/perf/mkchar_full.mjs
@@ -1,0 +1,370 @@
+// Full character-creation driver for the #537 perf sweep -- creates ONE
+// real character end-to-end via the actual wizard (Name/Race/Class/
+// Background/Abilities -> Begin Adventure), matching the real-route
+// convention from docs/evidence/idle-anim-506-real-route-reverify.md
+// (real characters through the real wizard, not devseed fixtures).
+//
+// Learned the hard way (see explore*/debug*/e*.mjs in this dir):
+//   - Filling the name field BEFORE opening the Race modal makes the
+//     "Choose Race" click flaky (layout shift race) -- fill name LAST.
+//   - Ability-score assignments and the name field are NOT persisted to
+//     the draft on the server between page loads -- this whole flow must
+//     run in one continuous browser session, no reload in between.
+//   - The name field only commits to the draft on blur/Enter (.fill()
+//     alone updates local input state only) -- must press Enter after.
+//   - Both the Race and Class picker modals default-select a race/class
+//     that VARIES per draft (looks server- or draft-seeded, not fixed).
+//     The race icon strip only shows 7 of 9 races and doesn't support a
+//     normal scrollIntoView, so clicking a specific named race is flaky
+//     whenever it isn't in the initially-visible slice. Since the exact
+//     race/class doesn't matter for this perf sweep (only a real,
+//     finalized character does), this script ACCEPTS whichever race/
+//     class the modal already has pre-selected rather than fighting the
+//     picker -- it reads the name back (race: the h3 under the icon
+//     strip; class: the second h2 in the modal) and picks its equipment/
+//     skill plan accordingly. If the class rolls Fighter, the script
+//     exits early with a distinct "ABORT_FIGHTER" line -- Fighter's
+//     level-1 "fighting style" choice is required by the backend but
+//     never rendered by this wizard build (ListClasses is called with
+//     includeFeatures:false), so Begin Adventure always 400s for it. The
+//     shell driver retries with a fresh playerId until it rolls one of
+//     the three usable classes.
+//
+// Usage: node mkchar_full.mjs <baseUrl> <playerId> <charName>
+import { chromium } from 'playwright';
+
+const [baseUrl, playerId, charName] = process.argv.slice(2);
+if (!baseUrl || !playerId || !charName) {
+  console.error('usage: node mkchar_full.mjs <baseUrl> <playerId> <charName>');
+  process.exit(1);
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1600, height: 900 } });
+page.on('pageerror', (e) => console.log(`[${playerId}] PAGEERROR:`, String(e)));
+
+async function step(name, fn, attempt = 1) {
+  try {
+    return await fn();
+  } catch (e) {
+    if (attempt < 3) {
+      console.log(`[${playerId}] retrying "${name}" (attempt ${attempt + 1})`);
+      await page.waitForTimeout(800);
+      return step(name, fn, attempt + 1);
+    }
+    console.log(`[${playerId}] FAIL at "${name}":`, String(e).slice(0, 300));
+    await page.screenshot({
+      path: `/tmp/mkchar-fail-${playerId}-${name}.png`,
+      fullPage: true,
+    });
+    throw e;
+  }
+}
+
+// Skill/equipment plan per class -- 2 (4 for Rogue, per 5e) skills off the
+// class's own list + the first-listed CONCRETE (non-"Plus choices from
+// categories") option in every equipment slot, so no slot needs a nested
+// "choose a specific item" <select>. Fighter kept for reference/rerolls
+// even though this sweep excludes it (see module docstring).
+const CLASS_PLAN = {
+  Fighter: {
+    skills: ['Athletics', 'Perception'],
+    equipmentByText: [
+      /Chain mail/,
+      /martial weapon and a shield/,
+      /light crossbow/,
+      /Dungeoneer/,
+    ],
+  },
+  Barbarian: {
+    skills: ['Athletics', 'Intimidation'],
+    equipmentByText: [/Greataxe/, /Two handaxes/, /Explorer/],
+  },
+  Monk: {
+    skills: ['Acrobatics', 'Stealth'],
+    equipmentByText: [/Shortsword/, /Explorer/],
+  },
+  Rogue: {
+    skills: ['Stealth', 'Acrobatics', 'Perception', 'Sleight of Hand'],
+    equipmentByText: [/Rapier/, /Shortbow/, /Burglar/],
+  },
+};
+
+// Opening any of the 4 section cards is oddly flaky: `.click()` on the
+// card's h3 sometimes throws a "TimeoutError ... intercepts pointer
+// events" even though the click DID register and the target modal ends
+// up fully open (confirmed by screenshot -- looks like the modal itself
+// becomes the intercepting element mid-actionability-check, which
+// Playwright treats as a failure even though functionally nothing is
+// wrong). So: attempt the click, but don't trust its own success/failure
+// signal -- just poll for the modal heading afterward either way.
+async function openModal(cardHeadingText, modalHeadingText) {
+  // Verifying the modal actually opened (isVisible()/waitFor()) turned out
+  // LESS reliable than just clicking and giving it a fixed settle window --
+  // in every case inspected, the modal was demonstrably open in the
+  // failure screenshot despite isVisible()/waitFor() reporting otherwise
+  // (root cause not fully pinned down; suspect an h2/h3 query racing a
+  // remount). Optimistic fixed wait + let downstream steps' own retry
+  // logic catch a genuinely-not-open modal instead.
+  for (let i = 0; i < 3; i++) {
+    try {
+      await page
+        .locator(`h3:has-text("${cardHeadingText}")`)
+        .click({ timeout: 8000 });
+      break;
+    } catch {
+      await page.waitForTimeout(500);
+    }
+  }
+  await page.waitForTimeout(1500);
+  void modalHeadingText;
+}
+
+await page.goto(`${baseUrl}/?playerId=${playerId}`, {
+  waitUntil: 'load',
+  timeout: 30000,
+});
+await page.waitForTimeout(1500);
+
+await step('create', () =>
+  page.getByRole('button', { name: 'Create' }).click({ timeout: 15000 })
+);
+await page.waitForTimeout(1200);
+
+await step('open-race', () => openModal('Choose Race', 'Choose Your Race'));
+await page.waitForTimeout(500);
+
+// Some races (Human: extra language; Dwarf: tool proficiency; possibly
+// others) require a sub-choice this script doesn't fill in, so "Select
+// <race>" silently fails validation and leaves the modal open. Detect
+// that generically (did the modal actually close?) instead of
+// maintaining a hardcoded "simple races" allowlist, and reroll to a
+// different visible race tile when it happens.
+const RACE_NAMES_EXACT =
+  /^(Human|Dwarf|Elf|Halfling|Dragonborn|Gnome|Half-Elf|Half-Orc|Tiefling)$/;
+// Tile buttons prefix the name with an emoji ("😈Tiefling"), so matching
+// them needs the same alternation WITHOUT anchors.
+const RACE_NAMES_LOOSE =
+  /(Human|Dwarf|Elf|Halfling|Dragonborn|Gnome|Half-Elf|Half-Orc|Tiefling)/;
+async function currentRaceName() {
+  return (
+    await page
+      .locator('h3')
+      .filter({ hasText: RACE_NAMES_EXACT })
+      .first()
+      .textContent({ timeout: 15000 })
+  ).trim();
+}
+let raceName = await step('read-default-race', currentRaceName);
+console.log(`[${playerId}] race: ${raceName}`);
+for (let attempt = 0; attempt < 6; attempt++) {
+  await step(`select-race-${raceName}`, () =>
+    page
+      .getByRole('button', { name: new RegExp('^Select ' + raceName) })
+      .click({ timeout: 15000 })
+  );
+  await page.waitForTimeout(600);
+  const stillOpen = await page
+    .locator('h2:has-text("Choose Your Race")')
+    .isVisible();
+  if (!stillOpen) break;
+  console.log(
+    `[${playerId}] ${raceName} needs an unhandled sub-choice, rerolling race`
+  );
+  // Click whichever OTHER race tile is currently rendered (the carousel
+  // always keeps several neighbors of the centered/selected race visible).
+  // The carousel renders all 9 races in DOM (centered on the current
+  // selection) but visually clips the ones farthest from center via
+  // overflow:hidden -- .first()/.last() tend to land on a clipped,
+  // non-visible one. The MIDDLE of the remaining (current-race-excluded)
+  // matches is always one of the immediate on-screen neighbors.
+  await step(`reroll-race-away-from-${raceName}`, async () => {
+    const others = page
+      .getByRole('button', { name: RACE_NAMES_LOOSE })
+      .filter({ hasNotText: raceName });
+    const count = await others.count();
+    await others.nth(Math.floor(count / 2)).click({ timeout: 15000 });
+  });
+  await page.waitForTimeout(500);
+  raceName = await step('read-rerolled-race', currentRaceName);
+  console.log(`[${playerId}] rerolled race: ${raceName}`);
+}
+await page.waitForTimeout(1000);
+
+await step('open-class', () => openModal('Choose Class', 'Choose Your Class'));
+await page.waitForTimeout(500);
+
+const CLASS_NAMES_EXACT = /^(Fighter|Barbarian|Monk|Rogue)$/;
+async function currentClassName() {
+  return (
+    await page
+      .locator('h2')
+      .filter({ hasText: CLASS_NAMES_EXACT })
+      .first()
+      .textContent({ timeout: 15000 })
+  ).trim();
+}
+let className = await step('read-default-class', currentClassName);
+console.log(`[${playerId}] class: ${className}`);
+// Fighter needs a "fighting style" pick this wizard build never renders
+// (see module docstring) and Monk's tool/instrument pick doesn't reliably
+// resolve generically -- unlike races (a 9-wide clipped carousel), all 4
+// class tiles are always on-screen at once, so just click a known-good
+// one directly instead of rerolling the whole character.
+if (className === 'Fighter' || className === 'Monk' || className === 'Rogue') {
+  const fallback = 'Barbarian';
+  console.log(`[${playerId}] ${className} unusable, switching to ${fallback}`);
+  await step(`switch-class-to-${fallback}`, () =>
+    page
+      .getByRole('button', { name: new RegExp(fallback) })
+      .first()
+      .click({ timeout: 15000 })
+  );
+  await page.waitForTimeout(800);
+  className = await step('read-switched-class', currentClassName);
+  console.log(`[${playerId}] class: ${className}`);
+}
+if (
+  !CLASS_PLAN[className] ||
+  className === 'Fighter' ||
+  className === 'Monk' ||
+  className === 'Rogue'
+) {
+  console.log(`[${playerId}] ABORT_UNKNOWN_CLASS ${className}`);
+  await browser.close();
+  process.exit(4);
+}
+
+await step('select-class-1', () =>
+  page
+    .getByRole('button', { name: new RegExp('^Select ' + className) })
+    .click({ timeout: 15000 })
+);
+await page.waitForTimeout(1000);
+
+const plan = CLASS_PLAN[className];
+for (const skill of plan.skills) {
+  await step(`skill-${skill}`, () =>
+    page
+      .getByRole('button', { name: skill, exact: true })
+      .first()
+      .click({ timeout: 15000 })
+  );
+  await page.waitForTimeout(250);
+}
+for (const eq of plan.equipmentByText) {
+  await step(`equip-${eq}`, () =>
+    page.getByRole('button', { name: eq }).first().click({ timeout: 15000 })
+  );
+  await page.waitForTimeout(300);
+  // Handle a nested "choose a specific item" <select>, if this pick opened one.
+  const nestedSelects = page.locator('select');
+  const count = await nestedSelects.count();
+  for (let i = 0; i < count; i++) {
+    const sel = nestedSelects.nth(i);
+    const val = await sel.inputValue();
+    if (!val) {
+      await step(`equip-${eq}-nested-select-${i}`, () =>
+        sel.selectOption({ index: 1 })
+      );
+      await page.waitForTimeout(300);
+    }
+  }
+}
+// Some classes (Monk: an artisan's-tools-or-musical-instrument pick;
+// possibly others) have one more required proficiency choice beyond
+// skills/equipment that isn't worth a per-class plan entry -- generically
+// resolve it: if "Select <class>" doesn't close the modal, click the
+// first option in whatever bordered list is still showing a validation
+// error and retry, up to a few rounds.
+const TOOL_OR_INSTRUMENT_NAMES =
+  /(Bagpipes|Drum|Dulcimer|Flute|Lute|Lyre|Horn|Pan flute|Shawm|Viol|Alchemist|Brewer|Calligrapher|Carpenter|Cartographer|Cobbler|Cook's|Glassblower|Jeweler|Leatherworker|Mason|Painter|Potter|Smith's|Tinker|Weaver|Woodcarver)/;
+for (let attempt = 0; attempt < 4; attempt++) {
+  await step(`select-class-2-attempt${attempt}`, () =>
+    page
+      .getByRole('button', { name: new RegExp('^Select ' + className) })
+      .click({ timeout: 15000 })
+  );
+  await page.waitForTimeout(800);
+  const stillOpen = await page
+    .locator('h2:has-text("Choose Your Class")')
+    .isVisible();
+  if (!stillOpen) break;
+  console.log(
+    `[${playerId}] ${className} has an unhandled extra proficiency choice, resolving generically`
+  );
+  await step(`resolve-extra-proficiency-${attempt}`, () =>
+    page
+      .getByRole('button', { name: TOOL_OR_INSTRUMENT_NAMES })
+      .first()
+      .click({ timeout: 15000 })
+  );
+  await page.waitForTimeout(500);
+}
+
+await step('open-background', () =>
+  openModal('Choose Background', 'Select Your Background')
+);
+await page.waitForTimeout(1000);
+await step('select-background', () =>
+  page
+    .getByRole('button', { name: 'Select Background' })
+    .click({ timeout: 15000 })
+);
+await page.waitForTimeout(1000);
+
+await step('open-appearance', () =>
+  openModal('Customize Appearance', 'Customize Appearance')
+);
+await page.waitForTimeout(1000);
+await step('apply-appearance', () =>
+  page.getByRole('button', { name: 'Apply' }).click({ timeout: 15000 })
+);
+await page.waitForTimeout(1000);
+
+const scores = ['15', '14', '13', '12', '10', '8'];
+const abilities = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
+for (let i = 0; i < 6; i++) {
+  await step(`assign-${scores[i]}-${abilities[i]}`, async () => {
+    await page
+      .getByText(scores[i], { exact: true })
+      .first()
+      .click({ timeout: 15000 });
+    await page.waitForTimeout(200);
+    await page
+      .getByText(abilities[i], { exact: true })
+      .first()
+      .click({ timeout: 15000 });
+  });
+  await page.waitForTimeout(250);
+}
+await step('confirm-ability-scores', () =>
+  page
+    .getByRole('button', { name: /confirm ability scores/i })
+    .click({ timeout: 15000 })
+);
+await page.waitForTimeout(800);
+
+await step('fill-name', async () => {
+  await page.fill(
+    'input[placeholder="Enter your character\'s name..."]',
+    charName
+  );
+  await page.keyboard.press('Enter');
+});
+await page.waitForTimeout(800);
+
+await step('begin-adventure', () =>
+  page
+    .getByRole('button', { name: /Begin Adventure/i })
+    .click({ timeout: 10000 })
+);
+await page.waitForTimeout(2500);
+
+await page.screenshot({
+  path: `/tmp/mkchar-done-${playerId}.png`,
+  fullPage: true,
+});
+console.log(`[${playerId}] DONE class=${className} url=${page.url()}`);
+
+await browser.close();

--- a/scripts/perf/sweep_party.mjs
+++ b/scripts/perf/sweep_party.mjs
@@ -83,11 +83,17 @@ await pages[0]
   .getByRole('button', { name: /Create lobby/i })
   .click({ timeout: 15000 });
 await pages[0].waitForTimeout(1500);
-const joinChipText = (
-  await pages[0]
-    .locator('[data-testid="join-code-display"]')
-    .textContent({ timeout: 15000 })
-).trim();
+const rawJoinChipText = await pages[0]
+  .locator('[data-testid="join-code-display"]')
+  .textContent({ timeout: 15000 });
+if (!rawJoinChipText || !rawJoinChipText.trim()) {
+  throw new Error(
+    'join code chip missing or empty -- [data-testid="join-code-display"] ' +
+      'returned no text content after Create lobby; the chip may not have ' +
+      'rendered yet or the lobby-create step failed silently'
+  );
+}
+const joinChipText = rawJoinChipText.trim();
 // The chip's full text is "Join code<code>Copy" -- pull out just the
 // join_<uuid> token.
 const joinCodeMatch = joinChipText.match(

--- a/scripts/perf/sweep_party.mjs
+++ b/scripts/perf/sweep_party.mjs
@@ -1,0 +1,231 @@
+// #537 perf sweep, "+4 characters" stage: creates 4 fresh, real,
+// finalized characters (via mkchar_full.mjs, run as child processes so
+// this script is self-contained and re-runnable end to end) and joins
+// them into ONE real lobby (Home -> select character -> Play ->
+// Create/Join lobby -> Ready up -> Start), landing all 4 in the same
+// live EncounterView. Measures the perf probe from player 1 (the
+// host)'s page once everyone has joined -- a cold-load pass (models
+// still Suspense-loading) and a warm pass (second reload, everything
+// cached) both, since the two look very different (see baseline doc).
+//
+// Usage: node sweep_party.mjs <baseUrl> <outDir> [playerIdPrefix]
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const [baseUrl, outDir, prefixArg] = process.argv.slice(2);
+if (!baseUrl || !outDir) {
+  console.error(
+    'usage: node sweep_party.mjs <baseUrl> <outDir> [playerIdPrefix]'
+  );
+  process.exit(1);
+}
+fs.mkdirSync(outDir, { recursive: true });
+
+// A fresh prefix every run avoids colliding with a previous run's
+// player -- once a player has an active lobby/encounter, the real route
+// auto-resumes into it instead of showing character selection, which
+// would break this script's "select character -> Play" step.
+const prefix = prefixArg || `sweep${Date.now().toString(36)}`;
+const PLAYERS = [1, 2, 3, 4].map((n) => ({
+  playerId: `${prefix}p${n}`,
+  charName: `${prefix} Hero ${n}`,
+}));
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+console.log('Creating 4 fresh characters via mkchar_full.mjs...');
+for (const { playerId, charName } of PLAYERS) {
+  execFileSync(
+    process.execPath,
+    [path.join(__dirname, 'mkchar_full.mjs'), baseUrl, playerId, charName],
+    { stdio: 'inherit' }
+  );
+}
+
+const browser = await chromium.launch();
+const contexts = [];
+const pages = [];
+for (const p of PLAYERS) {
+  const ctx = await browser.newContext({
+    viewport: { width: 1600, height: 900 },
+  });
+  const page = await ctx.newPage();
+  page.on('pageerror', (e) =>
+    console.log(`[${p.playerId}] PAGEERROR:`, String(e))
+  );
+  contexts.push(ctx);
+  pages.push(page);
+}
+
+async function selectAndPlay(page, playerId, charName) {
+  console.log(`[${playerId}] navigating...`);
+  await page.goto(`${baseUrl}/?playerId=${playerId}`, {
+    waitUntil: 'load',
+    timeout: 30000,
+  });
+  await page.waitForTimeout(1500);
+  await page
+    .getByRole('button', { name: `Select character: ${charName}` })
+    .click({ timeout: 15000 });
+  await page.waitForTimeout(500);
+  await page
+    .getByRole('button', { name: 'Play', exact: true })
+    .click({ timeout: 15000 });
+  await page.waitForTimeout(1000);
+}
+
+// Player 1: create the lobby, grab the join code.
+await selectAndPlay(pages[0], PLAYERS[0].playerId, PLAYERS[0].charName);
+console.log('[host] creating lobby...');
+await pages[0]
+  .getByRole('button', { name: /Create lobby/i })
+  .click({ timeout: 15000 });
+await pages[0].waitForTimeout(1500);
+const joinChipText = (
+  await pages[0]
+    .locator('[data-testid="join-code-display"]')
+    .textContent({ timeout: 15000 })
+).trim();
+// The chip's full text is "Join code<code>Copy" -- pull out just the
+// join_<uuid> token.
+const joinCodeMatch = joinChipText.match(
+  /join_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+);
+if (!joinCodeMatch) {
+  throw new Error(
+    `could not parse join code out of chip text: ${joinChipText}`
+  );
+}
+const joinCode = joinCodeMatch[0];
+console.log('[host] join code:', joinCode);
+await pages[0].screenshot({ path: `${outDir}/party-00-host-lobby.png` });
+
+// Players 2-4: select their character, then join via the code.
+for (let i = 1; i < PLAYERS.length; i++) {
+  const { playerId, charName } = PLAYERS[i];
+  await selectAndPlay(pages[i], playerId, charName);
+  console.log(`[${playerId}] joining lobby with code ${joinCode}...`);
+  await pages[i].fill('input[aria-label="join code"]', joinCode);
+  await pages[i]
+    .getByRole('button', { name: /^Join$/i })
+    .click({ timeout: 15000 });
+  await pages[i].waitForTimeout(1500);
+}
+
+await pages[0].screenshot({ path: `${outDir}/party-01-roster-full.png` });
+
+// Everyone readies up.
+for (let i = 0; i < PLAYERS.length; i++) {
+  const { playerId } = PLAYERS[i];
+  console.log(`[${playerId}] ready up...`);
+  await pages[i]
+    .getByRole('button', { name: /Ready up|Ready!/ })
+    .click({ timeout: 15000 });
+  await pages[i].waitForTimeout(800);
+}
+await pages[0].waitForTimeout(1500);
+await pages[0].screenshot({ path: `${outDir}/party-02-all-ready.png` });
+
+// Host starts the encounter.
+console.log('[host] starting encounter...');
+const startBtn = pages[0].getByTestId('start-encounter-button');
+await startBtn.waitFor({ state: 'visible', timeout: 15000 });
+await pages[0].waitForTimeout(1000);
+await startBtn.click({ timeout: 15000, force: true });
+
+for (let i = 0; i < pages.length; i++) {
+  try {
+    await pages[i].waitForSelector('[data-testid="encounter-map"] canvas', {
+      timeout: 20000,
+    });
+    console.log(`[${PLAYERS[i].playerId}] reached encounter map`);
+  } catch (e) {
+    console.log(
+      `[${PLAYERS[i].playerId}] FAILED to reach encounter map:`,
+      String(e).slice(0, 150)
+    );
+    await pages[i].screenshot({
+      path: `${outDir}/party-debug-p${i + 1}-stuck.png`,
+      fullPage: true,
+    });
+    const btns = await pages[i].locator('button').allTextContents();
+    console.log(
+      `[${PLAYERS[i].playerId}] buttons:`,
+      JSON.stringify(btns).slice(0, 500)
+    );
+  }
+}
+await pages[0].waitForTimeout(5000);
+for (let i = 0; i < pages.length; i++) {
+  await pages[i].screenshot({
+    path: `${outDir}/party-03-live-p${i + 1}.png`,
+  });
+}
+console.log('All 4 players in the live encounter.');
+
+// Measure from the host's page: reload with the probe flag (same
+// resume-after-refresh pattern as sweep_solo.mjs).
+const results = [];
+pages[0].on('console', (m) => {
+  const text = m.text();
+  if (text.startsWith('PERF_PROBE_RESULT:')) {
+    const result = JSON.parse(text.slice('PERF_PROBE_RESULT:'.length));
+    console.log(
+      `  -> captured "${result.label}": ${result.frameCount} frames, mean ${result.frameTimeMs.mean.toFixed(2)}ms, ` +
+        `p95 ${result.frameTimeMs.p95.toFixed(2)}ms, calls mean ${result.rendererInfo.calls.mean.toFixed(1)}, ` +
+        `triangles mean ${result.rendererInfo.triangles.mean.toFixed(0)}`
+    );
+    results.push(result);
+  }
+});
+const encounterUrl = new URL(pages[0].url());
+
+// Cold-load pass: all 4 GLB character models + baked-in weapons/textures
+// mount fresh on this reload, so a chunk of the window is spent in
+// Suspense before the canvas has anything new to paint -- expect a low
+// frame count with a huge mean (the "loading spike" itself is the
+// finding). windowMs is longer here specifically to still catch a
+// handful of real frames once everything resolves.
+encounterUrl.searchParams.set('perfProbe', '1');
+encounterUrl.searchParams.set('perfProbeLabel', 'four-characters-cold');
+encounterUrl.searchParams.set('perfProbeMs', '15000');
+console.log('\n=== Stage: +4 characters (cold load) ===');
+await pages[0].goto(encounterUrl.toString(), {
+  waitUntil: 'load',
+  timeout: 30000,
+});
+await pages[0].waitForSelector('[data-testid="encounter-map"] canvas', {
+  timeout: 30000,
+});
+await pages[0].waitForTimeout(16000);
+await pages[0].screenshot({ path: `${outDir}/party-04-four-characters.png` });
+
+// Warm pass: everything's now in the browser's HTTP cache and the
+// renderer/scene has already been built once this session -- reload
+// again for a steady-state reading uninflated by the cold-load stall.
+encounterUrl.searchParams.set('perfProbeLabel', 'four-characters-warm');
+encounterUrl.searchParams.set('perfProbeMs', '8000');
+console.log('\n=== Stage: +4 characters (warm) ===');
+await pages[0].goto(encounterUrl.toString(), {
+  waitUntil: 'load',
+  timeout: 30000,
+});
+await pages[0].waitForSelector('[data-testid="encounter-map"] canvas', {
+  timeout: 30000,
+});
+await pages[0].waitForTimeout(9500);
+await pages[0].screenshot({
+  path: `${outDir}/party-05-four-characters-warm.png`,
+});
+
+fs.writeFileSync(
+  `${outDir}/party-sweep-results.json`,
+  JSON.stringify(results, null, 2)
+);
+console.log(
+  `\nWrote ${outDir}/party-sweep-results.json (${results.length} stage results)`
+);
+
+await browser.close();

--- a/scripts/perf/sweep_solo.mjs
+++ b/scripts/perf/sweep_solo.mjs
@@ -1,0 +1,167 @@
+// #537 perf sweep, solo-character stages: empty -> with walls -> +props.
+// Drives the REAL rpg-dnd5e-web game route (Home -> select character ->
+// Play -> Create lobby -> Ready up -> Start encounter -> live
+// EncounterView), same flow as ~/tools/browser/drive_game_515.mjs.
+//
+// Methodology note: the perf probe (?perfProbe) is read via useMemo(...,[])
+// in EncounterMap.tsx -- it only activates ONCE, at mount -- so each stage
+// is captured by RELOADING the page with that stage's query params, not by
+// mutating the query string live. This works because revealed-hex/wall
+// state is server-side (GeometryRevealed/StreamEncounter snapshot), so a
+// reload resumes the SAME encounter with whatever's already been revealed
+// -- confirmed by this repo's "resume-after-refresh" (#444) convention.
+//
+// Usage: node sweep_solo.mjs <baseUrl> <playerId> <charName> <outDir>
+import fs from 'node:fs';
+import { chromium } from 'playwright';
+
+const [baseUrl, playerId, charName, outDir] = process.argv.slice(2);
+if (!baseUrl || !playerId || !charName || !outDir) {
+  console.error(
+    'usage: node sweep_solo.mjs <baseUrl> <playerId> <charName> <outDir>'
+  );
+  process.exit(1);
+}
+fs.mkdirSync(outDir, { recursive: true });
+
+const results = [];
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1600, height: 900 } });
+page.on('pageerror', (e) => console.log('PAGEERROR:', String(e)));
+page.on('console', (m) => {
+  const text = m.text();
+  if (text.startsWith('PERF_PROBE_RESULT:')) {
+    const result = JSON.parse(text.slice('PERF_PROBE_RESULT:'.length));
+    console.log(
+      `  -> captured stage "${result.label}": ${result.frameCount} frames, ` +
+        `mean ${result.frameTimeMs.mean.toFixed(2)}ms, p95 ${result.frameTimeMs.p95.toFixed(2)}ms, ` +
+        `calls mean ${result.rendererInfo.calls.mean.toFixed(1)}, triangles mean ${result.rendererInfo.triangles.mean.toFixed(0)}`
+    );
+    results.push(result);
+  }
+});
+
+async function shot(name) {
+  await page.screenshot({ path: `${outDir}/${name}.png` });
+  console.log('saved', `${outDir}/${name}.png`);
+}
+
+console.log('Navigating to', `${baseUrl}/?playerId=${playerId}`);
+await page.goto(`${baseUrl}/?playerId=${playerId}`, {
+  waitUntil: 'load',
+  timeout: 30000,
+});
+await page.waitForTimeout(1500);
+
+console.log(`Selecting ${charName}...`);
+await page
+  .getByRole('button', { name: `Select character: ${charName}` })
+  .click({ timeout: 15000 });
+await page.waitForTimeout(500);
+await page
+  .getByRole('button', { name: 'Play', exact: true })
+  .click({ timeout: 15000 });
+await page.waitForTimeout(1000);
+
+console.log('Creating lobby...');
+const createBtn = page.getByRole('button', { name: /Create lobby/i });
+if (await createBtn.count()) {
+  await createBtn.click({ timeout: 15000 });
+}
+await page.waitForTimeout(1500);
+
+console.log('Readying up...');
+const readyBtn = page.getByRole('button', { name: /Ready up|Ready!/ });
+await readyBtn.click({ timeout: 15000 });
+await page.waitForTimeout(1000);
+
+console.log('Starting encounter...');
+const startBtn = page.getByTestId('start-encounter-button');
+await startBtn.waitFor({ state: 'visible', timeout: 15000 });
+await page.waitForTimeout(1000);
+await startBtn.click({ timeout: 15000, force: true });
+
+console.log('Waiting for encounter map...');
+await page.waitForSelector('[data-testid="encounter-map"] canvas', {
+  timeout: 30000,
+});
+await page.waitForTimeout(4000);
+await shot('00-encounter-live');
+
+const encounterUrl = new URL(page.url());
+
+// --- Stage 1: empty (minimal reveal, right after Start) ---
+console.log('\n=== Stage 1: empty ===');
+const emptyUrl = new URL(encounterUrl);
+emptyUrl.searchParams.set('perfProbe', '1');
+emptyUrl.searchParams.set('perfProbeLabel', 'empty');
+emptyUrl.searchParams.set('perfProbeMs', '8000');
+await page.goto(emptyUrl.toString(), { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('[data-testid="encounter-map"] canvas', {
+  timeout: 30000,
+});
+await page.waitForTimeout(9500);
+await shot('01-empty');
+
+// --- Reveal walls: click a few hexes to move the character around ---
+console.log('\nMoving to reveal walls...');
+const canvas = page.locator('[data-testid="encounter-map"] canvas');
+const box = await canvas.boundingBox();
+if (box) {
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  const offsets = [
+    [80, 0],
+    [-160, 0],
+    [0, 80],
+    [0, -160],
+    [120, 80],
+  ];
+  for (const [dx, dy] of offsets) {
+    await page.mouse.click(cx + dx, cy + dy);
+    await page.waitForTimeout(1500);
+  }
+}
+await page.waitForTimeout(1500);
+await shot('02-after-movement');
+
+// --- Stage 2: with walls (reload to resume the now-more-revealed encounter) ---
+console.log('\n=== Stage 2: with walls ===');
+const wallsUrl = new URL(encounterUrl);
+wallsUrl.searchParams.set('perfProbe', '1');
+wallsUrl.searchParams.set('perfProbeLabel', 'walls');
+wallsUrl.searchParams.set('perfProbeMs', '8000');
+await page.goto(wallsUrl.toString(), { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('[data-testid="encounter-map"] canvas', {
+  timeout: 30000,
+});
+await page.waitForTimeout(9500);
+await shot('03-walls');
+
+// --- Stage 3: +props (devPropDemoKeys on top of the same revealed room) ---
+console.log('\n=== Stage 3: +props ===');
+const propsUrl = new URL(encounterUrl);
+propsUrl.searchParams.set('perfProbe', '1');
+propsUrl.searchParams.set('perfProbeLabel', 'props');
+propsUrl.searchParams.set('perfProbeMs', '8000');
+propsUrl.searchParams.set(
+  'devPropDemoKeys',
+  'barrel,pillar,rock-pile,crate,tomb,barricade'
+);
+await page.goto(propsUrl.toString(), { waitUntil: 'load', timeout: 30000 });
+await page.waitForSelector('[data-testid="encounter-map"] canvas', {
+  timeout: 30000,
+});
+await page.waitForTimeout(9500);
+await shot('04-props');
+
+fs.writeFileSync(
+  `${outDir}/solo-sweep-results.json`,
+  JSON.stringify(results, null, 2)
+);
+console.log(
+  `\nWrote ${outDir}/solo-sweep-results.json (${results.length} stage results)`
+);
+
+await browser.close();

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -34,6 +34,7 @@ import {
   buildRenderableEntities,
   buildTurnOrderCombatState,
   parseDevPropDemoKeys,
+  parsePerfProbeWindowMs,
   synthesizeFloorTiles,
 } from '../playtest/playtestMapHelpers';
 
@@ -175,16 +176,18 @@ export function EncounterMap({
   // the dev-mode gate App.tsx's showPlaytestHarness/isDevelopment flags
   // already use -- never active in a production build regardless of query
   // string. `?perfProbe` (presence, any value) turns it on; optional
-  // `?perfProbeMs=<n>` overrides the sampling window; optional
-  // `?perfProbeLabel=<slug>` stamps a label onto the emitted result (the
-  // sweep driver script uses this to tag which stage a result belongs to).
+  // `?perfProbeMs=<n>` overrides the sampling window (parsePerfProbeWindowMs
+  // validates it -- NaN/non-positive falls back to DevPerfProbe's own
+  // default instead of wedging the probe into never completing, Copilot
+  // review rpg-dnd5e-web#546); optional `?perfProbeLabel=<slug>` stamps a
+  // label onto the emitted result (the sweep driver script uses this to tag
+  // which stage a result belongs to).
   const perfProbe = useMemo(() => {
     if (import.meta.env.MODE !== 'development') return null;
     const params = new URLSearchParams(window.location.search);
     if (!params.has('perfProbe')) return null;
-    const msParam = params.get('perfProbeMs');
     return {
-      windowMs: msParam ? Number(msParam) : undefined,
+      windowMs: parsePerfProbeWindowMs(params.get('perfProbeMs')),
       label: params.get('perfProbeLabel') ?? undefined,
     };
   }, []);

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -25,6 +25,7 @@
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useMemo } from 'react';
+import { DevPerfProbe } from '../../dev/DevPerfProbe';
 import type { EntityMeta, EntityStatus } from '../../hooks/useEncounterState';
 import { HexGrid } from '../hex-grid';
 import type { CubeCoord } from '../hex-grid/hexMath';
@@ -169,6 +170,25 @@ export function EncounterMap({
     []
   );
 
+  // Dev-only runtime perf probe (rpg-dnd5e-web#537). Same read-once-via-
+  // useMemo / raw-URLSearchParams convention as syntyDungeon above, plus
+  // the dev-mode gate App.tsx's showPlaytestHarness/isDevelopment flags
+  // already use -- never active in a production build regardless of query
+  // string. `?perfProbe` (presence, any value) turns it on; optional
+  // `?perfProbeMs=<n>` overrides the sampling window; optional
+  // `?perfProbeLabel=<slug>` stamps a label onto the emitted result (the
+  // sweep driver script uses this to tag which stage a result belongs to).
+  const perfProbe = useMemo(() => {
+    if (import.meta.env.MODE !== 'development') return null;
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('perfProbe')) return null;
+    const msParam = params.get('perfProbeMs');
+    return {
+      windowMs: msParam ? Number(msParam) : undefined,
+      label: params.get('perfProbeLabel') ?? undefined,
+    };
+  }, []);
+
   return (
     <div
       data-testid="encounter-map"
@@ -201,7 +221,11 @@ export function EncounterMap({
         // Deliberately not wired — see PlaytestMap's identical note: HexGrid
         // fires both onAttackComplete AND onEntityClick for an attackable
         // monster click, so wiring both here would double-dispatch.
-      />
+      >
+        {perfProbe && (
+          <DevPerfProbe windowMs={perfProbe.windowMs} label={perfProbe.label} />
+        )}
+      </HexGrid>
     </div>
   );
 }

--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -18,6 +18,7 @@ import {
   buildTurnOrderCombatState,
   entityTypeToDisplay,
   parseDevPropDemoKeys,
+  parsePerfProbeWindowMs,
   synthesizeFloorTiles,
 } from './playtestMapHelpers';
 
@@ -416,5 +417,39 @@ describe('parseDevPropDemoKeys (Copilot review, rpg-dnd5e-web#530)', () => {
     expect(entities).toHaveLength(1);
     const ids = new Set(entities.map((e) => e.entityId));
     expect(ids.size).toBe(entities.length);
+  });
+});
+
+describe('parsePerfProbeWindowMs (Copilot review, rpg-dnd5e-web#546)', () => {
+  it('returns undefined for null input (param absent)', () => {
+    expect(parsePerfProbeWindowMs(null)).toBeUndefined();
+  });
+
+  it("returns undefined for a non-numeric value instead of NaN — the exact bug Copilot flagged: an unvalidated NaN windowMs makes DevPerfProbe's `elapsed >= windowMs` check never true, so the probe never completes", () => {
+    expect(parsePerfProbeWindowMs('abc')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(parsePerfProbeWindowMs('')).toBeUndefined();
+  });
+
+  it('returns undefined for zero', () => {
+    expect(parsePerfProbeWindowMs('0')).toBeUndefined();
+  });
+
+  it('returns undefined for a negative value', () => {
+    expect(parsePerfProbeWindowMs('-500')).toBeUndefined();
+  });
+
+  it('returns undefined for Infinity', () => {
+    expect(parsePerfProbeWindowMs('Infinity')).toBeUndefined();
+  });
+
+  it('parses a valid positive integer string', () => {
+    expect(parsePerfProbeWindowMs('5000')).toBe(5000);
+  });
+
+  it('parses a valid positive decimal string', () => {
+    expect(parsePerfProbeWindowMs('1500.5')).toBe(1500.5);
   });
 });

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -280,3 +280,25 @@ export function parseDevPropDemoKeys(raw: string | null): string[] {
     .filter(Boolean);
   return Array.from(new Set(parsed));
 }
+
+/**
+ * Parse EncounterMap's `?perfProbeMs=` query param value into a validated
+ * DevPerfProbe `windowMs` override, or `undefined` to let DevPerfProbe fall
+ * back to its own default (Copilot review, rpg-dnd5e-web#546: an
+ * unvalidated `Number(msParam)` turns a malformed value like
+ * `?perfProbeMs=abc` into `NaN`; DevPerfProbe's completion check is
+ * `elapsed >= windowMs`, and every comparison against `NaN` is `false`, so
+ * the probe would never finish — it keeps forcing `invalidate()` every
+ * frame forever instead of completing after one sampling window). A
+ * non-positive value (`0` or negative) is equally nonsensical as a
+ * sampling window, so it's rejected the same way. Returns `undefined`
+ * (not a hardcoded fallback number) for null/NaN/non-positive input so
+ * DevPerfProbe's own `windowMs = 8000` default prop stays the single
+ * source of truth for the default window length.
+ */
+export function parsePerfProbeWindowMs(raw: string | null): number | undefined {
+  if (raw === null) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}

--- a/src/dev/DevPerfProbe.tsx
+++ b/src/dev/DevPerfProbe.tsx
@@ -1,0 +1,264 @@
+/**
+ * DevPerfProbe — dev-only runtime performance probe for the real game
+ * route (rpg-dnd5e-web#537's "performance measurement foundation": mesh
+ * budgets in the asset pipeline + a runtime probe here, so future asset
+ * PRs can diff their impact against a committed baseline instead of
+ * guessing).
+ *
+ * Mounted via `EncounterMap`'s `<HexGrid>` `children` slot (the same slot
+ * `PlaytestHarness`'s Synty showcase already uses) -- this is the ONLY
+ * wiring point this feature touches; everything else lives in this one
+ * new file. Gated behind `import.meta.env.MODE === 'development'` (the
+ * same gate `App.tsx`'s `showPlaytestHarness`/`isDevelopment` flags use)
+ * AND a `?perfProbe` query flag, read the exact same way HexGrid's
+ * existing `?syntyDungeon=0` flag is (`EncounterMap.tsx`: raw
+ * `new URLSearchParams(window.location.search).get(...)`, read once via
+ * `useMemo`, no router/useSearchParams -- this app has neither).
+ *
+ * WHY IT NEEDS `invalidate()` EVERY FRAME
+ * ----------------------------------------
+ * HexGrid's `<Canvas>` runs `frameloop="demand"` -- it only renders (and
+ * only updates `gl.info`) when something calls `invalidate()`. Without
+ * this probe forcing a render every frame for the sampling window, the
+ * canvas would sit idle and `renderer.info`/frame-time samples would be
+ * empty or stale. Same trick `ClassCharacterModel.tsx`'s idle-clip
+ * playback already uses (`useFrame((state) => { if (hasIdleClip)
+ * state.invalidate(); })`) -- copied verbatim, not reinvented.
+ *
+ * WHAT GETS MEASURED
+ * -------------------
+ * Every frame during a fixed sampling window (`windowMs`, default 8000ms):
+ *   - wall-clock frame-to-frame delta (via `performance.now()`, not
+ *     r3f's `delta` arg, so results are comparable to the browser's own
+ *     frame-timing APIs a human would sanity-check against)
+ *   - `gl.info.render.{calls,triangles,lines,points}` -- these are the
+ *     LAST-COMPLETED-RENDER counters (three.js resets them at the start
+ *     of each `render()` call), so sampling them every frame and
+ *     reporting mean/max captures any true frame-to-frame variance
+ *     (e.g. future frustum culling) rather than a single point-in-time
+ *     snapshot.
+ * At window end, also snapshots the cumulative resource counts that
+ * DON'T reset per frame: `gl.info.memory.{geometries,textures}` and
+ * `gl.info.programs?.length` (compiled WebGL program count -- a materials/
+ * shader-variety proxy).
+ *
+ * OUTPUT
+ * ------
+ * On completion: (1) `console.log`s a single JSON-stringified line
+ * prefixed `PERF_PROBE_RESULT:` (a driver script can grep this straight
+ * out of Playwright's console listener without any page.evaluate
+ * round-trip), (2) stashes the result on `window.__rpgPerfProbeResults`
+ * (array, latest-last) AND `window.__rpgPerfProbeLatest` for a driver
+ * script that prefers `page.evaluate()`, and (3) triggers a same-page
+ * file download of the JSON (a real `<a download>` click, standard
+ * browser download trick -- satisfies "downloadable" for interactive/
+ * manual use, not just automated driving).
+ */
+import { useFrame, useThree } from '@react-three/fiber';
+import { useRef } from 'react';
+
+export interface PerfProbeFrameStats {
+  mean: number;
+  p50: number;
+  p95: number;
+  p99: number;
+  min: number;
+  max: number;
+}
+
+export interface PerfProbeRendererCounterStats {
+  mean: number;
+  max: number;
+}
+
+export interface PerfProbeResult {
+  probeVersion: 1;
+  /** Free-form label the caller supplies (e.g. sweep stage name) so a
+   * driver script's captured results are self-describing without
+   * needing to correlate against navigation order. */
+  label: string | null;
+  startedAt: string;
+  url: string;
+  requestedWindowMs: number;
+  actualDurationMs: number;
+  frameCount: number;
+  frameTimeMs: PerfProbeFrameStats;
+  fpsMean: number;
+  rendererInfo: {
+    calls: PerfProbeRendererCounterStats;
+    triangles: PerfProbeRendererCounterStats;
+    lines: PerfProbeRendererCounterStats;
+    points: PerfProbeRendererCounterStats;
+    geometries: number;
+    textures: number;
+    programs: number;
+  };
+}
+
+export interface DevPerfProbeProps {
+  /** Sampling window length in ms. Default 8000ms -- long enough at a
+   * healthy ~60fps (~480 frames) for a meaningful p95/p99, short enough
+   * a driver script's sweep doesn't stall for minutes. */
+  windowMs?: number;
+  /** Free-form label stamped onto the result (see PerfProbeResult.label). */
+  label?: string;
+  /** Fires once, in addition to the automatic console/window/download
+   * dump -- lets a caller inside the app react to completion (unused by
+   * the sweep driver, which reads the console line / window global from
+   * outside the page instead, but kept for parity with the codebase's
+   * callback-prop convention). */
+  onComplete?: (result: PerfProbeResult) => void;
+}
+
+declare global {
+  interface Window {
+    __rpgPerfProbeResults?: PerfProbeResult[];
+    __rpgPerfProbeLatest?: PerfProbeResult;
+  }
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function percentile(sortedAscending: number[], p: number): number {
+  if (sortedAscending.length === 0) return 0;
+  const idx = (sortedAscending.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.min(lo + 1, sortedAscending.length - 1);
+  const frac = idx - lo;
+  return (
+    sortedAscending[lo] + (sortedAscending[hi] - sortedAscending[lo]) * frac
+  );
+}
+
+function frameStats(deltasMs: number[]): PerfProbeFrameStats {
+  const sorted = [...deltasMs].sort((a, b) => a - b);
+  return {
+    mean: mean(deltasMs),
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    p99: percentile(sorted, 0.99),
+    min: sorted.length ? sorted[0] : 0,
+    max: sorted.length ? sorted[sorted.length - 1] : 0,
+  };
+}
+
+function counterStats(values: number[]): PerfProbeRendererCounterStats {
+  return { mean: mean(values), max: values.length ? Math.max(...values) : 0 };
+}
+
+function emitResult(result: PerfProbeResult): void {
+  // Grep-able by a Playwright console listener without a page.evaluate
+  // round-trip.
+  console.log('PERF_PROBE_RESULT:' + JSON.stringify(result));
+
+  window.__rpgPerfProbeResults = window.__rpgPerfProbeResults ?? [];
+  window.__rpgPerfProbeResults.push(result);
+  window.__rpgPerfProbeLatest = result;
+
+  try {
+    const blob = new Blob([JSON.stringify(result, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const stageSlug = (result.label ?? 'window').replace(/[^a-z0-9-]+/gi, '-');
+    a.download = `perf-probe-${stageSlug}-${Date.now()}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  } catch {
+    // Downloadable dump is a convenience for manual/interactive use --
+    // never let a download failure (e.g. a locked-down headless browser)
+    // take down the probe's console/window-global output, which the
+    // automated sweep driver actually depends on.
+  }
+}
+
+interface ProbeState {
+  done: boolean;
+  startPerf: number | null;
+  lastFrameAt: number | null;
+  frameDeltasMs: number[];
+  calls: number[];
+  triangles: number[];
+  lines: number[];
+  points: number[];
+}
+
+function freshState(): ProbeState {
+  return {
+    done: false,
+    startPerf: null,
+    lastFrameAt: null,
+    frameDeltasMs: [],
+    calls: [],
+    triangles: [],
+    lines: [],
+    points: [],
+  };
+}
+
+export function DevPerfProbe({
+  windowMs = 8000,
+  label,
+  onComplete,
+}: DevPerfProbeProps) {
+  const { gl } = useThree();
+  const stateRef = useRef<ProbeState>(freshState());
+
+  useFrame((r3fState) => {
+    const s = stateRef.current;
+    if (s.done) return;
+
+    const now = performance.now();
+    if (s.startPerf === null) s.startPerf = now;
+    if (s.lastFrameAt !== null) s.frameDeltasMs.push(now - s.lastFrameAt);
+    s.lastFrameAt = now;
+
+    const info = gl.info;
+    s.calls.push(info.render.calls);
+    s.triangles.push(info.render.triangles);
+    s.lines.push(info.render.lines);
+    s.points.push(info.render.points);
+
+    const elapsed = now - s.startPerf;
+    if (elapsed >= windowMs) {
+      s.done = true;
+      const ft = frameStats(s.frameDeltasMs);
+      const result: PerfProbeResult = {
+        probeVersion: 1,
+        label: label ?? null,
+        startedAt: new Date(Date.now() - elapsed).toISOString(),
+        url: window.location.href,
+        requestedWindowMs: windowMs,
+        actualDurationMs: elapsed,
+        frameCount: s.calls.length,
+        frameTimeMs: ft,
+        fpsMean: ft.mean > 0 ? 1000 / ft.mean : 0,
+        rendererInfo: {
+          calls: counterStats(s.calls),
+          triangles: counterStats(s.triangles),
+          lines: counterStats(s.lines),
+          points: counterStats(s.points),
+          geometries: info.memory.geometries,
+          textures: info.memory.textures,
+          programs: info.programs?.length ?? 0,
+        },
+      };
+      emitResult(result);
+      onComplete?.(result);
+      return;
+    }
+
+    // Force the demand-frameloop canvas to keep rendering for the
+    // duration of the sampling window -- see module docstring.
+    r3fState.invalidate();
+  });
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Web-side half of the performance measurement foundation (rpg-dnd5e-web#537): a dev-only runtime perf probe on the real game route, plus committed, re-runnable driver scripts and a first baseline report — so future asset PRs (and #536's wall-instancing work) can diff their impact against real numbers instead of guessing.

- **`src/dev/DevPerfProbe.tsx`** (new) — samples `renderer.info` (draw calls, triangles, lines, points, geometries, textures, programs) and frame-time percentiles every frame over a fixed sampling window. Gated behind `?perfProbe` (+ optional `?perfProbeMs`/`?perfProbeLabel`) and `import.meta.env.MODE === 'development'` — same query-flag convention as `HexGrid`'s existing `?syntyDungeon` flag. Emits `console.log('PERF_PROBE_RESULT:...')`, sets `window.__rpgPerfProbeResults`/`__rpgPerfProbeLatest`, and triggers a JSON file download.
- **One wiring point**: `EncounterMap.tsx` forwards the probe through `HexGrid`'s existing `children` slot — no changes to `HexGrid.tsx` itself.
- **`scripts/perf/{mkchar_full,sweep_solo,sweep_party}.mjs`** (new, Playwright now a devDependency) — a committed, re-runnable sweep driving the **real route** (never `/playtest`): character wizard → lobby → Start → live `EncounterView`, through empty → with-walls → +`devPropDemoKeys` props → +4-real-characters stages.
- **`docs/perf/baseline-2026-07-20.md`** — first committed baseline: methodology, full results table, per-stage caveats, and optimization findings ranked by impact.

## Baseline headline numbers

Captured against `main` @ `b133064` (post #536 phase 2 / #539 wall corner+end fittings), dev build, shared sandbox — see the doc's Methodology section for why absolute numbers are for **relative**, same-methodology comparison, not a production FPS claim.

| stage | frames | mean ms | p95 ms | draw calls (mean) | triangles (mean) |
|---|---|---|---|---|---|
| empty (solo, pre-combat) | 99 | 81.88 | 95.74 | 229.8 | 57,807 |
| walls (solo, combat w/ 2 goblins) | 119 | 68.19 | 66.21 | 217.8 | 45,463 |
| +props (solo, +6 devPropDemoKeys) | 110 | 73.80 | 73.10 | 217.1 | 47,598 |
| +4 characters (cold load) | 83 | 185.11 | 247.02 | 289.1 | 103,161 |
| +4 characters (warm) | 46 | 179.88 | 247.24 | 271.0 | 91,890 |

Full precision, `min`/`max`/`p50`/`p99`, and raw per-stage JSON: `playtest-evidence/asset-pipeline/pr-537-perf/` (evidence branch, this PR).

## Top optimization opportunities (ranked)

1. **Weapon standalone-prop texture bloat** (asset-side, rpg-game-assets#15) — every one of the 17 standalone weapon GLBs embeds a full 2048×2048 (16MB) or 4096×4096 (64MB) atlas for a 40-1,110-triangle mesh (~792MB total waste). Highest ROI fix found across both halves of #537.
2. **Walls: N segments = N draw calls, zero instancing.** `SyntyHexWall.tsx`'s `GlbInstance` renders one `scene.clone(true)`'d GLB `<primitive>` per wall/door edge segment, confirmed directly from source — no batching regardless of how many segments share the same GLB. Feeds #536's fix design directly: `ShadedHexFloor` → `InstancedHexTiles.tsx` already proves the `InstancedMesh`-per-`(file,scale)` pattern works in this exact codebase; applying it to `SyntyHexWall` would collapse wall+door draw calls from O(segments) to O(distinct variants).
3. **Floor tiles: the same gap, likely the bigger contributor.** `SyntyHexFloor.tsx`'s own docstring already names this as a "Known MVP limitation": one `<mesh>` per tile, explicitly contrasted with `ShadedHexFloor`'s `InstancedMesh`. A single room's floor runs into the hundreds of tiles — recommend scoping this fix together with #2.
4. **4-character load cost** (measured directly) — 1→4 characters raised mean frame time ~70-95ms → ~180ms and draw calls ~218-230 → ~271-289.

## Judgment calls

- **All 4 sweep characters are Barbarians**, not one-of-each-class. Two real app gaps found incidentally while driving the real wizard (not asset bugs, worth filing separately):
  - **Fighter**: `ListClasses` is called with `includeFeatures: false`, so the wizard never renders a "fighting style" picker, but `CreateCharacter` server-side validation requires one — every Fighter draft's Begin Adventure 400s with `"Choose a fighting style required"`, no UI path to satisfy it.
  - **Monk**: needs one more proficiency choice (artisan's-tools-or-musical-instrument) that didn't reliably resolve via a generic click-first-match fallback within this task's time budget.
  - **Rogue**: got through race/class/skills/equipment reliably but failed at the background step in every attempt; root cause not isolated.
  - Barbarian was the one class that created cleanly every time. Class variety is cosmetic for this baseline (each character is still one GLB + baked weapon, one draw call) — not a measurement-validity concern.
- **The race picker's carousel** clips 2 of 9 races out of the initially-visible slice and doesn't support a normal `scrollIntoView`, so hardcoding "always pick Tiefling" was flaky. `mkchar_full.mjs` instead accepts whatever race the modal defaults to, and generically detects+rerolls only when that race turns out to need an unhandled sub-choice (checked by whether "Select `<race>`" actually closed the modal).
- **"walls" stage isn't an isolated wall-count measurement** — movement clicks incidentally triggered combat with 2 nearby goblins. The empty→walls delta should be read with that caveat (see doc); the props delta is the closest to a clean single-variable comparison in this sweep.
- **Dev-build caveat**: unminified React/Three.js, StrictMode double-mounting, and a shared sandbox running several other concurrent dev servers. Treat all absolute numbers as relative/same-methodology baselines, not production FPS predictions.

## Evidence

Screenshots + raw `DevPerfProbe` JSON for every stage: `playtest-evidence/asset-pipeline/pr-537-perf/` — pushed as its own evidence branch per house rule. Highlights: `party-02-all-ready.png` (4/4 real characters ready in one lobby), `party-03-four-characters.png` (all 4 rendered together in the live encounter), `solo-04-props.png` (6 real prop GLBs rendered via `devPropDemoKeys` next to the character).

## Test plan

- [x] `npm run ci-check` — format, lint, typecheck, build, tests all pass
- [x] `scripts/perf/mkchar_full.mjs` — creates a real, finalized character through the actual wizard (confirmed via screenshot: character card shows HP/AC, "Play" enabled)
- [x] `scripts/perf/sweep_solo.mjs` — full run end-to-end: Home → wizard → lobby → Start → live `EncounterView`, 3 probe stages captured with real `PERF_PROBE_RESULT:` JSON
- [x] `scripts/perf/sweep_party.mjs` — full run end-to-end: 4 real characters created, joined one lobby via a real join code, all readied, host started, all 4 landed in the live encounter, cold + warm probe stages captured
- [x] Manually verified `?perfProbe` is a no-op with the flag absent (default real-route behavior unchanged) and is inert outside `import.meta.env.MODE === 'development'`

— asset-pipeline agent, on behalf of KirkDiggler
