### PR TITLE
fix(hex-grid): raise movement overlay Y-offsets above SyntyHexFloor's true top

### DIFF
--- a/src/components/hex-grid/MovementRangeBorder.tsx
+++ b/src/components/hex-grid/MovementRangeBorder.tsx
@@ -21,14 +21,18 @@ interface MovementRangeBorderProps {
 const DEFAULT_COLOR = '#00bcd4'; // Cyan
 const DEFAULT_OPACITY = 0.8;
 const DEFAULT_GLOW_INTENSITY = 2.0;
-// Y offset must clear the floor extrusion top to be visible. ShadedHexFloor
-// extrudes hex tiles from y=0.05 to y=0.15 (depth 0.1, then translated by
-// 0.05). The previous 0.05 placed the border at the floor's BOTTOM face —
-// invisible from above and only peeking through z-fighting from below,
-// matching Kirk's "renders below the floor" Wave 2 playtest report.
-// Raise to 0.17 so it sits above the floor's top face with a small margin
-// that prevents z-fighting against PathPreview at 0.16.
-const BORDER_Y_OFFSET = 0.17;
+// Y offset must clear the topmost floor renderer's top face to be visible.
+// ShadedHexFloor extrudes hex tiles from y=0.05 to y=0.15 (depth 0.1, then
+// translated by 0.05) — the previous 0.05 placed the border at the floor's
+// BOTTOM face, invisible from above, matching Kirk's "renders below the
+// floor" Wave 2 playtest report. A 0.17 fix cleared Shaded but not
+// SyntyHexFloor (the DEFAULT floor — PR #477, shipped after this fix), a
+// flat unextruded plane whose top IS its position, FLOOR_Y=0.2 — taller
+// than 0.17, silently reintroducing the same symptom (rpg-dnd5e-web#535).
+// Raise to 0.22: above Synty's 0.2 top with the same ~0.01 margin the
+// original fix used against Shaded's 0.15, and above PathPreview's 0.21 so
+// the two keep their relative z-order.
+const BORDER_Y_OFFSET = 0.22;
 const LINE_WIDTH = 0.08; // Width of the border line
 
 /**

--- a/src/components/hex-grid/PathPreview.tsx
+++ b/src/components/hex-grid/PathPreview.tsx
@@ -18,12 +18,18 @@ interface PathPreviewProps {
 
 const DEFAULT_COLOR = '#3b82f6'; // blue
 const DEFAULT_OPACITY = 0.4;
-// Y offset must clear the floor extrusion top to be visible. ShadedHexFloor
-// extrudes from y=0.05 to y=0.15. The previous 0.03 sat under the floor
-// entirely — same Wave 2 "below the floor" symptom as MovementRangeBorder.
-// Sits just above the floor top, slightly below MovementRangeBorder (0.17)
-// so the cyan range outline reads on top when both render the same edge.
-const PATH_Y_OFFSET = 0.16;
+// Y offset must clear the topmost floor renderer's top face to be visible.
+// ShadedHexFloor extrudes from y=0.05 to y=0.15. The previous 0.03 sat
+// under the floor entirely — same Wave 2 "below the floor" symptom as
+// MovementRangeBorder. A 0.16 fix cleared Shaded but not SyntyHexFloor
+// (the DEFAULT floor — PR #477, shipped after this fix), a flat unextruded
+// plane whose top IS its position, FLOOR_Y=0.2 — taller than 0.16,
+// silently reintroducing the same symptom (rpg-dnd5e-web#535). Raise to
+// 0.21: above Synty's 0.2 top with the same ~0.01 margin the original fix
+// used against Shaded's 0.15, and slightly below MovementRangeBorder
+// (0.22) so the cyan range outline still reads on top when both render the
+// same edge.
+const PATH_Y_OFFSET = 0.21;
 
 /**
  * Creates a flat hexagon shape for pointy-top orientation

--- a/src/components/hex-grid/floorOverlayHeights.test.ts
+++ b/src/components/hex-grid/floorOverlayHeights.test.ts
@@ -139,6 +139,10 @@ describe('floor overlay Y offsets clear the floor extrusion top', () => {
     // would need updating alongside.
     const src = readSource('./SyntyHexFloor.tsx');
     expect(src).toContain('new THREE.ShapeGeometry(shape)');
-    expect(src).not.toMatch(/ExtrudeGeometry/);
+    // Match actual constructor usage, not a bare word — a prose comment
+    // mentioning "ExtrudeGeometry" (e.g. contrasting with ShadedHexFloor)
+    // must not trip this guard; only a real `new ExtrudeGeometry(...)` call
+    // should.
+    expect(src).not.toMatch(/new\s+(THREE\.)?ExtrudeGeometry\(/);
   });
 });

--- a/src/components/hex-grid/floorOverlayHeights.test.ts
+++ b/src/components/hex-grid/floorOverlayHeights.test.ts
@@ -3,9 +3,12 @@
  *
  * Why this test exists:
  *
- * `ShadedHexFloor` (the canonical floor tile renderer) extrudes each hex
- * tile from y=0.05 to y=0.15 in world space. Two overlay components draw
- * on top of those tiles:
+ * `ShadedHexFloor` (the dev-flag-off floor renderer) extrudes each hex tile
+ * from y=0.05 to y=0.15 in world space. `SyntyHexFloor` (the DEFAULT floor
+ * renderer — see EncounterMap.tsx / PlaytestMap.tsx) is a flat, unextruded
+ * plane positioned at world y=0.2 (its `FLOOR_Y` const — the geometry has
+ * zero local thickness, so 0.2 is both its base AND its top). Two overlay
+ * components draw on top of whichever floor is mounted:
  *
  *   - `MovementRangeBorder` — cyan glowing perimeter around reachable hexes
  *   - `PathPreview`         — blue path-fill on hexes the player will cross
@@ -20,8 +23,15 @@
  * Both were occluded by the opaque top face at y=0.15 — the Wave 2
  * playtest "range indicator below the floor" symptom.
  *
+ * A 2026-05-05 fix (bd6c2db) raised both offsets above ShadedHexFloor's
+ * 0.15 top and added this test — but `SyntyHexFloor` shipped later (PR
+ * #477) with its opaque, depth-writing plane at 0.2, taller than Shaded's
+ * top and ABOVE the (then-adequate) overlay offsets, silently reintroducing
+ * the exact same "markers under the floor" symptom under the default floor
+ * renderer (rpg-dnd5e-web#535).
+ *
  * This test is a hard regression guard: any future change that drops these
- * offsets back below the floor extrusion top will fail loudly.
+ * offsets back below EITHER floor variant's top will fail loudly.
  *
  * Source-text inspection (matching AdvancedCharacterShader.test.ts) avoids
  * needing a real WebGL context.
@@ -48,6 +58,17 @@ const HERE = dirname(fileURLToPath(import.meta.url));
  * Any overlay drawn at y < 0.15 is INSIDE or BELOW the floor extrusion.
  */
 const FLOOR_TOP_Y = 0.15;
+
+/**
+ * SyntyHexFloor is the DEFAULT floor renderer (EncounterMap.tsx /
+ * PlaytestMap.tsx render it unconditionally; ShadedHexFloor only mounts
+ * behind the `?syntyDungeon=0` dev flag). Its tile mesh is a flat
+ * `ShapeGeometry` with no extrusion — `rotateX(-Math.PI / 2)` collapses all
+ * local Y to 0, so the mesh's `FLOOR_Y` position IS its top face, not a
+ * base under some taller top. Extracted from source (not hardcoded) so a
+ * future change to SyntyHexFloor's height can't silently desync this test.
+ */
+const SYNTY_FLOOR_TOP_CONST = 'FLOOR_Y';
 
 function readSource(relativePath: string): string {
   return readFileSync(resolve(HERE, relativePath), 'utf-8');
@@ -92,5 +113,32 @@ describe('floor overlay Y offsets clear the floor extrusion top', () => {
     const src = readSource('./ShadedHexFloor.tsx');
     expect(src).toContain('depth: 0.1');
     expect(src).toContain('geometry.translate(0, 0.05, 0)');
+  });
+
+  it('MovementRangeBorder Y offset is above SyntyHexFloor (the default floor) top', () => {
+    const overlaySrc = readSource('./MovementRangeBorder.tsx');
+    const floorSrc = readSource('./SyntyHexFloor.tsx');
+    const offset = extractNumberConst(overlaySrc, 'BORDER_Y_OFFSET');
+    const syntyTop = extractNumberConst(floorSrc, SYNTY_FLOOR_TOP_CONST);
+    expect(offset).toBeGreaterThan(syntyTop);
+  });
+
+  it('PathPreview Y offset is above SyntyHexFloor (the default floor) top', () => {
+    const overlaySrc = readSource('./PathPreview.tsx');
+    const floorSrc = readSource('./SyntyHexFloor.tsx');
+    const offset = extractNumberConst(overlaySrc, 'PATH_Y_OFFSET');
+    const syntyTop = extractNumberConst(floorSrc, SYNTY_FLOOR_TOP_CONST);
+    expect(offset).toBeGreaterThan(syntyTop);
+  });
+
+  it('SyntyHexFloor is unextruded, so FLOOR_Y is genuinely its top face', () => {
+    // Guard the "flat plane, position IS the top" assumption the two tests
+    // above rely on. If SyntyHexFloor ever grows real extrusion depth (an
+    // ExtrudeGeometry with a `depth` option instead of ShapeGeometry), its
+    // true top would be FLOOR_Y + depth, not FLOOR_Y, and the tests above
+    // would need updating alongside.
+    const src = readSource('./SyntyHexFloor.tsx');
+    expect(src).toContain('new THREE.ShapeGeometry(shape)');
+    expect(src).not.toMatch(/ExtrudeGeometry/);
   });
 });


