### PR TITLE
feat(monsters)#559: render real crypt-monster models instead of the blue placeholder

### DIFF
--- a/docs/evidence/crypt-monsters-594-reference-tomb.md
+++ b/docs/evidence/crypt-monsters-594-reference-tomb.md
@@ -42,7 +42,12 @@ matching `CHARACTER_Y_OFFSET=0.05` below the default Synty floor top of 0.20.
 The shared placement offset is now 0.21, above both Synty (0.20) and shaded
 (0.15) floor tops, with clearance for slightly negative GLB foot minima.
 
-No post-fix browser screenshot or dynamic movement/death observation is
-claimed: the browser screenshot capture timed out before a reload. The
-resolver's mappings, downed behavior, and two-clip asset contract remain
-covered by their existing unit and export checks.
+At `5904db5`, Kirk manually reloaded
+`http://127.0.0.1:3004/?playerId=alice`, confirmed that the skeleton runtime
+GLBs visibly load in the reference-tomb encounter, and approved Soldier01's
+post-fix floor contact as "looks great".
+
+This run does not claim captain visibility, `Walk_Forward` dynamic playback,
+or the downed sibling swap. The two-clip export contract and resolver/downed
+behavior remain supported separately by existing private export validation and
+web unit tests.

--- a/docs/evidence/crypt-monsters-594-reference-tomb.md
+++ b/docs/evidence/crypt-monsters-594-reference-tomb.md
@@ -1,0 +1,41 @@
+# Crypt Monsters PR #594 Evidence
+
+## Inputs
+
+- Private asset main: `05f33a7cd1d8ab0bbe530519d46dcfbde2191ac0`
+  (`Merge pull request #31 from KirkDiggler/asset/128-crypt-monsters-export`).
+- Asset manifest: all seven standing entries contain exactly
+  `Idle_Relaxed`, then `Walk_Forward`; the required
+  `skeleton-soldier-01.glb` and `skeleton-knight.glb` paths are present.
+- Resolver scope: `skeleton` deterministically selects Soldier01 and
+  `skeleton-captain` selects Knight. Slave, ghosts, and Tormented Soul remain
+  unselectable. Authoritative `monsterRefId` precedence and the #595
+  missing-downed fallback boundary remain unchanged.
+
+## Asset Sync
+
+`npm run assets:sync` cloned private `rpg-game-assets` at the asset SHA above
+and mirrored `harness/models/synty/` into ignored
+`public/models/synty/`. Both required standing GLBs exist locally.
+`git check-ignore -q public/models/synty/npcs/skeleton-soldier-01.glb` exited
+zero; `git status --short --ignored public/models/synty/npcs` reported only
+`!! public/models/synty/`. No public model files are committed.
+
+## Automated Checks
+
+- `npm run test:run -- src/components/hex-grid/monsterModels.test.ts src/components/hex-grid/HexEntity.test.ts`: 20 passing tests.
+- `npm run test:run`: 76 files and 1310 tests passing.
+- `npm run typecheck`: passing.
+- `npm run build`: passing (the established chunk-size warning remains).
+- `npm run ci-check`: passing.
+
+## Reference Tomb Browser Result
+
+Browser verification is blocked, so no screenshots are attached or claimed.
+The active browser session at `http://localhost:3004/?playerId=alice` shows a
+different existing encounter whose only monster label is `entrance...`.
+The current-worktree Vite server is not running, and the repositories contain
+no documented local-stack/content-loading command that imports
+`/home/kirk/game-dev/dungeon-content/reference-tomb.yaml` into the listener on
+port 8080. Consequently this PR has not yet proven the reference tomb's
+Soldier01/Knight standing, moving, and downed sibling rendering in a browser.

--- a/docs/evidence/crypt-monsters-594-reference-tomb.md
+++ b/docs/evidence/crypt-monsters-594-reference-tomb.md
@@ -31,11 +31,18 @@ zero; `git status --short --ignored public/models/synty/npcs` reported only
 
 ## Reference Tomb Browser Result
 
-Browser verification is blocked, so no screenshots are attached or claimed.
-The active browser session at `http://localhost:3004/?playerId=alice` shows a
-different existing encounter whose only monster label is `entrance...`.
-The current-worktree Vite server is not running, and the repositories contain
-no documented local-stack/content-loading command that imports
-`/home/kirk/game-dev/dungeon-content/reference-tomb.yaml` into the listener on
-port 8080. Consequently this PR has not yet proven the reference tomb's
-Soldier01/Knight standing, moving, and downed sibling rendering in a browser.
+The local content runtime is configured with `RPG_DUNGEON_KEY=reference-tomb`
+and `/home/kirk/game-dev/dungeon-content` mounted at `/content`. A PR-worktree
+Vite server was started on port 3004 with `VITE_API_HOST=http://localhost:8080`.
+Using Alice through the normal lobby flow (create, ready, Start) created a new
+local encounter; `StartEncounter` and `StreamEncounter` returned HTTP 200.
+
+The user-provided runtime screenshot showed both skeletons sunk by about 0.15,
+matching `CHARACTER_Y_OFFSET=0.05` below the default Synty floor top of 0.20.
+The shared placement offset is now 0.21, above both Synty (0.20) and shaded
+(0.15) floor tops, with clearance for slightly negative GLB foot minima.
+
+No post-fix browser screenshot or dynamic movement/death observation is
+claimed: the browser screenshot capture timed out before a reload. The
+resolver's mappings, downed behavior, and two-clip asset contract remain
+covered by their existing unit and export checks.

