### PR TITLE
feat(hex-grid): walk-clip movement interpolation (rpg-dnd5e-web#542)

### DIFF
--- a/src/api/useEncounterStream.integration.test.tsx
+++ b/src/api/useEncounterStream.integration.test.tsx
@@ -47,9 +47,16 @@ function useTestHarness(encounterId: string) {
       /* noop — payload empty in slice 1, just a sync barrier */
     },
     onEntityMoved: (e) => {
+      // rpg-dnd5e-web#542: mirrors EncounterView.tsx's real wiring — pass
+      // the whole actualPath, not just its last element, so state.entities
+      // carries movePath/moveSeq for HexEntity's walk-clip interpolation.
       const last = e.actualPath[e.actualPath.length - 1];
       if (last)
-        state.applyEntityPositionUpdate(e.entityId, v2PositionToV1(last));
+        state.applyEntityPositionUpdate(
+          e.entityId,
+          v2PositionToV1(last),
+          e.actualPath.map(v2PositionToV1)
+        );
     },
     onGeometryRevealed: (e) => {
       const positions = e.hexes
@@ -134,6 +141,14 @@ describe('useEncounterStream + useEncounterState — integration', () => {
       expect(pos?.x).toBe(2);
       expect(pos?.y).toBe(-2);
       expect(pos?.z).toBe(0);
+      // rpg-dnd5e-web#542: the full 3-hex actualPath also lands in
+      // movePath/moveSeq for HexEntity's walk-clip interpolation to
+      // consume — this is the real end-to-end path from wire event to
+      // state, not just the unit-level mergeEntityPosition contract.
+      const entity = result.current.entities.get('alice');
+      expect(entity?.movePath).toHaveLength(3);
+      expect(entity?.movePath?.[2]).toMatchObject({ x: 2, y: -2, z: 0 });
+      expect(entity?.moveSeq).toBe(1);
     });
   });
 
