### PR TITLE
feat(map): render locked doors

### DIFF
--- a/.claude/progress.json
+++ b/.claude/progress.json
@@ -1,7 +1,7 @@
 {
-  "branch": "feat/572-region-theme-state",
-  "issues": ["#572"],
-  "goal": "Retain server-authored Space.theme, Space.zones, and Hex.zoneId in canonical encounter state without topology inference, and expose a deterministic render lookup seam for #577.",
+  "branch": "feat/573-locked-door-compatibility",
+  "issues": ["#572", "#573"],
+  "goal": "Render WALL_KIND_DOOR_LOCKED as a distinct, interactive door while preserving the wire-designated edge and Wall.id -> Interact intent bridge. No client-side lock rules.",
   "sessions": [
     {
       "id": "2026-07-23-001",
@@ -18,11 +18,27 @@
       ],
       "commit": null,
       "notes": "Verified protos#196 merge bb80c98 is represented by generated commit 0e4e2d7 in v0.1.113; API#695 is merged. TDD RED: three missing reducer cases and three missing stream-delivery cases failed as expected. GREEN: 252 focused tests and npm run ci-check pass."
+    },
+    {
+      "id": "2026-07-23-002",
+      "task": "Locked-door rendering compatibility (#573)",
+      "status": "in_progress",
+      "artifacts": [
+        "package.json",
+        "package-lock.json",
+        "src/components/hex-grid/syntyHexWallHelpers.ts",
+        "src/components/hex-grid/SyntyHexWall.tsx",
+        "src/components/hex-grid/ShadedHexWall.tsx",
+        "src/components/hex-grid/HexGrid.tsx",
+        "src/hooks/dungeonMapGeometry.ts"
+      ],
+      "commit": null,
+      "notes": "Verified published proto floor v0.1.113 (commit 0e4e2d77d73a27a24f4a01ada4a015e20d07db66), then installed it with npm. RED: locked-door recognition, designated-edge/id, and geometry tests failed. GREEN: shared isDoorWallKind applies across Synty, fallback, and geometry; Synty click test forwards Wall.id; locked material is distinct. Mutation: removing locked from the classifier failed five assertions. Pending full CI and visual-harness assessment; no real locked fixture exists on origin/main and rpg-api#703 is not merged."
     }
   ],
   "next_steps": [
-    "Commit the dependency and state changes",
-    "Push and open a ready PR for #572",
+    "Commit the locked-door dependency and renderer changes",
+    "Push and open a ready PR for #573 with rpg-api#703 sequencing",
     "Acknowledge, address, and resolve every automated review comment"
   ]
 }

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -3,10 +3,10 @@
     {
       "id": "locked-door-573-focused",
       "feature": "locked-door-573",
-      "prompt": "Run `npm run test:run -- src/components/hex-grid/syntyHexWallHelpers.test.ts src/components/hex-grid/SyntyHexWall.test.tsx src/hooks/dungeonMapGeometry.test.ts`. Verify a locked door is classified as a door, keeps its designated edge and Wall.id, forwards its click to onDoorClick, uses a distinct visual state, remains blocked until open, and does not make solid walls interactive.",
+      "prompt": "Run `npm run test:run -- src/components/hex-grid/SyntyHexWall.test.tsx src/components/hex-grid/ShadedHexWall.test.tsx src/components/hex-grid/HexGrid.movement.test.ts src/components/hex-grid/syntyHexWallHelpers.test.ts src/hooks/dungeonMapGeometry.test.ts`. Verify R3F hit targets forward locked Wall.id in both renderers, locked tint/color is observable, solid walls have no hit target, and HexGrid's actual A* blocker rejects closed/locked while allowing open doors.",
       "passes": true,
       "last_checked": "2026-07-23",
-      "notes": "RED: four geometry/identity assertions failed before the shared door classifier; visual-state RED followed. GREEN: 62 focused tests passed. Mutation: removing DOOR_LOCKED from isDoorWallKind caused five locked-door assertions to fail, including Synty click forwarding; restored classifier passed."
+      "notes": "Initial RED/GREEN covered geometry and click forwarding. Follow-up RED: fallback color assertion rejected the one-off literal; GREEN uses WallColors.stoneDark. Follow-up mutation: removing DOOR_LOCKED from HexGrid's runtime blocker made A* return the formerly blocked path; restored condition passes. 69 focused tests pass."
     },
     {
       "id": "region-state-reducers",

--- a/.claude/tests.json
+++ b/.claude/tests.json
@@ -1,6 +1,14 @@
 {
   "tests": [
     {
+      "id": "locked-door-573-focused",
+      "feature": "locked-door-573",
+      "prompt": "Run `npm run test:run -- src/components/hex-grid/syntyHexWallHelpers.test.ts src/components/hex-grid/SyntyHexWall.test.tsx src/hooks/dungeonMapGeometry.test.ts`. Verify a locked door is classified as a door, keeps its designated edge and Wall.id, forwards its click to onDoorClick, uses a distinct visual state, remains blocked until open, and does not make solid walls interactive.",
+      "passes": true,
+      "last_checked": "2026-07-23",
+      "notes": "RED: four geometry/identity assertions failed before the shared door classifier; visual-state RED followed. GREEN: 62 focused tests passed. Mutation: removing DOOR_LOCKED from isDoorWallKind caused five locked-door assertions to fail, including Synty click forwarding; restored classifier passed."
+    },
+    {
       "id": "region-state-reducers",
       "feature": "572-region-theme-state",
       "prompt": "Run the focused useEncounterState tests. Verify multi-zone snapshot theme hydration, missing/unknown fallback, incremental Hex.zoneId retention, reconnect replacement, deterministic lookup, no topology inference, and prior-state non-mutation.",

--- a/docs/architecture/components/hex-grid.md
+++ b/docs/architecture/components/hex-grid.md
@@ -1,7 +1,7 @@
 ---
 name: hex-grid components and utils
 description: HexGrid, HexTile, HexEntity, MediumHumanoid, hexUtils, hexMath — well-tested geometry, no rendering tests
-updated: 2026-05-02
+updated: 2026-07-23
 confidence: high — verified by reading hexUtils.ts, hexMath.ts, useMovementRange.ts, useHexInteraction.ts, and their test files
 ---
 
@@ -41,6 +41,15 @@ confidence: high — verified by reading hexUtils.ts, hexMath.ts, useMovementRan
 | `PathPreview.tsx`                          | A\* path line preview                                            |
 | `TurnOrderOverlay.tsx`                     | Initiative order numbers on entities                             |
 | `ShadedHexFloor.tsx`                       | Floor with shader-based shading                                  |
+
+## Door wall contract
+
+`DOOR_CLOSED`, `DOOR_OPEN`, and `DOOR_LOCKED` are all door geometry, not
+solid walls. Each uses the wire-designated `Wall.from -> Wall.to` edge and
+retains `Wall.id` for the existing click -> `Interact(id)` intent path. The
+client only renders the state: the server owns lock checks, prompts, retries,
+and unlock outcomes. Locked doors use a distinct material state in both the
+Synty and fallback renderers; only `DOOR_OPEN` is walkable.
 
 ## MediumHumanoid: no error boundary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.38.0",
+        "@react-three/test-renderer": "^9.1.0",
         "@tailwindcss/postcss": "^4.1.11",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2161,6 +2162,18 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-three/test-renderer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@react-three/test-renderer/-/test-renderer-9.1.0.tgz",
+      "integrity": "sha512-bLjG+cdpVW69wG1W3TuziHrHvA1JQbLesYddY94QMaFF8yzpgwovWK8hGaHWBET1dvsCPIOWVNYHbKAbRj2xSg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-three/fiber": ">=9.0.0",
+        "react": "^19.0.0",
+        "three": ">=0.156"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.38.0",
+    "@react-three/test-renderer": "^9.1.0",
     "@tailwindcss/postcss": "^4.1.11",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/src/components/hex-grid/HexGrid.movement.test.ts
+++ b/src/components/hex-grid/HexGrid.movement.test.ts
@@ -1,0 +1,37 @@
+import { doorHexKinds } from '@/hooks/dungeonMapGeometry';
+import { create } from '@bufbuild/protobuf';
+import {
+  WallKind,
+  WallSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { describe, expect, it } from 'vitest';
+import { isHexBlocked } from './HexGrid';
+import { findPath } from './hexMath';
+
+const start = { x: 0, y: 0, z: 0 };
+const door = { x: 1, y: -1, z: 0 };
+const destination = { x: 2, y: -2, z: 0 };
+
+function pathForDoor(kind: WallKind) {
+  const walls = [
+    create(WallSchema, { from: door, to: destination, kind, id: 'boss-door' }),
+  ];
+  const floorTiles = new Set(['0,0,0', '1,-1,0', '2,-2,0']);
+  const doorKinds = doorHexKinds(walls);
+  return findPath(start, destination, (coord) =>
+    isHexBlocked(coord, floorTiles, [], undefined, doorKinds)
+  );
+}
+
+describe('HexGrid door movement boundary', () => {
+  it.each([WallKind.DOOR_CLOSED, WallKind.DOOR_LOCKED])(
+    '%s blocks A* traversal through the door hex',
+    (kind) => {
+      expect(pathForDoor(kind)).toEqual([]);
+    }
+  );
+
+  it('allows A* traversal through an open door hex outside revealed floor tiles', () => {
+    expect(pathForDoor(WallKind.DOOR_OPEN)).toEqual([start, door, destination]);
+  });
+});

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -364,7 +364,12 @@ function Scene({
     (coord: CubeCoord) => {
       const key = `${coord.x},${coord.y},${coord.z}`;
       const doorKind = doorKinds.get(key);
-      if (doorKind === WallKind.DOOR_CLOSED) return true;
+      if (
+        doorKind === WallKind.DOOR_CLOSED ||
+        doorKind === WallKind.DOOR_LOCKED
+      ) {
+        return true;
+      }
       if (doorKind !== WallKind.DOOR_OPEN && !floorTiles.has(key)) {
         return true;
       }

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -162,6 +162,31 @@ export interface HexGridProps {
 // Ground plane size - large enough to cover the entire grid with plenty of margin
 const GROUND_PLANE_SIZE = 200;
 
+// Scene consumes this exact helper; exporting it permits pathfinding coverage.
+// eslint-disable-next-line react-refresh/only-export-components
+export function isHexBlocked(
+  coord: CubeCoord,
+  floorTileKeys: Pick<ReadonlyMap<string, unknown>, 'has'>,
+  entities: HexGridProps['entities'],
+  currentEntityId: string | null | undefined,
+  doorKinds: ReadonlyMap<string, WallKind>
+): boolean {
+  const key = `${coord.x},${coord.y},${coord.z}`;
+  const doorKind = doorKinds.get(key);
+  if (doorKind === WallKind.DOOR_CLOSED || doorKind === WallKind.DOOR_LOCKED) {
+    return true;
+  }
+  if (doorKind !== WallKind.DOOR_OPEN && !floorTileKeys.has(key)) return true;
+  return entities.some(
+    (entity) =>
+      !entity.isDead &&
+      entity.position.x === coord.x &&
+      entity.position.y === coord.y &&
+      entity.position.z === coord.z &&
+      entity.entityId !== currentEntityId
+  );
+}
+
 /**
  * Scene component - renders inside the Canvas
  * Separated so we can use React Three Fiber hooks
@@ -361,27 +386,8 @@ function Scene({
   // floor tile.
   // Uses useCallback to ensure stable function reference for downstream memoization
   const isBlocked = useCallback(
-    (coord: CubeCoord) => {
-      const key = `${coord.x},${coord.y},${coord.z}`;
-      const doorKind = doorKinds.get(key);
-      if (
-        doorKind === WallKind.DOOR_CLOSED ||
-        doorKind === WallKind.DOOR_LOCKED
-      ) {
-        return true;
-      }
-      if (doorKind !== WallKind.DOOR_OPEN && !floorTiles.has(key)) {
-        return true;
-      }
-      return entities.some(
-        (entity) =>
-          !entity.isDead &&
-          entity.position.x === coord.x &&
-          entity.position.y === coord.y &&
-          entity.position.z === coord.z &&
-          entity.entityId !== currentEntityId
-      );
-    },
+    (coord: CubeCoord) =>
+      isHexBlocked(coord, floorTiles, entities, currentEntityId, doorKinds),
     [entities, currentEntityId, floorTiles, doorKinds]
   );
 

--- a/src/components/hex-grid/ShadedHexWall.test.tsx
+++ b/src/components/hex-grid/ShadedHexWall.test.tsx
@@ -1,0 +1,54 @@
+import { WallColors } from '@/rendering/WallBuilder';
+import {
+  WallKind,
+  type Wall,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import ReactThreeTestRenderer from '@react-three/test-renderer';
+import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+import { ShadedHexWall } from './ShadedHexWall';
+
+const context = { fillStyle: '', fillRect: vi.fn() };
+vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+  context as never
+);
+
+function wall(kind: WallKind, id = 'boss-door'): Wall {
+  return {
+    from: { x: 0, y: 0, z: 0 },
+    to: { x: 1, y: -1, z: 0 },
+    kind,
+    id,
+  } as Wall;
+}
+
+describe('ShadedHexWall R3F scene', () => {
+  it('renders a locked door hit target that forwards its exact Wall.id', async () => {
+    const onDoorClick = vi.fn();
+    const renderer = await ReactThreeTestRenderer.create(
+      <ShadedHexWall
+        wall={wall(WallKind.DOOR_LOCKED, 'locked-42')}
+        hexSize={1}
+        onDoorClick={onDoorClick}
+      />
+    );
+    const target = renderer.scene.find(
+      (node) => typeof node.props.onClick === 'function'
+    );
+    await renderer.fireEvent(target, 'click');
+    expect(onDoorClick).toHaveBeenCalledWith('locked-42');
+    const color = new THREE.Color(WallColors.stoneDark);
+    expect(context.fillStyle).toBe(
+      `rgb(${Math.floor(color.r * 255)}, ${Math.floor(color.g * 255)}, ${Math.floor(color.b * 255)})`
+    );
+  });
+
+  it('does not attach a hit target to a solid wall', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <ShadedHexWall wall={wall(WallKind.SOLID)} hexSize={1} />
+    );
+    expect(
+      renderer.scene.findAll((node) => typeof node.props.onClick === 'function')
+    ).toEqual([]);
+  });
+});

--- a/src/components/hex-grid/ShadedHexWall.tsx
+++ b/src/components/hex-grid/ShadedHexWall.tsx
@@ -20,6 +20,7 @@ import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { WallBuilder, WallColors } from '@/rendering/WallBuilder';
 
 import { cubeToWorld, getHexLine, type CubeCoord } from './hexMath';
+import { isDoorWallKind } from './syntyHexWallHelpers';
 
 export interface ShadedHexWallProps {
   wall: Wall;
@@ -40,6 +41,8 @@ function getKindColor(kind: WallKind): number {
   switch (kind) {
     case WallKind.DOOR_CLOSED:
       return WallColors.woodMedium;
+    case WallKind.DOOR_LOCKED:
+      return 0x4a3c35;
     case WallKind.DOOR_OPEN:
       return WallColors.woodLight;
     case WallKind.WINDOW:
@@ -75,8 +78,7 @@ export function ShadedHexWall({
     };
 
     const color = getKindColor(wall.kind);
-    const isDoor =
-      wall.kind === WallKind.DOOR_CLOSED || wall.kind === WallKind.DOOR_OPEN;
+    const isDoor = isDoorWallKind(wall.kind);
     const isRealPassageEdge =
       isDoor && !(start.x === end.x && start.y === end.y && start.z === end.z);
 
@@ -184,8 +186,7 @@ export function ShadedHexWall({
     };
   }, [wall, hexSize, invalidate]);
 
-  const isDoor =
-    wall.kind === WallKind.DOOR_CLOSED || wall.kind === WallKind.DOOR_OPEN;
+  const isDoor = isDoorWallKind(wall.kind);
 
   // Copilot review on #549: the click/hover handlers (and their
   // stopPropagation) must only attach for DOOR_* walls. A plain <group

--- a/src/components/hex-grid/ShadedHexWall.tsx
+++ b/src/components/hex-grid/ShadedHexWall.tsx
@@ -42,7 +42,7 @@ function getKindColor(kind: WallKind): number {
     case WallKind.DOOR_CLOSED:
       return WallColors.woodMedium;
     case WallKind.DOOR_LOCKED:
-      return 0x4a3c35;
+      return WallColors.stoneDark;
     case WallKind.DOOR_OPEN:
       return WallColors.woodLight;
     case WallKind.WINDOW:

--- a/src/components/hex-grid/SyntyHexWall.test.tsx
+++ b/src/components/hex-grid/SyntyHexWall.test.tsx
@@ -2,17 +2,24 @@ import {
   WallKind,
   type Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
-import { fireEvent, render } from '@testing-library/react';
+import ReactThreeTestRenderer from '@react-three/test-renderer';
+import * as THREE from 'three';
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('@react-three/drei', async () => {
-  const THREE = await import('three');
-  return { useGLTF: () => ({ scene: new THREE.Group() }) };
+vi.mock('@react-three/drei', () => {
+  const scene = new THREE.Group();
+  scene.add(
+    new THREE.Mesh(
+      new THREE.BoxGeometry(),
+      new THREE.MeshStandardMaterial({ color: 0xffffff })
+    )
+  );
+  return { useGLTF: () => ({ scene }) };
 });
 
 import { SyntyHexWall } from './SyntyHexWall';
 
-function wall(kind: WallKind, id?: string): Wall {
+function wall(kind: WallKind, id = 'boss-door'): Wall {
   return {
     from: { x: 0, y: 0, z: 0 },
     to: { x: 1, y: -1, z: 0 },
@@ -21,34 +28,60 @@ function wall(kind: WallKind, id?: string): Wall {
   } as Wall;
 }
 
-describe('SyntyHexWall', () => {
-  it('forwards a locked door click with its server-issued Wall.id', () => {
+describe('SyntyHexWall R3F scene', () => {
+  it('renders a tinted locked door hit target that forwards its exact Wall.id', async () => {
     const onDoorClick = vi.fn();
-    const { container } = render(
+    const renderer = await ReactThreeTestRenderer.create(
       <SyntyHexWall
-        walls={[wall(WallKind.DOOR_LOCKED, 'locked-door-1')]}
+        walls={[wall(WallKind.DOOR_LOCKED, 'locked-42')]}
         hexSize={1}
         onDoorClick={onDoorClick}
       />
     );
-
-    fireEvent.click(container.querySelector('group')!);
-
-    expect(onDoorClick).toHaveBeenCalledWith('locked-door-1');
+    const target = renderer.scene.find(
+      (node) => typeof node.props.onClick === 'function'
+    );
+    expect(target).toBeDefined();
+    await renderer.fireEvent(target, 'click');
+    expect(onDoorClick).toHaveBeenCalledWith('locked-42');
+    const tintedMeshes = renderer.scene.findAll((node) => {
+      const mesh = node.instance as THREE.Mesh;
+      return (
+        mesh instanceof THREE.Mesh &&
+        mesh.material instanceof THREE.MeshStandardMaterial
+      );
+    });
+    expect(
+      tintedMeshes.some((node) => {
+        const material = (node.instance as THREE.Mesh)
+          .material as THREE.MeshStandardMaterial;
+        return (
+          material.color.r < 0.5 &&
+          material.color.g < 0.5 &&
+          material.color.b < 0.5
+        );
+      })
+    ).toBe(true);
   });
 
-  it('does not attach the door interaction to a solid wall', () => {
-    const onDoorClick = vi.fn();
-    const { container } = render(
-      <SyntyHexWall
-        walls={[wall(WallKind.SOLID, 'not-a-door')]}
-        hexSize={1}
-        onDoorClick={onDoorClick}
-      />
+  it.each([WallKind.DOOR_CLOSED, WallKind.DOOR_OPEN])(
+    '%s preserves a door hit target',
+    async (kind) => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <SyntyHexWall walls={[wall(kind)]} hexSize={1} />
+      );
+      expect(
+        renderer.scene.find((node) => typeof node.props.onClick === 'function')
+      ).toBeDefined();
+    }
+  );
+
+  it('does not make a solid wall a door hit target', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <SyntyHexWall walls={[wall(WallKind.SOLID)]} hexSize={1} />
     );
-
-    fireEvent.click(container.querySelector('primitive')!);
-
-    expect(onDoorClick).not.toHaveBeenCalled();
+    expect(
+      renderer.scene.findAll((node) => typeof node.props.onClick === 'function')
+    ).toEqual([]);
   });
 });

--- a/src/components/hex-grid/SyntyHexWall.test.tsx
+++ b/src/components/hex-grid/SyntyHexWall.test.tsx
@@ -1,0 +1,54 @@
+import {
+  WallKind,
+  type Wall,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@react-three/drei', async () => {
+  const THREE = await import('three');
+  return { useGLTF: () => ({ scene: new THREE.Group() }) };
+});
+
+import { SyntyHexWall } from './SyntyHexWall';
+
+function wall(kind: WallKind, id?: string): Wall {
+  return {
+    from: { x: 0, y: 0, z: 0 },
+    to: { x: 1, y: -1, z: 0 },
+    kind,
+    id,
+  } as Wall;
+}
+
+describe('SyntyHexWall', () => {
+  it('forwards a locked door click with its server-issued Wall.id', () => {
+    const onDoorClick = vi.fn();
+    const { container } = render(
+      <SyntyHexWall
+        walls={[wall(WallKind.DOOR_LOCKED, 'locked-door-1')]}
+        hexSize={1}
+        onDoorClick={onDoorClick}
+      />
+    );
+
+    fireEvent.click(container.querySelector('group')!);
+
+    expect(onDoorClick).toHaveBeenCalledWith('locked-door-1');
+  });
+
+  it('does not attach the door interaction to a solid wall', () => {
+    const onDoorClick = vi.fn();
+    const { container } = render(
+      <SyntyHexWall
+        walls={[wall(WallKind.SOLID, 'not-a-door')]}
+        hexSize={1}
+        onDoorClick={onDoorClick}
+      />
+    );
+
+    fireEvent.click(container.querySelector('primitive')!);
+
+    expect(onDoorClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/hex-grid/SyntyHexWall.tsx
+++ b/src/components/hex-grid/SyntyHexWall.tsx
@@ -34,10 +34,7 @@
  */
 
 import { SYNTY_SCALE, WALL_HEIGHT } from '@/rendering/calibrationConstants';
-import {
-  WallKind,
-  type Wall,
-} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { type Wall } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useGLTF } from '@react-three/drei';
 import { Suspense, useEffect, useMemo } from 'react';
 import * as THREE from 'three';
@@ -45,9 +42,10 @@ import type { WorldPos } from './hexMath';
 import {
   buildDungeonWallSegments,
   classifyWallVertices,
-  edgePieceKind,
+  doorVisualState,
   FITTINGS,
   fittingScale,
+  isDoorWallKind,
   selectWallVariant,
   wallEndEdgeKeys,
   wallVariantScale,
@@ -83,6 +81,7 @@ const DOOR_SCALE = SYNTY_SCALE;
 // anticipating exactly this). The asset lane (web#523) owns the final open
 // pose/art; this is only a clearly-observable open-vs-closed state flip.
 const DOOR_OPEN_ROTATION_OFFSET = (80 * Math.PI) / 180;
+const LOCKED_DOOR_TINT = new THREE.Color(0.36, 0.31, 0.27);
 
 /**
  * Per-theme material tint (mid-flight scope addition, rpg-dnd5e-web#558 —
@@ -229,8 +228,8 @@ export function SyntyHexWall({
   return (
     <Suspense fallback={null}>
       {segments.map(({ key, edge, kind, id }) => {
-        if (edgePieceKind(kind) === 'door') {
-          const isOpen = kind === WallKind.DOOR_OPEN;
+        if (isDoorWallKind(kind)) {
+          const visualState = doorVisualState(kind)!;
           return (
             <group
               key={key}
@@ -256,9 +255,11 @@ export function SyntyHexWall({
                 file="SM_Env_Door_01.glb"
                 position={edge.a}
                 rotationY={
-                  edge.rotationY + (isOpen ? DOOR_OPEN_ROTATION_OFFSET : 0)
+                  edge.rotationY +
+                  (visualState === 'open' ? DOOR_OPEN_ROTATION_OFFSET : 0)
                 }
                 scale={DOOR_SCALE}
+                tint={visualState === 'locked' ? LOCKED_DOOR_TINT : undefined}
               />
             </group>
           );

--- a/src/components/hex-grid/syntyHexWallHelpers.test.ts
+++ b/src/components/hex-grid/syntyHexWallHelpers.test.ts
@@ -7,6 +7,7 @@ import { coordToKey, HEX_DIRECTIONS } from './hexMath';
 import {
   buildDungeonWallSegments,
   classifyWallVertices,
+  doorVisualState,
   edgePieceKind,
   FITTINGS,
   fittingScale,
@@ -18,15 +19,29 @@ import {
 } from './syntyHexWallHelpers';
 
 describe('edgePieceKind', () => {
-  it('maps DOOR_CLOSED and DOOR_OPEN to "door"', () => {
+  it('maps every DOOR_* kind to "door"', () => {
     expect(edgePieceKind(WallKind.DOOR_CLOSED)).toBe('door');
     expect(edgePieceKind(WallKind.DOOR_OPEN)).toBe('door');
+    expect(edgePieceKind(WallKind.DOOR_LOCKED)).toBe('door');
   });
 
   it('maps SOLID, UNSPECIFIED, and WINDOW to "wall" (no window piece yet)', () => {
     expect(edgePieceKind(WallKind.SOLID)).toBe('wall');
     expect(edgePieceKind(WallKind.UNSPECIFIED)).toBe('wall');
     expect(edgePieceKind(WallKind.WINDOW)).toBe('wall');
+  });
+});
+
+describe('doorVisualState', () => {
+  it('keeps locked visually distinct from closed and open doors', () => {
+    expect(doorVisualState(WallKind.DOOR_CLOSED)).toBe('closed');
+    expect(doorVisualState(WallKind.DOOR_OPEN)).toBe('open');
+    expect(doorVisualState(WallKind.DOOR_LOCKED)).toBe('locked');
+  });
+
+  it('does not assign a door visual state to non-door walls', () => {
+    expect(doorVisualState(WallKind.SOLID)).toBeUndefined();
+    expect(doorVisualState(WallKind.WINDOW)).toBeUndefined();
   });
 });
 
@@ -119,6 +134,27 @@ describe('buildDungeonWallSegments — door walls with a real passage edge (from
     expect(segments[0]!.key).toBe('0,0,0->1,-1,0');
     expect(segments[0]!.kind).toBe(WallKind.DOOR_CLOSED);
     expect(segments[0]!.id).toBe('door-1');
+  });
+
+  it('keeps a locked door interactive on its wire-designated edge', () => {
+    const walls = [
+      wall(
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+        WallKind.DOOR_LOCKED,
+        'locked-door-1'
+      ),
+    ];
+
+    const segments = buildDungeonWallSegments(walls, 1);
+
+    expect(segments).toEqual([
+      expect.objectContaining({
+        key: '0,0,0->1,-1,0',
+        kind: WallKind.DOOR_LOCKED,
+        id: 'locked-door-1',
+      }),
+    ]);
   });
 
   it('does NOT mark the passage neighbor as a wall hex — no phantom segments sourced from it', () => {

--- a/src/components/hex-grid/syntyHexWallHelpers.ts
+++ b/src/components/hex-grid/syntyHexWallHelpers.ts
@@ -49,20 +49,34 @@ import {
 
 export type EdgePieceKind = 'wall' | 'door';
 
+export function isDoorWallKind(kind: WallKind): boolean {
+  return (
+    kind === WallKind.DOOR_CLOSED ||
+    kind === WallKind.DOOR_OPEN ||
+    kind === WallKind.DOOR_LOCKED
+  );
+}
+
+export type DoorVisualState = 'closed' | 'open' | 'locked';
+
+export function doorVisualState(kind: WallKind): DoorVisualState | undefined {
+  switch (kind) {
+    case WallKind.DOOR_CLOSED:
+      return 'closed';
+    case WallKind.DOOR_OPEN:
+      return 'open';
+    case WallKind.DOOR_LOCKED:
+      return 'locked';
+    default:
+      return undefined;
+  }
+}
+
 /** Mirrors ShadedHexWall's getKindColor switch — no WINDOW-specific piece
  * exists in the synced asset set yet, so it falls back to the wall piece
  * (matches the investigation's honest MVP scoping, not silently wrong). */
 export function edgePieceKind(kind: WallKind): EdgePieceKind {
-  switch (kind) {
-    case WallKind.DOOR_CLOSED:
-    case WallKind.DOOR_OPEN:
-      return 'door';
-    case WallKind.WINDOW:
-    case WallKind.SOLID:
-    case WallKind.UNSPECIFIED:
-    default:
-      return 'wall';
-  }
+  return isDoorWallKind(kind) ? 'door' : 'wall';
 }
 
 export interface WallEdgeSegment {
@@ -249,8 +263,7 @@ function collectWallHexes(walls: Wall[]): Map<string, WallKind> {
     const end: CubeCoord = { x: wall.to.x, y: wall.to.y, z: wall.to.z };
     const isDegenerate =
       start.x === end.x && start.y === end.y && start.z === end.z;
-    const isDoor =
-      wall.kind === WallKind.DOOR_CLOSED || wall.kind === WallKind.DOOR_OPEN;
+    const isDoor = isDoorWallKind(wall.kind);
     // Door walls (design doc §Q2): from/to is a DESIGNATED PASSAGE EDGE —
     // `to` names which single edge of the door cell to draw the frame on,
     // not a second blocked cell. Decomposing via getHexLine (like solid
@@ -383,10 +396,7 @@ export function buildDungeonWallSegments(
   const directlyHandledHexKeys = new Set<string>();
   for (const wall of walls) {
     if (!wall.from || !wall.to) continue;
-    if (
-      wall.kind !== WallKind.DOOR_CLOSED &&
-      wall.kind !== WallKind.DOOR_OPEN
-    ) {
+    if (!isDoorWallKind(wall.kind)) {
       continue;
     }
     const hex: CubeCoord = { x: wall.from.x, y: wall.from.y, z: wall.from.z };
@@ -416,10 +426,7 @@ export function buildDungeonWallSegments(
   // through untouched to the generic per-wall-hex loop below.
   for (const wall of walls) {
     if (!wall.from || !wall.to) continue;
-    if (
-      wall.kind === WallKind.DOOR_CLOSED ||
-      wall.kind === WallKind.DOOR_OPEN
-    ) {
+    if (isDoorWallKind(wall.kind)) {
       continue; // handled above
     }
     const hex: CubeCoord = { x: wall.from.x, y: wall.from.y, z: wall.from.z };

--- a/src/hooks/dungeonMapGeometry.test.ts
+++ b/src/hooks/dungeonMapGeometry.test.ts
@@ -85,16 +85,28 @@ describe('doorHexKinds', () => {
       WallKind.DOOR_OPEN,
       'door-open'
     );
+    const locked = createWall(
+      10,
+      -10,
+      0,
+      11,
+      -11,
+      0,
+      WallKind.DOOR_LOCKED,
+      'door-locked'
+    );
 
-    const kinds = doorHexKinds([closed, open]);
+    const kinds = doorHexKinds([closed, open, locked]);
 
-    expect(kinds.size).toBe(2);
+    expect(kinds.size).toBe(3);
     expect(kinds.get('0,0,0')).toBe(WallKind.DOOR_CLOSED);
     expect(kinds.get('5,-5,0')).toBe(WallKind.DOOR_OPEN);
+    expect(kinds.get('10,-10,0')).toBe(WallKind.DOOR_LOCKED);
     // Never the passage neighbor (`to`) — that's real floor in the next
     // chamber, not the door's own cell.
     expect(kinds.has('1,-1,0')).toBe(false);
     expect(kinds.has('6,-6,0')).toBe(false);
+    expect(kinds.has('11,-11,0')).toBe(false);
   });
 
   it('ignores SOLID/WINDOW/UNSPECIFIED walls', () => {
@@ -155,12 +167,23 @@ describe('doorHexPositions', () => {
       'door-1'
     );
     const open = createWall(5, -5, 0, 6, -6, 0, WallKind.DOOR_OPEN, 'door-2');
+    const locked = createWall(
+      10,
+      -10,
+      0,
+      11,
+      -11,
+      0,
+      WallKind.DOOR_LOCKED,
+      'door-3'
+    );
 
-    const positions = doorHexPositions([closed, open]);
+    const positions = doorHexPositions([closed, open, locked]);
 
     expect(positions).toEqual([
       { x: 0, y: 0, z: 0 },
       { x: 5, y: -5, z: 0 },
+      { x: 10, y: -10, z: 0 },
     ]);
   });
 

--- a/src/hooks/dungeonMapGeometry.ts
+++ b/src/hooks/dungeonMapGeometry.ts
@@ -23,6 +23,7 @@ import {
   getHexNeighbors,
   type CubeCoord,
 } from '@/components/hex-grid/hexMath';
+import { isDoorWallKind } from '@/components/hex-grid/syntyHexWallHelpers';
 import {
   WallKind,
   type Wall,
@@ -60,10 +61,7 @@ function coordKey(x: number, y: number, z: number): string {
 export function doorHexKinds(walls: Iterable<Wall>): Map<string, WallKind> {
   const map = new Map<string, WallKind>();
   for (const wall of walls) {
-    if (
-      wall.kind !== WallKind.DOOR_CLOSED &&
-      wall.kind !== WallKind.DOOR_OPEN
-    ) {
+    if (!isDoorWallKind(wall.kind)) {
       continue;
     }
     if (!wall.from) continue;
@@ -81,10 +79,7 @@ export function doorHexKinds(walls: Iterable<Wall>): Map<string, WallKind> {
 export function doorHexPositions(walls: Iterable<Wall>): CubeCoord[] {
   const positions: CubeCoord[] = [];
   for (const wall of walls) {
-    if (
-      wall.kind !== WallKind.DOOR_CLOSED &&
-      wall.kind !== WallKind.DOOR_OPEN
-    ) {
+    if (!isDoorWallKind(wall.kind)) {
       continue;
     }
     if (!wall.from) continue;


### PR DESCRIPTION
Closes #573

## What changed
- Treats `WALL_KIND_DOOR_LOCKED` as door geometry in Synty, fallback, and door walkability paths.
- Preserves the wire-designated `Wall.from -> Wall.to` edge and `Wall.id` click target, so the existing `Interact -> InputRequired -> SubmitCheck` flow remains authoritative.
- Adds a muted locked material state while preserving closed/open poses and non-door non-interactivity.

## Evidence
- TDD RED: locked recognition, designated-edge/id, and geometry tests failed before implementation.
- GREEN: 62 focused tests passed, including locked click forwarding and solid-wall non-interaction.
- Mutation: removing `DOOR_LOCKED` from the classifier fails five locked-door assertions, including click forwarding.
- `npm run ci-check` passed on commit `1a1e5be` and again in the pre-push hook.
- `v0.1.113` is already present on latest `origin/main`, locked to published proto commit `0e4e2d7`; no redundant dependency diff was needed.

## Sequencing
This PR must merge and deploy **before or atomically with** rpg-api #703. #703 projects locked boss doors as `WALL_KIND_DOOR_LOCKED`; deploying it first would otherwise turn them into inert wall geometry.

Real-route locked-door screenshots are blocked until #703 is deployed because the current harness has no locked-wall fixture.

— asset-pipeline agent, on behalf of KirkDiggler