### PR TITLE
feat(map): retain server region theme state (#572)

### DIFF
--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -1,55 +1,28 @@
 {
-  "branch": "feat/576-item-icons",
-  "issues": ["#576"],
-  "goal": "Add a web-side, exhaustive canonical weapon (38) + armor (13) id -> icon lookup (src/utils/itemIcons.ts) and wire it into EquipmentSlots/InventoryLight so the live equipment popover shows an icon for every canonical item even though the server's icon_key is empty today, while preserving every existing accessibility/interaction contract. Plan: rpg-project ideas/equipment/item-icons/plan.md.",
+  "branch": "feat/572-region-theme-state",
+  "issues": ["#572"],
+  "goal": "Retain server-authored Space.theme, Space.zones, and Hex.zoneId in canonical encounter state without topology inference, and expose a deterministic render lookup seam for #577.",
   "sessions": [
     {
-      "id": "2026-07-21-001",
-      "task": "Task 1: Canonical registry + resolver (src/utils/itemIcons.ts)",
-      "status": "completed",
-      "artifacts": ["src/utils/itemIcons.test.ts", "src/utils/itemIcons.ts"],
-      "commit": "e19f9a04269d6e22e7af19dbf7c0850602e1da23",
-      "notes": "TDD: wrote itemIcons.test.ts first, confirmed RED (Vitest could not resolve ./itemIcons import), implemented itemIcons.ts per plan Task 1 verbatim, confirmed GREEN (21/21 focused tests, full suite 60 files/1064 tests green with no regressions). npm run typecheck exits 0, but is a no-op in this repo (root tsconfig.json has files: [] + references, no -b flag) -- confirmed the real satisfies-exhaustiveness check via `npx tsc -b --noEmit` (matches what `npm run build` runs), which correctly failed with 'Property whip is missing' when an entry was deliberately deleted, then passed clean once restored. Flagged as a repo tooling gap in the task report, not fixed here (out of Task 1 scope)."
-    },
-    {
-      "id": "2026-07-21-002",
-      "task": "Task 2: Wire getItemIconUrl into EquipmentSlots/InventoryLight (component tests + call-site swap)",
+      "id": "2026-07-23-001",
+      "task": "Dependency verification and TDD implementation",
       "status": "completed",
       "artifacts": [
-        "src/components/game/equipment/EquipmentSlots.test.tsx",
-        "src/components/game/equipment/EquipmentSlots.tsx",
-        "src/components/game/equipment/InventoryLight.test.tsx",
-        "src/components/game/equipment/InventoryLight.tsx"
+        "package.json",
+        "package-lock.json",
+        "src/hooks/useEncounterState.ts",
+        "src/hooks/useEncounterState.test.ts",
+        "src/api/useEncounterStream.integration.test.tsx",
+        "src/components/game/EncounterView.tsx",
+        "src/components/playtest/PlaytestHarness.tsx"
       ],
-      "commit": "18f3df1a9b079e0228c3a3d68451d1aee47c331f",
-      "notes": "TDD: replaced both test files per task-2-brief.md Steps 1-2 verbatim first, confirmed RED with the exact focused command (Test Files 2 failed (2), Tests 2 failed | 12 passed (14), both failures 'expected null not to be null' on the new canonical-icon-resolves test -- component still called resolveIconUrl('') which is always undefined). Swapped the import + one icon-resolution line in each component per brief Steps 4-5 (no other lines touched -- <img> JSX, onError, title/aria-label, disabled/busy logic all preserved verbatim). Confirmed GREEN: Test Files 2 passed (2), Tests 14 passed (14). Ran the real typecheck via `npx tsc -b --noEmit` (per Task 1's finding that plain `npm run typecheck` is a no-op) -- exit 0, no errors, before and after the pre-commit hook's lint-staged prettier/eslint --fix reordered the two import lines (cosmetic import/order only, reverified green + exit 0 after). Committed via the normal hook path (no --no-verify). Scope held to exactly the brief's two components/tests + call-site swap -- did not touch itemIcons.ts, architecture docs, CI config, or run full ci-check/visual verification (Task 3)."
-    },
-    {
-      "id": "2026-07-21-003",
-      "task": "Task 3 (partial -- docs, full CI, asset sync, and visual evidence only; PR/review/gate deliberately not run by this session's mandate)",
-      "status": "completed",
-      "artifacts": ["docs/architecture/components/equipment.md"],
-      "commit": "9aecf631721f889d19bcc0d309e5203f53cc6034",
-      "notes": "Docs (Steps 1-2 of task-3-brief.md): replaced the stale 'no icon mapping table' scope-decision bullet and added the itemIcons.test.ts Tests bullet exactly verbatim per the brief; frontmatter `updated:` was already today's date (2026-07-21), no change needed. Committed alone as 'docs(equipment): note the canonical item-icon lookup (#576)'. Full CI (Step 3): `npm run ci-check` from the worktree root -- format/lint/typecheck/build/full-test-suite all green ('All CI checks passed! Safe to push.'); full log at /tmp/opencode/task3-576-screenshots/ci-check-output.log. Asset sync (Step 4): symlinked ../rpg-game-assets -> /home/kirk/game-dev/rpg-game-assets exactly per the brief's idempotent guard, ran `npm run assets:sync` (pulled the existing checkout, synced harness/models/synty/ -> public/models/synty/), confirmed `test -f public/models/synty/ui/library/icons/weapons/ICON_SM_Wep_Sword_02_Clean.png` exits 0. Step 5 (/concepts, supporting): dev server on this repo's actual configured port 3001 (vite.config.ts pins `server.port: 3001` -- NOT the brief's assumed 5173 default; a real, pre-existing repo/brief discrepancy, not something this session changed). Screenshots (via tools/browser Playwright, since the chrome-devtools MCP had no reachable --remote-debugging-port on this box): Sir Aldric's longsword/shield/chain-mail/greatsword/handaxe all show icons; Remy's dagger rows still show their unrelated fixture icon. /tmp/opencode/task3-576-screenshots/step5-concepts-equipment-bench.png, step5-concepts-equipment-remy.png -- both independently re-opened and visually confirmed. Step 6 (MANDATORY real wire path): started a fresh `rpg-redis` container (6379), `docker compose up -d envoy` (rpg-api-envoy-1, 8080->50051), `AUTH_DEV_MODE=true go run ./cmd/server server` (foreground-equivalent, logs at /tmp/opencode/task3-576-screenshots/rpg-api-server.log, no errors), `go run ./cmd/devseed --fixture=equip-demo` (exit 0, seeded char-aldric + dev-encounter). Wrote `.env.local` (VITE_API_HOST=http://localhost:8080, VITE_DEV_PLAYER_ID=aldric, gitignored, not committed) and restarted the web dev server so Vite picked it up. IMPORTANT DEVIATION, documented not silently substituted: the brief's exact URL (`?encounterId=dev-encounter&playerId=aldric`) hard-gates into `PlaytestHarness` per `src/App.tsx`'s `showPlaytestHarness` check (`MODE === development && encounterId param present`) -- a pre-existing app-routing fact unrelated to Tasks 1-2's diff. `PlaytestHarness.tsx` has zero equipment/popover code (grepped, confirmed), so that literal URL cannot ever show `EquipmentSlots`/`InventoryLight`. Verified the same underlying claim (real-wire canonical icon rendering for the exact equip-demo aldric fixture: longsword/shield/chain-mail equipped, greatsword carried) via the real, un-modified production path instead: `http://localhost:3001/?playerId=aldric` (Home, sets playerId via the app's own `?playerId=` dev override, no encounterId param so PlaytestHarness never gates in) -> selected the 'Sir Aldric' card (ListCharacters confirmed via grpcurl this is the same char-aldric devseed wrote, with the same equipmentSlots/inventory) -> Play -> Create lobby -> Ready up -> Start -> real `EncounterView`/`EncounterDock` -> clicked the 'Open equipment' chestplate chip. Result: AC 18 (16 chain mail + 2 shield) server-computed header, MAIN HAND Longsword icon, OFF HAND Shield icon, ARMOR Chain Mail icon, CARRIED Greatsword icon -- all rendering via the real `CharacterData` -> `characterEquipmentFrom` -> `EquipmentPopover` wire path, matching the exact aldric equip-demo item set (just a freshly-created lobby/encounter id rather than literally reusing 'dev-encounter', since that id is only reachable through the PlaytestHarness gate). Mandatory screenshot: /tmp/opencode/task3-576-screenshots/step6-EQUIPMENT-POPOVER-REAL-WIRE.png, independently re-opened twice and visually confirmed both times. Intermediate flow screenshots (step6a through step6i) in the same directory. Step 7 (Discord Activity): BLOCKED, not fabricated. No tunnel (ngrok/cloudflared) was running; no reproducible local process exists in docs/architecture/components/discord.md or docs/how-to/local-dev.md for registering a live localhost URL as this Discord app's (client id 1064354130778411068, from .env) Activity URL Mapping without interactive Discord Developer Portal access this session does not have; launching/joining the actual Discord Activity inside the Discord desktop client also requires native-app UI interaction (join a voice channel, launch the activity) that chrome-devtools/Playwright cannot drive (Discord is a separate Electron app, not a Chrome tab). Did not invent a screenshot or a pass claim, and did not file the Outcome-B proxy-gap issue -- no proxy failure was ever demonstrated, only an inability to reach the surface at all. Cleanup: stopped (not removed) the fresh `rpg-redis` container and `rpg-api-envoy-1` (both `docker stop`, safe to `docker start` again), killed the `AUTH_DEV_MODE=true go run ./cmd/server server` process and its `go run` child, and killed the `npm run dev` (vite) process I started -- left every pre-existing container (`rpg-redis-dev`, `rpg-nginx-local`, `rpg-api`, `dnd-api`, `dnd-database`, etc.) and the user's own Chrome/Discord instances untouched. Did NOT push, open a PR, post any GitHub comment, file any issue, or invoke the Sol gate -- those remain for the controller after the broad branch review, per this session's explicit mandate. Full narrative + all evidence paths: rpg-project's .git/sdd/task-3-report.md."
-    },
-    {
-      "id": "2026-07-22-001",
-      "task": "Final-review Minor fix: bump equipment.md frontmatter `updated:` to today",
-      "status": "completed",
-      "artifacts": ["docs/architecture/components/equipment.md"],
-      "commit": "2df59ca",
-      "notes": "Task-3 session (2026-07-21-003) noted the frontmatter `updated:` was already correct at commit time (2026-07-21); a subsequent final review ran on 2026-07-22 and flagged it as stale (Minor). Bumped `updated: 2026-07-21` -> `updated: 2026-07-22` only, no other content touched. `npm run format:check` clean. Committed alone as 'docs(equipment): bump frontmatter updated date (#576)'."
-    },
-    {
-      "id": "2026-07-22-002",
-      "task": "Remediate PR #578 GATE REVIEW findings (issue comment 5048770903): Copilot thread not addressed, evidence not attached to PR",
-      "status": "completed",
-      "artifacts": ["docs/evidence/item-icons-576-real-wire.png"],
-      "commit": "f98b63d",
-      "notes": "Finding 1 (Copilot thread, itemIcons.ts:28, databaseId 3631945211): replied in-thread via `POST .../pulls/578/comments/3631945211/replies` (reply databaseId 3632038296) explaining equipmentTypes.ts is a pure wire-shaped boundary module (not a component), resolveIconUrl reuse keeps one manifest-base implementation with no cycle, and this is a deliberate minimal-diff choice, not an oversight; resolved the thread via GraphQL `resolveReviewThread` (PRRT_kwDOPMk6PM6S_R8G), independently re-queried after to confirm `isResolved: true`. Finding 2 (evidence not attached): verified source (/tmp/opencode/task3-576-screenshots/step6-EQUIPMENT-POPOVER-REAL-WIRE.png, 1600x1000 PNG) and destination (docs/evidence/, existing tracked-evidence directory) parents first, copied (not moved) the file to docs/evidence/item-icons-576-real-wire.png, verified byte-identical via sha256, independently re-opened the copied file and confirmed it shows AC 18 (16 chain mail + 2 shield) header + Longsword/Shield/Chain Mail/Greatsword icons. Committed alone (f98b63d), ran a fresh `npm run ci-check` (all green) before pushing, pushed (pre-push hook re-ran ci-check, also green). Posted a signed '## LOCAL REAL-WIRE EVIDENCE' PR comment (issuecomment-5048820504) embedding the raw.githubusercontent URL pinned to the push commit (f98b63d6bc30cf59fad5bf478a623198be209bbf) plus a viewed-statement; independently curl'd the raw URL after posting (200, no redirect, image/png, content-length and sha256 byte-identical to the committed file) to confirm it actually renders. Did not touch itemIcons.ts/EquipmentSlots.tsx/InventoryLight.tsx -- both findings were process/traceability per the gate comment, no code change required. Did NOT invoke a gate recheck and did NOT merge, per this session's explicit mandate -- normal-pr-review flipped true in tests.json (Copilot comment now addressed+resolved); sol-gate stays false (independent reviewer has not yet re-verdicted after remediation)."
+      "commit": null,
+      "notes": "Verified protos#196 merge bb80c98 is represented by generated commit 0e4e2d7 in v0.1.113; API#695 is merged. TDD RED: three missing reducer cases and three missing stream-delivery cases failed as expected. GREEN: 252 focused tests and npm run ci-check pass."
     }
   ],
   "next_steps": [
-    "Both GATE REVIEW findings from issue comment 5048770903 are remediated (Copilot thread replied+resolved; evidence committed to docs/evidence/ and posted as a signed PR comment, independently link-verified). NOT done by this session, by mandate: an independent (non-implementer, fresh-worktree) Sol gate re-verdict confirming MERGE-READY, and any merge action. Task 3 Step 7 Discord Activity /.proxy verification remains BLOCKED (no tunnel/Activity-URL-Mapping access) -- Kirk has accepted the real-local-game-route evidence as sufficient, with /.proxy left as a post-deploy smoke test; do not reopen this unless a real proxy failure is demonstrated post-deploy (then file the separate Outcome-B issue). Do not merge rpg-project PR #111 until the web PR merges."
+    "Commit the dependency and state changes",
+    "Push and open a ready PR for #572",
+    "Acknowledge, address, and resolve every automated review comment"
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -1,72 +1,32 @@
 {
   "tests": [
     {
-      "id": "itemicons-utility-tests",
-      "feature": "item-icons-task1",
-      "prompt": "Run `npm run test:run -- src/utils/itemIcons.test.ts`. Verify all 21 tests pass: exhaustiveness (38 weapon ids, 13 armor ids, no overlap, 51 total ITEM_ICONS entries), entry validity (non-empty path, valid quality) for both ITEM_ICONS and SUPPLEMENTAL_ITEM_ICONS, and getItemIconUrl resolution across dedicated/approximate/generic tiers, wire-override precedence, supplemental ids, and the unknown-id -> undefined case.",
+      "id": "region-state-reducers",
+      "feature": "572-region-theme-state",
+      "prompt": "Run the focused useEncounterState tests. Verify multi-zone snapshot theme hydration, missing/unknown fallback, incremental Hex.zoneId retention, reconnect replacement, deterministic lookup, no topology inference, and prior-state non-mutation.",
       "passes": true,
-      "last_checked": "2026-07-21"
+      "last_checked": "2026-07-23"
     },
     {
-      "id": "itemicons-typecheck",
-      "feature": "item-icons-task1",
-      "prompt": "Run `npm run typecheck`. Verify it passes with no errors, confirming the `satisfies Record<CanonicalItemId, ItemIconEntry>` compile-time exhaustiveness check on CANONICAL_ITEM_ICONS holds (delete one canonical entry and rerun to confirm it fails loudly, then restore it). NOTE: `npm run typecheck` (plain `tsc --noEmit`) is a no-op in this repo -- root tsconfig.json has `files: []` with only project references and no `-b` flag, so it never actually checks referenced projects. Use `npx tsc -b --noEmit` (matches what `npm run build` runs) for the real check; confirmed it correctly fails on a deliberately-removed entry and passes clean on the actual file.",
+      "id": "region-stream-delivery",
+      "feature": "572-region-theme-state",
+      "prompt": "Run stream and EncounterView tests. Verify SnapshotDelivered replaces region truth and GeometryRevealed merges full Hex records without changing existing v2 stream/entity behavior.",
       "passes": true,
-      "last_checked": "2026-07-21"
-    },
-    {
-      "id": "equipmentslots-component-tests",
-      "feature": "item-icons-task2",
-      "prompt": "Run `npm run test:run -- src/components/game/equipment/EquipmentSlots.test.tsx`. Verify all tests pass, including the canonical-icon-resolves-with-empty-iconKey test and the unknown-id-skips-img test, using getItemIconUrl instead of resolveIconUrl at the component's icon call site.",
-      "passes": true,
-      "last_checked": "2026-07-21"
-    },
-    {
-      "id": "inventorylight-component-tests",
-      "feature": "item-icons-task2",
-      "prompt": "Run `npm run test:run -- src/components/game/equipment/InventoryLight.test.tsx`. Verify all tests pass, including the canonical-icon-resolves-for-a-carried-item test, using getItemIconUrl instead of resolveIconUrl at the component's icon call site.",
-      "passes": true,
-      "last_checked": "2026-07-21"
+      "last_checked": "2026-07-23"
     },
     {
       "id": "full-ci-check",
-      "feature": "item-icons-task3",
-      "prompt": "Run `npm run ci-check` from the worktree root. Verify format check, lint, typecheck, build, and the full test suite all pass with zero regressions outside the touched files.",
+      "feature": "572-region-theme-state",
+      "prompt": "Run npm run ci-check. Verify formatting, lint, typecheck, build, and the full test suite pass.",
       "passes": true,
-      "last_checked": "2026-07-21",
-      "notes": "Ran clean after the docs commit (9aecf63). Output: Format check passed, Lint check passed, Type check passed, Build passed (+ theme CSS carries the combat-HUD block), Tests passed, 'All CI checks passed! Safe to push.' Full log: /tmp/opencode/task3-576-screenshots/ci-check-output.log."
+      "last_checked": "2026-07-23"
     },
     {
-      "id": "equip-demo-local-route",
-      "feature": "item-icons-task3",
-      "prompt": "With rpg-api's local stack running (redis, envoy, AUTH_DEV_MODE=true server, devseed --fixture=equip-demo) and the web dev server started with the aldric .env.local, navigate to http://localhost:5173/?encounterId=dev-encounter&playerId=aldric, open the equipment popover, and confirm EquipmentSlots shows icons for the equipped longsword/shield/chain-mail and InventoryLight shows an icon for the carried greatsword -- all via the real wire path, not fixtures. Capture a screenshot as evidence.",
-      "passes": true,
-      "last_checked": "2026-07-21",
-      "notes": "PASSED, via a documented real-path substitution -- not the literal URL. This repo's dev server actually runs on port 3001 (vite.config.ts server.port, not the brief/prompt's assumed 5173). More importantly, the exact `?encounterId=dev-encounter&playerId=aldric` URL hard-gates into `PlaytestHarness` per src/App.tsx's showPlaytestHarness check (dev mode + encounterId param present, pre-existing app behavior unrelated to #576's diff) -- and PlaytestHarness.tsx has zero equipment-popover code (grepped, confirmed), so that literal URL structurally cannot show EquipmentSlots/InventoryLight in this codebase. Verified the same claim instead via the real, unmodified production path: http://localhost:3001/?playerId=aldric (no encounterId param, so the harness gate never fires) -> Home shows the 'Sir Aldric' card (same char-aldric devseed wrote -- confirmed via `grpcurl ... CharacterService/ListCharacters` showing equipmentSlots.mainHand=longsword/offHand=shield/armor=chain-mail and inventory including greatsword) -> Play -> Create lobby -> Ready up -> Start -> real EncounterView/EncounterDock -> clicked the 'Open equipment' chip. Result, server-computed: 'AC 18 (16 chain mail + 2 shield)' header; MAIN HAND Longsword icon, OFF HAND Shield icon, ARMOR Chain Mail icon all rendering in EquipmentSlots; CARRIED Greatsword icon rendering in InventoryLight. Screenshot: /tmp/opencode/task3-576-screenshots/step6-EQUIPMENT-POPOVER-REAL-WIRE.png (independently re-opened twice, content confirmed both times). Supporting flow screenshots step6a-step6i in the same directory. Full narrative: rpg-project's .git/sdd/task-3-report.md."
-    },
-    {
-      "id": "discord-activity-verification",
-      "feature": "item-icons-task3",
-      "prompt": "Launch the Discord Activity as done for prior verified work in this repo, open the equipment popover on a character with equipped canonical items, and confirm icons render through the /.proxy path. Capture a screenshot. If icons don't render here but do on the real local game route, file the separate proxy-gap issue per plan.md Task 3 Step 7 Outcome B instead of blocking this PR.",
+      "id": "automated-review",
+      "feature": "572-region-theme-state",
+      "prompt": "After opening the PR, acknowledge, address, and resolve every Copilot review thread individually.",
       "passes": false,
-      "last_checked": "2026-07-21",
-      "notes": "BLOCKED, not attempted-and-failed -- no proxy failure was demonstrated, so per the brief's own Outcome-B language this does NOT warrant filing the proxy-gap issue. Blocker: no tunnel (ngrok/cloudflared) was running to expose localhost to a public HTTPS URL; registering that URL as this Discord app's (client id 1064354130778411068, from .env) Activity URL Mapping requires interactive Discord Developer Portal access this session does not have; and even with a mapping in place, launching/joining the actual Activity requires native Discord-desktop-client UI interaction (join a voice channel, launch the activity) that chrome-devtools/Playwright cannot drive -- Discord is a separate Electron app, not a Chrome tab this session controls. docs/architecture/components/discord.md and docs/how-to/local-dev.md describe the auth/proxy mechanism but no reproducible local tunnel-registration process. Did not invent a screenshot or a pass/fail claim about proxy behavior."
-    },
-    {
-      "id": "normal-pr-review",
-      "feature": "item-icons-task3",
-      "prompt": "After opening the PR, verify every automated (Copilot) review comment has been acknowledged individually and addressed or replied to, per the repo's standing review process.",
-      "passes": true,
-      "last_checked": "2026-07-22",
-      "notes": "Copilot's sole inline comment (databaseId 3631945211, src/utils/itemIcons.ts:28, utils->components import-direction concern) replied to in-thread via `POST .../pulls/578/comments/3631945211/replies` (reply databaseId 3632038296: explains equipmentTypes.ts is a pure wire-shaped boundary module not a component, resolveIconUrl reuse avoids a duplicate resolver, no cycle exists, deliberate minimal-diff choice) and resolved via GraphQL `resolveReviewThread` (thread PRRT_kwDOPMk6PM6S_R8G) -- independently re-queried after the mutation and confirmed `isResolved: true`."
-    },
-    {
-      "id": "sol-gate",
-      "feature": "item-icons-task3",
-      "prompt": "Verify an independent reviewer (not this task's implementer, in a fresh worktree) reran the full suite, audited the 38/13 exhaustiveness and icon path claims against the actual file contents, independently opened and viewed each screenshot attached in the PR (not just the viewed-statements), and posted a GATE REVIEW comment of MERGE-READY (or that any findings were remediated and rechecked).",
-      "passes": false,
-      "last_checked": "2026-07-22",
-      "notes": "Kirk's GATE REVIEW comment (issue comment 5048770903, a473bc1) posted FINDINGS -- DO NOT MERGE with two process/traceability findings (unresolved Copilot thread; evidence not attached to PR). Both remediated this session (see normal-pr-review notes and the docs/evidence commit + LOCAL REAL-WIRE EVIDENCE PR comment), but the independent gate has NOT yet rechecked/re-verdicted after remediation -- this session was explicitly scoped to remediation only, not a gate recheck. Do not read this as MERGE-READY."
+      "last_checked": null
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.110",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.113",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1391,7 +1391,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#7212a2d922f36938a83f379f4ef8445795fe510b",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#0e4e2d77d73a27a24f4a01ada4a015e20d07db66",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.110",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.113",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/api/useEncounterStream.integration.test.tsx
+++ b/src/api/useEncounterStream.integration.test.tsx
@@ -43,8 +43,12 @@ afterEach(() => {
 function useTestHarness(encounterId: string) {
   const state = useEncounterState();
   useEncounterStream(encounterId, 'alice', {
-    onSnapshotDelivered: () => {
-      /* noop — payload empty in slice 1, just a sync barrier */
+    onSnapshotDelivered: (e) => {
+      state.applySnapshotRegionState(
+        e.encounter?.space?.theme ?? '',
+        e.encounter?.space?.zones ?? [],
+        e.encounter?.space?.hexes ?? []
+      );
     },
     onEntityMoved: (e) => {
       // rpg-dnd5e-web#542: mirrors EncounterView.tsx's real wiring — pass
@@ -59,10 +63,7 @@ function useTestHarness(encounterId: string) {
         );
     },
     onGeometryRevealed: (e) => {
-      const positions = e.hexes
-        .map((h) => h.position)
-        .filter((p): p is NonNullable<typeof p> => p !== undefined);
-      state.applyHexRevealed(positions.map(protoPositionToHex));
+      state.applyHexesRevealed(e.hexes);
     },
     onEntityAppeared: (e) => {
       if (!e.entity || !e.entity.position) return;
@@ -207,6 +208,69 @@ describe('useEncounterStream + useEncounterState — integration', () => {
       expect(
         result.current.revealedHexes.has(hexKey({ q: 6, r: -3, s: -3 }))
       ).toBe(true);
+    });
+  });
+
+  it('replaces snapshot region truth and merges incremental hex zone identity', async () => {
+    const { result } = renderHook(() => useTestHarness('enc-1'));
+
+    act(() =>
+      fake.push(
+        makeEvent('snapshotDelivered', {
+          encounter: {
+            space: {
+              theme: 'crypt',
+              zones: [
+                { id: 'entrance', name: 'Entrance', archetype: 'entrance' },
+                { id: 'chamber', name: 'Chamber', archetype: 'chamber' },
+              ],
+              hexes: [{ position: { x: 0, y: 0, z: 0 }, zoneId: 'entrance' }],
+            },
+          },
+        })
+      )
+    );
+    act(() =>
+      fake.push(
+        makeEvent('geometryRevealed', {
+          hexes: [{ position: { x: 1, y: -1, z: 0 }, zoneId: 'chamber' }],
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(result.current.theme).toBe('crypt');
+      expect(
+        result.current.revealedHexes.get(hexKey({ q: 0, r: 0, s: 0 }))?.zoneId
+      ).toBe('entrance');
+      expect(
+        result.current.revealedHexes.get(hexKey({ q: 1, r: -1, s: 0 }))?.zoneId
+      ).toBe('chamber');
+    });
+
+    act(() =>
+      fake.push(
+        makeEvent('snapshotDelivered', {
+          encounter: {
+            space: {
+              theme: 'cave',
+              zones: [{ id: 'boss', name: 'Boss', archetype: 'boss' }],
+              hexes: [{ position: { x: 2, y: -2, z: 0 }, zoneId: 'boss' }],
+            },
+          },
+        })
+      )
+    );
+
+    await waitFor(() => {
+      expect(result.current.theme).toBe('cave');
+      expect(result.current.zones.has('entrance')).toBe(false);
+      expect(
+        result.current.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))
+      ).toBe(false);
+      expect(
+        result.current.revealedHexes.get(hexKey({ q: 2, r: -2, s: 0 }))?.zoneId
+      ).toBe('boss');
     });
   });
 

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -263,6 +263,11 @@ export function EncounterView({
           e.encounter.mode,
           e.encounter.turnState
         );
+        encounterState.applySnapshotRegionState(
+          e.encounter.space?.theme ?? '',
+          e.encounter.space?.zones ?? [],
+          e.encounter.space?.hexes ?? []
+        );
         const entityEntries = (e.encounter.space?.entities ?? [])
           .filter((entity) => entity.position !== undefined)
           .map((entity) => ({
@@ -339,10 +344,7 @@ export function EncounterView({
       }
     },
     onGeometryRevealed: (e) => {
-      const positions = e.hexes
-        .map((h) => h.position)
-        .filter((p): p is NonNullable<typeof p> => p !== undefined);
-      encounterState.applyHexRevealed(positions.map(protoPositionToHex));
+      encounterState.applyHexesRevealed(e.hexes);
       const walls = e.walls ?? [];
       if (walls.length > 0) {
         encounterState.applyWallsRevealed(walls);
@@ -813,7 +815,7 @@ export function EncounterView({
         <EncounterMap
           entities={encounterState.state.entities}
           entityMeta={encounterState.state.entityMeta}
-          revealedHexes={encounterState.state.revealedHexes}
+          revealedHexes={encounterState.state.revealedHexKeys}
           walls={encounterState.state.walls}
           entityHP={encounterState.state.entityHP}
           entityStatuses={encounterState.state.entityStatuses}

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -202,6 +202,11 @@ export function PlaytestHarness() {
             e.encounter.mode,
             e.encounter.turnState
           );
+          encounterState.applySnapshotRegionState(
+            e.encounter.space?.theme ?? '',
+            e.encounter.space?.zones ?? [],
+            e.encounter.space?.hexes ?? []
+          );
           // Seed entities from the snapshot's space entities list in a single
           // batch setState call to avoid N intermediate renders for N entities.
           const entityEntries = (e.encounter.space?.entities ?? [])
@@ -260,15 +265,12 @@ export function PlaytestHarness() {
         addLog(`EntityMoved ${e.entityId} → ${pos}`);
       },
       onGeometryRevealed: (e) => {
-        const positions = e.hexes
-          .map((h) => h.position)
-          .filter((p): p is NonNullable<typeof p> => p !== undefined);
-        encounterState.applyHexRevealed(positions.map(protoPositionToHex));
+        encounterState.applyHexesRevealed(e.hexes);
         const walls = e.walls ?? [];
         if (walls.length > 0) {
           encounterState.applyWallsRevealed(walls);
         }
-        addLog(`GeometryRevealed ${positions.length} hex(es)`);
+        addLog(`GeometryRevealed ${e.hexes.length} hex(es)`);
       },
       onEntityAppeared: (e) => {
         if (!e.entity || !e.entity.position) return;
@@ -662,7 +664,7 @@ export function PlaytestHarness() {
   };
 
   const entitiesArray = Array.from(encounterState.state.entities.entries());
-  const revealedKeys = Array.from(encounterState.state.revealedHexes);
+  const revealedKeys = Array.from(encounterState.state.revealedHexKeys);
   const openDoorKeys = Array.from(encounterState.state.openDoors);
   const myHP = encounterState.state.entityHP.get(entityId);
   const myStatuses = encounterState.state.entityStatuses.get(entityId) ?? [];
@@ -1094,7 +1096,7 @@ export function PlaytestHarness() {
           <PlaytestMap
             entities={encounterState.state.entities}
             entityMeta={encounterState.state.entityMeta}
-            revealedHexes={encounterState.state.revealedHexes}
+            revealedHexes={encounterState.state.revealedHexKeys}
             walls={encounterState.state.walls}
             entityHP={encounterState.state.entityHP}
             entityStatuses={encounterState.state.entityStatuses}

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -17,7 +17,10 @@ import { useInteract } from '../../api/useInteract';
 import { useMoveEntity } from '../../api/useMoveEntity';
 import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useTakeAction } from '../../api/useTakeAction';
-import { useEncounterState } from '../../hooks/useEncounterState';
+import {
+  hexesWithPosition,
+  useEncounterState,
+} from '../../hooks/useEncounterState';
 import { errorMessage, formatSourceRefs } from '../../utils/combatFormat';
 import { getConditionDisplay } from '../../utils/conditionIcons';
 import { protoPositionToHex } from '../../utils/hexCoord';
@@ -265,12 +268,13 @@ export function PlaytestHarness() {
         addLog(`EntityMoved ${e.entityId} → ${pos}`);
       },
       onGeometryRevealed: (e) => {
-        encounterState.applyHexesRevealed(e.hexes);
+        const revealedHexes = hexesWithPosition(e.hexes);
+        encounterState.applyHexesRevealed(revealedHexes);
         const walls = e.walls ?? [];
         if (walls.length > 0) {
           encounterState.applyWallsRevealed(walls);
         }
-        addLog(`GeometryRevealed ${e.hexes.length} hex(es)`);
+        addLog(`GeometryRevealed ${revealedHexes.length} hex(es)`);
       },
       onEntityAppeared: (e) => {
         if (!e.entity || !e.entity.position) return;

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -72,6 +72,7 @@ import {
   applyTurnStateChanged,
   applyWallsRevealed,
   createEmptyEncounterState,
+  hexesWithPosition,
   mergeEntityPosition,
   regionForHex,
   setPendingPromptReducer,
@@ -477,6 +478,13 @@ describe('v1alpha2 reducer additions', () => {
   });
 
   describe('applyHexesRevealed', () => {
+    it('filters malformed hexes before they reach reveal merges or harness logs', () => {
+      const positioned = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
+      const malformed = create(HexSchema, { zoneId: 'chamber' });
+
+      expect(hexesWithPosition([positioned, malformed])).toEqual([positioned]);
+    });
+
     it('adds hexes to revealedHexes without dropping existing reveals', () => {
       const prev = createEmptyEncounterState();
       const after1 = applyHexesRevealed(prev, [
@@ -499,6 +507,33 @@ describe('v1alpha2 reducer additions', () => {
       const after = applyHexesRevealed(prev, [hex]);
       expect(after.revealedHexes.size).toBe(1);
       expect(after).toBe(prev);
+    });
+
+    it('keeps reveal-key identity for metadata-only updates and replaces it for new coordinates', () => {
+      const entrance = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
+      const seeded = applyHexesRevealed(createEmptyEncounterState(), [
+        entrance,
+      ]);
+      const originalMap = seeded.revealedHexes;
+      const originalKeys = seeded.revealedHexKeys;
+      const chamber = makeTestHex({ x: 0, y: 0, z: 0 }, 'chamber');
+
+      const metadataUpdated = applyHexesRevealed(seeded, [chamber]);
+
+      expect(metadataUpdated.revealedHexes).not.toBe(originalMap);
+      expect(metadataUpdated.revealedHexes.get('0,0,0')).toBe(chamber);
+      expect(metadataUpdated.revealedHexKeys).toBe(originalKeys);
+      expect(seeded.revealedHexes.get('0,0,0')).toBe(entrance);
+
+      const withNewCoordinate = applyHexesRevealed(metadataUpdated, [
+        makeTestHex({ x: 1, y: -1, z: 0 }, 'corridor'),
+      ]);
+
+      expect(withNewCoordinate.revealedHexKeys).not.toBe(originalKeys);
+      expect(withNewCoordinate.revealedHexKeys).toEqual(
+        new Set(['0,0,0', '1,-1,0'])
+      );
+      expect(metadataUpdated.revealedHexKeys).toBe(originalKeys);
     });
   });
 

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -33,6 +33,7 @@ import {
   EconomySlot,
   EncounterMode,
   EntityType,
+  HexSchema,
   InputRequiredSchema,
   SkillCheckPromptSchema,
   type StatusEffect,
@@ -42,6 +43,7 @@ import {
   type Wall,
   WallKind,
   WallSchema,
+  ZoneSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
 import { hexKey } from '../utils/hexCoord';
@@ -58,9 +60,10 @@ import {
   applyEntityDisappeared,
   applyEntityMetaFromAppeared,
   applyEntityRemoved,
-  applyHexRevealed,
+  applyHexesRevealed,
   applyInitiativeRolled,
   applyModeChanged,
+  applySnapshotRegionState,
   applySnapshotTurnState,
   applyStatusApplied,
   applyStatusRemoved,
@@ -70,6 +73,7 @@ import {
   applyWallsRevealed,
   createEmptyEncounterState,
   mergeEntityPosition,
+  regionForHex,
   setPendingPromptReducer,
   setReactionReadyLocalReducer,
 } from './useEncounterState';
@@ -116,6 +120,20 @@ function makeTestWall(
   });
 }
 
+function makeTestHex(
+  position: { x: number; y: number; z: number },
+  zoneId = ''
+) {
+  return create(HexSchema, {
+    position: create(V2PositionSchema, position),
+    zoneId,
+  });
+}
+
+function makeTestZone(id: string, archetype = '') {
+  return create(ZoneSchema, { id, name: id, archetype });
+}
+
 describe('createEmptyEncounterState', () => {
   it('returns empty state with Maps and default values', () => {
     const state = createEmptyEncounterState();
@@ -124,8 +142,10 @@ describe('createEmptyEncounterState', () => {
     expect(state.dungeonId).toBe('');
     expect(state.entities).toBeInstanceOf(Map);
     expect(state.entities.size).toBe(0);
-    expect(state.revealedHexes).toBeInstanceOf(Set);
+    expect(state.revealedHexes).toBeInstanceOf(Map);
     expect(state.revealedHexes.size).toBe(0);
+    expect(state.revealedHexKeys).toBeInstanceOf(Set);
+    expect(state.revealedHexKeys.size).toBe(0);
     expect(state.walls).toBeInstanceOf(Map);
     expect(state.walls.size).toBe(0);
     expect(state.openDoors).toBeInstanceOf(Set);
@@ -378,13 +398,95 @@ function makeInitiativeRolled(order: string[]): InitiativeRolled {
 // ---------------------------------------------------------------------------
 
 describe('v1alpha2 reducer additions', () => {
-  describe('applyHexRevealed', () => {
+  describe('region identity', () => {
+    it('replaces snapshot region truth and looks up a hex zone by coordinate', () => {
+      const entrance = makeTestZone('entrance', 'entrance');
+      const chamber = makeTestZone('chamber', 'chamber');
+      const entranceHex = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
+      const chamberHex = makeTestHex({ x: 1, y: -1, z: 0 }, 'chamber');
+      const before = createEmptyEncounterState();
+      const snapshot = applySnapshotRegionState(
+        before,
+        'crypt',
+        [entrance, chamber],
+        [entranceHex, chamberHex]
+      );
+
+      expect(snapshot.theme).toBe('crypt');
+      expect(snapshot.zones.get('entrance')).toBe(entrance);
+      expect(snapshot.revealedHexes.get('1,-1,0')).toBe(chamberHex);
+      expect(regionForHex(snapshot, { q: 1, r: -1, s: 0 })).toEqual({
+        theme: 'crypt',
+        zone: chamber,
+      });
+      expect(before.zones.size).toBe(0);
+      expect(before.revealedHexes.size).toBe(0);
+    });
+
+    it('merges incremental hex identity and replaces it only on the next snapshot', () => {
+      const entrance = makeTestZone('entrance', 'entrance');
+      const chamber = makeTestZone('chamber', 'chamber');
+      const entranceHex = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
+      const chamberHex = makeTestHex({ x: 1, y: -1, z: 0 }, 'chamber');
+      const seeded = applySnapshotRegionState(
+        createEmptyEncounterState(),
+        'crypt',
+        [entrance, chamber],
+        [entranceHex]
+      );
+      const revealed = applyHexesRevealed(seeded, [chamberHex]);
+      const replacement = applySnapshotRegionState(
+        revealed,
+        'cave',
+        [chamber],
+        [chamberHex]
+      );
+
+      expect(revealed.revealedHexes.get('0,0,0')).toBe(entranceHex);
+      expect(revealed.revealedHexes.get('1,-1,0')).toBe(chamberHex);
+      expect(seeded.revealedHexes.has('1,-1,0')).toBe(false);
+      expect(replacement.theme).toBe('cave');
+      expect(replacement.revealedHexes.has('0,0,0')).toBe(false);
+      expect(replacement.zones.has('entrance')).toBe(false);
+    });
+
+    it('returns only server metadata for missing and unknown zone data', () => {
+      const unknown = makeTestZone('unknown', 'scrying-room');
+      const unknownHex = makeTestHex({ x: 2, y: -1, z: -1 }, 'unknown');
+      const unzonedHex = makeTestHex({ x: 3, y: -2, z: -1 });
+      const state = applySnapshotRegionState(
+        createEmptyEncounterState(),
+        '',
+        [unknown],
+        [unknownHex, unzonedHex]
+      );
+
+      expect(regionForHex(state, { q: 2, r: -1, s: -1 })).toEqual({
+        theme: undefined,
+        zone: unknown,
+      });
+      expect(regionForHex(state, { q: 3, r: -2, s: -1 })).toEqual({
+        theme: undefined,
+        zone: undefined,
+      });
+      expect(regionForHex(state, { q: 99, r: -99, s: 0 })).toEqual({
+        theme: undefined,
+        zone: undefined,
+      });
+    });
+  });
+
+  describe('applyHexesRevealed', () => {
     it('adds hexes to revealedHexes without dropping existing reveals', () => {
       const prev = createEmptyEncounterState();
-      const after1 = applyHexRevealed(prev, [{ q: 0, r: 0, s: 0 }]);
+      const after1 = applyHexesRevealed(prev, [
+        makeTestHex({ x: 0, y: 0, z: 0 }),
+      ]);
       expect(after1.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))).toBe(true);
 
-      const after2 = applyHexRevealed(after1, [{ q: 1, r: -1, s: 0 }]);
+      const after2 = applyHexesRevealed(after1, [
+        makeTestHex({ x: 1, y: -1, z: 0 }),
+      ]);
       expect(after2.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))).toBe(true);
       expect(after2.revealedHexes.has(hexKey({ q: 1, r: -1, s: 0 }))).toBe(
         true
@@ -392,11 +494,11 @@ describe('v1alpha2 reducer additions', () => {
     });
 
     it('is idempotent on duplicate hexes', () => {
-      const prev = applyHexRevealed(createEmptyEncounterState(), [
-        { q: 2, r: -1, s: -1 },
-      ]);
-      const after = applyHexRevealed(prev, [{ q: 2, r: -1, s: -1 }]);
+      const hex = makeTestHex({ x: 2, y: -1, z: -1 }, 'chamber');
+      const prev = applyHexesRevealed(createEmptyEncounterState(), [hex]);
+      const after = applyHexesRevealed(prev, [hex]);
       expect(after.revealedHexes.size).toBe(1);
+      expect(after).toBe(prev);
     });
   });
 
@@ -567,9 +669,9 @@ describe('v1alpha2 reducer additions', () => {
     it('does not touch revealedHexes (cause/effect split)', () => {
       // The toolkit emits DoorOpened (cause) and GeometryRevealed (effect)
       // as two events. applyDoorOpened only updates door state; the hex
-      // reveal flows through applyHexRevealed independently.
+      // reveal flows through applyHexesRevealed independently.
       let state = createEmptyEncounterState();
-      state = applyHexRevealed(state, [{ q: 1, r: -1, s: 0 }]);
+      state = applyHexesRevealed(state, [makeTestHex({ x: 1, y: -1, z: 0 })]);
       const beforeOpen = state.revealedHexes;
       state = applyDoorOpened(state, 'door-east');
       expect(state.revealedHexes).toBe(beforeOpen);

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -31,10 +31,12 @@ import type {
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import type {
+  Hex,
   InputRequired,
   StatusEffect,
   TurnState,
   Wall,
+  Zone,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
@@ -48,7 +50,11 @@ import type {
   ItemLike,
   SlotDefLike,
 } from '../components/game/equipment/equipmentTypes';
-import { hexKey, type CubeHexCoord } from '../utils/hexCoord';
+import {
+  hexKey,
+  protoPositionToHex,
+  type CubeHexCoord,
+} from '../utils/hexCoord';
 import { wallKey } from './dungeonMapGeometry';
 
 /** v1alpha2 per-entity HP, populated from EntityDamaged.hp_after. */
@@ -151,8 +157,14 @@ export interface LocalEncounterState {
     string,
     EntityState & { ghost?: boolean; movePath?: Position[]; moveSeq?: number }
   >;
-  /** v1alpha2-revealed hexes (per-hex granularity). */
-  revealedHexes: Set<string>;
+  /** v1alpha2-revealed hexes, keyed by stable cube coordinate. */
+  revealedHexes: Map<string, Hex>;
+  /** Compatibility projection for existing undifferentiated floor consumers. */
+  revealedHexKeys: Set<string>;
+  /** Server-authored dungeon-wide visual family, absent when unspecified. */
+  theme: string | undefined;
+  /** Server-authored zones keyed by their stable wire ID. */
+  zones: Map<string, Zone>;
   /**
    * v1alpha2 revealed walls, keyed by `wallKey` (canonical, direction-
    * normalized). Sticky like `revealedHexes` — populated from the
@@ -301,7 +313,10 @@ export function createEmptyEncounterState(): LocalEncounterState {
     encounterId: '',
     dungeonId: '',
     entities: new Map(),
-    revealedHexes: new Set(),
+    revealedHexes: new Map(),
+    revealedHexKeys: new Set(),
+    theme: undefined,
+    zones: new Map(),
     walls: new Map(),
     openDoors: new Set(),
     entityHP: new Map(),
@@ -368,20 +383,73 @@ export function mergeEntityPosition(
 }
 
 /**
- * Add hexes to the per-hex reveal set without dropping previously revealed hexes.
- * Uses hexKey() for stable 'q,r,s' string keys. Idempotent — re-adding an
- * already-revealed hex is a no-op (Set semantics).
+ * Replace region metadata from the server's snapshot. A reconnect snapshot is
+ * authoritative, so omitted theme/zones/hexes clear stale local values.
  * Exported for testing.
  */
-export function applyHexRevealed(
+export function applySnapshotRegionState(
   prev: LocalEncounterState,
-  hexes: CubeHexCoord[]
+  theme: string,
+  zones: Zone[],
+  hexes: Hex[]
 ): LocalEncounterState {
-  const next = new Set(prev.revealedHexes);
-  for (const h of hexes) {
-    next.add(hexKey(h));
+  const revealedHexes = new Map<string, Hex>();
+  for (const hex of hexes) {
+    if (!hex.position) continue;
+    revealedHexes.set(hexKey(protoPositionToHex(hex.position)), hex);
   }
-  return { ...prev, revealedHexes: next };
+  return {
+    ...prev,
+    theme: theme || undefined,
+    zones: new Map(zones.map((zone) => [zone.id, zone])),
+    revealedHexes,
+    revealedHexKeys: new Set(revealedHexes.keys()),
+  };
+}
+
+/**
+ * Merge newly revealed wire hexes without dropping previously revealed zone
+ * identity. A malformed incremental record with no zone ID cannot erase an
+ * existing record for that coordinate; the next snapshot remains the explicit
+ * server-authoritative replacement boundary.
+ * Exported for testing.
+ */
+export function applyHexesRevealed(
+  prev: LocalEncounterState,
+  hexes: Hex[]
+): LocalEncounterState {
+  let revealedHexes: Map<string, Hex> | undefined;
+  for (const hex of hexes) {
+    if (!hex.position) continue;
+    const key = hexKey(protoPositionToHex(hex.position));
+    const existing = (revealedHexes ?? prev.revealedHexes).get(key);
+    const next = !hex.zoneId && existing ? existing : hex;
+    if (existing === next) continue;
+    if (!revealedHexes) revealedHexes = new Map(prev.revealedHexes);
+    revealedHexes.set(key, next);
+  }
+  if (!revealedHexes) return prev;
+  return {
+    ...prev,
+    revealedHexes,
+    revealedHexKeys: new Set(revealedHexes.keys()),
+  };
+}
+
+/**
+ * Return only wire-authored metadata for a render coordinate. Unknown zone
+ * IDs and absent fields deliberately remain undefined; renderers choose their
+ * existing undifferentiated fallback without client-side inference.
+ */
+export function regionForHex(
+  state: LocalEncounterState,
+  coord: CubeHexCoord
+): { theme: string | undefined; zone: Zone | undefined } {
+  const hex = state.revealedHexes.get(hexKey(coord));
+  return {
+    theme: state.theme,
+    zone: hex?.zoneId ? state.zones.get(hex.zoneId) : undefined,
+  };
 }
 
 /**
@@ -721,9 +789,9 @@ export function applyEntityDisappeared(
  * same DOOR_OPEN entry; whichever arrives first wins, the second is a
  * same-kind no-op).
  *
- * Does not touch the per-hex revealedHexes set; the toolkit emits a parallel
+ * Does not touch the per-hex revealedHexes map; the toolkit emits a parallel
  * GeometryRevealed event for the newly-visible cells (cause/effect split),
- * which the existing applyHexRevealed reducer handles.
+ * which the applyHexesRevealed reducer handles.
  * Exported for testing.
  */
 export function applyDoorOpened(
@@ -1121,8 +1189,14 @@ export interface UseEncounterStateResult {
   /** Reset to empty state (new encounter or disconnect) */
   reset: () => void;
   // v1alpha2 additions
-  /** Add hexes to the per-hex reveal set (additive, idempotent) */
-  applyHexRevealed: (hexes: CubeHexCoord[]) => void;
+  /** Replace theme, zones, and revealed hexes from an authoritative snapshot. */
+  applySnapshotRegionState: (
+    theme: string,
+    zones: Zone[],
+    hexes: Hex[]
+  ) => void;
+  /** Merge newly revealed wire hexes (additive, identity-preserving). */
+  applyHexesRevealed: (hexes: Hex[]) => void;
   /** Add walls to the sticky wall map, keyed by `wallKey` (additive, idempotent) */
   applyWallsRevealed: (walls: Wall[]) => void;
   /** Add or revive an entity at its first-visible position, clearing ghost */
@@ -1271,8 +1345,15 @@ export function useEncounterState(): UseEncounterStateResult {
     setState(createEmptyEncounterState());
   }, []);
 
-  const applyHexRevealedCallback = useCallback((hexes: CubeHexCoord[]) => {
-    setState((prev) => applyHexRevealed(prev, hexes));
+  const applySnapshotRegionStateCallback = useCallback(
+    (theme: string, zones: Zone[], hexes: Hex[]) => {
+      setState((prev) => applySnapshotRegionState(prev, theme, zones, hexes));
+    },
+    []
+  );
+
+  const applyHexesRevealedCallback = useCallback((hexes: Hex[]) => {
+    setState((prev) => applyHexesRevealed(prev, hexes));
   }, []);
 
   const applyWallsRevealedCallback = useCallback((walls: Wall[]) => {
@@ -1430,7 +1511,8 @@ export function useEncounterState(): UseEncounterStateResult {
     state,
     applyEntityPositionUpdate,
     reset,
-    applyHexRevealed: applyHexRevealedCallback,
+    applySnapshotRegionState: applySnapshotRegionStateCallback,
+    applyHexesRevealed: applyHexesRevealedCallback,
     applyWallsRevealed: applyWallsRevealedCallback,
     applyEntityAppeared: applyEntityAppearedCallback,
     applyEntityDisappeared: applyEntityDisappearedCallback,

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -383,6 +383,19 @@ export function mergeEntityPosition(
 }
 
 /**
+ * Return only hexes eligible for coordinate-keyed reveal state. The shared
+ * filter keeps stream reducers and harness diagnostics consistent.
+ */
+export function hexesWithPosition(
+  hexes: Hex[]
+): Array<Hex & { position: NonNullable<Hex['position']> }> {
+  return hexes.filter(
+    (hex): hex is Hex & { position: NonNullable<Hex['position']> } =>
+      hex.position !== undefined
+  );
+}
+
+/**
  * Replace region metadata from the server's snapshot. A reconnect snapshot is
  * authoritative, so omitted theme/zones/hexes clear stale local values.
  * Exported for testing.
@@ -394,8 +407,7 @@ export function applySnapshotRegionState(
   hexes: Hex[]
 ): LocalEncounterState {
   const revealedHexes = new Map<string, Hex>();
-  for (const hex of hexes) {
-    if (!hex.position) continue;
+  for (const hex of hexesWithPosition(hexes)) {
     revealedHexes.set(hexKey(protoPositionToHex(hex.position)), hex);
   }
   return {
@@ -419,20 +431,24 @@ export function applyHexesRevealed(
   hexes: Hex[]
 ): LocalEncounterState {
   let revealedHexes: Map<string, Hex> | undefined;
-  for (const hex of hexes) {
-    if (!hex.position) continue;
+  let revealedHexKeys: Set<string> | undefined;
+  for (const hex of hexesWithPosition(hexes)) {
     const key = hexKey(protoPositionToHex(hex.position));
     const existing = (revealedHexes ?? prev.revealedHexes).get(key);
     const next = !hex.zoneId && existing ? existing : hex;
     if (existing === next) continue;
     if (!revealedHexes) revealedHexes = new Map(prev.revealedHexes);
     revealedHexes.set(key, next);
+    if (!existing) {
+      if (!revealedHexKeys) revealedHexKeys = new Set(prev.revealedHexKeys);
+      revealedHexKeys.add(key);
+    }
   }
   if (!revealedHexes) return prev;
   return {
     ...prev,
     revealedHexes,
-    revealedHexKeys: new Set(revealedHexes.keys()),
+    revealedHexKeys: revealedHexKeys ?? prev.revealedHexKeys,
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #572.

- Updates `@kirkdiggler/rpg-api-protos` to `v0.1.113`, whose generated commit `0e4e2d7` descends from merged protos #196 (`bb80c98`) and exposes `Space.theme`, `Space.zones`, `Zone.archetype`, and `Hex.zoneId`.
- Confirms API #695 is merged, then projects those server-owned fields into canonical encounter state: `theme`, zones by ID, and full revealed `Hex` records by cube key.
- Snapshot delivery replaces region truth for reconnect/resync; `GeometryRevealed` merges full `Hex` records without dropping existing zone identity. `regionForHex()` is the deterministic #577 render seam.
- Keeps existing floor consumers on a compatibility `revealedHexKeys` projection. No topology inference, flood-fill, defaults, or crypt/rendering/UI changes.

## Verification

- RED: reducer tests failed for missing snapshot/lookup APIs; stream integration failed for absent snapshot and incremental projection.
- GREEN: focused reducers/stream/component tests: 252 passing.
- Review follow-up RED/GREEN: metadata-only Hex updates now preserve the compatibility Set reference while immutable maps update; new coordinate keys replace the Set reference. Shared valid-position filtering keeps malformed Hex records out of both reducer state and harness logs.
- `npm run ci-check` passed before and during push: format, lint, typecheck, build, and full tests.
- No generated files were edited manually.

No browser claim: this is a state-only seam and the existing fixture/dev route does not provide server region metadata to render.

— platform agent, on behalf of KirkDiggler