### PR TITLE
feat(map)#569: brazier/torch-ornate light-anchor glow on the real route

### DIFF
--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -832,6 +832,114 @@ describe('buildCryptMoodLights (rpg-dnd5e-web#558 crypt spike, mood-lighting pas
     const lights = buildCryptMoodLights(props);
     expect(lights).toHaveLength(candleCount);
   });
+
+  it('produces a light for each of the three known light-anchor props (candles, brazier, torch-ornate) — rpg-toolkit#839 light-anchor set pieces, rpg-dnd5e-web#569', () => {
+    const props = [
+      {
+        entityId: 'a',
+        name: 'candle',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'candles',
+      },
+      {
+        entityId: 'b',
+        name: 'brazier',
+        position: { x: 1, y: -1, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'brazier',
+      },
+      {
+        entityId: 'c',
+        name: 'torch',
+        position: { x: 2, y: -2, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'torch-ornate',
+      },
+    ];
+    const lights = buildCryptMoodLights(props);
+    expect(lights).toHaveLength(3);
+  });
+
+  it('brazier and torch-ornate lights use the warm-orange glow color (the door-light family), not the candle green', () => {
+    const [brazier] = buildCryptMoodLights([
+      {
+        entityId: 'b',
+        name: 'brazier',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'brazier',
+      },
+    ]);
+    const [torch] = buildCryptMoodLights([
+      {
+        entityId: 't',
+        name: 'torch',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'torch-ornate',
+      },
+    ]);
+    expect(brazier!.color).toBe('#ff9d52');
+    expect(torch!.color).toBe('#ff9d52');
+  });
+
+  it('brazier is the brightest/widest-reaching mood light — the room anchor, tuned stronger and wider than both the candle accent pools and the torch-ornate secondary fixture', () => {
+    const [candle] = buildCryptMoodLights([
+      {
+        entityId: 'a',
+        name: 'candle',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'candles',
+      },
+    ]);
+    const [brazier] = buildCryptMoodLights([
+      {
+        entityId: 'b',
+        name: 'brazier',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'brazier',
+      },
+    ]);
+    const [torch] = buildCryptMoodLights([
+      {
+        entityId: 'c',
+        name: 'torch',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'torch-ornate',
+      },
+    ]);
+    expect(brazier!.intensity).toBeGreaterThan(candle!.intensity);
+    expect(brazier!.distance).toBeGreaterThan(candle!.distance);
+    expect(brazier!.intensity).toBeGreaterThan(torch!.intensity);
+    expect(brazier!.distance).toBeGreaterThan(torch!.distance);
+  });
+
+  it("torch-ornate reads slightly stronger/wider than the inferred door-frame glow below — it's a real light-source dressing piece, not just a highlight — while still sharing that glow's warm color", () => {
+    const [torch] = buildCryptMoodLights([
+      {
+        entityId: 'c',
+        name: 'torch',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle' as const,
+        propRefId: 'torch-ornate',
+      },
+    ]);
+    const [door] = buildCryptDoorLights([
+      wall(
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: -1, z: 0 },
+        WallKind.DOOR_CLOSED,
+        'door-a'
+      ),
+    ]);
+    expect(torch!.color).toBe(door!.color);
+    expect(torch!.intensity).toBeGreaterThan(door!.intensity);
+    expect(torch!.distance).toBeGreaterThan(door!.distance);
+  });
 });
 
 describe('buildCryptDoorLights (mid-flight scope addition — warm torch contrast + door visibility)', () => {
@@ -1053,5 +1161,114 @@ describe('buildThemeMoodLights (rpg-dnd5e-web#558 real-route mood-light assembly
     expect(lights).toHaveLength(1);
     // near candle's world position is [0,...,0]; far candle's is far from [0,0].
     expect(lights[0]!.position[0]).toBeCloseTo(0, 5);
+  });
+
+  it("returns [] for a non-'crypt' theme even when brazier/torch-ornate light-anchor props are present — the new mappings never leak lights into an unthemed/differently-themed space", () => {
+    const brazierProp: RenderableEntity = {
+      entityId: 'brazier-1',
+      name: 'brazier',
+      position: { x: 0, y: 0, z: 0 },
+      type: 'obstacle',
+      propRefId: 'brazier',
+    };
+    const torchProp: RenderableEntity = {
+      entityId: 'torch-1',
+      name: 'torch',
+      position: { x: 1, y: -1, z: 0 },
+      type: 'obstacle',
+      propRefId: 'torch-ornate',
+    };
+    expect(
+      buildThemeMoodLights(undefined, [doorWall], [brazierProp, torchProp], 8)
+    ).toEqual([]);
+  });
+
+  it('caps a MIXED set of light-anchor types (candles, braziers, torch-ornate) plus door lights at the budget, keeping the ones nearest the reference position regardless of prop type — rpg-toolkit#839 real content will mix these, unlike the homogeneous-candles cap test above', () => {
+    // 2 candles + 2 braziers + 3 torch-ornate (one deliberately far) + 2
+    // doors = 9 raw sources, one over the 8 budget. Every non-far source
+    // sits within world x=0..8 of the [0,0] reference; the far torch sits
+    // at world x=100 — unambiguously the single farthest source — so
+    // exactly it should be the one the cap drops.
+    const mixedProps: RenderableEntity[] = [
+      {
+        entityId: 'candle-1',
+        name: 'candle',
+        position: { x: 0, y: 0, z: 0 },
+        type: 'obstacle',
+        propRefId: 'candles',
+      },
+      {
+        entityId: 'candle-2',
+        name: 'candle',
+        position: { x: 1, y: -1, z: 0 },
+        type: 'obstacle',
+        propRefId: 'candles',
+      },
+      {
+        entityId: 'brazier-1',
+        name: 'brazier',
+        position: { x: 2, y: -2, z: 0 },
+        type: 'obstacle',
+        propRefId: 'brazier',
+      },
+      {
+        entityId: 'brazier-2',
+        name: 'brazier',
+        position: { x: 3, y: -3, z: 0 },
+        type: 'obstacle',
+        propRefId: 'brazier',
+      },
+      {
+        entityId: 'torch-1',
+        name: 'torch',
+        position: { x: 4, y: -4, z: 0 },
+        type: 'obstacle',
+        propRefId: 'torch-ornate',
+      },
+      {
+        entityId: 'torch-2',
+        name: 'torch',
+        position: { x: 5, y: -5, z: 0 },
+        type: 'obstacle',
+        propRefId: 'torch-ornate',
+      },
+      {
+        entityId: 'torch-far',
+        name: 'torch (far outlier)',
+        position: { x: 100, y: -100, z: 0 },
+        type: 'obstacle',
+        propRefId: 'torch-ornate',
+      },
+    ];
+    const doorWalls = [
+      wall(
+        { x: 6, y: -6, z: 0 },
+        { x: 7, y: -7, z: 0 },
+        WallKind.DOOR_CLOSED,
+        'door-1'
+      ),
+      wall(
+        { x: 7, y: -7, z: 0 },
+        { x: 8, y: -8, z: 0 },
+        WallKind.DOOR_CLOSED,
+        'door-2'
+      ),
+    ];
+    const lights = buildThemeMoodLights(
+      'crypt',
+      doorWalls,
+      mixedProps,
+      8,
+      [0, 0]
+    );
+    expect(lights).toHaveLength(8);
+    // Distinguish surviving lights by type via their (color, intensity,
+    // distance) spec, since MoodPointLight carries no entityId to check
+    // directly. Each of the 4 non-far types keeps its full count; only the
+    // lone far torch-ornate is dropped, leaving 2 of its 3 instances.
+    expect(lights.filter((l) => l.distance === 4.5)).toHaveLength(2); // candles
+    expect(lights.filter((l) => l.distance === 5.5)).toHaveLength(2); // braziers
+    expect(lights.filter((l) => l.distance === 3.6)).toHaveLength(2); // torch-ornate (near only)
+    expect(lights.filter((l) => l.distance === 3)).toHaveLength(2); // doors
   });
 });

