### PR TITLE
fix(doors)#589: surface the locked-door skill-check prompt in the game view

### DIFF
--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -16,7 +16,13 @@ import {
   EntityType,
   TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createFakeStream,
@@ -113,6 +119,11 @@ beforeEach(() => {
   hoisted.endTurnFn.mockReset();
   hoisted.setReactionReadyFn.mockReset();
   hoisted.interactFn.mockReset();
+  // Default: the unlocked-door answer — an empty InteractResponse. The real
+  // RPC always resolves with a message (the prompt field is optional), so
+  // leaving this as bare undefined would let a caller that mishandles the
+  // response still pass. See the #589 tests below.
+  hoisted.interactFn.mockResolvedValue({} as InteractResponse);
   hoisted.equipItemFn.mockReset();
   hoisted.unequipItemFn.mockReset();
 });
@@ -433,6 +444,96 @@ describe('EncounterView door click -> Interact bridge (rpg-dnd5e-web#526)', () =
     });
 
     expect(hoisted.interactFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('EncounterView locked-door skill-check prompt (rpg-dnd5e-web#589)', () => {
+  // A locked door answers Interact with InputRequired{skill_check} on the RPC
+  // RESPONSE. That is the ONLY delivery channel for it: rpg-api's interact.go
+  // behavior contract says the prompt is "caller-private (no broker event)",
+  // and the server's PublishInputRequired is only ever called for *reaction*
+  // prompts (take_action.go). Nothing re-delivers it either — the Encounter
+  // snapshot message carries no prompt field, so a reconnect resync can't
+  // recover one.
+  //
+  // That makes dropping the response a soft-lock, not a cosmetic miss: the
+  // prompt is persisted server-side, so every subsequent verb is refused with
+  // "resolve the pending prompt before issuing another action" while the
+  // player sees no prompt at all. That is the live bug in #589.
+  function lockedDoorResponse(): InteractResponse {
+    return {
+      inputRequired: {
+        kind: { case: 'skillCheck', value: { dc: 12, ability: 'DEX' } },
+      },
+    } as unknown as InteractResponse;
+  }
+
+  it('renders the skill-check prompt carried on the Interact response', async () => {
+    hoisted.interactFn.mockResolvedValue(lockedDoorResponse());
+
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stub-click-door'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+    expect(screen.getByText(/Skill check: DEX \(DC 12\)/)).toBeTruthy();
+    // The roll entry + submit path must be reachable — a visible prompt with
+    // no way to resolve it is the same soft-lock wearing a hat.
+    expect(screen.getByLabelText(/roll \(1-20\)/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /submit roll/i })).toBeTruthy();
+  });
+
+  it('offers no Dismiss escape hatch — the prompt blocks server-side and there is no cancel verb', async () => {
+    // PromptModal's Dismiss only clears CLIENT state. The server-side
+    // PendingPrompt survives it, so dismissing in the real game silently
+    // re-enters the exact soft-lock this issue is about. There is no cancel
+    // RPC to wire it to (SubmitCheck is the only resolver), so the real game
+    // route must not present the button at all. The playtest harness keeps it
+    // deliberately — see PromptModal's allowDismiss prop.
+    hoisted.interactFn.mockResolvedValue(lockedDoorResponse());
+
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stub-click-door'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+    expect(screen.queryByRole('button', { name: /dismiss/i })).toBeNull();
+  });
+
+  it('leaves no prompt up for an unlocked door (empty InteractResponse)', async () => {
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stub-click-door'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId('skill-check-prompt')).toBeNull();
   });
 });
 

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -683,14 +683,30 @@ export function EncounterView({
   };
 
   // rpg-dnd5e-web#526 (wave rpg-project#96 Slice 2): door click -> Interact
-  // bridge. The server decides what happens — open, or (a locked door,
-  // Slice 3) a skill-check prompt via InputRequiredDelivered — so this
-  // handler computes nothing and gates on nothing; it only forwards the
-  // click intent (matches PlaytestHarness's identical
-  // `interact(encounterId, id, 'open')` call).
+  // bridge. The server decides what happens — open, or (a locked door) a
+  // skill-check prompt — so this handler computes nothing and gates on
+  // nothing; it only forwards the click intent and surfaces whatever comes
+  // back (matches PlaytestHarness's identical `interact(encounterId, id,
+  // 'open')` call + response handling).
+  //
+  // rpg-dnd5e-web#589: the locked-door prompt rides the RPC RESPONSE and
+  // nothing else. This comment used to claim it arrived via
+  // InputRequiredDelivered; it does not. rpg-api's interact.go behavior
+  // contract calls the prompt "caller-private (no broker event)", and the
+  // server's PublishInputRequired fires only for reaction prompts
+  // (take_action.go). Dropping the response therefore soft-locked the
+  // player: the prompt persists server-side, so every later verb is refused
+  // with "resolve the pending prompt before issuing another action" while
+  // nothing is on screen to resolve. The world-changing half (door opens,
+  // hexes reveal) still flows as DoorOpened/GeometryRevealed events.
   const handleDoorClick = async (doorId: string) => {
     try {
-      await interact(encounterId, doorId, 'open');
+      const response = await interact(encounterId, doorId, 'open');
+      if (response.inputRequired) {
+        // PromptModal resets its own transient result/timer state whenever
+        // the prompt object identity changes — no reset needed here.
+        encounterState.setPendingPrompt(response.inputRequired);
+      }
     } catch {
       // error surfaced via interactError below
     }
@@ -805,6 +821,12 @@ export function EncounterView({
         entityId={entityId}
         prompt={encounterState.state.pendingPrompt}
         onDismiss={() => encounterState.setPendingPrompt(null)}
+        // rpg-dnd5e-web#589: no Dismiss on the real game route. It would clear
+        // only client state and strand the server-side PendingPrompt, which is
+        // precisely the invisible soft-lock this fix removes. onDismiss still
+        // runs for the post-resolution auto-clear — that path has already
+        // consumed the prompt via SubmitCheck.
+        allowDismiss={false}
       />
 
       {/* Map fills whatever the header/banner/dock don't take — this

--- a/src/components/game/PromptModal.tsx
+++ b/src/components/game/PromptModal.tsx
@@ -27,6 +27,20 @@ export interface PromptModalProps {
   onDismiss: () => void;
   /** Optional event-log sink (PlaytestHarness's Recent-events log). */
   onLog?: (message: string) => void;
+  /**
+   * Whether the skill-check branch offers a Dismiss button. Defaults to true
+   * for the playtest harness, where poking at a prompt and walking away is
+   * the point.
+   *
+   * The real game route passes false (rpg-dnd5e-web#589). Dismiss only clears
+   * CLIENT state — the server-side PendingPrompt survives it, and there is no
+   * cancel verb to wire it to (SubmitCheck is the only resolver). So in the
+   * real game a Dismiss puts the player straight back into the invisible
+   * soft-lock #589 is about: prompt pending on the server, nothing on screen,
+   * every subsequent action refused with "resolve the pending prompt before
+   * issuing another action".
+   */
+  allowDismiss?: boolean;
 }
 
 export function PromptModal({
@@ -35,6 +49,7 @@ export function PromptModal({
   prompt,
   onDismiss,
   onLog,
+  allowDismiss = true,
 }: PromptModalProps) {
   const {
     submitCheck,
@@ -228,19 +243,21 @@ export function PromptModal({
             >
               {submitCheckLoading ? 'Submitting…' : 'Submit roll'}
             </button>
-            <button
-              onClick={onDismiss}
-              style={{
-                padding: '4px 8px',
-                background: '#2a2a2a',
-                color: '#888',
-                border: '1px solid #444',
-                cursor: 'pointer',
-                fontSize: 11,
-              }}
-            >
-              Dismiss
-            </button>
+            {allowDismiss && (
+              <button
+                onClick={onDismiss}
+                style={{
+                  padding: '4px 8px',
+                  background: '#2a2a2a',
+                  color: '#888',
+                  border: '1px solid #444',
+                  cursor: 'pointer',
+                  fontSize: 11,
+                }}
+              >
+                Dismiss
+              </button>
+            )}
           </div>
         )}
         {submitCheckError && (


### PR DESCRIPTION
Closes #589.

## The bug

At the crypt's locked boss door, clicking it did nothing visible, and every action afterwards was refused with:

```
Door interaction error: [failed_precondition] resolve the pending prompt before issuing another action
```

An invisible soft-lock: a prompt pending server-side, nothing on screen to resolve it.

## Root cause

`EncounterView.handleDoorClick` awaited `interact()` and threw the response away.

The locked-door prompt rides the `InteractResponse` **and nothing else**:

- rpg-api's `interact.go` behavior contract calls it *"caller-private (no broker event)"* — it is deliberately not broadcast.
- The server's `PublishInputRequired` fires only for **reaction** prompts (`take_action.go`).
- Nothing re-delivers it. The `Encounter` snapshot message (`types.proto:347`) carries `id`, `mode`, `space`, `turn_state` — no prompt field — so a reconnect resync can't recover one either.

The comment above the handler asserted the prompt arrived via `InputRequiredDelivered`. It doesn't. `PlaytestHarness` handled the response correctly (`PlaytestHarness.tsx:511-520`), which is exactly why this only ever reproduced on the real game route.

`useEncounterState`'s own docs already specify the contract the game view was missing: *"Callers set this explicitly via `setPendingPrompt(response.inputRequired)` after an RPC returns with inputRequired set."*

## Changes

- **`EncounterView.handleDoorClick`** captures `response.inputRequired` and calls `setPendingPrompt`, mirroring the harness.
- **No Dismiss on the real game route.** `PromptModal` gains an `allowDismiss` prop (default `true`, preserving harness behavior and its existing test); `EncounterView` passes `false`. Dismiss clears only *client* state — the server-side `PendingPrompt` survives it, so in the real game pressing it walked straight back into the same soft-lock. There is no cancel verb to wire it to; `SubmitCheck` is the only resolver.

## Tests

Three new tests in `EncounterView.test.tsx`:
- the skill-check prompt renders from the Interact response, with roll entry and Submit reachable
- no Dismiss escape hatch on the game route
- an unlocked door (empty response) leaves no prompt up

`interactFn` now defaults to an empty `InteractResponse` in `beforeEach`, so a caller that mishandles the response can't pass by accident — with a bare `mockReset()` the old broken code still passed the existing assertions.

Verified: `npx vitest run` — 73 files, 1279 tests, all passing. `npm run ci-check` green (format/lint/typecheck/build/tests).

## Done bar

> Click locked door → skill-check prompt visibly appears → resolve → success opens/failure informs; no state where actions are refused with no visible pending prompt.

Met for the click path. **One gap deliberately left open:** a page reload still can't recover a pending prompt, because the snapshot has no field to carry one. That needs `optional InputRequired pending_prompt` on the `Encounter` message plus projection from `Data.PendingPrompts[playerID]` in rpg-api — a cross-repo change worth its own issue rather than smuggling into this fix. Practical impact is now small: the only way to acquire a prompt is to click a door, and that click now shows it.

Not verified in a live browser against a real crypt encounter — worth a playtest pass on the actual locked boss door before closing #589 out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BewLGfsex9kW23pd1NVEea