### PR TITLE
Register crypt prop keys from rpg-game-assets #22/#23 (#559)

### DIFF
--- a/src/components/hex-grid/propManifest.ts
+++ b/src/components/hex-grid/propManifest.ts
@@ -53,8 +53,9 @@ export const PROPS_MODEL_BASE = '/models/synty/';
 
 /**
  * key -> ordered variant list, mirroring rpg-game-assets manifest.json's
- * `keys` index exactly (same 17 keys as the #523 comment thread's agreed
- * list). Variant order matches the source manifest's piece order.
+ * `keys` index exactly (the wave-1 17 keys agreed on the #523 comment
+ * thread, plus the 12 keys #559's crypt-dressing wave appended -- 29
+ * total). Variant order matches the source manifest's piece order.
  */
 export const PROP_KEYS: Record<string, PropVariant[]> = {
   'dnd5e:props:pillar': [
@@ -275,6 +276,149 @@ export const PROP_KEYS: Record<string, PropVariant[]> = {
       blocksLoS: false,
     },
   ],
+
+  // --- rpg-dnd5e-web#559 crypt-dressing wave (rpg-game-assets#22/#23,
+  // both merged) -- 12 newly-minted keys extending the wave-1 17-key list
+  // per prop-role-map.json's $crypt559KeysNote. All themes: ["crypt"]. ---
+  'dnd5e:props:altar': [
+    {
+      name: 'SM_Env_Alter_01',
+      file: 'props/SM_Env_Alter_01.glb',
+      role: 'obstacle',
+      footprintHexes: 3,
+      blocksLoS: true,
+    },
+  ],
+  'dnd5e:props:statue-reaper': [
+    {
+      name: 'SM_Env_Statue_01',
+      file: 'props/SM_Env_Statue_01.glb',
+      role: 'obstacle',
+      footprintHexes: 3,
+      blocksLoS: true,
+    },
+  ],
+  'dnd5e:props:statue-knight-hooded': [
+    {
+      name: 'SM_Env_Statue_03',
+      file: 'props/SM_Env_Statue_03.glb',
+      role: 'obstacle',
+      footprintHexes: 2,
+      blocksLoS: true,
+    },
+  ],
+  'dnd5e:props:obelisk': [
+    {
+      name: 'SM_Env_Obelisk_01',
+      file: 'props/SM_Env_Obelisk_01.glb',
+      role: 'obstacle',
+      footprintHexes: 3,
+      blocksLoS: true,
+    },
+  ],
+  'dnd5e:props:skeleton-cage': [
+    {
+      name: 'SM_Prop_Skeleton_Cage_01',
+      file: 'props/SM_Prop_Skeleton_Cage_01.glb',
+      role: 'obstacle',
+      footprintHexes: 1,
+      blocksLoS: true,
+    },
+  ],
+  'dnd5e:props:coffin': [
+    {
+      name: 'SM_Prop_Coffin_01',
+      file: 'props/SM_Prop_Coffin_01.glb',
+      role: 'cover',
+      footprintHexes: 2,
+      blocksLoS: false,
+    },
+  ],
+  'dnd5e:props:skeleton-table': [
+    {
+      name: 'SM_Prop_Skeleton_Table_01',
+      file: 'props/SM_Prop_Skeleton_Table_01.glb',
+      role: 'cover',
+      footprintHexes: 1,
+      blocksLoS: false,
+    },
+  ],
+  // Shares one key across 4 size/shape variants -- same bone-pile family,
+  // same $keyNote convention as barrel/crate/etc above.
+  'dnd5e:props:bone-pile': [
+    {
+      name: 'SM_Env_BonePile_01',
+      file: 'props/SM_Env_BonePile_01.glb',
+      role: 'decor',
+      footprintHexes: 3,
+      blocksLoS: false,
+    },
+    {
+      name: 'SM_Env_BonePile_02',
+      file: 'props/SM_Env_BonePile_02.glb',
+      role: 'decor',
+      footprintHexes: 4,
+      blocksLoS: false,
+    },
+    {
+      name: 'SM_Env_BonePile_03',
+      file: 'props/SM_Env_BonePile_03.glb',
+      role: 'decor',
+      footprintHexes: 2,
+      blocksLoS: false,
+    },
+    {
+      name: 'SM_Env_BonePile_Small_01',
+      file: 'props/SM_Env_BonePile_Small_01.glb',
+      role: 'decor',
+      footprintHexes: 2,
+      blocksLoS: false,
+    },
+  ],
+  // Shares one key across 2 length variants -- same chain family.
+  'dnd5e:props:chain': [
+    {
+      name: 'SM_Prop_Chain_01',
+      file: 'props/SM_Prop_Chain_01.glb',
+      role: 'decor',
+      footprintHexes: 1,
+      blocksLoS: false,
+    },
+    {
+      name: 'SM_Prop_Chain_02',
+      file: 'props/SM_Prop_Chain_02.glb',
+      role: 'decor',
+      footprintHexes: 1,
+      blocksLoS: false,
+    },
+  ],
+  'dnd5e:props:brazier': [
+    {
+      name: 'SM_Prop_Brazier_01',
+      file: 'props/SM_Prop_Brazier_01.glb',
+      role: 'decor',
+      footprintHexes: 1,
+      blocksLoS: false,
+    },
+  ],
+  'dnd5e:props:torch-ornate': [
+    {
+      name: 'SM_Prop_Torch_Ornate_01',
+      file: 'props/SM_Prop_Torch_Ornate_01.glb',
+      role: 'decor',
+      footprintHexes: 1,
+      blocksLoS: false,
+    },
+  ],
+  'dnd5e:props:skeleton-remains': [
+    {
+      name: 'SM_Prop_Skeleton_01',
+      file: 'props/SM_Prop_Skeleton_01.glb',
+      role: 'decor',
+      footprintHexes: 2,
+      blocksLoS: false,
+    },
+  ],
 };
 
 /**
@@ -306,6 +450,20 @@ export const EXPECTED_PROP_KEYS: readonly string[] = [
   'dnd5e:props:banner',
   'dnd5e:props:books',
   'dnd5e:props:armor-stand',
+  // rpg-dnd5e-web#559 crypt-dressing wave (rpg-game-assets#22/#23) -- 12
+  // more keys appended per this file's own doc comment above.
+  'dnd5e:props:altar',
+  'dnd5e:props:statue-reaper',
+  'dnd5e:props:statue-knight-hooded',
+  'dnd5e:props:obelisk',
+  'dnd5e:props:skeleton-cage',
+  'dnd5e:props:coffin',
+  'dnd5e:props:skeleton-table',
+  'dnd5e:props:bone-pile',
+  'dnd5e:props:chain',
+  'dnd5e:props:brazier',
+  'dnd5e:props:torch-ornate',
+  'dnd5e:props:skeleton-remains',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Registers the 12 newly-minted crypt prop keys (rpg-game-assets `library/prop-role-map.json`, `$crypt559KeysNote`) into `src/components/hex-grid/propManifest.ts`, the hand-maintained client mirror of the asset repo's generated `harness/models/synty/props/manifest.json`. Source PRs rpg-game-assets#22 and #23 (both **merged**) promoted the crypt-dressing GLBs and minted these keys.

Keys added (all `themes: ["crypt"]`, appended to both `PROP_KEYS` and `EXPECTED_PROP_KEYS`, total 17 → 29):

| key | role | pieces |
|---|---|---|
| `dnd5e:props:altar` | obstacle | SM_Env_Alter_01 |
| `dnd5e:props:statue-reaper` | obstacle | SM_Env_Statue_01 |
| `dnd5e:props:statue-knight-hooded` | obstacle | SM_Env_Statue_03 |
| `dnd5e:props:obelisk` | obstacle | SM_Env_Obelisk_01 |
| `dnd5e:props:skeleton-cage` | obstacle | SM_Prop_Skeleton_Cage_01 |
| `dnd5e:props:coffin` | cover | SM_Prop_Coffin_01 |
| `dnd5e:props:skeleton-table` | cover | SM_Prop_Skeleton_Table_01 |
| `dnd5e:props:bone-pile` | decor | SM_Env_BonePile_01/02/03/Small_01 (4 variants) |
| `dnd5e:props:chain` | decor | SM_Prop_Chain_01/02 (2 variants) |
| `dnd5e:props:brazier` | decor | SM_Prop_Brazier_01 |
| `dnd5e:props:torch-ornate` | decor | SM_Prop_Torch_Ornate_01 |
| `dnd5e:props:skeleton-remains` | decor | SM_Prop_Skeleton_01 |

`role`/`footprintHexes`/`blocksLoS` for each piece copied directly from the generated `harness/models/synty/props/manifest.json` (measured geometry + QA overrides), not re-derived.

## Verification

- Ran `npm run assets:sync` from the main checkout (worktree-safe per the known nested-worktree limitation) and copied `public/models/synty/` into this worktree.
- Confirmed all 16 backing GLB files for the 12 keys exist in the synced tree.
- Scripted check of every `file:` reference in `propManifest.ts` (all 42, not just the new 12) against the synced tree: **0 missing**.
- `propManifest.test.ts`'s `EXPECTED_PROP_KEYS` guard loop picks up the 12 new keys automatically (no test-file changes needed) — 68/68 tests pass in that file (82/82 across `propManifest.test.ts` + `obstaclePropKeys.test.ts` combined).
- `npm run ci-check` passes (format, lint, typecheck, build, tests) — ran clean both pre-commit and again via the pre-push hook.

## Not in scope for this PR (flagging for visibility)

- `library/prop-role-map.json` also added `SM_Prop_Tomb_Royal_01` as a second variant of the **existing** `dnd5e:props:tomb` key (not one of the 12 new keys). Left untouched here to keep this PR focused on the #559 ask; happy to add it in a follow-up or this PR if preferred.
- `obstaclePropKeys.ts`'s `OBSTACLE_TYPE_TO_PROP_KEY` table has an explicit comment noting `STATUE`, `ALTAR`, `BRAZIER`, `TABLE` were left unmapped because "no matching piece in the wave-1 catalog... revisit if a dedicated piece ships." That piece now exists for altar/brazier/statue (reaper+knight-hooded)/skeleton-table. Wiring the v1alpha1 `ObstacleType` enum mapping is a separate, optional enhancement beyond registering the keys themselves (the v1alpha2 `propRefId` path already resolves these mechanically, no table needed) — left alone here, flagging for a follow-up decision.
- Visual placement evidence (contact sheet / in-engine screenshots) comes via the crypt-room spike PR, which is in flight separately.

— asset-pipeline agent, on behalf of KirkDiggler