--- a/src/components/hex-grid/ClassCharacterModel.tsx
+++ b/src/components/hex-grid/ClassCharacterModel.tsx
@@ -70,6 +70,12 @@ export interface ClassCharacterModelProps {
    * instead of idle. Defaults false (idle), matching every pre-#542 caller
    * unchanged. */
   isMoving?: boolean;
+  /** True when `url` resolves a downed/dead-pose GLB (rpg-dnd5e-web#501/
+   * #559) — those ship with 0 baked clips BY DESIGN (a static collapsed
+   * pose, not an animated one), so the dev-mode zero-clip warning below
+   * doesn't fire for them. Defaults false, matching every pre-existing
+   * standing-model caller. */
+  isDownedVariant?: boolean;
 }
 
 export function ClassCharacterModel({
@@ -78,6 +84,7 @@ export function ClassCharacterModel({
   isGhost = false,
   facingRotation = 0,
   isMoving = false,
+  isDownedVariant = false,
 }: ClassCharacterModelProps) {
   // useGLTF returns drei's shared, URL-keyed cache — mutating it directly
   // during render is a render-phase side effect on shared state (same
@@ -175,6 +182,32 @@ export function ClassCharacterModel({
       action?.fadeOut(0.2);
     };
   }, [actions, resolvedClipName]);
+
+  // Dev-mode-only zero-clip warning (rpg-dnd5e-web#559 review). A standing
+  // model with NO baked clip at all renders at its raw bind pose, which
+  // reads fine ONLY if the rig's rest pose was itself authored to be
+  // presentable (Kirk: Auto-Rig Pro "made it much easier to get the default
+  // non t pose" — the fix belongs on the asset side, in the rig's rest
+  // pose, not by refusing to mount a perfectly good model here). When it
+  // wasn't, this is silent and looks like a bug rather than reading as an
+  // intentional pose — the exact hazard classCharacterModels.ts's
+  // `_animFixComment`/`_idleClipsComment` already documents for a DIFFERENT
+  // Synty pack ("Stance clips bake their held pose into the FBX's own rest
+  // matrices... silently reproduces the target's T-pose bind"). Warn loudly
+  // in dev instead of suppressing the model — never fires for downed
+  // variants, which ship 0 clips by design (a static collapsed pose).
+  useEffect(() => {
+    if (isDownedVariant) return;
+    if (names.length > 0) return;
+    if (import.meta.env.MODE !== 'development') return;
+    console.warn(
+      `[ClassCharacterModel] ${url} mounted with zero animation clips — ` +
+        'it will render at its raw bind pose. If that pose was not authored ' +
+        "to stand presentably (see this effect's doc comment), it will " +
+        'read as a broken/T-posed model rather than an intentional static ' +
+        'look.'
+    );
+  }, [isDownedVariant, names, url]);
 
   // HexGrid's Canvas runs frameloop="demand" (only re-renders on explicit
   // invalidate() calls, not every rAF tick — see HexEntity.tsx's identical

--- a/src/components/hex-grid/HexEntity.test.ts
+++ b/src/components/hex-grid/HexEntity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { shouldTiltDeadOrDowned } from './HexEntity';
+
+describe('shouldTiltDeadOrDowned', () => {
+  // The six combinations a reviewer verified by hand on PR #594
+  // (rpg-dnd5e-web#559) -- pinned here so a future change can't quietly
+  // break one without a red test, the same "arithmetic, not a screenshot"
+  // reasoning as facing.test.ts's constant-split parity assertions.
+
+  it('dead + no resolved model (MediumHumanoid fallback) -> tilts', () => {
+    expect(shouldTiltDeadOrDowned(true, false, false)).toBe(true);
+  });
+
+  it('dead + a resolved model (its own posed downed GLB) -> does NOT tilt', () => {
+    expect(shouldTiltDeadOrDowned(true, false, true)).toBe(false);
+  });
+
+  it('downed + no resolved model (MediumHumanoid fallback) -> tilts', () => {
+    expect(shouldTiltDeadOrDowned(false, true, false)).toBe(true);
+  });
+
+  it('downed + a resolved model (its own posed downed GLB) -> does NOT tilt', () => {
+    expect(shouldTiltDeadOrDowned(false, true, true)).toBe(false);
+  });
+
+  it('alive (neither dead nor downed) + no resolved model -> does NOT tilt', () => {
+    expect(shouldTiltDeadOrDowned(false, false, false)).toBe(false);
+  });
+
+  it('alive (neither dead nor downed) + a resolved model -> does NOT tilt', () => {
+    expect(shouldTiltDeadOrDowned(false, false, true)).toBe(false);
+  });
+
+  it('both dead and downed set (should never happen on the real route, but the OR shape must not double-negate) -> tilts without a resolved model', () => {
+    expect(shouldTiltDeadOrDowned(true, true, false)).toBe(true);
+  });
+});

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -28,10 +28,12 @@ import { resolveClassCharacterModelUrl } from './classCharacterModels';
 import {
   DEFAULT_HEADING_BY_TYPE,
   MEDIUM_HUMANOID_FORWARD_OFFSET,
+  POLYGON_DUNGEON_FORWARD_OFFSET,
   SYNTY_GLB_FORWARD_OFFSET,
 } from './facing';
 import { cubeToWorld, type CubeCoord } from './hexMath';
 import { MediumHumanoid, type SkinTone } from './MediumHumanoid';
+import { resolveMonsterModelUrl } from './monsterModels';
 import { resolvePropVariantForEntity } from './obstaclePropKeys';
 import { PROPS_MODEL_BASE } from './propManifest';
 import { PropModel } from './PropModel';
@@ -50,6 +52,13 @@ export interface HexEntityProps {
   character?: Character;
   /** Monster data for texture selection (includes monsterType) */
   monster?: MonsterCombatState;
+  /** v1alpha2 MonsterData.monster_ref.id (e.g. "skeleton",
+   * "skeleton-captain") — resolves an npc GLB for monster entities
+   * (rpg-dnd5e-web#559), the monster-side counterpart of `classRefId`.
+   * Preferred over `monster?.monsterType` when present
+   * (monsterModels.ts's resolveMonsterModelUrl). Unmapped/undefined falls
+   * back to MediumHumanoid, unchanged (the #479 boundary lineage). */
+  monsterRefId?: string;
   /** Override hair style (proto doesn't have this field yet) */
   hairStyle?: HairStyle;
   /** Override hair color as hex string (proto doesn't have this field yet) */
@@ -225,6 +234,7 @@ export function HexEntity({
   onClick,
   character,
   monster,
+  monsterRefId,
   hairStyle,
   hairColor,
   facialHairStyle,
@@ -269,22 +279,27 @@ export function HexEntity({
   );
 
   // Same "sticky failure keyed by url, not a bare boolean" shape as
-  // failedClassModelUrl below — a prop GLB that fails to load falls back
+  // failedEntityModelUrl below — a prop GLB that fails to load falls back
   // to the primitive capsule, but a later obstacleType change (a
   // different resolved url) isn't permanently masked by a stale failure.
   const [failedPropModelUrl, setFailedPropModelUrl] = useState<
     string | undefined
   >(undefined);
 
-  // Tracks a class-model GLB url that failed to load (ErrorBoundary caught
-  // a terminal load error), so the downed-tilt check below can still fire
-  // once we've fallen back to MediumHumanoid — otherwise a downed player
-  // whose class GLB happens to be missing/broken would render upright
-  // (rpg-dnd5e-web#502 gate note). Compared against the *current*
-  // classModelUrl each render rather than a bare boolean so a later class/
-  // asset change (new classRefId, or the file becoming available again)
-  // isn't permanently masked by a stale failure from a different url.
-  const [failedClassModelUrl, setFailedClassModelUrl] = useState<
+  // Tracks a resolved Synty GLB url that failed to load (ErrorBoundary
+  // caught a terminal load error) so the downed-tilt check below can still
+  // fire once we've fallen back to MediumHumanoid — otherwise a downed/dead
+  // entity whose GLB happens to be missing/broken would render upright
+  // (rpg-dnd5e-web#502 gate note). One slot covers BOTH the player class
+  // model and the monster model (rpg-dnd5e-web#559) — the two are mutually
+  // exclusive per `type` (a player entity's resolved url is always
+  // `classModelUrl`, a monster's always `monsterModelUrl`, see
+  // `resolvedModelUrl` below), so there's no cross-contamination risk in
+  // sharing one slot. Compared against the *current* resolvedModelUrl each
+  // render rather than a bare boolean so a later class/monster-ref/asset
+  // change (or the file becoming available again) isn't permanently masked
+  // by a stale failure from a different url.
+  const [failedEntityModelUrl, setFailedEntityModelUrl] = useState<
     string | undefined
   >(undefined);
 
@@ -367,21 +382,44 @@ export function HexEntity({
       : resolveWeaponType(character, 'offHand');
     const shield = isTwoHanded ? undefined : resolveShield(character);
 
-    // rpg-dnd5e-web#501: monsters stay on MediumHumanoid this slice (scope
-    // decision — goblin/WarChief GLBs exist but monster classRef mapping is
-    // a different shape). Unmapped class / missing classRefId also falls
-    // through to undefined here, which is exactly the MediumHumanoid
-    // fallback signal below (the #479 boundary lineage: a data gap
-    // degrades to the known-working placeholder, never a broken model ref).
+    // Player class GLB (rpg-dnd5e-web#501). Unmapped class / missing
+    // classRefId falls through to undefined here, which is exactly the
+    // MediumHumanoid fallback signal below (the #479 boundary lineage: a
+    // data gap degrades to the known-working placeholder, never a broken
+    // model ref).
     const classModelUrl =
       type === 'player'
         ? resolveClassCharacterModelUrl(classRefId, isDowned)
         : undefined;
-    // undefined once classModelUrl itself is undefined, or once THIS url
+    // Monster npc GLB (rpg-dnd5e-web#559) — the same resolve-or-undefined
+    // shape as classModelUrl above, one entry per promoted crypt-roster
+    // monster (monsterModels.ts). `isDead` (not `isDowned`, which is a
+    // CHARACTER-only "unconscious" concept — see buildRenderableEntities)
+    // is this family's "use the downed pose variant" signal: monsters die
+    // at 0 HP rather than going unconscious.
+    const monsterModelUrl =
+      type === 'monster'
+        ? resolveMonsterModelUrl(monsterRefId, monsterType, isDead)
+        : undefined;
+    // Mutually exclusive by `type` — never both defined for the same
+    // entity, so combining them into one resolved url + one sticky-failure
+    // slot (failedEntityModelUrl above) is safe.
+    const resolvedModelUrl = classModelUrl ?? monsterModelUrl;
+    // The forward-axis correction is a property of WHICH rig is mounted,
+    // not of the entity type in the abstract — a player's resolved model is
+    // always the Fantasy Rivals class rig, a monster's is always the
+    // POLYGON Dungeon npc rig (facing.ts's #559 hazard callout: never reach
+    // for MEDIUM_HUMANOID_FORWARD_OFFSET once an entity renders a real
+    // Synty GLB instead of the MediumHumanoid placeholder).
+    const modelForwardOffset =
+      type === 'player'
+        ? SYNTY_GLB_FORWARD_OFFSET
+        : POLYGON_DUNGEON_FORWARD_OFFSET;
+    // undefined once resolvedModelUrl itself is undefined, or once THIS url
     // has failed to load — never stuck failed against a different url.
-    const effectiveClassModelUrl =
-      classModelUrl && classModelUrl !== failedClassModelUrl
-        ? classModelUrl
+    const effectiveModelUrl =
+      resolvedModelUrl && resolvedModelUrl !== failedEntityModelUrl
+        ? resolvedModelUrl
         : undefined;
 
     // Shared fallback element — used both as the "no class model" branch
@@ -426,13 +464,15 @@ export function HexEntity({
     return (
       <group ref={movingGroupRef} {...interactionProps}>
         {/* Dead/downed entities rendered with tilt when using the
-            MediumHumanoid fallback (no separate collapsed pose asset);
-            the class model's own downed GLB variant is already posed for
-            it, so no extra tilt there. Ghost entities rendered with ghost
+            MediumHumanoid fallback (no separate collapsed pose asset); a
+            resolved GLB's own downed/dead variant is already posed for it,
+            so no extra tilt there — true for both the player class model
+            and the monster npc model (rpg-dnd5e-web#559 generalized this
+            from a player-only check). Ghost entities rendered with ghost
             shader/opacity either way. */}
         <group
           rotation={
-            isDead || (isDowned && !effectiveClassModelUrl)
+            (isDead || isDowned) && !effectiveModelUrl
               ? [0, 0, Math.PI / 3]
               : [0, 0, 0]
           }
@@ -440,16 +480,16 @@ export function HexEntity({
           <Suspense
             fallback={<LoadingPlaceholder color={color} hexSize={hexSize} />}
           >
-            {effectiveClassModelUrl ? (
+            {effectiveModelUrl ? (
               <ErrorBoundary
                 fallback={mediumHumanoidElement}
-                onError={() => setFailedClassModelUrl(effectiveClassModelUrl)}
+                onError={() => setFailedEntityModelUrl(effectiveModelUrl)}
               >
                 <ClassCharacterModel
-                  url={effectiveClassModelUrl}
+                  url={effectiveModelUrl}
                   isSelected={!isDead && isSelected}
                   isGhost={isGhost}
-                  facingRotation={SYNTY_GLB_FORWARD_OFFSET}
+                  facingRotation={modelForwardOffset}
                   isMoving={!isDead && !isGhost && isMoving}
                 />
               </ErrorBoundary>

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -119,8 +119,8 @@ const ENTITY_HEIGHT = 1.5; // Height of the cylinder
 const ENTITY_RADIUS_SCALE = 0.3; // Radius as fraction of hex size
 const Y_OFFSET = 0.1; // Small Y offset to sit above the hex plane
 
-// Character model Y offset (characters stand on the ground)
-const CHARACTER_Y_OFFSET = 0.05;
+// Clear the default 0.20 Synty floor and slightly negative GLB foot minima.
+const CHARACTER_Y_OFFSET = 0.21;
 
 /**
  * Whether the dead/downed corpse tilt (60 degrees about Z) should apply.

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -122,6 +122,30 @@ const Y_OFFSET = 0.1; // Small Y offset to sit above the hex plane
 // Character model Y offset (characters stand on the ground)
 const CHARACTER_Y_OFFSET = 0.05;
 
+/**
+ * Whether the dead/downed corpse tilt (60 degrees about Z) should apply.
+ * Exported + pure so the six dead/downed x mapped/unmapped combinations are
+ * covered by a real test (HexEntity.test.ts) instead of only by a reviewer
+ * reading the JSX carefully — same "pull the composition into arithmetic a
+ * test can pin" reasoning as facing.ts's constant-split parity assertions
+ * (#590/#592) and the same "export a pure helper straight off the component
+ * file for coverage" precedent as HexGrid.tsx's isHexBlocked.
+ *
+ * Only tilt when falling back to the primitive/MediumHumanoid rendering
+ * (`!hasResolvedModel`) — a resolved GLB's own downed/dead variant is
+ * already posed for it (rpg-dnd5e-web#501 for players, generalized to
+ * monsters by rpg-dnd5e-web#559), so tilting it on top would double up on
+ * an already-prone body.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function shouldTiltDeadOrDowned(
+  isDead: boolean,
+  isDowned: boolean,
+  hasResolvedModel: boolean
+): boolean {
+  return (isDead || isDowned) && !hasResolvedModel;
+}
+
 /** Map Race enum to head variant for 3D model */
 const RACE_TO_HEAD_VARIANT: Partial<Record<Race, HeadVariant>> = {
   [Race.HUMAN]: 'human',
@@ -405,6 +429,12 @@ export function HexEntity({
     // entity, so combining them into one resolved url + one sticky-failure
     // slot (failedEntityModelUrl above) is safe.
     const resolvedModelUrl = classModelUrl ?? monsterModelUrl;
+    // Same per-type selection the two resolver calls above already made
+    // (isDowned for player, isDead for monster) — exposed as its own value
+    // so ClassCharacterModel knows whether a zero-clip mount is expected
+    // (a downed variant's static collapsed pose) or worth its dev-mode
+    // warning (a standing model that should hold a presentable pose).
+    const isDownedModelVariant = type === 'player' ? isDowned : isDead;
     // The forward-axis correction is a property of WHICH rig is mounted,
     // not of the entity type in the abstract — a player's resolved model is
     // always the Fantasy Rivals class rig, a monster's is always the
@@ -472,7 +502,7 @@ export function HexEntity({
             shader/opacity either way. */}
         <group
           rotation={
-            (isDead || isDowned) && !effectiveModelUrl
+            shouldTiltDeadOrDowned(isDead, isDowned, !!effectiveModelUrl)
               ? [0, 0, Math.PI / 3]
               : [0, 0, 0]
           }
@@ -491,6 +521,7 @@ export function HexEntity({
                   isGhost={isGhost}
                   facingRotation={modelForwardOffset}
                   isMoving={!isDead && !isGhost && isMoving}
+                  isDownedVariant={isDownedModelVariant}
                 />
               </ErrorBoundary>
             ) : (

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -63,6 +63,10 @@ export interface HexGridProps {
     /** v1alpha2 CharacterData.class_ref.id — drives class-model selection
      * for player entities (rpg-dnd5e-web#501). */
     classRefId?: string;
+    /** v1alpha2 MonsterData.monster_ref.id — drives npc-model selection
+     * for monster entities (rpg-dnd5e-web#559), the monster-side
+     * counterpart of classRefId. */
+    monsterRefId?: string;
     /** True for a CHARACTER entity carrying the "unconscious" condition —
      * the downed class-model swap (rpg-dnd5e-web#501). */
     isDowned?: boolean;
@@ -732,6 +736,7 @@ function Scene({
           onClick={handleEntityClick}
           character={characterMap.get(entity.entityId)}
           monster={monsterMap.get(entity.entityId)}
+          monsterRefId={entity.monsterRefId}
           isDead={entity.isDead}
           isGhost={entity.isGhost}
           classRefId={entity.classRefId}

--- a/src/components/hex-grid/facing.test.ts
+++ b/src/components/hex-grid/facing.test.ts
@@ -121,6 +121,12 @@ describe('constant split reproduces the pre-#590 hardcoded values', () => {
     ).toBeCloseTo(Math.PI, 12);
   });
 
+  it('monster on a POLYGON Dungeon npc GLB composes to 0 (rpg-dnd5e-web#559) -- mirrors the player+Synty case above; inert today since both terms are zero, which is exactly when a silent-cancellation bug would hide', () => {
+    expect(
+      norm(DEFAULT_HEADING_BY_TYPE.monster + POLYGON_DUNGEON_FORWARD_OFFSET)
+    ).toBeCloseTo(0, 12);
+  });
+
   it('measured forward offsets are zero because both rigs are +Z-forward', () => {
     // Recorded as an assertion, not just a comment: this is the MEASURED
     // finding (see the constants' doc comment). If a future model family

--- a/src/components/hex-grid/facing.test.ts
+++ b/src/components/hex-grid/facing.test.ts
@@ -4,6 +4,7 @@ import {
   easeHeading,
   headingFromDelta,
   MEDIUM_HUMANOID_FORWARD_OFFSET,
+  POLYGON_DUNGEON_FORWARD_OFFSET,
   shortestTurn,
   SYNTY_GLB_FORWARD_OFFSET,
   TURN_RATE_RAD_PER_SEC,
@@ -127,6 +128,10 @@ describe('constant split reproduces the pre-#590 hardcoded values', () => {
     // than these changing.
     expect(SYNTY_GLB_FORWARD_OFFSET).toBe(0);
     expect(MEDIUM_HUMANOID_FORWARD_OFFSET).toBe(0);
+  });
+
+  it('the POLYGON Dungeon npc rig also measures +Z-forward (rpg-dnd5e-web#559) — its own constant, not a reuse of SYNTY_GLB_FORWARD_OFFSET, even though the value agrees', () => {
+    expect(POLYGON_DUNGEON_FORWARD_OFFSET).toBe(0);
   });
 
   it('a heading of 0 points along world +Z, matching the rigs', () => {

--- a/src/components/hex-grid/facing.ts
+++ b/src/components/hex-grid/facing.ts
@@ -115,6 +115,30 @@ export const SYNTY_GLB_FORWARD_OFFSET = 0;
 export const MEDIUM_HUMANOID_FORWARD_OFFSET = 0;
 
 /**
+ * Per-model-family correction for the POLYGON Dungeon npc rigs
+ * (rpg-dnd5e-web#559 monster-model resolver) — a DIFFERENT Synty source
+ * pack from the Fantasy Rivals class models `SYNTY_GLB_FORWARD_OFFSET`
+ * measures, so its forward axis is not assumed to match (the #590 design
+ * doc's explicit hazard: two fused terms that happen to both be zero look
+ * identical to "one shared constant" until a future pack isn't zero).
+ *
+ * MEASURED, not assumed (rpg-dnd5e-web#559): rendered Character_
+ * Skeleton_Soldier_01.glb and Character_Skeleton_Knight.glb (the boss
+ * candidate — a visually distinct rig within the same pack, not just the
+ * same asset twice) via the real ClassCharacterModel component at rotation
+ * 0 and rotation PI, camera fixed on the world +Z axis. Both show the
+ * FACE at 0 and the BACK at PI, for both rigs — i.e. this pack is also
+ * already authored +Z-forward, the same convention `headingFromDelta`
+ * produces. Kept as its own named constant rather than reusing
+ * SYNTY_GLB_FORWARD_OFFSET even though the measured value is identical:
+ * the two packs are independent measurements that happen to agree, not one
+ * fact — a future POLYGON Dungeon asset revision or a different npc family
+ * needs this seam to diverge from Fantasy Rivals without touching that
+ * constant's own (separately measured) meaning.
+ */
+export const POLYGON_DUNGEON_FORWARD_OFFSET = 0;
+
+/**
  * Spawn pose. NOT a model correction — this is staging: players face up-board
  * and monsters face down-board so an encounter reads as two sides squaring off.
  * Preserved deliberately (Kirk, 2026-07-24); entities turn out of it as soon as

--- a/src/components/hex-grid/floorOverlayHeights.test.ts
+++ b/src/components/hex-grid/floorOverlayHeights.test.ts
@@ -131,6 +131,16 @@ describe('floor overlay Y offsets clear the floor extrusion top', () => {
     expect(offset).toBeGreaterThan(syntyTop);
   });
 
+  it('shared character placement clears both floor renderers', () => {
+    const entitySrc = readSource('./HexEntity.tsx');
+    const floorSrc = readSource('./SyntyHexFloor.tsx');
+    const characterOffset = extractNumberConst(entitySrc, 'CHARACTER_Y_OFFSET');
+    const syntyTop = extractNumberConst(floorSrc, SYNTY_FLOOR_TOP_CONST);
+
+    expect(characterOffset).toBeGreaterThan(FLOOR_TOP_Y);
+    expect(characterOffset).toBeGreaterThan(syntyTop);
+  });
+
   it('SyntyHexFloor is unextruded, so FLOOR_Y is genuinely its top face', () => {
     // Guard the "flat plane, position IS the top" assumption the two tests
     // above rely on. If SyntyHexFloor ever grows real extrusion depth (an

--- a/src/components/hex-grid/monsterModels.test.ts
+++ b/src/components/hex-grid/monsterModels.test.ts
@@ -3,10 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { resolveMonsterModelUrl } from './monsterModels';
 
 describe('resolveMonsterModelUrl', () => {
-  it('resolves the standing model for "skeleton" (v1alpha2 monsterRefId) to its first candidate look', () => {
-    // Skeleton has two promoted looks (Soldier_01/02, rpg-dnd5e-web#559) --
-    // this resolver, like resolvePropVariant's PROP_KEYS[key]?.[0], doesn't
-    // do per-instance variant selection yet, so the first candidate wins.
+  it('resolves the standing model for "skeleton" (v1alpha2 monsterRefId) to deterministic Soldier01', () => {
     expect(resolveMonsterModelUrl('skeleton', undefined, false)).toBe(
       '/models/synty/npcs/skeleton-soldier-01.glb'
     );
@@ -57,13 +54,21 @@ describe('resolveMonsterModelUrl', () => {
     ).toBe('/models/synty/npcs/skeleton-knight.glb');
   });
 
-  it('returns undefined for an unmapped monsterRefId (no promoted GLB yet)', () => {
-    // "ghost"/"specter" have no rpg-toolkit monster ref at all yet (the
-    // undead roster promoted for rpg-dnd5e-web#559 ships those GLBs ahead
-    // of the rules-engine identity that would ever select them) --
-    // MediumHumanoid fallback is correct here, not a gap to fix.
+  it('keeps asset-ready Slave and spirits unselectable in Phase 1', () => {
+    expect(
+      resolveMonsterModelUrl('skeleton-slave', undefined, false)
+    ).toBeUndefined();
     expect(resolveMonsterModelUrl('ghost', undefined, false)).toBeUndefined();
     expect(resolveMonsterModelUrl('specter', undefined, false)).toBeUndefined();
+    expect(
+      resolveMonsterModelUrl('tormented-soul', undefined, false)
+    ).toBeUndefined();
+  });
+
+  it('keeps an authoritative unmapped monsterRefId over a mapped enum fallback', () => {
+    expect(
+      resolveMonsterModelUrl('ghost', MonsterType.SKELETON, false)
+    ).toBeUndefined();
   });
 
   it('returns undefined for an unmapped MonsterType (no zombie GLB is promoted -- rpg-dnd5e-web#559 tracks a green-tinted class-model reuse instead)', () => {

--- a/src/components/hex-grid/monsterModels.test.ts
+++ b/src/components/hex-grid/monsterModels.test.ts
@@ -1,0 +1,94 @@
+import { MonsterType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+import { describe, expect, it } from 'vitest';
+import { resolveMonsterModelUrl } from './monsterModels';
+
+describe('resolveMonsterModelUrl', () => {
+  it('resolves the standing model for "skeleton" (v1alpha2 monsterRefId) to its first candidate look', () => {
+    // Skeleton has two promoted looks (Soldier_01/02, rpg-dnd5e-web#559) --
+    // this resolver, like resolvePropVariant's PROP_KEYS[key]?.[0], doesn't
+    // do per-instance variant selection yet, so the first candidate wins.
+    expect(resolveMonsterModelUrl('skeleton', undefined, false)).toBe(
+      '/models/synty/npcs/skeleton-soldier-01.glb'
+    );
+  });
+
+  it('resolves the downed model for "skeleton"', () => {
+    expect(resolveMonsterModelUrl('skeleton', undefined, true)).toBe(
+      '/models/synty/npcs/skeleton-soldier-01-downed.glb'
+    );
+  });
+
+  it('resolves the boss "skeleton-captain" ref id (rpg-toolkit#816 non-wight boss) to the promoted Skeleton_Knight visual', () => {
+    expect(resolveMonsterModelUrl('skeleton-captain', undefined, false)).toBe(
+      '/models/synty/npcs/skeleton-knight.glb'
+    );
+    expect(resolveMonsterModelUrl('skeleton-captain', undefined, true)).toBe(
+      '/models/synty/npcs/skeleton-knight-downed.glb'
+    );
+  });
+
+  it('is case-insensitive and trims whitespace, matching resolveClassCharacterModelUrl', () => {
+    expect(resolveMonsterModelUrl(' SKELETON ', undefined, false)).toBe(
+      '/models/synty/npcs/skeleton-soldier-01.glb'
+    );
+  });
+
+  it('falls back to the v1alpha1 MonsterType enum when monsterRefId is absent', () => {
+    expect(resolveMonsterModelUrl(undefined, MonsterType.SKELETON, false)).toBe(
+      '/models/synty/npcs/skeleton-soldier-01.glb'
+    );
+    expect(
+      resolveMonsterModelUrl(undefined, MonsterType.SKELETON_CAPTAIN, true)
+    ).toBe('/models/synty/npcs/skeleton-knight-downed.glb');
+  });
+
+  it('falls back to the v1alpha1 MonsterType enum when monsterRefId is an empty string', () => {
+    expect(resolveMonsterModelUrl('', MonsterType.SKELETON, false)).toBe(
+      '/models/synty/npcs/skeleton-soldier-01.glb'
+    );
+  });
+
+  it('prefers monsterRefId over monsterType when both are present', () => {
+    // Deliberately mismatched inputs -- not a real server response -- to
+    // prove precedence, same shape as obstaclePropKeys.test.ts's dual-signal
+    // precedence coverage.
+    expect(
+      resolveMonsterModelUrl('skeleton-captain', MonsterType.SKELETON, false)
+    ).toBe('/models/synty/npcs/skeleton-knight.glb');
+  });
+
+  it('returns undefined for an unmapped monsterRefId (no promoted GLB yet)', () => {
+    // "ghost"/"specter" have no rpg-toolkit monster ref at all yet (the
+    // undead roster promoted for rpg-dnd5e-web#559 ships those GLBs ahead
+    // of the rules-engine identity that would ever select them) --
+    // MediumHumanoid fallback is correct here, not a gap to fix.
+    expect(resolveMonsterModelUrl('ghost', undefined, false)).toBeUndefined();
+    expect(resolveMonsterModelUrl('specter', undefined, false)).toBeUndefined();
+  });
+
+  it('returns undefined for an unmapped MonsterType (no zombie GLB is promoted -- rpg-dnd5e-web#559 tracks a green-tinted class-model reuse instead)', () => {
+    expect(
+      resolveMonsterModelUrl(undefined, MonsterType.ZOMBIE, false)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an unmapped MonsterType with no promoted GLB (ghoul, skeleton-archer)', () => {
+    expect(
+      resolveMonsterModelUrl(undefined, MonsterType.GHOUL, false)
+    ).toBeUndefined();
+    expect(
+      resolveMonsterModelUrl(undefined, MonsterType.SKELETON_ARCHER, false)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when neither signal is present', () => {
+    expect(resolveMonsterModelUrl(undefined, undefined, false)).toBeUndefined();
+    expect(
+      resolveMonsterModelUrl(undefined, MonsterType.UNSPECIFIED, false)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an empty monsterRefId with no MonsterType fallback', () => {
+    expect(resolveMonsterModelUrl('', undefined, false)).toBeUndefined();
+  });
+});

--- a/src/components/hex-grid/monsterModels.ts
+++ b/src/components/hex-grid/monsterModels.ts
@@ -115,7 +115,16 @@ const MONSTER_TYPE_TO_REF_ID: Partial<Record<MonsterType, string>> = {
 };
 
 /** Insert the `-downed` suffix before the extension, matching
- * characters/manifest.json's `<name>-downed.glb` convention. */
+ * characters/manifest.json's `<name>-downed.glb` convention.
+ *
+ * TODO(rpg-dnd5e-web#595): this derivation assumes every promoted standing
+ * candidate has a `-downed.glb` sibling. True for all 7 GLBs promoted this
+ * wave, but nothing enforces it — the first future ref promoted with only a
+ * standing look gets a 404 here, which HexEntity's single ErrorBoundary
+ * currently degrades all the way to a generic MediumHumanoid (losing the
+ * monster's identity, not just its pose). #595 proposes a second fallback
+ * tier (standing GLB, tilted) between this and MediumHumanoid; deliberately
+ * not attempted in this PR. */
 function withDownedSuffix(file: string): string {
   return file.replace(/\.glb$/, '-downed.glb');
 }
@@ -143,6 +152,11 @@ function withDownedSuffix(file: string): string {
 export function resolveMonsterModelUrl(
   monsterRefId: string | undefined,
   monsterType: MonsterType | undefined,
+  /** Named `isDowned` to mirror resolveClassCharacterModelUrl's parameter
+   * (same "pick the downed variant file" meaning), but monsters don't have
+   * a CHARACTER-only "unconscious" concept to feed it with — HexEntity.tsx's
+   * only call site passes `isDead` here instead (monsters die at 0 HP
+   * rather than going unconscious; see buildRenderableEntities). */
   isDowned: boolean
 ): string | undefined {
   const trimmedRefId = monsterRefId?.trim().toLowerCase();

--- a/src/components/hex-grid/monsterModels.ts
+++ b/src/components/hex-grid/monsterModels.ts
@@ -1,0 +1,159 @@
+/**
+ * Monster-ref-keyed NPC model lookup (rpg-dnd5e-web#559 client half),
+ * mirroring classCharacterModels.ts's resolveClassCharacterModelUrl for the
+ * monster side of HexEntity. rpg-game-assets promotes converted POLYGON
+ * Dungeon undead as harness/models/synty/npcs/<asset-name>.glb (+
+ * -downed.glb), synced here to public/models/synty/npcs/, hardcoded here
+ * rather than fetched at runtime (see that file's doc comment for the
+ * established reasoning).
+ *
+ * Filenames are ASSET-source-named (e.g. "skeleton-soldier-01.glb"), NOT
+ * ref-id-named — a deliberate call (director sync, rpg-dnd5e-web#559,
+ * 2026-07-25), for two reasons neither classCharacterModels.ts's 1:1
+ * class:file convention nor an earlier draft of this file hit:
+ * (1) there is no toolkit ref for "ghost"/"specter" at all (see below), so a
+ * ref-id-only naming scheme can't even name half the promoted roster; (2)
+ * the SRD mapping isn't 1:1 — Skeleton maps to TWO promoted looks
+ * (Soldier_01/02) — a ref-id filename would force an arbitrary pick and
+ * then lie about it. rpg-game-assets' npcs/manifest.json is the seam that
+ * carries the rules mapping (which ref -> which asset file(s)); this table
+ * is this repo's hand-kept mirror of that mapping, same discipline as
+ * classCharacterModels.ts's CLASS_CHARACTER_MODELS.
+ *
+ * MONSTER_REF_MODELS is ref -> ORDERED CANDIDATE LIST (not ref -> single
+ * file), matching propManifest.ts's `PROP_KEYS: Record<string,
+ * PropVariant[]>` shape exactly, because Skeleton already has two looks.
+ * resolveMonsterModelUrl below picks candidates[0] — no per-instance
+ * variant selection yet (same "first available" convention as
+ * resolvePropVariant's `PROP_KEYS[key]?.[0]` and
+ * classCharacterModels.ts's resolveIdleClipName fallback). Choosing a
+ * SPECIFIC look per monster instance (so a room of skeletons doesn't look
+ * cloned) is a real future improvement, out of scope here.
+ *
+ * This hardcoded table is a stopgap for this slice, not the intended end
+ * state. propManifest.ts / rpg-game-assets' prop-role-map.json is the
+ * precedent for where this should eventually live: a generated
+ * manifest-driven `keys` index synced from rpg-game-assets, not a hand-kept
+ * TS literal. Re-derive this table by hand against
+ * rpg-game-assets:harness/models/synty/npcs/manifest.json after any change
+ * there, same discipline as propManifest.ts's own doc comment describes,
+ * until a manifest-driven monster resolver replaces it outright.
+ *
+ * Two identity signals exist on the wire, same dual-signal shape as
+ * obstaclePropKeys.ts's resolvePropKeyForEntity:
+ *
+ * 1. v1alpha2 `MonsterData.monster_ref.id` (e.g. "skeleton",
+ *    "skeleton-captain") — a direct rpg-toolkit ref id
+ *    (rulebooks/dnd5e/refs/monsters.go), not an enum needing a
+ *    hand-authored name table. Unlike obstacle_ref/prop_ref (verified
+ *    unpopulated by any server code path as of rpg-dnd5e-web#528), monster
+ *    identity is fundamental to spawning a monster at all — every MONSTER
+ *    entity on the real route carries this today (see EncounterView.tsx's
+ *    onSnapshotDelivered/onEntityAppeared, which have populated
+ *    `entityMeta.monsterRefId` since before this file existed). Preferred
+ *    whenever present, matching resolvePropKeyForEntity's precedence rule.
+ *
+ * 2. v1alpha1 `MonsterCombatState.monster_type` (`MonsterType` enum,
+ *    @kirkdiggler/rpg-api-protos' enums_pb.ts) — the harness/dev-injected
+ *    shape (HexGrid's `monsters` prop) and any older caller that hasn't
+ *    wired the v1alpha2 meta through yet. Only mapped for the two
+ *    MonsterType values that actually have a promoted GLB this wave
+ *    (SKELETON, SKELETON_CAPTAIN) — every other value (ZOMBIE, GHOUL,
+ *    SKELETON_ARCHER, and every non-undead monster) resolves to undefined
+ *    here on purpose, same as an unmapped classRefId.
+ *
+ * Both signals resolve into the SAME ref-id key space before the single
+ * table lookup below, so "resolved model" only ever needs one table.
+ *
+ * Deliberately NOT mapped this wave (rpg-dnd5e-web#559 issue thread):
+ * - "ghost" / "specter": Character_Ghost_01/02 and Character_Tormented_Soul
+ *   are promoted GLBs, but no rpg-toolkit monster ref for either exists yet
+ *   (rulebooks/dnd5e/refs/monsters.go's Undead set is Skeleton/Zombie/
+ *   SkeletonArcher/SkeletonCaptain/Ghoul only) -- the server can never send
+ *   a monsterRefId that would select them today. Wiring them is a follow-up
+ *   the moment the toolkit grows those refs, not a client gap now.
+ * - "zombie": no zombie GLB is promoted this wave — issue #559 tracks a
+ *   green-tinted material reuse of the barbarian CLASS model instead (no
+ *   zombie model exists in any owned Synty pack), a materially different
+ *   mechanism (a tint on an existing rig, not an npc GLB) that this
+ *   resolver doesn't attempt. Falls through to MediumHumanoid until that
+ *   lands.
+ * - "ghoul" / "skeleton-archer": refs exist in the toolkit but neither has
+ *   a promoted GLB in this issue's asset list.
+ */
+
+import { MonsterType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
+
+const MONSTER_MODEL_BASE = '/models/synty/npcs/';
+
+/** Keyed by the rpg-toolkit monster ref id (rulebooks/dnd5e/refs/monsters.go
+ * — e.g. `refs.Monsters.Skeleton().ID == "skeleton"`), verified directly
+ * against that file rather than guessed from the proto's MonsterType enum
+ * names (which use a different casing convention and, for GHOST/SPECTER,
+ * have no equivalent at all). Each value is an ORDERED candidate list of
+ * asset-source-named standing-pose files (see this module's doc comment for
+ * why); resolveMonsterModelUrl picks candidates[0] and derives the downed
+ * filename by suffix. */
+const MONSTER_REF_MODELS: Record<string, string[]> = {
+  skeleton: ['skeleton-soldier-01.glb', 'skeleton-soldier-02.glb'],
+  // The boss's rules identity is skeleton-captain-shaped (rpg-project#110
+  // Slice 3 / rpg-toolkit#816 correction — NOT a wight, NOT a juvenile
+  // variant of a bigger monster), but the promoted Character_Skeleton_Knight
+  // visual remains the right model for it: only the rules identity changed,
+  // not the asset. Filed under the boss's real ref id, not a "wight"
+  // placeholder.
+  'skeleton-captain': ['skeleton-knight.glb'],
+};
+
+/** The only MonsterType enum values with a promoted GLB this wave, mapped
+ * into the same ref-id key space MONSTER_REF_MODELS is keyed by. Every
+ * other enum value (including every non-undead monster) is intentionally
+ * absent -- see this module's doc comment. */
+const MONSTER_TYPE_TO_REF_ID: Partial<Record<MonsterType, string>> = {
+  [MonsterType.SKELETON]: 'skeleton',
+  [MonsterType.SKELETON_CAPTAIN]: 'skeleton-captain',
+};
+
+/** Insert the `-downed` suffix before the extension, matching
+ * characters/manifest.json's `<name>-downed.glb` convention. */
+function withDownedSuffix(file: string): string {
+  return file.replace(/\.glb$/, '-downed.glb');
+}
+
+/**
+ * Resolve a monster GLB URL for a server monster identity, if one is
+ * mapped. Prefers the v1alpha2 `monsterRefId` when present (even if it
+ * fails to resolve -- richer signal wins outright, not just when it
+ * happens to succeed) and falls back to the v1alpha1 `monsterType` enum
+ * otherwise. Returns undefined for an unmapped/unknown identity or when
+ * both signals are absent — callers MUST fall back to the existing
+ * MediumHumanoid path in that case, never a broken model reference
+ * (rpg-dnd5e-web#479 boundary lineage, same as resolveClassCharacterModelUrl).
+ *
+ * @example
+ * ```typescript
+ * resolveMonsterModelUrl('skeleton', undefined, false);
+ * // '/models/synty/npcs/skeleton-soldier-01.glb' -- first candidate look
+ * resolveMonsterModelUrl(undefined, MonsterType.SKELETON_CAPTAIN, true);
+ * // '/models/synty/npcs/skeleton-knight-downed.glb'
+ * resolveMonsterModelUrl('goblin', undefined, false);
+ * // undefined — no crypt-roster GLB mapped for goblin
+ * ```
+ */
+export function resolveMonsterModelUrl(
+  monsterRefId: string | undefined,
+  monsterType: MonsterType | undefined,
+  isDowned: boolean
+): string | undefined {
+  const trimmedRefId = monsterRefId?.trim().toLowerCase();
+  const refId =
+    trimmedRefId ||
+    (monsterType !== undefined
+      ? MONSTER_TYPE_TO_REF_ID[monsterType]
+      : undefined);
+  if (!refId) return undefined;
+  const candidates = MONSTER_REF_MODELS[refId];
+  const file = candidates?.[0];
+  if (!file) return undefined;
+  return MONSTER_MODEL_BASE + (isDowned ? withDownedSuffix(file) : file);
+}

--- a/src/components/hex-grid/monsterModels.ts
+++ b/src/components/hex-grid/monsterModels.ts
@@ -13,22 +13,15 @@
  * class:file convention nor an earlier draft of this file hit:
  * (1) there is no toolkit ref for "ghost"/"specter" at all (see below), so a
  * ref-id-only naming scheme can't even name half the promoted roster; (2)
- * the SRD mapping isn't 1:1 — Skeleton maps to TWO promoted looks
- * (Soldier_01/02) — a ref-id filename would force an arbitrary pick and
- * then lie about it. rpg-game-assets' npcs/manifest.json is the seam that
- * carries the rules mapping (which ref -> which asset file(s)); this table
+ * asset source names remain stable when a rules mapping changes. The private
+ * NPC manifest is the seam that carries the rules mapping; this table
  * is this repo's hand-kept mirror of that mapping, same discipline as
  * classCharacterModels.ts's CLASS_CHARACTER_MODELS.
  *
- * MONSTER_REF_MODELS is ref -> ORDERED CANDIDATE LIST (not ref -> single
- * file), matching propManifest.ts's `PROP_KEYS: Record<string,
- * PropVariant[]>` shape exactly, because Skeleton already has two looks.
- * resolveMonsterModelUrl below picks candidates[0] — no per-instance
- * variant selection yet (same "first available" convention as
- * resolvePropVariant's `PROP_KEYS[key]?.[0]` and
- * classCharacterModels.ts's resolveIdleClipName fallback). Choosing a
- * SPECIFIC look per monster instance (so a room of skeletons doesn't look
- * cloned) is a real future improvement, out of scope here.
+ * Phase 1 has one deterministic candidate per mapped reference: Soldier01
+ * for skeleton and Knight for skeleton-captain. The seven private standing
+ * assets each export exactly `Idle_Relaxed` [2,55] then in-place
+ * `Walk_Forward` [2,33]; only these two assets are runtime-selectable here.
  *
  * This hardcoded table is a stopgap for this slice, not the intended end
  * state. propManifest.ts / rpg-game-assets' prop-role-map.json is the
@@ -91,11 +84,9 @@ const MONSTER_MODEL_BASE = '/models/synty/npcs/';
  * against that file rather than guessed from the proto's MonsterType enum
  * names (which use a different casing convention and, for GHOST/SPECTER,
  * have no equivalent at all). Each value is an ORDERED candidate list of
- * asset-source-named standing-pose files (see this module's doc comment for
- * why); resolveMonsterModelUrl picks candidates[0] and derives the downed
- * filename by suffix. */
+ * asset-source-named standing-pose files. */
 const MONSTER_REF_MODELS: Record<string, string[]> = {
-  skeleton: ['skeleton-soldier-01.glb', 'skeleton-soldier-02.glb'],
+  skeleton: ['skeleton-soldier-01.glb'],
   // The boss's rules identity is skeleton-captain-shaped (rpg-project#110
   // Slice 3 / rpg-toolkit#816 correction — NOT a wight, NOT a juvenile
   // variant of a bigger monster), but the promoted Character_Skeleton_Knight

--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -297,6 +297,18 @@ describe('buildRenderableEntities', () => {
     expect(list[0]?.classRefId).toBe('barbarian');
   });
 
+  it('passes monsterRefId through from entityMeta to the renderable entity (rpg-dnd5e-web#559 monster-model resolver signal)', () => {
+    const entities = new Map([
+      ['skeleton-1', makeEntityState('skeleton-1', { x: 1, y: -1, z: 0 })],
+    ]);
+    const meta = new Map<string, EntityMeta>([
+      ['skeleton-1', { type: EntityType.MONSTER, monsterRefId: 'skeleton' }],
+    ]);
+
+    const list = buildRenderableEntities(entities, meta, new Map());
+    expect(list[0]?.monsterRefId).toBe('skeleton');
+  });
+
   it('propagates ghost flag from EntityDisappeared (entity outside LoS)', () => {
     const entities = new Map([
       ['goblin-2', makeEntityState('goblin-2', { x: 4, y: -4, z: 0 }, true)],

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -43,6 +43,11 @@ export interface RenderableEntity {
    * rpg-dnd5e-web#501 class-model hookup. Undefined for monsters/obstacles
    * or when the server hasn't set a class ref. */
   classRefId?: string;
+  /** v1alpha2 MonsterData.monster_ref.id (e.g. "skeleton",
+   * "skeleton-captain"), from entityMeta — rpg-dnd5e-web#559 monster-model
+   * hookup, the monster-side counterpart of `classRefId`. Undefined for
+   * players/obstacles or when the server hasn't set a monster ref. */
+  monsterRefId?: string;
   /** True for CHARACTER entities carrying the "unconscious" condition
    * (rpg-dnd5e-web#501) — the honest downed signal for players, matching
    * entityHelpers.ts's established "only monsters die at 0 HP, characters
@@ -176,6 +181,7 @@ export function buildRenderableEntities(
       isDead,
       isGhost: entity.ghost === true,
       classRefId: meta?.classRefId,
+      monsterRefId: meta?.monsterRefId,
       isDowned,
       propRefId: meta?.propRefId,
       movePath: entity.movePath,


### PR DESCRIPTION
Closes #559 (client half). Server/asset half tracked separately by the asset-pipeline team (rpg-game-assets undead-roster promotion).

## What changed

Monsters render as `MediumHumanoid` with `variant="goblin"` today — a placeholder, regardless of what the server says the monster actually is. This adds a real monster-model resolver, mirroring the player class-model path from #501/#502:

- **`src/components/hex-grid/monsterModels.ts`** — `resolveMonsterModelUrl(monsterRefId, monsterType, isDowned)`. Dual identity signal, same shape as `obstaclePropKeys.ts`'s `resolvePropKeyForEntity`: prefers the v1alpha2 `MonsterData.monster_ref.id` (a direct rpg-toolkit ref id — verified against `rulebooks/dnd5e/refs/monsters.go`: `"skeleton"`, `"zombie"`, `"skeleton-archer"`, `"skeleton-captain"`, `"ghoul"`), falls back to the v1alpha1 `MonsterType` enum for callers that haven't wired the v2 meta through (the dev/harness `monsters` prop shape).
  - Mapped this wave: `skeleton` -> `['skeleton-soldier-01.glb', 'skeleton-soldier-02.glb']`, `skeleton-captain` (the crypt boss) -> `['skeleton-knight.glb']`. Ref -> **ordered candidate list**, not ref -> single file (mirrors `propManifest.ts`'s `PROP_KEYS: Record<string, PropVariant[]>`), since Skeleton already has two promoted looks; `candidates[0]` wins for now (same "first available" convention as `resolvePropVariant`), per-instance variant selection is a follow-up.
  - Filenames are **asset-source-named** (`skeleton-soldier-01.glb`, not `skeleton.glb`), a deliberate call synced with the asset-pipeline team: a ref-id-only naming scheme can't name `ghost-01.glb`/`tormented-soul.glb` at all (no toolkit ref exists for ghost/specter yet), and the Skeleton mapping isn't 1:1 anyway.
  - Deliberately **not** mapped: `ghost`/`specter` (promoted GLBs, but no toolkit ref exists yet to ever select them — the rules engine can't send an identity that doesn't exist), `zombie` (issue #559: no zombie model exists in any owned Synty pack; tracked as a future green-tinted class-model reuse, a different mechanism this resolver doesn't attempt), `ghoul`/`skeleton-archer` (refs exist, no promoted GLB in this wave's asset list).
  - This hardcoded table is a stopgap for this slice, not the intended end state — noted in the file's doc comment pointing at `propManifest.ts`/`prop-role-map.json` as the eventual manifest-driven home.

- **`src/components/hex-grid/HexEntity.tsx`** — unified the player-class-model and monster-model resolution into one `resolvedModelUrl` / `effectiveModelUrl` / `failedEntityModelUrl` (mutually exclusive per `type`, so one sticky-failure slot is safe), both routed through `ClassCharacterModel` -> `Suspense`/`ErrorBoundary` -> `MediumHumanoid` fallback (the #479 boundary lineage: an unmapped identity or a failed GLB load degrades to the known-working placeholder, never a broken model ref or an unmounted Canvas subtree).

- **`src/components/hex-grid/facing.ts`** — added `POLYGON_DUNGEON_FORWARD_OFFSET`, a new named constant (not a reuse of `SYNTY_GLB_FORWARD_OFFSET`, even though the measured value is identical) for the POLYGON Dungeon npc rig family, which is a different Synty source pack from the Fantasy Rivals class models #590 measured. **Measured, not assumed**: rendered `Character_Skeleton_Soldier_01.glb` and `Character_Skeleton_Knight.glb` (the boss's visual) through the real `ClassCharacterModel` component at rotation 0 vs PI, camera fixed on the world +Z axis — both show FACE at 0 and BACK at PI, so this pack is also already +Z-forward. Parity assertion added to `facing.test.ts`.

- **`src/components/hex-grid/HexGrid.tsx`**, **`src/components/playtest/playtestMapHelpers.ts`** — plumbed `monsterRefId` through `HexGridProps.entities[]` and `buildRenderableEntities`. The signal already existed in `entityMeta` (populated live by `EncounterView.tsx`/`PlaytestHarness.tsx` from `MonsterData.monster_ref.id` — monster identity is fundamental to spawning at all, unlike `obstacle_ref`/`prop_ref` which no server code path sets yet) but was only ever used for a harness debug label before this PR.

## One intentional behavior change

The dead/downed tilt group (`HexEntity.tsx`) used to apply unconditionally whenever `isDead` was true, because monsters could never resolve a real GLB before this PR — it was always the `MediumHumanoid` fallback. Now that a monster can resolve its own GLB (with its own authored downed pose), the tilt is gated on `!effectiveModelUrl` for `isDead` too, the same rule `isDowned` already followed for players (#501): a resolved GLB's own posed variant doesn't get double-tilted on top of itself.

This is a no-op for every case reachable before this PR (no monster GLB has ever resolved, so `effectiveModelUrl` was always undefined for monsters) — the change only engages once a monster identity actually maps to a promoted GLB, which is new behavior this PR introduces.

Captured with real assets (assets-undead's in-progress promotion, symlinked in locally for evidence and removed before commit — not part of this diff):
- Unmapped dead monster (no `monsterRefId`): `MediumHumanoid` goblin, tilted 60° — unchanged from before this PR, confirming no regression for the common case (no monster GLB is synced to `public/` yet on `main`).
- Mapped dead monster (`monsterRefId=skeleton`): renders `skeleton-soldier-01-downed.glb` lying flat in its own authored corpse pose, **not** additionally tilted — the fix working as intended.
- Mapped live monster (`monsterRefId=skeleton`, not dead): stands upright, correctly composed with #592's heading rotation (tilt group nests inside heading rotation; default monster heading 0 + `POLYGON_DUNGEON_FORWARD_OFFSET` 0 compose correctly).

## Sequencing note

The promoted GLBs (`harness/models/synty/npcs/skeleton-soldier-01.glb` etc.) are not yet synced to this repo's `public/models/synty/npcs/` — that lands via `npm run assets:sync` once rpg-game-assets' undead-roster promotion PR merges (their manifest.json/mesh-stats/README work is in flight in parallel). Until then this resolver is dormant on the deployed app exactly the same way `resolveClassCharacterModelUrl` was dormant for `fighter`/`barbarian`/etc. before those GLBs synced — unmapped/missing falls straight through to `MediumHumanoid`, never a broken reference.

## Verification

`npm run ci-check` green (format, lint, typecheck, build, full test suite). New/updated tests: `monsterModels.test.ts` (12), `facing.test.ts` (+1 parity assertion), `playtestMapHelpers.test.ts` (+1). Full `hex-grid`/`playtest`/`game` suite (780 tests) passing with no regressions.

— asset-pipeline agent, on behalf of KirkDiggler