--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -940,6 +940,22 @@ describe('buildCryptMoodLights (rpg-dnd5e-web#558 crypt spike, mood-lighting pas
     expect(torch!.intensity).toBeGreaterThan(door!.intensity);
     expect(torch!.distance).toBeGreaterThan(door!.distance);
   });
+
+  it("skips a propRefId matching a Object.prototype member name ('constructor', 'toString', '__proto__') instead of resolving it through the prototype chain into a truthy non-spec value (Copilot review, PR #588: a plain-object index lookup would let these slip past the falsy-spec skip check)", () => {
+    const props = [
+      'constructor',
+      'toString',
+      'hasOwnProperty',
+      '__proto__',
+    ].map((propRefId, i) => ({
+      entityId: `p${i}`,
+      name: propRefId,
+      position: { x: i, y: -i, z: 0 },
+      type: 'obstacle' as const,
+      propRefId,
+    }));
+    expect(buildCryptMoodLights(props)).toEqual([]);
+  });
 });
 
 describe('buildCryptDoorLights (mid-flight scope addition — warm torch contrast + door visibility)', () => {

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -723,12 +723,19 @@ interface MoodLightSpec {
  *   room, so it needs the largest reach of the three to plausibly read as
  *   the room's own light source: brighter and wider than even the
  *   candles' accent pools.
+ *
+ * A `Map`, not a plain object: `propRefId` traces back to server-sent
+ * obstacle_ref/prop_ref ids (Copilot review, PR #588) — a plain-object
+ * index lookup would resolve a propRefId of `'constructor'`/`'toString'`/
+ * etc. through the prototype chain to a truthy `Function`, slipping past
+ * `if (!spec) continue` below and pushing a light built from `undefined`
+ * fields. `Map.prototype.get` has no such prototype-chain fallback.
  */
-const MOOD_LIGHT_SPEC_BY_PROP_REF: Record<string, MoodLightSpec> = {
-  candles: { color: '#3ddc84', intensity: 2, distance: 4.5 },
-  'torch-ornate': { color: WARM_LIGHT_COLOR, intensity: 1.6, distance: 3.6 },
-  brazier: { color: WARM_LIGHT_COLOR, intensity: 2.8, distance: 5.5 },
-};
+const MOOD_LIGHT_SPEC_BY_PROP_REF: Map<string, MoodLightSpec> = new Map([
+  ['candles', { color: '#3ddc84', intensity: 2, distance: 4.5 }],
+  ['torch-ornate', { color: WARM_LIGHT_COLOR, intensity: 1.6, distance: 3.6 }],
+  ['brazier', { color: WARM_LIGHT_COLOR, intensity: 2.8, distance: 5.5 }],
+]);
 
 export interface MoodPointLight {
   position: [number, number, number];
@@ -749,7 +756,9 @@ export function buildCryptMoodLights(
 ): MoodPointLight[] {
   const lights: MoodPointLight[] = [];
   for (const prop of props) {
-    const spec = prop.propRefId && MOOD_LIGHT_SPEC_BY_PROP_REF[prop.propRefId];
+    const spec = prop.propRefId
+      ? MOOD_LIGHT_SPEC_BY_PROP_REF.get(prop.propRefId)
+      : undefined;
     if (!spec) continue;
     const world = cubeToWorld(prop.position, HEX_SIZE);
     lights.push({

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -689,12 +689,45 @@ export function buildCryptLayout(): CryptLayout {
  * a lighting approximation, not a per-model attachment point). */
 const MOOD_LIGHT_HEIGHT = 1.2;
 
-/** propRefId -> glow color. Only 'candles' has a shipped catalog piece
- * today (obstaclePropKeys.ts's own doc comment: BRAZIER has no matching
- * wave-1 piece yet) — brazier/torch entries would slot in here once one
- * exists, warm orange instead of green. */
-const MOOD_LIGHT_COLOR_BY_PROP_REF: Record<string, string> = {
-  candles: '#3ddc84',
+/** Warm-orange glow — the "warm torch contrast" half of Kirk's POLYGON
+ * Dark Fortress reference palette. Shared by three distinct fixtures
+ * (brazier, torch-ornate, and the door lights below) so the palette reads
+ * as one consistent warm-light family rather than three near-identical
+ * oranges picked independently. */
+const WARM_LIGHT_COLOR = '#ff9d52';
+
+interface MoodLightSpec {
+  color: string;
+  intensity: number;
+  distance: number;
+}
+
+/**
+ * propRefId -> mood light spec (color + falloff), for every light-anchor
+ * prop rpg-toolkit#839 places in a generated crypt (rpg-dnd5e-web#569).
+ * `candles` shipped first (#558); `brazier`/`torch-ornate` both have
+ * shipped catalog pieces (propManifest.ts) but only start actually
+ * appearing in real layouts once toolkit#839 lands.
+ *
+ * Intensity/distance are tuned by role, not just color, smallest to
+ * largest reach:
+ * - candles: the sickly-green ACCENT POOLS — a room can hold several
+ *   (buildCryptLayout's demo places 2 per chamber), so each stays modest;
+ *   many small pools read better than one loud one. Unchanged from #558.
+ * - torch-ornate: a warm wall-mounted dressing piece — a real light
+ *   source (unlike the door glow below, which is an inferred door-frame
+ *   highlight with no prop behind it), but still a secondary/accent
+ *   fixture a room can hold several of, so only a shade past the door
+ *   glow's own falloff.
+ * - brazier: the warm ROOM ANCHOR — toolkit#839 places at most one per
+ *   room, so it needs the largest reach of the three to plausibly read as
+ *   the room's own light source: brighter and wider than even the
+ *   candles' accent pools.
+ */
+const MOOD_LIGHT_SPEC_BY_PROP_REF: Record<string, MoodLightSpec> = {
+  candles: { color: '#3ddc84', intensity: 2, distance: 4.5 },
+  'torch-ornate': { color: WARM_LIGHT_COLOR, intensity: 1.6, distance: 3.6 },
+  brazier: { color: WARM_LIGHT_COLOR, intensity: 2.8, distance: 5.5 },
 };
 
 export interface MoodPointLight {
@@ -716,35 +749,34 @@ export function buildCryptMoodLights(
 ): MoodPointLight[] {
   const lights: MoodPointLight[] = [];
   for (const prop of props) {
-    const color =
-      prop.propRefId && MOOD_LIGHT_COLOR_BY_PROP_REF[prop.propRefId];
-    if (!color) continue;
+    const spec = prop.propRefId && MOOD_LIGHT_SPEC_BY_PROP_REF[prop.propRefId];
+    if (!spec) continue;
     const world = cubeToWorld(prop.position, HEX_SIZE);
     lights.push({
       position: [world.x, MOOD_LIGHT_HEIGHT, world.z],
-      color,
-      intensity: 2,
-      distance: 4.5,
+      color: spec.color,
+      intensity: spec.intensity,
+      distance: spec.distance,
     });
   }
   return lights;
 }
 
-/** Warm-orange glow color for door lights below — the "warm torch
- * contrast" half of Kirk's reference palette, otherwise unused today
- * since no brazier/torch prop exists yet (see MOOD_LIGHT_COLOR_BY_PROP_REF's
- * doc comment). */
-const DOOR_LIGHT_COLOR = '#ff9d52';
+/** Warm-orange glow color for door lights below — shares WARM_LIGHT_COLOR
+ * with the brazier/torch-ornate entries above rather than hand-picking its
+ * own shade, so all three warm fixtures read as one family. */
+const DOOR_LIGHT_COLOR = WARM_LIGHT_COLOR;
 
 /**
  * A small warm point light at each door's own cell — two practical wins
  * at once: (1) the "warm torch contrast" half of the reference palette
- * actually shows up somewhere even without a shipped brazier/torch prop,
- * and (2) doors sit far from the nearest candle (entrance/boss chamber
- * centers) so without this they're nearly invisible under the near-dark
- * mood lighting, undermining "click the door to open it." Lower intensity/
- * distance than a candle (a door isn't the room's centerpiece light) —
- * just enough to read the frame and leaf against the dark wall around it.
+ * shows up at every door, independent of whether a brazier/torch-ornate
+ * prop happens to be placed nearby, and (2) doors sit far from the nearest
+ * candle (entrance/boss chamber centers) so without this they're nearly
+ * invisible under the near-dark mood lighting, undermining "click the door
+ * to open it." Lower intensity/distance than a candle (a door isn't the
+ * room's centerpiece light) — just enough to read the frame and leaf
+ * against the dark wall around it.
  */
 export function buildCryptDoorLights(walls: Wall[]): MoodPointLight[] {
   const lights: MoodPointLight[] = [];
@@ -898,12 +930,13 @@ export function capMoodLights(
  *
  * Real crypt encounters place obstacle props like obelisk/pillar/coffin/
  * altar/statue (api#702) — NONE of which match
- * `MOOD_LIGHT_COLOR_BY_PROP_REF`'s `'candles'` key (the only shipped
- * light-source prop today), so `buildCryptMoodLights` legitimately
- * contributes zero lights for a real crypt today. That's correct, not a
- * bug: the real route still gets ambient + door lights, matching the
- * demo's "warm torch contrast" half of the palette, just not the
- * candle-glow half until a real encounter places a candle prop.
+ * `MOOD_LIGHT_SPEC_BY_PROP_REF`'s keys (`candles`/`torch-ornate`/`brazier`),
+ * so `buildCryptMoodLights` legitimately contributes zero lights for a real
+ * crypt until rpg-toolkit#839's light-anchor set pieces land. That's
+ * correct, not a bug: the real route still gets ambient + door lights,
+ * matching the demo's "warm torch contrast" half of the palette, just not
+ * the candle/brazier/torch glow half until a real encounter places one of
+ * those props.
  */
 export function buildThemeMoodLights(
   theme: 'crypt' | undefined,


### PR DESCRIPTION
— implementer (asset-pipeline), on behalf of KirkDiggler

Extends the crypt mood-light derivation (`MOOD_LIGHT_SPEC_BY_PROP_REF` in `src/components/playtest/playtestMapHelpers.ts`, ex-`MOOD_LIGHT_COLOR_BY_PROP_REF`) so the light-anchor props rpg-toolkit#839 is adding to the generated crypt (brazier, torch-ornate, plus candles/bone-pile) actually glow when placed, rather than only `candles` producing light.

## What changed

- `MOOD_LIGHT_COLOR_BY_PROP_REF: Record<string, string>` (color only) became `MOOD_LIGHT_SPEC_BY_PROP_REF: Record<string, MoodLightSpec>` (color + intensity + distance), because braziers and torch-ornate pieces need different falloff than candles, not just a different color:
  - `candles` — sickly-green **accent pools** (unchanged from #558: intensity 2, distance 4.5). A room can hold several, so each stays modest.
  - `torch-ornate` — warm orange (`#ff9d52`, the existing `DOOR_LIGHT_COLOR` family), intensity 1.6 / distance 3.6. A real light-source dressing piece (unlike the inferred door-frame glow), but still a secondary fixture a room can hold several of — tuned only a shade past the door glow's own falloff.
  - `brazier` — same warm family, intensity 2.8 / distance 5.5. toolkit#839 places at most one per room, so it's tuned as the **room anchor**: the brightest/widest-reaching of the three, wider even than the candle accent pools.
  - `DOOR_LIGHT_COLOR` now derives from the same `WARM_LIGHT_COLOR` constant instead of an independently hand-picked hex value, so all three warm fixtures read as one palette family.
- `buildCryptMoodLights` now looks up the full spec (not just a color) per `propRefId`.
- Updated doc comments that referenced the old map name / the "only candles ships today" framing.

## Why this is safe to merge independently of toolkit#839

This is the client-side seam only. `buildCryptMoodLights` skips any `propRefId` it doesn't recognize, so until rpg-toolkit#839 merges and the api bump lands, real encounters never send `propRefId: 'brazier'` or `'torch-ornate'` — the new map entries are simply dead code paths today, producing zero behavior change. Today's rendering (candles glow, everything else doesn't) is byte-identical. The visible brazier/torch glow only shows up once toolkit#839's light-anchor set pieces start appearing in generated crypts and the api dependency bump ships.

## Testing

Added to `playtestMapHelpers.test.ts`:
- Color mapping: brazier/torch-ornate both resolve to the warm-orange family (`#ff9d52`), not candle green.
- Intensity/distance ordering: brazier > candle > torch-ornate > door-glow's own falloff (asserted directly, not just "non-zero").
- Cap behavior with a **mixed** set (2 candles + 2 braziers + 3 torch-ornate incl. one far outlier + 2 doors = 9 raw sources over the budget-of-8 cap) — verifies the nearest-N cap still behaves correctly once sources aren't all one type, dropping exactly the single farthest outlier regardless of its prop type.
- No-op regression: a non-`'crypt'` theme still returns `[]` even when brazier/torch-ornate props are present in the entity list — new mappings never leak lights into an unthemed/differently-themed space.

Verified regression coverage is real by temporarily reverting `MOOD_LIGHT_SPEC_BY_PROP_REF` to its pre-PR (`candles`-only) shape and confirming 5 of the new tests go red, then restoring.

`npm run ci-check` green (format/lint/typecheck/build/tests) before push.

Refs #569, rpg-toolkit#839.

## Test plan
- [x] `npm run ci-check` passes
- [x] Reverted the new mappings locally and confirmed tests fail red, then restored
- [ ] Visual confirmation once toolkit#839 merges + api bump lands (out of scope for this PR — no shipped brazier/torch-ornate props exist server-side yet)