### PR TITLE
feat(stream): expose envelope metadata to callbacks (#582)

### DIFF
--- a/docs/architecture/components/use-encounter-stream.md
+++ b/docs/architecture/components/use-encounter-stream.md
@@ -1,7 +1,7 @@
 ---
 name: useEncounterStream
 description: The only real-time event delivery path — v1alpha2 StreamEncounter, load-bearing for every game route and the playtest harness
-updated: 2026-07-12
+updated: 2026-07-24
 confidence: high — verified by reading useEncounterStream.ts and encounterStreamDispatch.ts in full
 ---
 
@@ -53,12 +53,20 @@ _or_ re-arming its own zombie reconnect that clobbers it.
 ## Event dispatch
 
 `dispatchEncounterStreamEvent` (`src/api/encounterStreamDispatch.ts`) is a
-pure switch over `event.event.case` — one optional callback per event
-type in `EncounterStreamOptions`. It handles reveals (`GeometryRevealed`),
-entity appear/disappear/damage/status, door state, mode/turn changes, the
-TakeAction-wave `TurnStateChanged` menu push, death/removal/encounter-end,
-and stream-delivered prompts. `useEncounterState`'s reducers are the
-typical callback targets — see [use-encounter-state.md](use-encounter-state.md).
+pure switch over `event.event.case` — one optional callback per event type in
+`EncounterStreamOptions`. Every callback receives `(payload, metadata)`, where
+`metadata` is the verbatim wire-derived `EncounterEventMetadata` object:
+`sequence` stays `bigint`, `timestamp` stays `Timestamp | undefined`, and
+`correlationId` stays a string including `""`. The dispatcher constructs one
+metadata object for each envelope and does not validate, convert, group,
+deduplicate, buffer, delay, or otherwise interpret it. Existing one-argument
+callbacks remain valid and continue receiving their unchanged payload.
+
+It handles reveals (`GeometryRevealed`), entity appear/disappear/damage/status,
+door state, mode/turn changes, the TakeAction-wave `TurnStateChanged` menu
+push, death/removal/encounter-end, and stream-delivered prompts.
+`useEncounterState`'s reducers are the typical callback targets — see
+[use-encounter-state.md](use-encounter-state.md).
 
 ## No tests on the hook itself
 

--- a/src/api/encounterStreamDispatch.test.ts
+++ b/src/api/encounterStreamDispatch.test.ts
@@ -2,104 +2,95 @@ import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/ap
 import { describe, expect, it, vi } from 'vitest';
 import {
   dispatchEncounterStreamEvent,
+  type EncounterEventMetadata,
   type EncounterStreamOptions,
 } from './encounterStreamDispatch';
 
 function makeEvent<K extends string, V>(
   caseName: K,
   value: V,
-  sequence: bigint = 1n
+  metadata: EncounterEventMetadata = {
+    sequence: 1n,
+    timestamp: undefined,
+    correlationId: '',
+  }
 ): EncounterEvent {
   return {
-    sequence,
+    ...metadata,
     event: { case: caseName, value },
-    // Other EncounterEvent fields (timestamp, correlationId) — minimal shape;
-    // tests are checking dispatch only, not full proto validity
   } as unknown as EncounterEvent;
 }
 
+const routedCases = [
+  ['snapshotDelivered', 'onSnapshotDelivered', { encounter: undefined }],
+  ['entityMoved', 'onEntityMoved', { entityId: 'a', actualPath: [] }],
+  ['geometryRevealed', 'onGeometryRevealed', { hexes: [] }],
+  ['entityAppeared', 'onEntityAppeared', { entity: { id: 'g' }, reason: '' }],
+  ['entityDisappeared', 'onEntityDisappeared', { entityId: 'g' }],
+  ['doorOpened', 'onDoorOpened', { doorEntityId: 'door-east' }],
+  ['entityDamaged', 'onEntityDamaged', { entityId: 'g', amount: 5 }],
+  ['statusApplied', 'onStatusApplied', { entityId: 'g', status: {} }],
+  ['statusRemoved', 'onStatusRemoved', { entityId: 'g', statusSource: {} }],
+  ['modeChanged', 'onModeChanged', { from: 1, to: 2, reason: 'ambush' }],
+  ['initiativeRolled', 'onInitiativeRolled', { order: [] }],
+  ['turnStarted', 'onTurnStarted', { entityId: 'a', round: 1 }],
+  ['turnEnded', 'onTurnEnded', { entityId: 'a' }],
+  [
+    'actionResolved',
+    'onActionResolved',
+    {
+      actorEntityId: 'a',
+      actionRef: {},
+      targetEntityId: 'g',
+      economyConsumed: {},
+    },
+  ],
+  [
+    'attackResolved',
+    'onAttackResolved',
+    {
+      attackerEntityId: 'a',
+      targetEntityId: 'g',
+      hit: false,
+      critical: false,
+      attackRoll: 4,
+      attackBonus: 5,
+      targetAc: 13,
+    },
+  ],
+  ['turnStateChanged', 'onTurnStateChanged', { turnState: {} }],
+  ['entityDied', 'onEntityDied', { entityId: 'g' }],
+  ['entityRemoved', 'onEntityRemoved', { entityId: 'g', reason: 'destroyed' }],
+  ['encounterEnded', 'onEncounterEnded', { reason: 'ended' }],
+  ['deathSaveRolled', 'onDeathSaveRolled', { entityId: 'a', roll: 14 }],
+  ['entityStabilized', 'onEntityStabilized', { entityId: 'a' }],
+  ['inputRequiredDelivered', 'onInputRequiredDelivered', { inputRequired: {} }],
+] as const;
+
 describe('dispatchEncounterStreamEvent', () => {
-  it('routes snapshotDelivered to onSnapshotDelivered', () => {
-    const onSnapshotDelivered = vi.fn();
-    const options: EncounterStreamOptions = { onSnapshotDelivered };
-    const event = makeEvent('snapshotDelivered', { encounter: undefined });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onSnapshotDelivered).toHaveBeenCalledTimes(1);
-  });
+  describe.each(routedCases)('%s', (caseName, callbackName, payload) => {
+    it(`routes payload and exact envelope metadata to ${callbackName}`, () => {
+      const callback = vi.fn();
+      const metadata: EncounterEventMetadata = {
+        sequence: 9007199254740993n,
+        timestamp: {
+          seconds: 1721815200n,
+          nanos: 123456789,
+        } as EncounterEventMetadata['timestamp'],
+        correlationId: `corr-${caseName}`,
+      };
 
-  it('routes entityMoved to onEntityMoved', () => {
-    const onEntityMoved = vi.fn();
-    const options: EncounterStreamOptions = { onEntityMoved };
-    const event = makeEvent('entityMoved', {
-      entityId: 'a',
-      actualPath: [{ x: 0, y: 0, z: 0 }],
+      dispatchEncounterStreamEvent(makeEvent(caseName, payload, metadata), {
+        [callbackName]: callback,
+      } as EncounterStreamOptions);
+
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(payload, metadata);
     });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityMoved).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes geometryRevealed to onGeometryRevealed', () => {
-    const onGeometryRevealed = vi.fn();
-    const options: EncounterStreamOptions = { onGeometryRevealed };
-    const event = makeEvent('geometryRevealed', { hexes: [] });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onGeometryRevealed).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes entityAppeared to onEntityAppeared', () => {
-    const onEntityAppeared = vi.fn();
-    const options: EncounterStreamOptions = { onEntityAppeared };
-    // NOTE: v1alpha2 Entity uses `id` (not `entityId`); see types_pb.ts.
-    const event = makeEvent('entityAppeared', {
-      entity: { id: 'g', position: { x: 1, y: -1, z: 0 } },
-      reason: '',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityAppeared).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes entityDisappeared to onEntityDisappeared', () => {
-    const onEntityDisappeared = vi.fn();
-    const options: EncounterStreamOptions = { onEntityDisappeared };
-    const event = makeEvent('entityDisappeared', {
-      entityId: 'g',
-      lastKnownPosition: { x: 2, y: -2, z: 0 },
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityDisappeared).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes doorOpened to onDoorOpened', () => {
-    const onDoorOpened = vi.fn();
-    const options: EncounterStreamOptions = { onDoorOpened };
-    // Wave 2.7: revealedHexes/walls/removedWalls intentionally empty here;
-    // the geometry side flows on a separate GeometryRevealed event.
-    const event = makeEvent('doorOpened', {
-      doorEntityId: 'door-east',
-      revealedHexes: [],
-      revealedWalls: [],
-      removedWalls: [],
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onDoorOpened).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes entityDamaged to onEntityDamaged', () => {
-    const onEntityDamaged = vi.fn();
-    const options: EncounterStreamOptions = { onEntityDamaged };
-    const event = makeEvent('entityDamaged', {
-      entityId: 'goblin-1',
-      amount: 5,
-      hpAfter: { current: 2, max: 7 },
-      sourceEntityId: 'char-alice',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityDamaged).toHaveBeenCalledTimes(1);
   });
 
   it('passes damageBreakdown components to onEntityDamaged when present', () => {
     const onEntityDamaged = vi.fn();
-    const options: EncounterStreamOptions = { onEntityDamaged };
     const event = makeEvent('entityDamaged', {
       entityId: 'goblin-1',
       amount: 10,
@@ -110,8 +101,9 @@ describe('dispatchEncounterStreamEvent', () => {
         { source: 'dnd5e:features:sneak_attack', amount: 1, isCritical: false },
       ],
     });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityDamaged).toHaveBeenCalledTimes(1);
+
+    dispatchEncounterStreamEvent(event, { onEntityDamaged });
+
     const received = onEntityDamaged.mock.calls[0][0];
     expect(received.damageBreakdown).toHaveLength(3);
     expect(received.damageBreakdown[0].source).toBe('dnd5e:weapons:shortsword');
@@ -120,265 +112,161 @@ describe('dispatchEncounterStreamEvent', () => {
     );
   });
 
-  it('routes statusApplied to onStatusApplied', () => {
-    const onStatusApplied = vi.fn();
-    const options: EncounterStreamOptions = { onStatusApplied };
-    const event = makeEvent('statusApplied', {
-      entityId: 'char-alice',
-      status: {
-        source: { module: 'dnd5e', type: 'condition', id: 'poisoned' },
-        displayName: 'Poisoned',
-      },
-      sourceEntityId: 'goblin-1',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onStatusApplied).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes statusRemoved to onStatusRemoved', () => {
-    const onStatusRemoved = vi.fn();
-    const options: EncounterStreamOptions = { onStatusRemoved };
-    const event = makeEvent('statusRemoved', {
-      entityId: 'char-alice',
-      statusSource: { module: 'dnd5e', type: 'condition', id: 'poisoned' },
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onStatusRemoved).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes modeChanged to onModeChanged', () => {
-    const onModeChanged = vi.fn();
-    const options: EncounterStreamOptions = { onModeChanged };
-    // EncounterMode enum values: UNSPECIFIED=0, FREE_ROAM=1, TURN_BASED=2.
-    const event = makeEvent('modeChanged', {
-      from: 1,
-      to: 2,
-      reason: 'ambush',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onModeChanged).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes initiativeRolled to onInitiativeRolled', () => {
-    const onInitiativeRolled = vi.fn();
-    const options: EncounterStreamOptions = { onInitiativeRolled };
-    const event = makeEvent('initiativeRolled', {
-      order: ['char-alice', 'goblin-1', 'char-bob'],
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onInitiativeRolled).toHaveBeenCalledTimes(1);
-    const arg = onInitiativeRolled.mock.calls[0]?.[0] as { order?: string[] };
-    expect(arg.order).toEqual(['char-alice', 'goblin-1', 'char-bob']);
-  });
-
-  it('dispatches modeChanged and initiativeRolled independently even when they share the same wire sequence', () => {
-    // Pins the real wire shape: the api can't mint a fresh broker sequence
-    // for the synthesized InitiativeRolled envelope, so it reuses the
-    // preceding ModeChanged event's sequence number (two envelopes, one
-    // sequence — a toolkit fix for a real per-envelope sequence is filed
-    // separately). dispatchEncounterStreamEvent has no sequence-based
-    // dedup/ordering anywhere (confirmed: no consumer in this repo reads
-    // EncounterEvent.sequence at all) — both envelopes must still be
-    // dispatched and applied in full.
-    const onModeChanged = vi.fn();
-    const onInitiativeRolled = vi.fn();
-    const options: EncounterStreamOptions = {
-      onModeChanged,
-      onInitiativeRolled,
-    };
-    const sharedSequence = 42n;
-    const modeChangedEvent = makeEvent(
-      'modeChanged',
-      { from: 1, to: 2, reason: 'sighted' },
-      sharedSequence
-    );
-    const initiativeRolledEvent = makeEvent(
-      'initiativeRolled',
-      { order: ['char-alice', 'goblin-1'] },
-      sharedSequence
-    );
-
-    dispatchEncounterStreamEvent(modeChangedEvent, options);
-    dispatchEncounterStreamEvent(initiativeRolledEvent, options);
-
-    expect(onModeChanged).toHaveBeenCalledTimes(1);
-    expect(onInitiativeRolled).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes turnStarted to onTurnStarted', () => {
-    const onTurnStarted = vi.fn();
-    const options: EncounterStreamOptions = { onTurnStarted };
-    const event = makeEvent('turnStarted', {
-      entityId: 'char-alice',
-      round: 1,
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onTurnStarted).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes turnEnded to onTurnEnded', () => {
-    const onTurnEnded = vi.fn();
-    const options: EncounterStreamOptions = { onTurnEnded };
-    const event = makeEvent('turnEnded', {
-      entityId: 'char-alice',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onTurnEnded).toHaveBeenCalledTimes(1);
-  });
-
-  // Wave 2.10: death + encounter resolution
-  it('routes entityDied to onEntityDied', () => {
-    const onEntityDied = vi.fn();
-    const options: EncounterStreamOptions = { onEntityDied };
-    const event = makeEvent('entityDied', {
-      entityId: 'goblin-1',
-      killerEntityId: 'char-alice',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityDied).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes entityRemoved to onEntityRemoved', () => {
-    const onEntityRemoved = vi.fn();
-    const options: EncounterStreamOptions = { onEntityRemoved };
-    const event = makeEvent('entityRemoved', {
-      entityId: 'goblin-1',
-      reason: 'destroyed',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityRemoved).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes encounterEnded to onEncounterEnded', () => {
-    const onEncounterEnded = vi.fn();
-    const options: EncounterStreamOptions = { onEncounterEnded };
-    const event = makeEvent('encounterEnded', {
-      reason: 'all hostiles defeated',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEncounterEnded).toHaveBeenCalledTimes(1);
-  });
-
-  // Death-save arc (rpg-toolkit#742, wave KirkDiggler/rpg-project#75)
-  it('routes deathSaveRolled to onDeathSaveRolled', () => {
-    const onDeathSaveRolled = vi.fn();
-    const options: EncounterStreamOptions = { onDeathSaveRolled };
-    const event = makeEvent('deathSaveRolled', {
-      entityId: 'char-alice',
-      roll: 14,
-      successes: 2,
-      failures: 1,
-      isCriticalFail: false,
-      isCriticalSuccess: false,
-      stabilized: false,
-      dead: false,
-      regainedConsciousness: false,
-      hpRestored: 0,
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onDeathSaveRolled).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes entityStabilized to onEntityStabilized', () => {
-    const onEntityStabilized = vi.fn();
-    const options: EncounterStreamOptions = { onEntityStabilized };
-    const event = makeEvent('entityStabilized', {
-      entityId: 'char-alice',
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onEntityStabilized).toHaveBeenCalledTimes(1);
-  });
-
-  // Wave 2.11d: stream-delivered InputRequired prompts (e.g. NPC-attacker
-  // reaction prompts whose reactor is not the action's caller).
-  it('routes inputRequiredDelivered to onInputRequiredDelivered', () => {
-    const onInputRequiredDelivered = vi.fn();
-    const options: EncounterStreamOptions = { onInputRequiredDelivered };
-    const event = makeEvent('inputRequiredDelivered', {
-      inputRequired: {
-        kind: {
-          case: 'reactionPrompt',
-          value: {
-            reactionRef: {
-              module: 'dnd5e',
-              type: 'spells',
-              id: 'shield',
-            },
-            triggerKind: 'incoming_attack',
-            triggerSourceEntityId: 'goblin-1',
-            displayText: 'Goblin attacks — react with Shield?',
-          },
-        },
-      },
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onInputRequiredDelivered).toHaveBeenCalledTimes(1);
-    // First arg is the InputRequiredDelivered payload itself; callers read
-    // .inputRequired to extract the prompt for setPendingPrompt.
-    const arg = onInputRequiredDelivered.mock.calls[0]?.[0] as {
-      inputRequired?: { kind?: { case?: string } };
-    };
-    expect(arg.inputRequired?.kind?.case).toBe('reactionPrompt');
-  });
-
-  // TakeAction wave (#426): the verb-resolution + live-menu spine.
-  it('routes actionResolved to onActionResolved', () => {
-    const onActionResolved = vi.fn();
-    const options: EncounterStreamOptions = { onActionResolved };
-    const event = makeEvent('actionResolved', {
-      actorEntityId: 'char-alice',
-      actionRef: { module: 'dnd5e', type: 'combat_abilities', id: 'attack' },
-      targetEntityId: 'goblin-1',
-      economyConsumed: { actions: 1 },
-    });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onActionResolved).toHaveBeenCalledTimes(1);
-  });
-
-  it('routes attackResolved to onAttackResolved (including a miss)', () => {
+  it('dispatches attackResolved including a miss', () => {
     const onAttackResolved = vi.fn();
-    const options: EncounterStreamOptions = { onAttackResolved };
     const event = makeEvent('attackResolved', {
       attackerEntityId: 'char-alice',
       targetEntityId: 'goblin-1',
-      hit: false, // #594: a miss must still dispatch
+      hit: false,
       critical: false,
       attackRoll: 4,
       attackBonus: 5,
       targetAc: 13,
     });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onAttackResolved).toHaveBeenCalledTimes(1);
-    const arg = onAttackResolved.mock.calls[0]?.[0] as { hit?: boolean };
-    expect(arg.hit).toBe(false);
+
+    dispatchEncounterStreamEvent(event, { onAttackResolved });
+
+    expect(onAttackResolved.mock.calls[0][0].hit).toBe(false);
   });
 
-  it('routes turnStateChanged to onTurnStateChanged', () => {
-    const onTurnStateChanged = vi.fn();
-    const options: EncounterStreamOptions = { onTurnStateChanged };
-    const event = makeEvent('turnStateChanged', {
-      turnState: {
-        economy: { actionsRemaining: 1, bonusActionsRemaining: 1 },
-        availableActions: [],
+  it('passes input prompts to onInputRequiredDelivered', () => {
+    const onInputRequiredDelivered = vi.fn();
+    const event = makeEvent('inputRequiredDelivered', {
+      inputRequired: {
+        kind: {
+          case: 'reactionPrompt',
+          value: {
+            reactionRef: { module: 'dnd5e', type: 'spells', id: 'shield' },
+            triggerKind: 'incoming_attack',
+            triggerSourceEntityId: 'goblin-1',
+            displayText: 'Goblin attacks - react with Shield?',
+          },
+        },
       },
     });
-    dispatchEncounterStreamEvent(event, options);
-    expect(onTurnStateChanged).toHaveBeenCalledTimes(1);
+
+    dispatchEncounterStreamEvent(event, { onInputRequiredDelivered });
+
+    expect(
+      onInputRequiredDelivered.mock.calls[0][0].inputRequired.kind.case
+    ).toBe('reactionPrompt');
+  });
+
+  it('passes exact per-envelope metadata with one shared correlation to ActionResolved, AttackResolved, and EntityDamaged', () => {
+    const action = vi.fn();
+    const attack = vi.fn();
+    const damage = vi.fn();
+    const actionMetadata: EncounterEventMetadata = {
+      sequence: 91n,
+      timestamp: {
+        seconds: 1721815200n,
+        nanos: 100,
+      } as EncounterEventMetadata['timestamp'],
+      correlationId: 'corr-attack-chain',
+    };
+    const attackMetadata: EncounterEventMetadata = {
+      sequence: 92n,
+      timestamp: {
+        seconds: 1721815201n,
+        nanos: 200,
+      } as EncounterEventMetadata['timestamp'],
+      correlationId: 'corr-attack-chain',
+    };
+    const damageMetadata: EncounterEventMetadata = {
+      sequence: 93n,
+      timestamp: {
+        seconds: 1721815202n,
+        nanos: 300,
+      } as EncounterEventMetadata['timestamp'],
+      correlationId: 'corr-attack-chain',
+    };
+    const options: EncounterStreamOptions = {
+      onActionResolved: action,
+      onAttackResolved: attack,
+      onEntityDamaged: damage,
+    };
+
+    dispatchEncounterStreamEvent(
+      makeEvent('actionResolved', { actorEntityId: 'a' }, actionMetadata),
+      options
+    );
+    dispatchEncounterStreamEvent(
+      makeEvent('attackResolved', { attackerEntityId: 'a' }, attackMetadata),
+      options
+    );
+    dispatchEncounterStreamEvent(
+      makeEvent('entityDamaged', { entityId: 'g', amount: 7 }, damageMetadata),
+      options
+    );
+
+    expect(action.mock.calls[0][1]).toEqual(actionMetadata);
+    expect(attack.mock.calls[0][1]).toEqual(attackMetadata);
+    expect(damage.mock.calls[0][1]).toEqual(damageMetadata);
+    expect(action.mock.calls[0][1].correlationId).toBe(
+      attack.mock.calls[0][1].correlationId
+    );
+    expect(attack.mock.calls[0][1].correlationId).toBe(
+      damage.mock.calls[0][1].correlationId
+    );
+  });
+
+  it('passes empty correlationId and undefined timestamp through unchanged', () => {
+    const onTurnStateChanged = vi.fn();
+    const metadata: EncounterEventMetadata = {
+      sequence: 42n,
+      timestamp: undefined,
+      correlationId: '',
+    };
+
+    dispatchEncounterStreamEvent(
+      makeEvent('turnStateChanged', { turnState: {} }, metadata),
+      { onTurnStateChanged }
+    );
+
+    expect(onTurnStateChanged).toHaveBeenCalledWith(
+      { turnState: {} },
+      metadata
+    );
+  });
+
+  it('dispatches modeChanged and initiativeRolled independently when they share the same wire sequence', () => {
+    const onModeChanged = vi.fn();
+    const onInitiativeRolled = vi.fn();
+    const metadata: EncounterEventMetadata = {
+      sequence: 42n,
+      timestamp: undefined,
+      correlationId: '',
+    };
+
+    dispatchEncounterStreamEvent(
+      makeEvent('modeChanged', { from: 1, to: 2, reason: 'sighted' }, metadata),
+      { onModeChanged, onInitiativeRolled }
+    );
+    dispatchEncounterStreamEvent(
+      makeEvent(
+        'initiativeRolled',
+        { order: ['char-alice', 'goblin-1'] },
+        metadata
+      ),
+      { onModeChanged, onInitiativeRolled }
+    );
+
+    expect(onModeChanged).toHaveBeenCalledOnce();
+    expect(onInitiativeRolled).toHaveBeenCalledOnce();
   });
 
   it('logs a warning for unknown event cases without throwing', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const event = makeEvent('someUnknownCase' as 'snapshotDelivered', {});
+
     expect(() => dispatchEncounterStreamEvent(event, {})).not.toThrow();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
 
   it('is a no-op when no callback is registered for the event type', () => {
-    const event = makeEvent('entityMoved', {
-      entityId: 'x',
-      actualPath: [],
-    });
+    const event = makeEvent('entityMoved', { entityId: 'x', actualPath: [] });
+
     expect(() => dispatchEncounterStreamEvent(event, {})).not.toThrow();
   });
 });

--- a/src/api/encounterStreamDispatch.ts
+++ b/src/api/encounterStreamDispatch.ts
@@ -24,6 +24,16 @@ import type {
   TurnStateChanged,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 
+export type EncounterEventMetadata = Pick<
+  EncounterEvent,
+  'sequence' | 'timestamp' | 'correlationId'
+>;
+
+export type EncounterStreamHandler<T> = (
+  event: T,
+  metadata: EncounterEventMetadata
+) => void;
+
 /**
  * Per-event-type callbacks for the v1alpha2 encounter stream.
  * Mirrors the v1 hook's options shape (one optional callback per event type).
@@ -46,41 +56,41 @@ import type {
  */
 export interface EncounterStreamOptions {
   /** slice-1: encounter field is empty; treat as connect-confirm only. */
-  onSnapshotDelivered?: (event: SnapshotDelivered) => void;
-  onEntityMoved?: (event: EntityMoved) => void;
-  onGeometryRevealed?: (event: GeometryRevealed) => void;
-  onEntityAppeared?: (event: EntityAppeared) => void;
-  onEntityDisappeared?: (event: EntityDisappeared) => void;
+  onSnapshotDelivered?: EncounterStreamHandler<SnapshotDelivered>;
+  onEntityMoved?: EncounterStreamHandler<EntityMoved>;
+  onGeometryRevealed?: EncounterStreamHandler<GeometryRevealed>;
+  onEntityAppeared?: EncounterStreamHandler<EntityAppeared>;
+  onEntityDisappeared?: EncounterStreamHandler<EntityDisappeared>;
   /**
    * Wave 2.7: door state transitions to open. The event's revealedHexes /
    * revealedWalls / removedWalls fields are intentionally empty — the
    * geometry side flows on a separate GeometryRevealed event.
    */
-  onDoorOpened?: (event: DoorOpened) => void;
+  onDoorOpened?: EncounterStreamHandler<DoorOpened>;
   // Wave 2.8: combat events (TURN_BASED mode + attacks + turn cycle).
   /** Authoritative HP update; carries `hp_after` and `amount`. */
-  onEntityDamaged?: (event: EntityDamaged) => void;
+  onEntityDamaged?: EncounterStreamHandler<EntityDamaged>;
   /** Condition applied to a target; carries the StatusEffect ref + display. */
-  onStatusApplied?: (event: StatusApplied) => void;
+  onStatusApplied?: EncounterStreamHandler<StatusApplied>;
   /**
    * Condition cleared from a target; carries the source Ref that matches
    * an earlier StatusApplied.status.source. Consumers remove the matching
    * entry from their status list — the badge then clears automatically.
    */
-  onStatusRemoved?: (event: StatusRemoved) => void;
+  onStatusRemoved?: EncounterStreamHandler<StatusRemoved>;
   /** Encounter-mode transition (e.g. FREE_ROAM → TURN_BASED). */
-  onModeChanged?: (event: ModeChanged) => void;
+  onModeChanged?: EncounterStreamHandler<ModeChanged>;
   /**
    * Full initiative roster, synthesized by the server alongside the
    * FREE_ROAM -> TURN_BASED ModeChanged translation (rpg-api#644 playtest
    * follow-up) so a mid-stream combat start populates the turn-order
    * overlay immediately, without waiting for the next SnapshotDelivered.
    */
-  onInitiativeRolled?: (event: InitiativeRolled) => void;
+  onInitiativeRolled?: EncounterStreamHandler<InitiativeRolled>;
   /** Active actor + round update; signals "X's turn now". */
-  onTurnStarted?: (event: TurnStarted) => void;
+  onTurnStarted?: EncounterStreamHandler<TurnStarted>;
   /** Active actor finished; the next TurnStarted is authoritative for who's next. */
-  onTurnEnded?: (event: TurnEnded) => void;
+  onTurnEnded?: EncounterStreamHandler<TurnEnded>;
   // TakeAction wave (#426): the verb-resolution + live-menu spine.
   /**
    * Umbrella beat for any action a character takes (attack, dodge, dash, …).
@@ -89,36 +99,36 @@ export interface EncounterStreamOptions {
    * correlated EntityDamaged. Web renders this as a combat-log line — server is
    * authoritative, web computes nothing.
    */
-  onActionResolved?: (event: ActionResolved) => void;
+  onActionResolved?: EncounterStreamHandler<ActionResolved>;
   /**
    * Per-attack roll detail. CRUCIAL: fires on a MISS too (`hit=false`) — the
    * #594 fix. Web renders the hit OR miss in the combat log so a whiff is no
    * longer silent.
    */
-  onAttackResolved?: (event: AttackResolved) => void;
+  onAttackResolved?: EncounterStreamHandler<AttackResolved>;
   /**
    * The live menu/economy push (Invariant 12, no polling). Carries the
    * recomputed TurnState (economy + available_actions). The web swaps it in
    * wholesale and re-renders the action menu — it never recomputes availability
    * client-side. This is the event that drives the server-authored action menu.
    */
-  onTurnStateChanged?: (event: TurnStateChanged) => void;
+  onTurnStateChanged?: EncounterStreamHandler<TurnStateChanged>;
   // Wave 2.10: death + encounter resolution events.
   /**
    * Entity HP reached 0. The entity remains in the entities map until
    * EntityRemoved arrives. Useful for transient death narration in the log.
    */
-  onEntityDied?: (event: EntityDied) => void;
+  onEntityDied?: EncounterStreamHandler<EntityDied>;
   /**
    * Entity fully removed from the encounter space (after death or other removal
    * reason). The reducer removes the entity from the entities Map on receipt.
    */
-  onEntityRemoved?: (event: EntityRemoved) => void;
+  onEntityRemoved?: EncounterStreamHandler<EntityRemoved>;
   /**
    * Encounter is over. Carries a human-readable `reason` (e.g. "all hostiles
    * defeated"). The reducer sets `encounterStatus = "ended"` on receipt.
    */
-  onEncounterEnded?: (event: EncounterEnded) => void;
+  onEncounterEnded?: EncounterStreamHandler<EncounterEnded>;
   // Death-save arc (rpg-toolkit#742, wave KirkDiggler/rpg-project#75).
   /**
    * Fires on EVERY death save roll for an unconscious entity, including
@@ -126,12 +136,12 @@ export interface EncounterStreamOptions {
    * (is_critical_fail/success, stabilized, dead, regained_consciousness,
    * hp_restored) are copied verbatim from the toolkit — never re-derived.
    */
-  onDeathSaveRolled?: (event: DeathSaveRolled) => void;
+  onDeathSaveRolled?: EncounterStreamHandler<DeathSaveRolled>;
   /**
    * Fires once when an unconscious entity accumulates 3 successful death
    * saves. Death itself still rides the existing EntityDied.
    */
-  onEntityStabilized?: (event: EntityStabilized) => void;
+  onEntityStabilized?: EncounterStreamHandler<EntityStabilized>;
   // Wave 2.11d: stream-delivered InputRequired prompts.
   /**
    * Server-pushed InputRequired payload (Wave 2.11d). Used for reaction
@@ -143,7 +153,7 @@ export interface EncounterStreamOptions {
    * path used by Interact/TakeAction responses; the InputRequired payload
    * shape is identical, and the existing prompt modal/dispatch reuses it.
    */
-  onInputRequiredDelivered?: (event: InputRequiredDelivered) => void;
+  onInputRequiredDelivered?: EncounterStreamHandler<InputRequiredDelivered>;
 }
 
 /**
@@ -156,72 +166,77 @@ export function dispatchEncounterStreamEvent(
   options: EncounterStreamOptions
 ): void {
   const payload = event.event;
+  const metadata: EncounterEventMetadata = {
+    sequence: event.sequence,
+    timestamp: event.timestamp,
+    correlationId: event.correlationId,
+  };
   switch (payload.case) {
     case 'snapshotDelivered':
-      options.onSnapshotDelivered?.(payload.value);
+      options.onSnapshotDelivered?.(payload.value, metadata);
       break;
     case 'entityMoved':
-      options.onEntityMoved?.(payload.value);
+      options.onEntityMoved?.(payload.value, metadata);
       break;
     case 'geometryRevealed':
-      options.onGeometryRevealed?.(payload.value);
+      options.onGeometryRevealed?.(payload.value, metadata);
       break;
     case 'entityAppeared':
-      options.onEntityAppeared?.(payload.value);
+      options.onEntityAppeared?.(payload.value, metadata);
       break;
     case 'entityDisappeared':
-      options.onEntityDisappeared?.(payload.value);
+      options.onEntityDisappeared?.(payload.value, metadata);
       break;
     case 'doorOpened':
-      options.onDoorOpened?.(payload.value);
+      options.onDoorOpened?.(payload.value, metadata);
       break;
     case 'entityDamaged':
-      options.onEntityDamaged?.(payload.value);
+      options.onEntityDamaged?.(payload.value, metadata);
       break;
     case 'statusApplied':
-      options.onStatusApplied?.(payload.value);
+      options.onStatusApplied?.(payload.value, metadata);
       break;
     case 'statusRemoved':
-      options.onStatusRemoved?.(payload.value);
+      options.onStatusRemoved?.(payload.value, metadata);
       break;
     case 'modeChanged':
-      options.onModeChanged?.(payload.value);
+      options.onModeChanged?.(payload.value, metadata);
       break;
     case 'initiativeRolled':
-      options.onInitiativeRolled?.(payload.value);
+      options.onInitiativeRolled?.(payload.value, metadata);
       break;
     case 'turnStarted':
-      options.onTurnStarted?.(payload.value);
+      options.onTurnStarted?.(payload.value, metadata);
       break;
     case 'turnEnded':
-      options.onTurnEnded?.(payload.value);
+      options.onTurnEnded?.(payload.value, metadata);
       break;
     case 'actionResolved':
-      options.onActionResolved?.(payload.value);
+      options.onActionResolved?.(payload.value, metadata);
       break;
     case 'attackResolved':
-      options.onAttackResolved?.(payload.value);
+      options.onAttackResolved?.(payload.value, metadata);
       break;
     case 'turnStateChanged':
-      options.onTurnStateChanged?.(payload.value);
+      options.onTurnStateChanged?.(payload.value, metadata);
       break;
     case 'entityDied':
-      options.onEntityDied?.(payload.value);
+      options.onEntityDied?.(payload.value, metadata);
       break;
     case 'entityRemoved':
-      options.onEntityRemoved?.(payload.value);
+      options.onEntityRemoved?.(payload.value, metadata);
       break;
     case 'encounterEnded':
-      options.onEncounterEnded?.(payload.value);
+      options.onEncounterEnded?.(payload.value, metadata);
       break;
     case 'deathSaveRolled':
-      options.onDeathSaveRolled?.(payload.value);
+      options.onDeathSaveRolled?.(payload.value, metadata);
       break;
     case 'entityStabilized':
-      options.onEntityStabilized?.(payload.value);
+      options.onEntityStabilized?.(payload.value, metadata);
       break;
     case 'inputRequiredDelivered':
-      options.onInputRequiredDelivered?.(payload.value);
+      options.onInputRequiredDelivered?.(payload.value, metadata);
       break;
     default:
       // Either out-of-current-scope but known to the proto (entityHealed,

--- a/src/api/encounterStreamDispatch.ts
+++ b/src/api/encounterStreamDispatch.ts
@@ -241,7 +241,7 @@ export function dispatchEncounterStreamEvent(
     default:
       // Either out-of-current-scope but known to the proto (entityHealed,
       // dialogue, etc. — the proto defines 30 event cases;
-      // we currently handle 21) OR a genuinely unknown case from a proto
+      // we currently handle 22) OR a genuinely unknown case from a proto
       // version mismatch. Either way: warn + continue so the stream doesn't
       // tear down. Add a case arm + callback when the feature lands.
       // The cast strips the narrowed-to-undefined `case` so we can log it.


### PR DESCRIPTION
Closes #582.

Relates to KirkDiggler/rpg-api#701. Both this PR and rpg-api#701 are required before #581.

Canonical design and plan: KirkDiggler/rpg-project#118.

## Contract

This is an additive contract: all 22 typed callbacks receive their unchanged payload plus a wire-derived `{sequence, timestamp, correlationId}` second argument. Existing one-argument handlers remain compatible. The dispatcher does no grouping, deduplication, buffering, state delay, or UI pacing.

## Verification

TDD evidence: 24/30 tests failed RED before implementation; 30/30 targeted tests were GREEN. Fresh `npm run ci-check` passes format, lint, typecheck, build, CSS guard, and tests. Full Vitest implementer verification passed: 69 files / 1,190 tests.

Coverage includes the ActionResolved -> AttackResolved -> EntityDamaged chain with a shared correlation ID and distinct sequences, plus empty `correlationId` and `undefined` timestamp passthrough.

— asset-pipeline agent, on behalf of KirkDiggler