### PR TITLE
fix(theme): cache-bust theme stylesheets — stale base.css leaves combat HUD unstyled after deploys

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,6 +97,7 @@ jobs:
           build-args: |
             VITE_DISCORD_CLIENT_ID=${{ secrets.VITE_DISCORD_CLIENT_ID }}
             VITE_API_HOST=${{ secrets.VITE_API_HOST }}
+            BUILD_ID=${{ github.sha }}
 
       - name: Trigger deployment
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,15 @@ COPY . .
 # Accept build arguments for environment variables
 ARG VITE_DISCORD_CLIENT_ID
 ARG VITE_API_HOST
+# Cache-bust id for /themes/*.css links (web#553). .dockerignore excludes
+# .git, so vite.config.ts can't derive a SHA in-image — the workflow passes
+# github.sha through this arg instead.
+ARG BUILD_ID
 
 # Set environment variables for the build
 ENV VITE_DISCORD_CLIENT_ID=$VITE_DISCORD_CLIENT_ID
 ENV VITE_API_HOST=$VITE_API_HOST
+ENV BUILD_ID=$BUILD_ID
 
 # Copy theme files to public directory before build
 RUN mkdir -p public/themes && cp -r src/themes/*.css public/themes/

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,0 +1,63 @@
+/**
+ * useTheme cache-busting (web#553): /themes/*.css live in public/ and are not
+ * fingerprinted by Vite, so every runtime-injected stylesheet link must carry
+ * a ?v=<build id> query — otherwise CDN/browser caches serve stale theme CSS
+ * after deploys and the combat HUD renders unstyled.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useTheme } from './useTheme';
+
+function themeLinks(): HTMLLinkElement[] {
+  return Array.from(document.querySelectorAll('link[data-theme]'));
+}
+
+describe('useTheme stylesheet cache-busting', () => {
+  afterEach(() => {
+    themeLinks().forEach((l) => l.remove());
+    localStorage.clear();
+  });
+
+  it('appends a ?v= build version to base and theme stylesheet links', async () => {
+    renderHook(() => useTheme());
+
+    await waitFor(() => {
+      expect(themeLinks().length).toBeGreaterThanOrEqual(2);
+    });
+
+    for (const link of themeLinks()) {
+      const url = new URL(link.href, 'http://localhost');
+      expect(url.pathname).toMatch(/^\/themes\/[\w-]+\.css$/);
+      const v = url.searchParams.get('v');
+      expect(v, `${url.pathname} must carry a ?v= build id`).toBeTruthy();
+      expect(v!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the version query when switching themes at runtime', async () => {
+    const { result } = renderHook(() => useTheme());
+
+    await waitFor(() => {
+      expect(themeLinks().length).toBeGreaterThanOrEqual(2);
+    });
+
+    // Not awaited: loadTheme blocks on link.onload, which jsdom never fires.
+    // The link element itself is appended synchronously before that await.
+    act(() => {
+      void result.current.changeTheme('arcane');
+    });
+
+    await waitFor(() => {
+      expect(
+        themeLinks().some((l) => l.href.includes('/themes/arcane.css'))
+      ).toBe(true);
+    });
+
+    const arcane = themeLinks().find((l) =>
+      l.href.includes('/themes/arcane.css')
+    );
+    expect(
+      new URL(arcane!.href, 'http://localhost').searchParams.get('v')
+    ).toBeTruthy();
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -31,6 +31,18 @@ export const themes: Theme[] = [
 const THEME_STORAGE_KEY = 'rpg-dnd5e-theme';
 const DEFAULT_THEME = 'dark-fantasy';
 
+// /themes/*.css live in public/ and are NOT fingerprinted by Vite, so without
+// a version query Cloudflare/browser caches keep serving the pre-deploy file
+// forever (web#553: prod rendered the combat-HUD primitives unstyled). The
+// build id is a Vite define (short commit SHA); the typeof guard covers any
+// runtime where the define was not applied.
+const THEME_CSS_VERSION =
+  typeof __BUILD_ID__ !== 'undefined' ? __BUILD_ID__ : 'dev';
+
+function themeHref(file: string): string {
+  return `/themes/${file}.css?v=${THEME_CSS_VERSION}`;
+}
+
 export function useTheme() {
   const [currentTheme, setCurrentTheme] = useState<string>(DEFAULT_THEME);
   const [isLoading, setIsLoading] = useState(true);
@@ -55,7 +67,7 @@ export function useTheme() {
       if (!document.querySelector('link[data-theme="base"]')) {
         const baseLink = document.createElement('link');
         baseLink.rel = 'stylesheet';
-        baseLink.href = `/themes/base.css`;
+        baseLink.href = themeHref('base');
         baseLink.setAttribute('data-theme', 'base');
         document.head.appendChild(baseLink);
       }
@@ -63,7 +75,7 @@ export function useTheme() {
       // Load theme-specific styles
       const themeLink = document.createElement('link');
       themeLink.rel = 'stylesheet';
-      themeLink.href = `/themes/${themeId}.css`;
+      themeLink.href = themeHref(themeId);
       themeLink.setAttribute('data-theme', themeId);
       document.head.appendChild(themeLink);
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -34,8 +34,9 @@ const DEFAULT_THEME = 'dark-fantasy';
 // /themes/*.css live in public/ and are NOT fingerprinted by Vite, so without
 // a version query Cloudflare/browser caches keep serving the pre-deploy file
 // forever (web#553: prod rendered the combat-HUD primitives unstyled). The
-// build id is a Vite define (short commit SHA); the typeof guard covers any
-// runtime where the define was not applied.
+// build id is a Vite define — BUILD_ID env (Docker: github.sha build-arg),
+// else git SHA, else per-build timestamp; see vite.config.ts buildId(). The
+// typeof guard covers any runtime where the define was not applied.
 const THEME_CSS_VERSION =
   typeof __BUILD_ID__ !== 'undefined' ? __BUILD_ID__ : 'dev';
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+/**
+ * Build identifier injected by vite.config.ts `define` (short commit SHA).
+ * Used to cache-bust runtime-loaded /themes/*.css links (web#553).
+ */
+declare const __BUILD_ID__: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,9 @@
 /// <reference types="vite/client" />
 
 /**
- * Build identifier injected by vite.config.ts `define` (short commit SHA).
- * Used to cache-bust runtime-loaded /themes/*.css links (web#553).
+ * Build identifier injected by vite.config.ts `define`. Tiered source:
+ * BUILD_ID env var (Docker builds — github.sha via build-arg, since the
+ * image has no .git), else short commit SHA via git, else a per-build
+ * timestamp. Used to cache-bust runtime-loaded /themes/*.css links (web#553).
  */
 declare const __BUILD_ID__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,18 @@ import { defineConfig } from 'vitest/config';
 // fingerprinted by Vite, so runtime-injected stylesheet links append this as a
 // ?v= query — otherwise Cloudflare/browser caches serve stale theme CSS after
 // deploys (web#553: combat HUD rendered unstyled in prod).