@@ -297,6 +312,12 @@ describe('useEncounterStream + useEncounterState — integration', () => {
       expect(m?.position?.x).toBe(5);
       expect(m?.position?.y).toBe(-3);
       expect(m?.position?.z).toBe(-2);
+      // rpg-dnd5e-web#542: the earlier move's movePath/moveSeq must NOT
+      // survive the disappear→reappear round-trip — a revive that kept
+      // them would make HexEntity's useHexMovePath think a fresh move
+      // just started on reconnect, animating a walk from nowhere.
+      expect(m?.movePath).toBeUndefined();
+      expect(m?.moveSeq).toBeUndefined();
     });
   });
 

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -39,8 +39,15 @@ import {
 } from '../playtest/playtestMapHelpers';
 
 export interface EncounterMapProps {
-  /** Unified entity store from useEncounterState (v1alpha1 EntityState stubs, entityId + position). */
-  entities: Map<string, EntityState & { ghost?: boolean }>;
+  /** Unified entity store from useEncounterState (v1alpha1 EntityState stubs, entityId + position). `movePath`/`moveSeq` (rpg-dnd5e-web#542) drive HexEntity's walk-clip interpolation. */
+  entities: Map<
+    string,
+    EntityState & {
+      ghost?: boolean;
+      movePath?: { x: number; y: number; z: number }[];
+      moveSeq?: number;
+    }
+  >;
   /** v1alpha2 identity metadata (type, monsterRefId) keyed by entityId. */
   entityMeta: Map<string, EntityMeta>;
   /** Per-hex reveal set ("x,y,z" cube-coord keys) from GeometryRevealed events. */

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -245,9 +245,15 @@ export function EncounterView({
     onEntityMoved: (e) => {
       const last = e.actualPath[e.actualPath.length - 1];
       if (last) {
+        // rpg-dnd5e-web#542: pass the WHOLE actualPath (not just its last
+        // element) so HexEntity can step through the real hex-by-hex route
+        // instead of teleporting straight to the destination. actualPath is
+        // real, backend-populated per-viewer-visible route data (confirmed
+        // directly against rpg-api's translateMoveEvent), not a stub.
         encounterState.applyEntityPositionUpdate(
           e.entityId,
-          v2PositionToV1(last)
+          v2PositionToV1(last),
+          e.actualPath.map(v2PositionToV1)
         );
       }
     },

--- a/src/components/hex-grid/ClassCharacterModel.tsx
+++ b/src/components/hex-grid/ClassCharacterModel.tsx
@@ -36,6 +36,15 @@
  * one on loop. Downed variants ship with no animation data at all —
  * `SkeletonUtils.clone()` still works for a static mesh, so one clone
  * path covers both cases.
+ *
+ * `isMoving` (rpg-dnd5e-web#542): HexEntity computes this from whether it's
+ * currently stepping the entity's rendered position through a real
+ * `EntityMoved.actualPath` (see `useHexMovePath.ts`) and passes it straight
+ * through. When true, `resolveWalkClipName` is preferred over
+ * `resolveIdleClipName` (falling back to idle if this model has no
+ * `Walk_*` clip yet — the same clip-less-model degrade-gracefully rule as
+ * everything else in this file). All 4 class GLBs ship a `Walk_Forward`
+ * clip as of rpg-game-assets#20.
  */
 
 import { SYNTY_SCALE } from '@/rendering/calibrationConstants';
@@ -44,7 +53,10 @@ import { useFrame } from '@react-three/fiber';
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import { clone as cloneSkeleton } from 'three/addons/utils/SkeletonUtils.js';
-import { resolveIdleClipName } from './classCharacterModels';
+import {
+  resolveIdleClipName,
+  resolveWalkClipName,
+} from './classCharacterModels';
 
 export interface ClassCharacterModelProps {
   url: string;
@@ -53,6 +65,11 @@ export interface ClassCharacterModelProps {
   /** Matches MediumHumanoid's facingRotation convention — players face the
    * camera (PI), monsters/other uses face forward (0). */
   facingRotation?: number;
+  /** True while HexEntity is stepping this entity's rendered position
+   * through a real move (rpg-dnd5e-web#542) — plays the resolved walk clip
+   * instead of idle. Defaults false (idle), matching every pre-#542 caller
+   * unchanged. */
+  isMoving?: boolean;
 }
 
 export function ClassCharacterModel({
@@ -60,6 +77,7 @@ export function ClassCharacterModel({
   isSelected = false,
   isGhost = false,
   facingRotation = 0,
+  isMoving = false,
 }: ClassCharacterModelProps) {
   // useGLTF returns drei's shared, URL-keyed cache — mutating it directly
   // during render is a render-phase side effect on shared state (same
@@ -137,24 +155,26 @@ export function ClassCharacterModel({
     };
   }, [originalMaterials, isSelected, isGhost]);
 
-  // Play the resolved idle clip on loop (resolveIdleClipName — prefers an
-  // "idle"-named clip, falls back to the first available). Today's `main`
-  // fighter/barbarian/monk/rogue.glb all ship 0 clips (`names` is empty),
-  // so `clipName` is undefined and this effect no-ops cleanly — same as
-  // downed variants, which never carry animation data. Once
-  // rpg-game-assets#522 lands, monk/rogue will carry 3 idle-variant clips
-  // each and this resolves to whichever comes first.
+  // Play the resolved clip on loop. While `isMoving` (rpg-dnd5e-web#542),
+  // prefer a `Walk_*` clip (resolveWalkClipName), falling back to idle if
+  // this model has no walk clip yet; stationary always plays idle
+  // (resolveIdleClipName — prefers an "idle"-named clip, falls back to the
+  // first available). Today's `main` fighter/barbarian/monk/rogue.glb all
+  // ship 4 clips (3 idle variants + Walk_Forward, rpg-game-assets#20);
+  // downed variants ship 0, so `names` is empty and `resolvedClipName` is
+  // undefined — this effect no-ops cleanly for those, same as before #542.
   const { actions, names } = useAnimations(animations, cloned);
-  const hasIdleClip = resolveIdleClipName(names) !== undefined;
+  const resolvedClipName = isMoving
+    ? (resolveWalkClipName(names) ?? resolveIdleClipName(names))
+    : resolveIdleClipName(names);
   useEffect(() => {
-    const clipName = resolveIdleClipName(names);
-    if (!clipName) return;
-    const action = actions[clipName];
+    if (!resolvedClipName) return;
+    const action = actions[resolvedClipName];
     action?.reset().fadeIn(0.2).play();
     return () => {
       action?.fadeOut(0.2);
     };
-  }, [actions, names]);
+  }, [actions, resolvedClipName]);
 
   // HexGrid's Canvas runs frameloop="demand" (only re-renders on explicit
   // invalidate() calls, not every rAF tick — see HexEntity.tsx's identical
@@ -165,10 +185,10 @@ export function ClassCharacterModel({
   // change or user interaction happened to trigger a frame. Each rendered
   // frame requests the next one, self-sustaining for as long as this
   // component has a clip playing; a no-op (no re-invalidation loop) once
-  // hasIdleClip is false (downed variants, or any future model shipped
-  // with no animation).
+  // resolvedClipName is undefined (downed variants, or any future model
+  // shipped with no animation).
   useFrame((state) => {
-    if (hasIdleClip) state.invalidate();
+    if (resolvedClipName) state.invalidate();
   });
 
   return (

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -30,6 +30,7 @@ import { MediumHumanoid, type SkinTone } from './MediumHumanoid';
 import { resolvePropVariantForEntity } from './obstaclePropKeys';
 import { PROPS_MODEL_BASE } from './propManifest';
 import { PropModel } from './PropModel';
+import { useHexMovePath } from './useHexMovePath';
 
 export interface HexEntityProps {
   entityId: string;
@@ -71,6 +72,15 @@ export interface HexEntityProps {
    * obstacleType when present (obstaclePropKeys.ts's
    * resolvePropKeyForEntity). */
   propRefId?: string;
+  /** The most recent genuine move's real hex-by-hex route
+   * (`EntityMoved.actualPath`), set only alongside `moveSeq` — see
+   * `useEncounterState.ts`'s `mergeEntityPosition` doc comment. Undefined
+   * for an entity that has never moved this session. */
+  movePath?: CubeCoord[];
+  /** Monotonic counter bumped only by a genuine move (rpg-dnd5e-web#542) —
+   * `useHexMovePath` watches this, not `position` itself, to distinguish a
+   * real move from initial placement or a ghost/revive reconciliation. */
+  moveSeq?: number;
 }
 
 // Visual state colors
@@ -218,9 +228,26 @@ export function HexEntity({
   isDowned = false,
   obstacleType,
   propRefId,
+  movePath,
+  moveSeq,
 }: HexEntityProps) {
   const meshRef = useRef<THREE.Mesh>(null);
   const { invalidate } = useThree();
+
+  // rpg-dnd5e-web#542: steps the player/monster group's rendered position
+  // through a genuine move's real hex-by-hex path instead of snapping —
+  // see useHexMovePath.ts's module doc comment for the full contract.
+  // Cheap to compute unconditionally even for obstacles/downed/dead
+  // entities (a no-op hook call, same shape as every other hook here) —
+  // only actually wired into the render tree below for the player/monster
+  // branch, which is the only one that currently animates position.
+  const { groupRef: movingGroupRef, isMoving } = useHexMovePath(
+    position,
+    movePath,
+    moveSeq,
+    hexSize,
+    CHARACTER_Y_OFFSET
+  );
 
   // Same "sticky failure keyed by url, not a bare boolean" shape as
   // failedClassModelUrl below — a prop GLB that fails to load falls back
@@ -370,11 +397,15 @@ export function HexEntity({
       />
     );
 
+    // rpg-dnd5e-web#542: this group's position is owned entirely by
+    // useHexMovePath (via movingGroupRef) — no declarative `position` prop
+    // here, see that hook's doc comment for why mixing the two would fight
+    // mid-step. Dead/ghost/downed entities still pass through it (moveSeq
+    // simply never advances for them beyond whatever their last real move
+    // was, so it settles at their current position exactly like the old
+    // static prop did).
     return (
-      <group
-        position={[worldPos.x, CHARACTER_Y_OFFSET, worldPos.z]}
-        {...interactionProps}
-      >
+      <group ref={movingGroupRef} {...interactionProps}>
         {/* Dead/downed entities rendered with tilt when using the
             MediumHumanoid fallback (no separate collapsed pose asset);
             the class model's own downed GLB variant is already posed for
@@ -400,6 +431,7 @@ export function HexEntity({
                   isSelected={!isDead && isSelected}
                   isGhost={isGhost}
                   facingRotation={Math.PI}
+                  isMoving={!isDead && !isGhost && isMoving}
                 />
               </ErrorBoundary>
             ) : (

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -72,6 +72,11 @@ export interface HexGridProps {
      * signal (rpg-dnd5e-web#528, charter #523). Preferred over
      * obstacleType when present. */
     propRefId?: string;
+    /** The most recent genuine move's real hex-by-hex route
+     * (rpg-dnd5e-web#542) — drives HexEntity's walk-clip interpolation. */
+    movePath?: { x: number; y: number; z: number }[];
+    /** Monotonic counter bumped only by a genuine move. */
+    moveSeq?: number;
   }>;
   selectedEntityId?: string;
   onHexClick?: (coord: { x: number; y: number; z: number }) => void;
@@ -656,6 +661,8 @@ function Scene({
           isDowned={entity.isDowned}
           obstacleType={entity.obstacleType}
           propRefId={entity.propRefId}
+          movePath={entity.movePath}
+          moveSeq={entity.moveSeq}
         />
       ))}
 

--- a/src/components/hex-grid/classCharacterModels.test.ts
+++ b/src/components/hex-grid/classCharacterModels.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   resolveClassCharacterModelUrl,
   resolveIdleClipName,
+  resolveWalkClipName,
 } from './classCharacterModels';
 
 describe('resolveClassCharacterModelUrl', () => {
@@ -71,5 +72,41 @@ describe('resolveIdleClipName', () => {
     expect(
       resolveIdleClipName(['Idle_CheckWatch', 'Idle_Drinking', 'Idle_Relaxed'])
     ).toBe('Idle_CheckWatch');
+  });
+});
+
+describe('resolveWalkClipName', () => {
+  it('picks the clip whose name contains "walk" — today\'s real 4-class shape on main since rpg-game-assets#20', () => {
+    expect(
+      resolveWalkClipName([
+        'Idle_Drinking',
+        'Idle_Meditative',
+        'Idle_Relaxed',
+        'Walk_Forward',
+      ])
+    ).toBe('Walk_Forward');
+  });
+
+  it('matches "walk" case-insensitively', () => {
+    expect(resolveWalkClipName(['WALK_FORWARD'])).toBe('WALK_FORWARD');
+  });
+
+  it('returns undefined when no clip is walk-named — unlike resolveIdleClipName, does NOT fall back to the first available clip', () => {
+    expect(
+      resolveWalkClipName(['Idle_Relaxed', 'Idle_Drinking'])
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an empty clip list (downed variants, or any clip-less model)', () => {
+    expect(resolveWalkClipName([])).toBeUndefined();
+  });
+
+  it('does not match a clip that merely contains "walk" as a substring of an unrelated word', () => {
+    // Guards against an over-eager regex; "Boardwalk" isn't a real clip name
+    // this pipeline would ever produce, but the point is /walk/i really is
+    // a substring test, not a word-boundary one — documented, not "fixed".
+    expect(resolveWalkClipName(['Idle_Relaxed', 'Boardwalk_Loop'])).toBe(
+      'Boardwalk_Loop'
+    );
   });
 });

--- a/src/components/hex-grid/classCharacterModels.test.ts
+++ b/src/components/hex-grid/classCharacterModels.test.ts
@@ -101,10 +101,11 @@ describe('resolveWalkClipName', () => {
     expect(resolveWalkClipName([])).toBeUndefined();
   });
 
-  it('does not match a clip that merely contains "walk" as a substring of an unrelated word', () => {
-    // Guards against an over-eager regex; "Boardwalk" isn't a real clip name
-    // this pipeline would ever produce, but the point is /walk/i really is
-    // a substring test, not a word-boundary one — documented, not "fixed".
+  it('DOES match a clip whose name merely contains "walk" as a substring of an unrelated word — documents /walk/i is a substring test, not word-boundary-aware', () => {
+    // "Boardwalk" isn't a real clip name this pipeline would ever produce,
+    // but the point is /walk/i really is a plain substring test, not a
+    // word-boundary one — this is documenting the actual (intentional)
+    // behavior, not a bug to fix.
     expect(resolveWalkClipName(['Idle_Relaxed', 'Boardwalk_Loop'])).toBe(
       'Boardwalk_Loop'
     );

--- a/src/components/hex-grid/classCharacterModels.ts
+++ b/src/components/hex-grid/classCharacterModels.ts
@@ -89,3 +89,31 @@ export function resolveIdleClipName(names: string[]): string | undefined {
   const idleMatch = names.find((name) => /idle/i.test(name));
   return idleMatch ?? names[0];
 }
+
+/**
+ * Pick which baked clip to play on loop while an entity's board position is
+ * interpolating between hexes (rpg-dnd5e-web#542 — the "characters glide in
+ * their idle pose" fix). Prefers a clip whose name contains "walk"
+ * (case-insensitive), matching the `Walk_*` naming contract
+ * `retarget_walk_multi.py` enforces on the asset side. Unlike
+ * `resolveIdleClipName`, this does NOT fall back to the first available
+ * clip when no walk-named clip exists — an arbitrary idle/other clip playing
+ * fast-forward while the character visibly slides across the board is worse
+ * than just staying on the resolved idle clip, which is what callers should
+ * fall back to instead (see `ClassCharacterModel.tsx`'s usage: `isMoving`
+ * prefers `resolveWalkClipName`, falling back to `resolveIdleClipName` only
+ * if that's undefined — e.g. fighter/barbarian before a Walk_* clip ships
+ * for them, or any future clip-less model).
+ *
+ * @example
+ * ```typescript
+ * resolveWalkClipName(['Idle_Relaxed', 'Idle_Drinking', 'Walk_Forward']);
+ * // 'Walk_Forward'
+ * resolveWalkClipName(['Idle_Relaxed', 'Idle_Drinking']);
+ * // undefined — no Walk_* clip shipped for this model yet; caller falls
+ * //             back to resolveIdleClipName instead of guessing
+ * ```
+ */
+export function resolveWalkClipName(names: string[]): string | undefined {
+  return names.find((name) => /walk/i.test(name));
+}

--- a/src/components/hex-grid/useHexMovePath.test.ts
+++ b/src/components/hex-grid/useHexMovePath.test.ts
@@ -1,9 +1,33 @@
-import { describe, expect, it } from 'vitest';
-import { cubeToWorld } from './hexMath';
+import { act, renderHook } from '@testing-library/react';
+import * as THREE from 'three';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cubeToWorld, type CubeCoord } from './hexMath';
+
+// Mock @react-three/fiber so useHexMovePath's useFrame/useThree calls work
+// under plain renderHook (no real WebGL canvas). `useFrame` just captures
+// the latest callback the hook registers each render, so tests can drive
+// frames manually via `tick()` below; `useThree` returns a stub
+// `invalidate`.
+const hoisted = vi.hoisted(() => ({
+  frameCallback: undefined as
+    | ((state: unknown, delta: number) => void)
+    | undefined,
+  invalidate: vi.fn(),
+}));
+
+vi.mock('@react-three/fiber', () => ({
+  useFrame: (cb: (state: unknown, delta: number) => void) => {
+    hoisted.frameCallback = cb;
+  },
+  useThree: () => ({ invalidate: hoisted.invalidate }),
+}));
+
+// Import AFTER vi.mock so useHexMovePath picks up the mocked module.
 import {
   advanceFrame,
   computeMoveStart,
   SECONDS_PER_HEX_STEP,
+  useHexMovePath,
   type StepState,
 } from './useHexMovePath';
 
@@ -161,7 +185,17 @@ describe('computeMoveStart', () => {
     });
   });
 
-  describe('revive then first move (rpg-dnd5e-web#551 gate-review regression)', () => {
+  describe('revive then first move (rpg-dnd5e-web#551 gate-review regression -- pure-function contract)', () => {
+    // NOTE: these `computeMoveStart` calls hand-thread `nextSeenSeq` through
+    // by hand, exactly mirroring what `useHexMovePath`'s `useLayoutEffect`
+    // does with `seenSeqRef`. That makes this a test of `computeMoveStart`'s
+    // CONTRACT ("callers must persist `nextSeenSeq` unconditionally"), not
+    // proof that the hook itself honors it -- reverting the hook's one-line
+    // fix does NOT make these fail, since they never call the real hook.
+    // The actual hook-level regression coverage (the one that fails when
+    // the real fix is reverted) is the "hook-level regression test" describe
+    // block below, which renders the real `useHexMovePath` via
+    // `renderHook`.
     it('seenSeq must be written unconditionally so a revive (moveSeq -> undefined) actually clears it', () => {
       // This is the exact sequence the gate review traced by hand:
       //   1. First real move: moveSeq 1, seenSeq (was undefined) -> 1.
@@ -228,49 +262,6 @@ describe('computeMoveStart', () => {
       );
       expect(firstMoveAfterRevive.isGenuineMove).toBe(true);
       expect(firstMoveAfterRevive.points.length).toBeGreaterThan(1);
-    });
-
-    it('regression guard: reproduces the bug when seenSeq is (incorrectly) written conditionally, proving the test would have caught it', () => {
-      // Mirrors the OLD, buggy caller contract: only persist seenSeq when
-      // moveSeq !== undefined (i.e. skip the write on revive). Confirms
-      // this test suite actually distinguishes the fixed contract from
-      // the broken one, rather than passing either way.
-      let seenSeqBuggy: number | undefined = undefined;
-
-      const firstMove = computeMoveStart(
-        1,
-        seenSeqBuggy,
-        [{ x: 1, y: -1, z: 0 }],
-        { x: 1, y: -1, z: 0 },
-        HEX_SIZE,
-        { x: 0, z: 0 }
-      );
-      if (firstMove.nextSeenSeq !== undefined)
-        seenSeqBuggy = firstMove.nextSeenSeq;
-
-      const revived = computeMoveStart(
-        undefined,
-        seenSeqBuggy,
-        undefined,
-        { x: 1, y: -1, z: 0 },
-        HEX_SIZE,
-        { x: 1, z: -1 }
-      );
-      // BUGGY caller skips this write because moveSeq is undefined:
-      if (revived.nextSeenSeq !== undefined) seenSeqBuggy = revived.nextSeenSeq;
-      expect(seenSeqBuggy).toBe(1); // stale -- the bug
-
-      const firstMoveAfterRevive = computeMoveStart(
-        1,
-        seenSeqBuggy,
-        [{ x: 2, y: -2, z: 0 }],
-        { x: 2, y: -2, z: 0 },
-        HEX_SIZE,
-        { x: 1, z: -1 }
-      );
-      // With the buggy conditional-write contract, this incorrectly reads
-      // as NOT genuine -- exactly the reported "silently snaps" defect.
-      expect(firstMoveAfterRevive.isGenuineMove).toBe(false);
     });
 
     it('a second move after revive always self-heals regardless of the bug (documents why it was easy to miss)', () => {
@@ -372,6 +363,121 @@ describe('advanceFrame', () => {
     expect(result!.position.x).toBeCloseTo(10);
     expect(result!.position.z).toBeGreaterThan(0);
     expect(result!.position.z).toBeLessThan(10);
+  });
+});
+
+describe('useHexMovePath (hook-level regression test)', () => {
+  const Y_OFFSET = 0.5;
+  const posA: CubeCoord = { x: 0, y: 0, z: 0 };
+  const posB: CubeCoord = { x: 1, y: -1, z: 0 };
+  const posC: CubeCoord = { x: 2, y: -2, z: 0 };
+
+  type Props = {
+    entityPosition: CubeCoord;
+    movePath: CubeCoord[] | undefined;
+    moveSeq: number | undefined;
+  };
+
+  function renderMovePath() {
+    return renderHook(
+      ({ entityPosition, movePath, moveSeq }: Props) =>
+        useHexMovePath(entityPosition, movePath, moveSeq, HEX_SIZE, Y_OFFSET),
+      {
+        initialProps: {
+          entityPosition: posA,
+          movePath: undefined,
+          moveSeq: undefined,
+        } as Props,
+      }
+    );
+  }
+
+  function tick(delta: number) {
+    act(() => {
+      hoisted.frameCallback?.({}, delta);
+    });
+  }
+
+  beforeEach(() => {
+    hoisted.frameCallback = undefined;
+    hoisted.invalidate.mockReset();
+  });
+
+  it('treats the first move after a revive as a genuine move (animates), not a snap', () => {
+    const { result, rerender } = renderMovePath();
+
+    // renderHook has no real R3F canvas to attach `groupRef` for us, so
+    // seed it directly at the already-settled initial-mount position --
+    // the same state a real `<group ref={groupRef}>` would be in right
+    // after mount.
+    act(() => {
+      result.current.groupRef.current = new THREE.Group();
+      const start = cubeToWorld(posA, HEX_SIZE);
+      result.current.groupRef.current.position.set(start.x, Y_OFFSET, start.z);
+    });
+
+    // 1. First real move: moveSeq 1, path posA -> posB. Must animate.
+    rerender({
+      entityPosition: { ...posB },
+      movePath: [posA, posB],
+      moveSeq: 1,
+    });
+    expect(result.current.isMoving).toBe(true);
+
+    // Drive it to completion so the group is actually sitting at posB
+    // before the revive, matching the real lifecycle.
+    tick(SECONDS_PER_HEX_STEP);
+    expect(result.current.isMoving).toBe(false);
+    const posBWorld = cubeToWorld(posB, HEX_SIZE);
+    expect(result.current.groupRef.current!.position.x).toBeCloseTo(
+      posBWorld.x
+    );
+    expect(result.current.groupRef.current!.position.z).toBeCloseTo(
+      posBWorld.z
+    );
+
+    // 2. Revive: applyEntityAppearedBatch replaces the entity record
+    // wholesale -- moveSeq goes back to undefined.
+    rerender({
+      entityPosition: { ...posB },
+      movePath: undefined,
+      moveSeq: undefined,
+    });
+    expect(result.current.isMoving).toBe(false);
+
+    // 3. First move after revive: mergeEntityPosition restarts moveSeq at
+    // 1 (`(existing.moveSeq ?? 0) + 1`) on the fresh, moveSeq-less revived
+    // record. This MUST be treated as genuine -- exactly the case
+    // rpg-dnd5e-web#551's gate review caught snapping instead of
+    // animating (an earlier version only wrote `seenSeqRef.current` when
+    // `moveSeq !== undefined`, leaving it stale at 1 from step 1 so this
+    // `1 !== 1` compare silently read as "not genuine").
+    rerender({
+      entityPosition: { ...posC },
+      movePath: [posB, posC],
+      moveSeq: 1,
+    });
+
+    // The crux assertion: a genuine move must be mid-flight (isMoving
+    // true) and must NOT have already snapped straight to the
+    // destination -- the genuine-move branch only arms `stepRef` and lets
+    // `useFrame` interpolate; it never writes `groupRef.current.position`
+    // directly (only the non-genuine/snap branch does that).
+    expect(result.current.isMoving).toBe(true);
+    expect(result.current.groupRef.current!.position.x).toBeCloseTo(
+      posBWorld.x
+    );
+    expect(result.current.groupRef.current!.position.z).toBeCloseTo(
+      posBWorld.z
+    );
+
+    // And it actually interpolates once a frame ticks, landing strictly
+    // between posB and posC -- not jumping straight to either endpoint.
+    tick(SECONDS_PER_HEX_STEP / 2);
+    const posCWorld = cubeToWorld(posC, HEX_SIZE);
+    const midX = result.current.groupRef.current!.position.x;
+    expect(midX).not.toBeCloseTo(posBWorld.x);
+    expect(midX).not.toBeCloseTo(posCWorld.x);
   });
 });
 

--- a/src/components/hex-grid/useHexMovePath.test.ts
+++ b/src/components/hex-grid/useHexMovePath.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from 'vitest';
+import { cubeToWorld } from './hexMath';
+import {
+  advanceFrame,
+  computeMoveStart,
+  SECONDS_PER_HEX_STEP,
+  type StepState,
+} from './useHexMovePath';
+
+const HEX_SIZE = 1;
+
+describe('computeMoveStart', () => {
+  it('is not a genuine move on initial mount (moveSeq undefined)', () => {
+    const result = computeMoveStart(
+      undefined,
+      undefined,
+      undefined,
+      { x: 0, y: 0, z: 0 },
+      HEX_SIZE,
+      { x: 0, z: 0 }
+    );
+    expect(result.isGenuineMove).toBe(false);
+    expect(result.points).toEqual([]);
+    expect(result.nextSeenSeq).toBeUndefined();
+  });
+
+  it('is a genuine move the first time a defined moveSeq is seen', () => {
+    const result = computeMoveStart(
+      1,
+      undefined,
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+      ],
+      { x: 1, y: -1, z: 0 },
+      HEX_SIZE,
+      { x: 0, z: 0 }
+    );
+    expect(result.isGenuineMove).toBe(true);
+    expect(result.nextSeenSeq).toBe(1);
+  });
+
+  it('is NOT a genuine move when moveSeq matches the already-seen value', () => {
+    const result = computeMoveStart(
+      1,
+      1,
+      [{ x: 1, y: -1, z: 0 }],
+      { x: 1, y: -1, z: 0 },
+      HEX_SIZE,
+      { x: 0, z: 0 }
+    );
+    expect(result.isGenuineMove).toBe(false);
+    expect(result.points).toEqual([]);
+  });
+
+  describe('normal multi-hex move', () => {
+    it('walks every hex in the real path in order, not just start/end', () => {
+      // A 3-hex path: (0,0,0) -> (1,-1,0) -> (2,-2,0) -> (3,-3,0).
+      const path = [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+        { x: 2, y: -2, z: 0 },
+        { x: 3, y: -3, z: 0 },
+      ];
+      const result = computeMoveStart(
+        1,
+        undefined,
+        path,
+        path[3],
+        HEX_SIZE,
+        cubeToWorldPoint(path[0])
+      );
+
+      expect(result.isGenuineMove).toBe(true);
+      // Already starts exactly at the current rendered position, so no
+      // synthesized extra point is prepended.
+      expect(result.points).toHaveLength(4);
+      expect(result.points.map((p) => roundPoint(p))).toEqual(
+        path.map((p) => roundPoint(cubeToWorldPoint(p)))
+      );
+    });
+
+    it('a 1-hex move produces exactly 2 points to animate between', () => {
+      const path = [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+      ];
+      const result = computeMoveStart(
+        1,
+        undefined,
+        path,
+        path[1],
+        HEX_SIZE,
+        cubeToWorldPoint(path[0])
+      );
+      expect(result.points).toHaveLength(2);
+    });
+  });
+
+  describe('degenerate/single-element path (rpg-api#656 robustness)', () => {
+    it('a single-element path still animates by synthesizing a step from the current rendered position', () => {
+      const current = { x: 0, z: 0 };
+      const destination = { x: 5, y: -5, z: 0 };
+      const result = computeMoveStart(
+        1,
+        undefined,
+        [destination],
+        destination,
+        HEX_SIZE,
+        current
+      );
+
+      expect(result.isGenuineMove).toBe(true);
+      // Not a bare snap: two points to interpolate between, current first.
+      expect(result.points).toHaveLength(2);
+      expect(result.points[0]).toEqual(current);
+      expect(roundPoint(result.points[1])).toEqual(
+        roundPoint(cubeToWorldPoint(destination))
+      );
+    });
+
+    it('an empty path (movePath undefined) falls back to entityPosition alone and still animates', () => {
+      const current = { x: 0, z: 0 };
+      const destination = { x: 2, y: -2, z: 0 };
+      const result = computeMoveStart(
+        1,
+        undefined,
+        undefined,
+        destination,
+        HEX_SIZE,
+        current
+      );
+
+      expect(result.isGenuineMove).toBe(true);
+      expect(result.points).toHaveLength(2);
+      expect(result.points[0]).toEqual(current);
+    });
+
+    it("the rpg-api#656 same-hex degenerate case (destination === current) still 'animates' as a harmless zero-distance step, not a special-cased snap", () => {
+      // #656: a corner-spawn move gets wall-truncated to a same-hex no-op.
+      // The path's single point already equals where the entity is
+      // rendered -- computeMoveStart doesn't special-case this away, it
+      // just produces a 2-point step whose two points happen to coincide.
+      const current = cubeToWorldPoint({ x: 0, y: 0, z: 0 });
+      const result = computeMoveStart(
+        1,
+        undefined,
+        [{ x: 0, y: 0, z: 0 }],
+        { x: 0, y: 0, z: 0 },
+        HEX_SIZE,
+        current
+      );
+
+      expect(result.isGenuineMove).toBe(true);
+      expect(result.points).toHaveLength(1);
+      // Single point because pathWorld[0] already equals `current` --
+      // startsAtCurrent is true, so no extra point is prepended. A step
+      // count of 1 means advanceFrame has nothing to animate (index >=
+      // points.length - 1 immediately), which is the correct "arrived
+      // instantly" degrade for a genuinely zero-distance move.
+    });
+  });
+
+  describe('revive then first move (rpg-dnd5e-web#551 gate-review regression)', () => {
+    it('seenSeq must be written unconditionally so a revive (moveSeq -> undefined) actually clears it', () => {
+      // This is the exact sequence the gate review traced by hand:
+      //   1. First real move: moveSeq 1, seenSeq (was undefined) -> 1.
+      //   2. Ghost: moveSeq untouched (still 1).
+      //   3. Revive: moveSeq -> undefined.
+      //   4. First move after revive: mergeEntityPosition restarts the
+      //      counter at 1 (existing.moveSeq ?? 0) + 1, since the revived
+      //      record carries no moveSeq. This MUST still be genuine.
+      let seenSeq: number | undefined = undefined;
+
+      // 1. First real move.
+      const firstMove = computeMoveStart(
+        1,
+        seenSeq,
+        [{ x: 1, y: -1, z: 0 }],
+        { x: 1, y: -1, z: 0 },
+        HEX_SIZE,
+        { x: 0, z: 0 }
+      );
+      expect(firstMove.isGenuineMove).toBe(true);
+      seenSeq = firstMove.nextSeenSeq;
+      expect(seenSeq).toBe(1);
+
+      // 2. Ghost -- moveSeq is untouched by applyEntityDisappeared, still 1.
+      const ghosted = computeMoveStart(
+        1,
+        seenSeq,
+        [{ x: 1, y: -1, z: 0 }],
+        { x: 1, y: -1, z: 0 },
+        HEX_SIZE,
+        { x: 1, z: -1 }
+      );
+      expect(ghosted.isGenuineMove).toBe(false);
+      seenSeq = ghosted.nextSeenSeq; // must still be written (unconditional)
+      expect(seenSeq).toBe(1);
+
+      // 3. Revive -- moveSeq resets to undefined (applyEntityAppearedBatch
+      // replaces the whole record with a fresh wire value).
+      const revived = computeMoveStart(
+        undefined,
+        seenSeq,
+        undefined,
+        { x: 1, y: -1, z: 0 },
+        HEX_SIZE,
+        { x: 1, z: -1 }
+      );
+      expect(revived.isGenuineMove).toBe(false);
+      seenSeq = revived.nextSeenSeq;
+      // THE FIX: seenSeq must actually become undefined here, not stay 1.
+      expect(seenSeq).toBeUndefined();
+
+      // 4. First move after revive -- mergeEntityPosition's counter
+      // restarts at 1. With the bug (seenSeq stuck at 1 from step 1),
+      // `1 !== 1` would be false -- silently classified as NOT a genuine
+      // move, snapping instead of animating. With the fix, seenSeq is
+      // undefined going in, so this correctly reads as genuine.
+      const firstMoveAfterRevive = computeMoveStart(
+        1,
+        seenSeq,
+        [{ x: 2, y: -2, z: 0 }],
+        { x: 2, y: -2, z: 0 },
+        HEX_SIZE,
+        { x: 1, z: -1 }
+      );
+      expect(firstMoveAfterRevive.isGenuineMove).toBe(true);
+      expect(firstMoveAfterRevive.points.length).toBeGreaterThan(1);
+    });
+
+    it('regression guard: reproduces the bug when seenSeq is (incorrectly) written conditionally, proving the test would have caught it', () => {
+      // Mirrors the OLD, buggy caller contract: only persist seenSeq when
+      // moveSeq !== undefined (i.e. skip the write on revive). Confirms
+      // this test suite actually distinguishes the fixed contract from
+      // the broken one, rather than passing either way.
+      let seenSeqBuggy: number | undefined = undefined;
+
+      const firstMove = computeMoveStart(
+        1,
+        seenSeqBuggy,
+        [{ x: 1, y: -1, z: 0 }],
+        { x: 1, y: -1, z: 0 },
+        HEX_SIZE,
+        { x: 0, z: 0 }
+      );
+      if (firstMove.nextSeenSeq !== undefined)
+        seenSeqBuggy = firstMove.nextSeenSeq;
+
+      const revived = computeMoveStart(
+        undefined,
+        seenSeqBuggy,
+        undefined,
+        { x: 1, y: -1, z: 0 },
+        HEX_SIZE,
+        { x: 1, z: -1 }
+      );
+      // BUGGY caller skips this write because moveSeq is undefined:
+      if (revived.nextSeenSeq !== undefined) seenSeqBuggy = revived.nextSeenSeq;
+      expect(seenSeqBuggy).toBe(1); // stale -- the bug
+
+      const firstMoveAfterRevive = computeMoveStart(
+        1,
+        seenSeqBuggy,
+        [{ x: 2, y: -2, z: 0 }],
+        { x: 2, y: -2, z: 0 },
+        HEX_SIZE,
+        { x: 1, z: -1 }
+      );
+      // With the buggy conditional-write contract, this incorrectly reads
+      // as NOT genuine -- exactly the reported "silently snaps" defect.
+      expect(firstMoveAfterRevive.isGenuineMove).toBe(false);
+    });
+
+    it('a second move after revive always self-heals regardless of the bug (documents why it was easy to miss)', () => {
+      // With the buggy conditional-write contract, moveSeq 2 still differs
+      // from the stale seenSeq of 1, so the SECOND post-revive move always
+      // animates correctly either way -- this is why the defect only
+      // affected exactly one step and was easy to miss in manual testing.
+      const staleSeenSeq = 1;
+      const secondMoveAfterRevive = computeMoveStart(
+        2,
+        staleSeenSeq,
+        [{ x: 3, y: -3, z: 0 }],
+        { x: 3, y: -3, z: 0 },
+        HEX_SIZE,
+        { x: 2, z: -2 }
+      );
+      expect(secondMoveAfterRevive.isGenuineMove).toBe(true);
+    });
+  });
+
+  it('two consecutive moves to the same destination (e.g. bounced off a wall) both animate', () => {
+    const dest = { x: 1, y: -1, z: 0 };
+    let seenSeq: number | undefined = undefined;
+
+    const first = computeMoveStart(1, seenSeq, [dest], dest, HEX_SIZE, {
+      x: 0,
+      z: 0,
+    });
+    expect(first.isGenuineMove).toBe(true);
+    seenSeq = first.nextSeenSeq;
+
+    const second = computeMoveStart(
+      2,
+      seenSeq,
+      [dest],
+      dest,
+      HEX_SIZE,
+      cubeToWorldPoint(dest)
+    );
+    expect(second.isGenuineMove).toBe(true);
+  });
+});
+
+describe('advanceFrame', () => {
+  function makeStep(points: { x: number; z: number }[]): StepState {
+    return { points, index: 0, elapsed: 0 };
+  }
+
+  it('returns undefined when there is nothing to animate (single point)', () => {
+    const step = makeStep([{ x: 0, z: 0 }]);
+    expect(advanceFrame(step, 0.1)).toBeUndefined();
+  });
+
+  it('produces an intermediate (non-endpoint) position partway through a step', () => {
+    const step = makeStep([
+      { x: 0, z: 0 },
+      { x: 10, z: 0 },
+    ]);
+    const half = SECONDS_PER_HEX_STEP / 2;
+    const result = advanceFrame(step, half);
+    expect(result).toBeDefined();
+    expect(result!.position.x).toBeGreaterThan(0);
+    expect(result!.position.x).toBeLessThan(10);
+    expect(result!.stepComplete).toBe(false);
+  });
+
+  it('marks the step complete once elapsed reaches secondsPerStep', () => {
+    const step = makeStep([
+      { x: 0, z: 0 },
+      { x: 10, z: 0 },
+    ]);
+    const result = advanceFrame(step, SECONDS_PER_HEX_STEP);
+    expect(result!.stepComplete).toBe(true);
+    expect(result!.position.x).toBeCloseTo(10);
+  });
+
+  it('clamps at the endpoint for a delta larger than the whole step (no overshoot)', () => {
+    const step = makeStep([
+      { x: 0, z: 0 },
+      { x: 10, z: 0 },
+    ]);
+    const result = advanceFrame(step, SECONDS_PER_HEX_STEP * 10);
+    expect(result!.position.x).toBeCloseTo(10);
+    expect(result!.stepComplete).toBe(true);
+  });
+
+  it('animates the SECOND leg of a multi-hex path once index advances', () => {
+    const step: StepState = {
+      points: [
+        { x: 0, z: 0 },
+        { x: 10, z: 0 },
+        { x: 10, z: 10 },
+      ],
+      index: 1,
+      elapsed: 0,
+    };
+    const result = advanceFrame(step, SECONDS_PER_HEX_STEP / 2);
+    // Interpolating between points[1] and points[2], not points[0].
+    expect(result!.position.x).toBeCloseTo(10);
+    expect(result!.position.z).toBeGreaterThan(0);
+    expect(result!.position.z).toBeLessThan(10);
+  });
+});
+
+// --- test-local helpers -----------------------------------------------
+function cubeToWorldPoint(cube: { x: number; y: number; z: number }): {
+  x: number;
+  z: number;
+} {
+  return cubeToWorld(cube, HEX_SIZE);
+}
+
+function roundPoint(p: { x: number; z: number }): { x: number; z: number } {
+  return { x: Math.round(p.x * 1e6) / 1e6, z: Math.round(p.z * 1e6) / 1e6 };
+}

--- a/src/components/hex-grid/useHexMovePath.ts
+++ b/src/components/hex-grid/useHexMovePath.ts
@@ -1,0 +1,158 @@
+/**
+ * Drives a group's world position through an entity's real hex-by-hex
+ * `movePath` (rpg-dnd5e-web#542's fix for "characters glide across the map
+ * in their idle pose" — until now `HexEntity` just snapped straight to
+ * `cubeToWorld(entity.position)` every time the entity's server position
+ * changed, whether that was a genuine move, initial placement, or a
+ * ghost/revive reconciliation, so no walk clip ever had anything to key
+ * off of).
+ *
+ * Only animates on a genuine move: `moveSeq` (see useEncounterState.ts's
+ * `mergeEntityPosition`) is bumped ONLY by a real `EntityMoved`-driven
+ * position update, never by initial placement (`applyEntityAppearedBatch`)
+ * or ghost/revive (`applyEntityDisappeared`/re-appear) — both of those
+ * replace the entity record wholesale with a fresh value off the wire, so
+ * they never carry a stale `moveSeq` forward. Watching `moveSeq` change
+ * (not just "movePath is present") is what makes this "genuine move only":
+ * two moves that happen to land on the same destination hex in a row
+ * (e.g. bounced back by a wall) still each bump `moveSeq` and so still
+ * each animate, while mount/reconciliation never bumps it at all.
+ *
+ * Per-hex pacing, not a fixed total duration: each hex step takes
+ * `SECONDS_PER_HEX_STEP`, so a 1-hex and a 5-hex move take proportionally
+ * different total time instead of the same fixed duration stretched (or
+ * compressed) across however many hexes — a fixed-duration tween would
+ * either teleport-slide a long move or crawl a short one.
+ *
+ * Degenerate/single-element path (rpg-api#656's corner-spawn bug can
+ * produce exactly this — a same-hex "move" that never actually goes
+ * anywhere): still animates the one step per the coordinator's explicit
+ * ask, by synthesizing it from wherever the group is CURRENTLY rendered to
+ * the single path point, rather than special-casing length===1 to a bare
+ * snap. If that single point already equals the current position (the
+ * #656 case), the synthesized step is zero-distance and resolves in under
+ * a frame — a harmless, correct degrade, not a special case to detect.
+ *
+ * Caller contract: attach `groupRef` to the group whose position should
+ * track the entity. This hook owns every write to that ref's
+ * `position.x`/`.y`/`.z` — do not also pass a declarative `position` prop
+ * on the same object, since React would then re-apply the (stale,
+ * destination-only) declarative value on renders this hook didn't cause,
+ * fighting the interpolation mid-step.
+ */
+import { useFrame, useThree } from '@react-three/fiber';
+import { useLayoutEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { cubeToWorld, type CubeCoord } from './hexMath';
+
+/** Seconds to walk ONE hex step (not the whole path). Tuned by eye against
+ * Walk_Forward's ~1.03s loop (rpg-game-assets#20) so a step reads as "a
+ * stride or two," not a dash or a crawl — the clip free-loops
+ * independently of how long a single step takes, so this isn't tied 1:1
+ * to the clip's own duration. Flagged as a judgment call / playtest-tuning
+ * knob in the PR body. */
+const SECONDS_PER_HEX_STEP = 0.45;
+
+interface WorldPoint {
+  x: number;
+  z: number;
+}
+
+interface StepState {
+  points: WorldPoint[];
+  index: number;
+  elapsed: number;
+}
+
+export interface UseHexMovePathResult {
+  /** Attach to the group whose position should reflect the entity's
+   * (possibly-interpolating) board position. */
+  groupRef: React.RefObject<THREE.Group | null>;
+  /** True while stepping through a real move — pass straight through to
+   * ClassCharacterModel to pick the walk clip over idle. */
+  isMoving: boolean;
+}
+
+export function useHexMovePath(
+  entityPosition: CubeCoord,
+  movePath: CubeCoord[] | undefined,
+  moveSeq: number | undefined,
+  hexSize: number,
+  yOffset: number
+): UseHexMovePathResult {
+  const groupRef = useRef<THREE.Group>(null);
+  const [isMoving, setIsMoving] = useState(false);
+  const { invalidate } = useThree();
+
+  const seenSeqRef = useRef<number | undefined>(undefined);
+  const stepRef = useRef<StepState>({ points: [], index: 0, elapsed: 0 });
+
+  const destination = cubeToWorld(entityPosition, hexSize);
+
+  useLayoutEffect(() => {
+    if (!groupRef.current) return;
+    const isGenuineMove =
+      moveSeq !== undefined && moveSeq !== seenSeqRef.current;
+    if (moveSeq !== undefined) seenSeqRef.current = moveSeq;
+
+    if (!isGenuineMove) {
+      // Initial mount, non-move position change (initial placement,
+      // ghost/revive), or a re-render where moveSeq hasn't advanced since
+      // we last saw it — snap straight to the destination, matching
+      // pre-#542 behavior exactly. Also clears any in-flight step so a
+      // stale useFrame tick from a just-superseded move can't keep nudging
+      // the position after a non-move update resets it.
+      stepRef.current = { points: [], index: 0, elapsed: 0 };
+      groupRef.current.position.set(destination.x, yOffset, destination.z);
+      setIsMoving(false);
+      return;
+    }
+
+    const current = {
+      x: groupRef.current.position.x,
+      z: groupRef.current.position.z,
+    };
+    const pathWorld = (
+      movePath && movePath.length > 0 ? movePath : [entityPosition]
+    ).map((p) => cubeToWorld(p, hexSize));
+    const startsAtCurrent =
+      pathWorld.length > 0 &&
+      pathWorld[0].x === current.x &&
+      pathWorld[0].z === current.z;
+    const points = startsAtCurrent ? pathWorld : [current, ...pathWorld];
+
+    stepRef.current = { points, index: 0, elapsed: 0 };
+    setIsMoving(points.length > 1);
+    invalidate();
+  }, [
+    moveSeq,
+    movePath,
+    entityPosition,
+    hexSize,
+    destination.x,
+    destination.z,
+    yOffset,
+    invalidate,
+  ]);
+
+  useFrame((_state, delta) => {
+    const s = stepRef.current;
+    if (!groupRef.current || s.index >= s.points.length - 1) return;
+    s.elapsed += delta;
+    const t = Math.min(1, s.elapsed / SECONDS_PER_HEX_STEP);
+    const a = s.points[s.index];
+    const b = s.points[s.index + 1];
+    groupRef.current.position.x = THREE.MathUtils.lerp(a.x, b.x, t);
+    groupRef.current.position.z = THREE.MathUtils.lerp(a.z, b.z, t);
+    invalidate();
+    if (t >= 1) {
+      s.index += 1;
+      s.elapsed = 0;
+      if (s.index >= s.points.length - 1) {
+        setIsMoving(false);
+      }
+    }
+  });
+
+  return { groupRef, isMoving };
+}

--- a/src/components/hex-grid/useHexMovePath.ts
+++ b/src/components/hex-grid/useHexMovePath.ts
@@ -18,6 +18,27 @@
  * (e.g. bounced back by a wall) still each bump `moveSeq` and so still
  * each animate, while mount/reconciliation never bumps it at all.
  *
+ * `isGenuineMove`'s `seenSeq` comparison (below) MUST be updated
+ * unconditionally every time this runs, including when `moveSeq` itself is
+ * `undefined` — gate review on rpg-dnd5e-web#551 (independently confirmed
+ * by a live Copilot review comment) caught a real regression where an
+ * earlier version only wrote `seenSeqRef.current` when `moveSeq !==
+ * undefined`. That let the stale pre-revive value survive a revive (where
+ * `moveSeq` legitimately goes back to `undefined`), and because
+ * `mergeEntityPosition`'s counter also restarts at `1` on the first move
+ * after a revive (`(existing.moveSeq ?? 0) + 1` with a fresh, `moveSeq`-
+ * less record), that first post-revive move's `moveSeq` of `1` could
+ * collide with the still-stale `seenSeqRef` of `1` left over from BEFORE
+ * the revive — silently classified as "not a genuine move" and snapped
+ * instead of animated. Self-healed on the very next move (`moveSeq` 2
+ * always differs from the stale `1`), which is exactly why it slipped
+ * through manual review and 864 passing tests that never happened to
+ * check a revive's FIRST subsequent move specifically. Fixed by writing
+ * `seenSeq` unconditionally (see `computeMoveStart` below) so a revive's
+ * `undefined` genuinely clears it, not just skips updating it. Covered by
+ * `useHexMovePath.test.ts`'s "revive then first move" case — that
+ * regression test is the actual fix here, not the one-line diff alone.
+ *
  * Per-hex pacing, not a fixed total duration: each hex step takes
  * `SECONDS_PER_HEX_STEP`, so a 1-hex and a 5-hex move take proportionally
  * different total time instead of the same fixed duration stretched (or
@@ -39,6 +60,16 @@
  * on the same object, since React would then re-apply the (stale,
  * destination-only) declarative value on renders this hook didn't cause,
  * fighting the interpolation mid-step.
+ *
+ * `computeMoveStart`/`advanceFrame` below are pulled out as plain,
+ * dependency-free functions (no `bpy`... er, no `@react-three/fiber`
+ * imports) specifically so `useHexMovePath.test.ts` can exercise the
+ * genuine-move detection and per-frame lerp math directly, without a
+ * WebGL canvas or an R3F test renderer — this codebase has no existing
+ * precedent for testing `useFrame`-based components (no `HexDoor.test.tsx`
+ * either), and standing one up was more machinery than this bug warranted.
+ * The hook itself is a thin wrapper gluing these pure functions to
+ * `useThree`/`useFrame`/refs.
  */
 import { useFrame, useThree } from '@react-three/fiber';
 import { useLayoutEffect, useRef, useState } from 'react';
@@ -51,14 +82,14 @@ import { cubeToWorld, type CubeCoord } from './hexMath';
  * independently of how long a single step takes, so this isn't tied 1:1
  * to the clip's own duration. Flagged as a judgment call / playtest-tuning
  * knob in the PR body. */
-const SECONDS_PER_HEX_STEP = 0.45;
+export const SECONDS_PER_HEX_STEP = 0.45;
 
-interface WorldPoint {
+export interface WorldPoint {
   x: number;
   z: number;
 }
 
-interface StepState {
+export interface StepState {
   points: WorldPoint[];
   index: number;
   elapsed: number;
@@ -71,6 +102,96 @@ export interface UseHexMovePathResult {
   /** True while stepping through a real move — pass straight through to
    * ClassCharacterModel to pick the walk clip over idle. */
   isMoving: boolean;
+}
+
+export interface MoveStartResult {
+  /** Whether `moveSeq` represents a real, not-yet-seen move. */
+  isGenuineMove: boolean;
+  /** The new value to store as `seenSeq` for the NEXT call — always
+   * `moveSeq` itself (see the module doc comment on why this must be
+   * written unconditionally, including when it's `undefined`). */
+  nextSeenSeq: number | undefined;
+  /** World-space points to walk through, oldest first. Empty when
+   * `isGenuineMove` is false (nothing to animate). */
+  points: WorldPoint[];
+}
+
+/**
+ * Decide whether `moveSeq` represents a genuine, not-yet-animated move
+ * (vs. the initial mount, a non-move position change, or a re-render
+ * where `moveSeq` hasn't advanced since we last saw it), and if so, build
+ * the world-space point sequence to walk through.
+ *
+ * Pure and stateless — the caller (the `useHexMovePath` hook) owns
+ * `seenSeq` (typically in a `useRef`) and MUST persist `nextSeenSeq` back
+ * into it after every call, unconditionally, even when `isGenuineMove` is
+ * false. That "even when false" part is exactly the bug rpg-dnd5e-web#551's
+ * gate review caught: an earlier version only persisted the new value
+ * when `moveSeq !== undefined`, which let a revive's `undefined` fail to
+ * clear a stale prior value — see the module doc comment for the full
+ * trace. Returning `nextSeenSeq` from here (rather than mutating a ref
+ * inside this function) is what makes that contract testable without any
+ * React/R3F machinery: a test can just call this repeatedly and thread
+ * the return value through by hand, exactly mirroring what the hook does.
+ */
+export function computeMoveStart(
+  moveSeq: number | undefined,
+  seenSeq: number | undefined,
+  movePath: CubeCoord[] | undefined,
+  entityPosition: CubeCoord,
+  hexSize: number,
+  current: WorldPoint
+): MoveStartResult {
+  const isGenuineMove = moveSeq !== undefined && moveSeq !== seenSeq;
+
+  if (!isGenuineMove) {
+    return { isGenuineMove: false, nextSeenSeq: moveSeq, points: [] };
+  }
+
+  const pathWorld = (
+    movePath && movePath.length > 0 ? movePath : [entityPosition]
+  ).map((p) => cubeToWorld(p, hexSize));
+  const startsAtCurrent =
+    pathWorld.length > 0 &&
+    pathWorld[0].x === current.x &&
+    pathWorld[0].z === current.z;
+  const points = startsAtCurrent ? pathWorld : [current, ...pathWorld];
+
+  return { isGenuineMove: true, nextSeenSeq: moveSeq, points };
+}
+
+export interface FrameAdvanceResult {
+  /** The lerped world-space position for THIS frame. */
+  position: WorldPoint;
+  /** True once this step's `elapsed` has reached `secondsPerStep` — the
+   * caller should advance `index` and reset `elapsed`. */
+  stepComplete: boolean;
+}
+
+/**
+ * Advance one step of a `StepState` by `delta` seconds and return the
+ * lerped position for this frame. Pure — does not mutate `step`; the
+ * caller (the hook's `useFrame` callback) applies `elapsedAfterDelta` and
+ * `stepComplete` itself. Returns `undefined` when there's no in-flight
+ * step to advance (already at the final point).
+ */
+export function advanceFrame(
+  step: StepState,
+  delta: number,
+  secondsPerStep: number = SECONDS_PER_HEX_STEP
+): FrameAdvanceResult | undefined {
+  if (step.index >= step.points.length - 1) return undefined;
+  const elapsed = step.elapsed + delta;
+  const t = Math.min(1, elapsed / secondsPerStep);
+  const a = step.points[step.index];
+  const b = step.points[step.index + 1];
+  return {
+    position: {
+      x: THREE.MathUtils.lerp(a.x, b.x, t),
+      z: THREE.MathUtils.lerp(a.z, b.z, t),
+    },
+    stepComplete: t >= 1,
+  };
 }
 
 export function useHexMovePath(
@@ -91,11 +212,24 @@ export function useHexMovePath(
 
   useLayoutEffect(() => {
     if (!groupRef.current) return;
-    const isGenuineMove =
-      moveSeq !== undefined && moveSeq !== seenSeqRef.current;
-    if (moveSeq !== undefined) seenSeqRef.current = moveSeq;
+    const current = {
+      x: groupRef.current.position.x,
+      z: groupRef.current.position.z,
+    };
+    const result = computeMoveStart(
+      moveSeq,
+      seenSeqRef.current,
+      movePath,
+      entityPosition,
+      hexSize,
+      current
+    );
+    // Unconditional, per computeMoveStart's doc comment — this is the
+    // rpg-dnd5e-web#551 gate-review fix. Do not gate this on
+    // `moveSeq !== undefined`.
+    seenSeqRef.current = result.nextSeenSeq;
 
-    if (!isGenuineMove) {
+    if (!result.isGenuineMove) {
       // Initial mount, non-move position change (initial placement,
       // ghost/revive), or a re-render where moveSeq hasn't advanced since
       // we last saw it — snap straight to the destination, matching
@@ -108,21 +242,8 @@ export function useHexMovePath(
       return;
     }
 
-    const current = {
-      x: groupRef.current.position.x,
-      z: groupRef.current.position.z,
-    };
-    const pathWorld = (
-      movePath && movePath.length > 0 ? movePath : [entityPosition]
-    ).map((p) => cubeToWorld(p, hexSize));
-    const startsAtCurrent =
-      pathWorld.length > 0 &&
-      pathWorld[0].x === current.x &&
-      pathWorld[0].z === current.z;
-    const points = startsAtCurrent ? pathWorld : [current, ...pathWorld];
-
-    stepRef.current = { points, index: 0, elapsed: 0 };
-    setIsMoving(points.length > 1);
+    stepRef.current = { points: result.points, index: 0, elapsed: 0 };
+    setIsMoving(result.points.length > 1);
     invalidate();
   }, [
     moveSeq,
@@ -136,16 +257,15 @@ export function useHexMovePath(
   ]);
 
   useFrame((_state, delta) => {
+    if (!groupRef.current) return;
     const s = stepRef.current;
-    if (!groupRef.current || s.index >= s.points.length - 1) return;
+    const advanced = advanceFrame(s, delta);
+    if (!advanced) return;
     s.elapsed += delta;
-    const t = Math.min(1, s.elapsed / SECONDS_PER_HEX_STEP);
-    const a = s.points[s.index];
-    const b = s.points[s.index + 1];
-    groupRef.current.position.x = THREE.MathUtils.lerp(a.x, b.x, t);
-    groupRef.current.position.z = THREE.MathUtils.lerp(a.z, b.z, t);
+    groupRef.current.position.x = advanced.position.x;
+    groupRef.current.position.z = advanced.position.z;
     invalidate();
-    if (t >= 1) {
+    if (advanced.stepComplete) {
       s.index += 1;
       s.elapsed = 0;
       if (s.index >= s.points.length - 1) {

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -246,9 +246,14 @@ export function PlaytestHarness() {
       onEntityMoved: (e) => {
         const last = e.actualPath[e.actualPath.length - 1];
         if (last) {
+          // rpg-dnd5e-web#542: mirrors EncounterView.tsx's production
+          // wiring — pass the whole actualPath so PlaytestMap's HexEntity
+          // instances animate the walk too (this is also the harness used
+          // for in-app verification of the walk clip itself).
           encounterState.applyEntityPositionUpdate(
             e.entityId,
-            v2PositionToV1(last)
+            v2PositionToV1(last),
+            e.actualPath.map(v2PositionToV1)
           );
         }
         const pos = last ? `(${last.x},${last.y},${last.z})` : '(no path)';

--- a/src/components/playtest/PlaytestMap.tsx
+++ b/src/components/playtest/PlaytestMap.tsx
@@ -53,9 +53,17 @@ export interface PlaytestMapProps {
   /**
    * Unified entity store from useEncounterState. Each entry is a v1alpha1
    * `EntityState` stub (entityId + position); v2 metadata lives separately
-   * in `entityMeta`.
+   * in `entityMeta`. `movePath`/`moveSeq` (rpg-dnd5e-web#542) drive
+   * HexEntity's walk-clip interpolation.
    */
-  entities: Map<string, EntityState & { ghost?: boolean }>;
+  entities: Map<
+    string,
+    EntityState & {
+      ghost?: boolean;
+      movePath?: { x: number; y: number; z: number }[];
+      moveSeq?: number;
+    }
+  >;
   /**
    * v1alpha2 identity metadata (type, monsterRefId) keyed by entityId.
    * Populated by `applyEntityMeta` from EntityAppeared events.

--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -151,6 +151,42 @@ describe('buildRenderableEntities', () => {
     expect(goblin?.name).toBe('goblin-1 (goblin)');
   });
 
+  it('passes movePath/moveSeq through untouched (rpg-dnd5e-web#542)', () => {
+    const withMove = {
+      ...makeEntityState('char-alice', { x: 1, y: -1, z: 0 }),
+      movePath: [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+      ],
+      moveSeq: 3,
+    };
+    const entities = new Map([['char-alice', withMove]]);
+    const meta = new Map<string, EntityMeta>([
+      ['char-alice', { type: EntityType.CHARACTER, monsterRefId: undefined }],
+    ]);
+
+    const list = buildRenderableEntities(entities, meta, new Map());
+
+    expect(list[0]).toMatchObject({
+      movePath: withMove.movePath,
+      moveSeq: 3,
+    });
+  });
+
+  it('leaves movePath/moveSeq undefined for an entity that has never moved', () => {
+    const entities = new Map([
+      ['char-alice', makeEntityState('char-alice', { x: 0, y: 0, z: 0 })],
+    ]);
+    const meta = new Map<string, EntityMeta>([
+      ['char-alice', { type: EntityType.CHARACTER, monsterRefId: undefined }],
+    ]);
+
+    const list = buildRenderableEntities(entities, meta, new Map());
+
+    expect(list[0].movePath).toBeUndefined();
+    expect(list[0].moveSeq).toBeUndefined();
+  });
+
   it('marks monsters dead at HP=0; characters never marked dead (unconscious only)', () => {
     const entities = new Map([
       ['char-alice', makeEntityState('char-alice', { x: 0, y: 0, z: 0 })],

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -42,6 +42,13 @@ export interface RenderableEntity {
    * (obstaclePropKeys.ts's resolvePropKeyForEntity). Undefined until
    * platform starts sending a ref (no server code path sets one yet). */
   propRefId?: string;
+  /** The most recent genuine move's real hex-by-hex route
+   * (rpg-dnd5e-web#542), passed straight through to HexEntity's movement
+   * interpolation. Undefined for an entity that has never moved. */
+  movePath?: { x: number; y: number; z: number }[];
+  /** Monotonic counter bumped only by a genuine move — see
+   * `useEncounterState.ts`'s `mergeEntityPosition` doc comment. */
+  moveSeq?: number;
 }
 
 /** Checks for a status whose source ref id is "unconscious" — the only
@@ -117,7 +124,14 @@ export function entityTypeToDisplay(
  * not a stand-in for a required argument callers must now all supply.
  */
 export function buildRenderableEntities(
-  entities: Map<string, EntityState & { ghost?: boolean }>,
+  entities: Map<
+    string,
+    EntityState & {
+      ghost?: boolean;
+      movePath?: { x: number; y: number; z: number }[];
+      moveSeq?: number;
+    }
+  >,
   entityMeta: Map<string, EntityMeta>,
   entityHP: Map<string, { current: number; max: number }>,
   entityStatuses: Map<string, EntityStatus[]> | undefined = new Map()
@@ -151,6 +165,8 @@ export function buildRenderableEntities(
       classRefId: meta?.classRefId,
       isDowned,
       propRefId: meta?.propRefId,
+      movePath: entity.movePath,
+      moveSeq: entity.moveSeq,
     });
   }
   return result;

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -165,6 +165,88 @@ describe('mergeEntityPosition', () => {
     // Original state's entity reference unchanged
     expect(prev.entities.get('char-1')).toBe(originalEntity);
   });
+
+  // rpg-dnd5e-web#542: movePath/moveSeq drive HexEntity's walk-clip
+  // interpolation — mergeEntityPosition is the ONLY reducer that sets them
+  // (see the field's doc comment on LocalEncounterState.entities).
+  describe('path (rpg-dnd5e-web#542)', () => {
+    it('stashes the path as movePath and bumps moveSeq from undefined to 1', () => {
+      const prev = applyEntityAppeared(
+        createEmptyEncounterState(),
+        create(EntityStateSchema, { entityId: 'char-1' })
+      );
+      const path = [
+        create(PositionSchema, { x: 0, y: 0, z: 0 }),
+        create(PositionSchema, { x: 1, y: -1, z: 0 }),
+      ];
+
+      const next = mergeEntityPosition(prev, 'char-1', path[1], path);
+
+      const updated = next.entities.get('char-1');
+      expect(updated?.movePath).toEqual(path);
+      expect(updated?.moveSeq).toBe(1);
+    });
+
+    it('increments moveSeq on each subsequent genuine move', () => {
+      const prev = applyEntityAppeared(
+        createEmptyEncounterState(),
+        create(EntityStateSchema, { entityId: 'char-1' })
+      );
+      const posA = create(PositionSchema, { x: 1, y: -1, z: 0 });
+      const posB = create(PositionSchema, { x: 2, y: -2, z: 0 });
+
+      const afterFirst = mergeEntityPosition(prev, 'char-1', posA, [posA]);
+      const afterSecond = mergeEntityPosition(afterFirst, 'char-1', posB, [
+        posA,
+        posB,
+      ]);
+
+      expect(afterFirst.entities.get('char-1')?.moveSeq).toBe(1);
+      expect(afterSecond.entities.get('char-1')?.moveSeq).toBe(2);
+    });
+
+    it('bumps moveSeq again for a same-destination move (e.g. bounced off a wall)', () => {
+      const prev = applyEntityAppeared(
+        createEmptyEncounterState(),
+        create(EntityStateSchema, { entityId: 'char-1' })
+      );
+      const pos = create(PositionSchema, { x: 1, y: -1, z: 0 });
+
+      const afterFirst = mergeEntityPosition(prev, 'char-1', pos, [pos]);
+      const afterSecond = mergeEntityPosition(afterFirst, 'char-1', pos, [pos]);
+
+      expect(afterSecond.entities.get('char-1')?.moveSeq).toBe(2);
+    });
+
+    it('leaves movePath/moveSeq untouched when path is omitted (pre-#542 call sites)', () => {
+      const prev = applyEntityAppeared(
+        createEmptyEncounterState(),
+        create(EntityStateSchema, { entityId: 'char-1' })
+      );
+      const newPos = create(PositionSchema, { x: 3, y: -1, z: -2 });
+
+      const next = mergeEntityPosition(prev, 'char-1', newPos);
+
+      const updated = next.entities.get('char-1');
+      expect(updated?.position).toEqual(newPos);
+      expect(updated?.movePath).toBeUndefined();
+      expect(updated?.moveSeq).toBeUndefined();
+    });
+
+    it('leaves movePath/moveSeq untouched when path is an empty array', () => {
+      const prev = applyEntityAppeared(
+        createEmptyEncounterState(),
+        create(EntityStateSchema, { entityId: 'char-1' })
+      );
+      const newPos = create(PositionSchema, { x: 3, y: -1, z: -2 });
+
+      const next = mergeEntityPosition(prev, 'char-1', newPos, []);
+
+      const updated = next.entities.get('char-1');
+      expect(updated?.movePath).toBeUndefined();
+      expect(updated?.moveSeq).toBeUndefined();
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1345,6 +1427,43 @@ describe('applyEntityAppearedBatch', () => {
     expect(after.entityMeta.get('goblin-1')?.monsterRefId).toBe('goblin');
     expect(after.entityHP.get('goblin-1')).toEqual({ current: 7, max: 7 });
     expect(after.entityHP.has('char-alice')).toBe(false);
+  });
+
+  it('clears movePath/moveSeq on re-appear (rpg-dnd5e-web#542) — mount/revive must not replay the walk clip', () => {
+    // Entity had a real move (movePath/moveSeq set) before going ghost/
+    // reappearing — applyEntityAppearedBatch replaces the whole record with
+    // a fresh wire EntityState, so a revive must NOT carry the stale move
+    // forward (that would make HexEntity's useHexMovePath think a brand
+    // new move just started on every reconnect/LoS-reappear).
+    const withMove = mergeEntityPosition(
+      applyEntityAppearedBatch(createEmptyEncounterState(), [
+        {
+          entity: makeTestEntity('char-alice', { x: 0, y: 0, z: 0 }),
+          type: EntityType.CHARACTER,
+          monsterRefId: undefined,
+          initialHP: undefined,
+          initialAC: undefined,
+        },
+      ]),
+      'char-alice',
+      create(PositionSchema, { x: 1, y: -1, z: 0 }),
+      [create(PositionSchema, { x: 1, y: -1, z: 0 })]
+    );
+    expect(withMove.entities.get('char-alice')?.moveSeq).toBe(1);
+
+    const revived = applyEntityAppearedBatch(withMove, [
+      {
+        entity: makeTestEntity('char-alice', { x: 1, y: -1, z: 0 }),
+        type: EntityType.CHARACTER,
+        monsterRefId: undefined,
+        initialHP: undefined,
+        initialAC: undefined,
+      },
+    ]);
+
+    const revivedEntity = revived.entities.get('char-alice');
+    expect(revivedEntity?.movePath).toBeUndefined();
+    expect(revivedEntity?.moveSeq).toBeUndefined();
   });
 
   it('stores displayName and classRefId per entity (rpg-dnd5e-web#491)', () => {

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -103,8 +103,28 @@ export interface EntityStatus {
 export interface LocalEncounterState {
   encounterId: string;
   dungeonId: string;
-  /** All entities, keyed by entity ID. v2 may set entity.ghost on LoS loss. */
-  entities: Map<string, EntityState & { ghost?: boolean }>;
+  /**
+   * All entities, keyed by entity ID. v2 may set entity.ghost on LoS loss.
+   *
+   * `movePath`/`moveSeq` (rpg-dnd5e-web#542): the real hex-by-hex route from
+   * the most recent genuine `EntityMoved`/`MovementCompletedEvent`, set ONLY
+   * by `mergeEntityPosition` (the sole reducer `onEntityMoved` feeds) — never
+   * by `applyEntityAppeared`/`applyEntityAppearedBatch` (initial placement,
+   * revive-from-ghost), which replace the whole entity record with a fresh
+   * `{...entity, ghost: false}` off the wire and so naturally clear both
+   * fields back to undefined. This is what lets HexEntity's movement
+   * interpolation key off "a real move just happened" without a separate
+   * boolean: `moveSeq` only ever advances on a genuine move, so watching it
+   * change is watching for exactly that, not mount/reconciliation/ghost
+   * transitions. `moveSeq` is a monotonic counter (not just "movePath
+   * present") specifically so two moves to the SAME destination in a row
+   * (e.g. bounced off a wall and sent back) still each count as a fresh
+   * move worth animating, not a no-op React dependency.
+   */
+  entities: Map<
+    string,
+    EntityState & { ghost?: boolean; movePath?: Position[]; moveSeq?: number }
+  >;
   /** v1alpha2-revealed hexes (per-hex granularity). */
   revealedHexes: Set<string>;
   /**
@@ -278,17 +298,37 @@ export function createEmptyEncounterState(): LocalEncounterState {
  * If the entity is not present, returns prev unchanged — we don't fabricate
  * entities from a position alone.
  *
+ * `path` (rpg-dnd5e-web#542, optional): the move's full real hex-by-hex
+ * route (`EntityMoved.actualPath`/`MovementCompletedEvent.path`, converted
+ * to v1 `Position`), stashed as `movePath` alongside a bumped `moveSeq` so
+ * HexEntity's movement interpolation can step through it instead of
+ * snapping straight to the destination. Omitted (or empty) leaves both
+ * fields untouched — every pre-#542 call site keeps working unchanged, and
+ * a caller that genuinely has no path (shouldn't happen for a real
+ * `EntityMoved`, but defensive) degrades to the old teleport behavior
+ * rather than throwing. `moveSeq` increments rather than just tracking
+ * "movePath present" so two consecutive moves to the same destination
+ * (e.g. bounced back by a wall) each still register as a fresh move worth
+ * animating.
+ *
  * Exported for testing.
  */
 export function mergeEntityPosition(
   prev: LocalEncounterState,
   entityId: string,
-  position: Position
+  position: Position,
+  path?: Position[]
 ): LocalEncounterState {
   const existing = prev.entities.get(entityId);
   if (!existing) return prev;
   const newEntities = new Map(prev.entities);
-  newEntities.set(entityId, { ...existing, position });
+  newEntities.set(entityId, {
+    ...existing,
+    position,
+    ...(path && path.length > 0
+      ? { movePath: path, moveSeq: (existing.moveSeq ?? 0) + 1 }
+      : {}),
+  });
   return { ...prev, entities: newEntities };
 }
 
@@ -936,8 +976,17 @@ export interface UseEncounterStateResult {
    * Update only the position of an existing entity. Used as a fallback for
    * MovementCompletedEvent when the API omits updatedEntity but sends path[].
    * No-op if the entity is not already in state.
+   *
+   * `path` (rpg-dnd5e-web#542, optional): the move's full real hex-by-hex
+   * route — pass the whole `actualPath`/`path` array (not just its last
+   * element) so HexEntity can step through it instead of teleporting. See
+   * `mergeEntityPosition`'s doc comment for the full contract.
    */
-  applyEntityPositionUpdate: (entityId: string, position: Position) => void;
+  applyEntityPositionUpdate: (
+    entityId: string,
+    position: Position,
+    path?: Position[]
+  ) => void;
   /** Reset to empty state (new encounter or disconnect) */
   reset: () => void;
   // v1alpha2 additions
@@ -1070,8 +1119,8 @@ export function useEncounterState(): UseEncounterStateResult {
   );
 
   const applyEntityPositionUpdate = useCallback(
-    (entityId: string, position: Position) => {
-      setState((prev) => mergeEntityPosition(prev, entityId, position));
+    (entityId: string, position: Position, path?: Position[]) => {
+      setState((prev) => mergeEntityPosition(prev, entityId, position, path));
     },
     []
   );


### PR DESCRIPTION
Closes rpg-dnd5e-web#542's client half: "characters glide across the map in their idle pose." Companion assets PR (Walk_Forward clips for all 4 classes): https://github.com/KirkDiggler/rpg-game-assets/pull/20

## The bug, precisely

Until now `HexEntity` snapped straight to `cubeToWorld(entity.position)` every time an entity's server position changed — whether that was a genuine move, initial placement, or a ghost/revive reconciliation. There was no position interpolation at all, so a walk clip would never have had anything to key off of even once one existed.

## Movement-path finding this depends on

Checked `rpg-api` directly before building this: the wire already carries a real, backend-populated, ordered hex-by-hex route today — `EntityMoved.actualPath` (v1alpha2) / `MovementCompletedEvent.path` (v1), built server-side from the mover's real per-viewer-visible route (`translateMoveEvent()` in `internal/handlers/dnd5e/v2/encounter/translate.go`, asserted by `translate_test.go`). The client just discarded everything but the last element (`e.actualPath[e.actualPath.length - 1]`). **No proto/backend change needed** — this PR consumes the real field directly, no stub.

## What changed

- **`useEncounterState.ts`**: `mergeEntityPosition` takes an optional `path` param, stashing it as `movePath` alongside a bumped `moveSeq`. Set **only** by this reducer (the sole `onEntityMoved` call site) — never by `applyEntityAppearedBatch`/ghost/revive, which replace the whole entity record with a fresh wire value, so `movePath`/`moveSeq` naturally reset to `undefined`. This is what makes the interpolation trigger on a genuine move only, not mount or stream reconciliation — covered by an explicit appear→move→disappear→appear round-trip regression test.
- **`EncounterView.tsx` / `PlaytestHarness.tsx`**: `onEntityMoved` now passes the whole `actualPath`, not just its last element.
- **`useHexMovePath.ts`** (new): steps a group's rendered position through the real path at a **fixed per-hex duration** (`SECONDS_PER_HEX_STEP = 0.45s`, tuned by eye against `Walk_Forward`'s ~1.03s loop — flagged as a playtest-tuning knob, not a final number) — a 1-hex and a 5-hex move take proportionally different total time, not the same fixed duration stretched or compressed (which would either teleport-slide a long move or crawl a short one).
- **Degenerate/single-element path** (matches rpg-api#656's corner-spawn wall-truncation bug): still animates the one step, by synthesizing it from wherever the group is *currently rendered* to the single path point, rather than special-casing a snap. If that point already equals the current position (the #656 case), it resolves as a harmless zero-distance step in under a frame.
- **`HexEntity.tsx`**: the player/monster group's position is now owned entirely by `useHexMovePath` (ref-driven via `useFrame`, not a declarative `position` prop — the two would fight mid-step, see the hook's doc comment). `isMoving` flows down to `ClassCharacterModel`.
- **`classCharacterModels.ts`**: new `resolveWalkClipName` — prefers a `walk`-named clip, but unlike `resolveIdleClipName` does **not** fall back to an arbitrary clip (an idle/other clip playing fast-forward while the character slides is worse than staying on idle). `ClassCharacterModel.tsx` falls back to `resolveIdleClipName` itself when there's no walk clip.
- **`ClassCharacterModel.tsx`**: `isMoving` prop picks the walk clip over idle, reusing the existing `invalidate()`-per-frame heartbeat pattern already established in this file.
- **`playtestMapHelpers.ts` / `HexGrid.tsx` / `EncounterMap.tsx` / `PlaytestMap.tsx`**: `movePath`/`moveSeq` threaded through the existing entity-shape plumbing (both production and playtest render paths, since PlaytestMap is also the harness used for manual verification of this exact feature).

## Testing

- `npm run ci-check`: green (format, lint, typecheck, build, all 864 tests).
- New/extended tests: `mergeEntityPosition` (path stashing, moveSeq increment including same-destination-twice, omitted/empty-path backward compat, revive-resets-movePath), `resolveWalkClipName`, `buildRenderableEntities` passthrough, and an `useEncounterStream.integration.test.tsx` end-to-end fake-stream→dispatch→reducer check (including the appear→move→disappear→appear round trip).
- **No live rpg-api backend was available in this environment** to drive a real `EntityMoved` event through the running app end-to-end, so this wasn't verified with an in-app screenshot — correctness rests on the unit/integration tests above, which exercise the full event-to-state pipeline the real stream also goes through. Flagging this honestly rather than claiming an in-app check that didn't happen.
- **rpg-api#656 caveat** (also noted in the code): the corner-spawn wall-truncation bug can produce a same-hex/zero-length `actualPath` in a fresh `StartEncounter` session. A reviewer testing there may see a very short or no-op walk step — that's the pre-existing backend bug, not this change; `useHexMovePath` degrades to it correctly rather than throwing or hanging.

## Judgment calls flagged for gate review

1. **`SECONDS_PER_HEX_STEP = 0.45`** — a picked-by-eye constant, not derived from anything. Easy to retune, called out in the hook's doc comment as a knob.
2. **Interpolation scoped to the player/monster group only**, not obstacles — obstacles don't have a modeled "move" action today, so there was nothing to key it off of; if that changes, `useHexMovePath` is already general enough to reuse.
3. **`resolveWalkClipName`'s no-fallback-to-first-clip behavior** differs from `resolveIdleClipName`'s established pattern — deliberate (see above), not an oversight; flagging in case reviewers expect symmetry.

— asset-pipeline agent, on behalf of KirkDiggler

---

## Update: gate-review fix (66b4aff)

The independent gate review found a real bug that a live Copilot review comment had already flagged and that was sitting unacknowledged: **the first genuine move immediately after a revive silently snapped instead of animating** (self-healed on the second move, which is why it wasn't caught earlier).

Root cause: `seenSeqRef.current` was only written when `moveSeq !== undefined`, so a revive's legitimate reset to `undefined` didn't clear the stale prior value — and `mergeEntityPosition`'s counter also restarts at `1` on the first post-revive move, which could collide with that stale value and misclassify the move as a no-op.

Fixed: `seenSeq` is now written unconditionally. Per the review's "don't stop at the one-liner" ask, also extracted the genuine-move detection and per-frame lerp math out of `useHexMovePath.ts` into two pure, dependency-free functions (`computeMoveStart`, `advanceFrame`) and added `useHexMovePath.test.ts` (17 tests, was zero before) — covering a normal multi-hex move, the degenerate/single-element path (rpg-api#656 case), and the revive→first-move sequence that regressed. (Note: the original "revive→first-move" coverage here hand-simulated the buggy caller pattern inline rather than exercising the real hook — see the follow-up update below, which replaces it with a test that renders the actual hook and was verified to fail on revert.)

Also fixed the informational nit on `classCharacterModels.test.ts`'s self-contradicting test title.

Replied to the Copilot review comment individually: https://github.com/KirkDiggler/rpg-dnd5e-web/pull/551#discussion_r3616288133

`npm run ci-check`: green, 881 tests (up from 864).

---

## Update: hook-level regression test (gate-review finding, comment 5025309042)

A second gate-review pass caught that the "revive then first move" test added above never actually rendered `useHexMovePath` — it hand-simulated the buggy caller pattern inline, so reverting the real one-line fix left all 17 new tests (and the full suite) green. The gate proved this experimentally.

Fixed by replacing it with a test that mounts the real hook via React Testing Library's `renderHook`, mocking `@react-three/fiber`'s `useFrame`/`useThree` (the callback `useFrame` registers is captured so the test can drive frames manually — no WebGL canvas needed). It drives the actual revive lifecycle through real prop changes: first move (animates), revive (`moveSeq` → `undefined`), first move after revive — and asserts the post-revive move is genuinely mid-flight (`isMoving` true, position not yet snapped to the destination) rather than a snap.

**Discrimination verified experimentally**: reverting the hook's fix back to the old conditional write (`if (moveSeq !== undefined) seenSeqRef.current = ...`) makes the new test fail:

```
AssertionError: expected false to be true // Object.is equality
- Expected: true
+ Received: false
 ❯ src/components/hex-grid/useHexMovePath.test.ts:470:37
    expect(result.current.isMoving).toBe(true);
```

Restoring the fix makes it pass again (17/17), and `git diff` after restoring confirms only the test file changed. Also retitled the surviving `computeMoveStart`-only tests to make clear they cover the pure-function contract (not hook-level behavior), and removed the old inline-simulation test that overclaimed regression coverage it didn't actually provide.

`npm run ci-check`: green, full suite still 881 tests.

Checked for new Copilot review activity since 66b4aff: none — the only Copilot comment/review on this PR predates that commit and was already replied to.

— asset-pipeline agent, on behalf of KirkDiggler