### PR DESCRIPTION
## Load-bearing digest

- **Bug**: `MovementRangeBorder` (cyan range perimeter) and `PathPreview` (blue path fill) render UNDER the default floor mesh in the top-down ortho view — both invisible.
- **Root cause**: `SyntyHexFloor` (the DEFAULT floor renderer since PR #477 — mounted unconditionally by `EncounterMap.tsx`/`PlaytestMap.tsx`; `ShadedHexFloor` only shows behind `?syntyDungeon=0`) is opaque and depth-writing. Its tile mesh is a flat, **unextruded** `ShapeGeometry` — `rotateX(-Math.PI/2)` collapses all local Y to 0, so the mesh's `FLOOR_Y = 0.2` position IS its top face, not a base under a taller top. `BORDER_Y_OFFSET=0.17` and `PATH_Y_OFFSET=0.16` clear `ShadedHexFloor`'s extruded top (0.15, fixed 2026-05-05 in bd6c2db) but sit below Synty's 0.2.
- **True Synty top-face height verified**: `0.2` (not higher — confirmed by reading the geometry construction: `ShapeGeometry` has zero local Z/thickness before the rotation, so nothing survives above the `position` Y).
- **Fix**: raise `BORDER_Y_OFFSET` to `0.22` and `PATH_Y_OFFSET` to `0.21` (border stays above path, same ~0.01 margins as the original Shaded-targeted fix), and extend `floorOverlayHeights.test.ts` to assert both offsets clear Synty's top too — extracted from source, not hardcoded, so a future third floor variant can't silently reintroduce this again.
- **Negative control**: added the two new Synty-top assertions to the test FIRST, ran against the unfixed offsets — both failed (`0.17 > 0.2` and `0.16 > 0.2` both false), proving the test genuinely catches the bug. Then applied the offset fix — all 7 tests (5 pre-existing + 2 new) pass.
- **Sanity**: the pre-existing Shaded-top (0.15) assertions still pass unchanged — the `?syntyDungeon=0` path does not regress.

## Scope decisions

- Kept the codebase's established Y-offset + regression-test pattern rather than switching to `renderOrder`/`depthTest:false`. The Y-banding approach is simple, already proven (this is its second use), and the new source-extracted test closes the actual gap (no per-floor-variant coverage) rather than the mechanism. Did not touch `SyntyHexFloor`'s own geometry/material — its comment explicitly says it sits high (0.2) to avoid z-fighting `ShadedHexFloor`, and lowering it wasn't asked for and would reopen that concern.
- Touches movement-overlay Y-offsets only. Does not touch floor mesh art (asset lane) or panels (UX lane).

Closes #535