+//
+// Three tiers, in order:
+//   1. BUILD_ID env var — the Docker image build (docker.yml) passes
+//      github.sha through a build-arg, because .dockerignore excludes .git
+//      and `git rev-parse` is impossible in-image. This is what prod ships.
+//   2. `git rev-parse --short HEAD` — local/CI builds with a repo present.
+//   3. Timestamp fallback — any environment with neither; still unique
+//      per build, so cache-busting works everywhere even without a SHA.
 function buildId(): string {
+  if (process.env.BUILD_ID) {
+    return process.env.BUILD_ID.slice(0, 12);
+  }
   try {
     return execSync('git rev-parse --short HEAD').toString().trim();
   } catch {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,26 @@
 import react from '@vitejs/plugin-react';
+import { execSync } from 'child_process';
 import { resolve } from 'path';
 import { defineConfig } from 'vitest/config';
+
+// Computed once per build. public/ assets (the /themes/*.css files) are not
+// fingerprinted by Vite, so runtime-injected stylesheet links append this as a
+// ?v= query — otherwise Cloudflare/browser caches serve stale theme CSS after
+// deploys (web#553: combat HUD rendered unstyled in prod).
+function buildId(): string {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return Date.now().toString(36);
+  }
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __BUILD_ID__: JSON.stringify(buildId()),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),


### PR DESCRIPTION
Closes #553

Kirk's live prod screenshot showed the combat dock rendering as bare unstyled text — no verb chrome, no cost badges, no commit End Turn — while the #543/#552 verified builds render full styling. Root cause: `src/hooks/useTheme.ts` injects `/themes/*.css` links by bare URL; Vite does not fingerprint `public/` assets, and prod sits behind Cloudflare + browser caches, so clients keep serving the pre-deploy `base.css` — which is where all the combat-HUD primitive styles live (#538/#543).

## Change

- `vite.config.ts`: `__BUILD_ID__` define, computed once per build. Tiered source (in order): **(1)** `BUILD_ID` env var — the Docker image build passes `github.sha` through a build-arg, because `.dockerignore` excludes `.git` so `git rev-parse` is impossible in-image (this is what prod ships); **(2)** `git rev-parse --short HEAD` for local/CI builds with a repo; **(3)** per-build timestamp fallback — still unique per build, so cache-busting works even without a SHA.
- `docker.yml` + `Dockerfile`: `BUILD_ID=${{ github.sha }}` build-arg threaded to the build env.
- `useTheme.ts`: every injected theme link (base + theme-specific) now carries `?v=<build id>`, so each deploy is a new cache key. Runtime theme-swap mechanism unchanged.
- `useTheme.test.ts` (new): asserts the version query on initial links and across runtime theme switches (non-awaited switch — jsdom never fires `link.onload`, and `loadTheme` blocks on it).

## Scope-decisions

- Smallest correct fix: version query only. Migrating theme CSS into Vite's fingerprinted pipeline (imports instead of public/ files) would be stronger but restructures the runtime theme-swap system — deliberately not done here; possible future hardening.
- The `typeof __BUILD_ID__` guard keeps the hook safe in any runtime where the define isn't applied.

## Load-bearing digest

- `/themes/*.css` are public/ assets: NOT fingerprinted, cached indefinitely by CDN/browser without a version query.
- All combat-HUD primitive CSS lives in `public/themes/base.css` — stale cache = unstyled dock in prod.
- `__BUILD_ID__` tiering: Docker build-arg (github.sha) → git SHA → timestamp; the image has no `.git`, so without the build-arg prod would silently ship the timestamp tier.
- Verify after deploy: normal refresh (not hard refresh) must show styled verb buttons, and `?v=` should be a 12-char SHA prefix, not a timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YtfYA1YiXnsTNTTdEGZPM
