### PR TITLE
fix(prompts)#597: roll a real d20 for skill checks in the game route

### DIFF
--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -8,6 +8,7 @@ import type {
   InteractResponse,
   MoveEntityResponse,
   SetReactionReadyResponse,
+  SubmitCheckResponse,
   TakeActionResponse,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 import {
@@ -41,6 +42,7 @@ const hoisted = vi.hoisted(() => ({
   setReactionReadyFn:
     vi.fn<(req: unknown) => Promise<SetReactionReadyResponse>>(),
   interactFn: vi.fn<(req: unknown) => Promise<InteractResponse>>(),
+  submitCheckFn: vi.fn<(req: unknown) => Promise<SubmitCheckResponse>>(),
   equipItemFn: vi.fn<(req: unknown) => Promise<EquipItemResponse>>(),
   unequipItemFn: vi.fn<(req: unknown) => Promise<UnequipItemResponse>>(),
 }));
@@ -58,6 +60,7 @@ vi.mock('../../api/client', () => ({
     endTurn: hoisted.endTurnFn,
     setReactionReady: hoisted.setReactionReadyFn,
     interact: hoisted.interactFn,
+    submitCheck: hoisted.submitCheckFn,
   },
   characterV2Client: {
     equipItem: hoisted.equipItemFn,
@@ -124,6 +127,11 @@ beforeEach(() => {
   // leaving this as bare undefined would let a caller that mishandles the
   // response still pass. See the #589 tests below.
   hoisted.interactFn.mockResolvedValue({} as InteractResponse);
+  hoisted.submitCheckFn.mockReset();
+  hoisted.submitCheckFn.mockResolvedValue({
+    success: true,
+    total: 18,
+  } as SubmitCheckResponse);
   hoisted.equipItemFn.mockReset();
   hoisted.unequipItemFn.mockReset();
 });
@@ -486,9 +494,11 @@ describe('EncounterView locked-door skill-check prompt (rpg-dnd5e-web#589)', () 
       expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
     );
     expect(screen.getByText(/Skill check: DEX \(DC 12\)/)).toBeTruthy();
-    // The roll entry + submit path must be reachable — a visible prompt with
-    // no way to resolve it is the same soft-lock wearing a hat.
-    expect(screen.getByLabelText(/roll \(1-20\)/i)).toBeTruthy();
+    // The roll + submit path must be reachable — a visible prompt with no
+    // way to resolve it is the same soft-lock wearing a hat. rpg-dnd5e-web
+    // #597 replaced the hand-typed roll with a real client-rolled d20 — see
+    // the "rolls a real d20" describe block below for that behavior.
+    expect(screen.getByTestId('rolled-value')).toBeTruthy();
     expect(screen.getByRole('button', { name: /submit roll/i })).toBeTruthy();
   });
 
@@ -534,6 +544,115 @@ describe('EncounterView locked-door skill-check prompt (rpg-dnd5e-web#589)', () 
     });
 
     expect(screen.queryByTestId('skill-check-prompt')).toBeNull();
+  });
+});
+
+describe('EncounterView rolls a real d20 for skill checks (rpg-dnd5e-web#597)', () => {
+  // The pre-#597 bug: PromptModal's skill-check branch was a bare
+  // <input type="number"> defaulting to 10 — the player typed their own
+  // roll and the server accepted it outright. The real game route must
+  // instead roll a real d20 client-side, show it, and submit exactly that
+  // value. (The playtest harness keeps the typed input on purpose — see
+  // PlaytestHarness.test.tsx — since its tests depend on forcing specific
+  // rolls; that path is unaffected by this describe block.)
+  function lockedDoorResponse(): InteractResponse {
+    return {
+      inputRequired: {
+        kind: { case: 'skillCheck', value: { dc: 12, ability: 'DEX' } },
+      },
+    } as unknown as InteractResponse;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows no editable roll input — the value is not hand-typed', async () => {
+    hoisted.interactFn.mockResolvedValue(lockedDoorResponse());
+
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stub-click-door'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+
+    const promptEl = screen.getByTestId('skill-check-prompt');
+    expect(promptEl.querySelector('input')).toBeNull();
+  });
+
+  it('submits the client-rolled value, and shows the player that same value', async () => {
+    // Deterministic under test — rollD20 is Math.random-backed by default,
+    // so pin the RNG rather than depending on real Math.random output.
+    // 0.65 -> Math.floor(0.65 * 20) + 1 = 14.
+    vi.spyOn(Math, 'random').mockReturnValue(0.65);
+    hoisted.interactFn.mockResolvedValue(lockedDoorResponse());
+
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stub-click-door'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+
+    // The rolled value shown to the player...
+    const rolledEl = screen.getByTestId('rolled-value');
+    expect(rolledEl.textContent).toContain('14');
+
+    fireEvent.click(screen.getByRole('button', { name: /submit roll/i }));
+
+    // ...is exactly the value submitted to the server.
+    await waitFor(() => {
+      expect(hoisted.submitCheckFn).toHaveBeenCalledOnce();
+    });
+    expect(hoisted.submitCheckFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        encounterId: 'enc-1',
+        entityId: 'char-alice',
+        roll: 14,
+      })
+    );
+  });
+
+  it('rolls a value within [1, 20] regardless of the RNG draw', async () => {
+    hoisted.interactFn.mockResolvedValue(lockedDoorResponse());
+
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stub-click-door'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('skill-check-prompt')).toBeTruthy()
+    );
+
+    const rolled = Number(
+      screen.getByTestId('rolled-value').textContent?.match(/\d+/)?.[0]
+    );
+    expect(rolled).toBeGreaterThanOrEqual(1);
+    expect(rolled).toBeLessThanOrEqual(20);
   });
 });
 

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -827,6 +827,11 @@ export function EncounterView({
         // runs for the post-resolution auto-clear — that path has already
         // consumed the prompt via SubmitCheck.
         allowDismiss={false}
+        // rpg-dnd5e-web#597: the real game route rolls a real d20 client-side
+        // and shows it — it does not let the player type their own roll. The
+        // playtest harness keeps the typed input (allowManualRoll defaults to
+        // true there) because its tests depend on forcing specific rolls.
+        allowManualRoll={false}
       />
 
       {/* Map fills whatever the header/banner/dock don't take — this

--- a/src/components/game/PromptModal.tsx
+++ b/src/components/game/PromptModal.tsx
@@ -16,6 +16,7 @@
 import type { InputRequired } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useEffect, useRef, useState } from 'react';
 import { useSubmitCheck } from '../../api/useSubmitCheck';
+import { rollD20 } from '../../utils/rollD20';
 
 export interface PromptModalProps {
   encounterId: string;
@@ -41,6 +42,25 @@ export interface PromptModalProps {
    * issuing another action".
    */
   allowDismiss?: boolean;
+  /**
+   * Whether the skill-check branch shows a typed roll input (the playtest
+   * harness, which needs to force specific rolls for its tests) or rolls a
+   * real d20 client-side and just displays it (the real game route).
+   * Defaults to true — same harness-first default as allowDismiss.
+   *
+   * The real game route passes false (rpg-dnd5e-web#597): a bare
+   * `<input type="number">` let the player type their own roll and the
+   * server accepted it outright — there was no dice roll anywhere. The
+   * server contract is unchanged either way: the client supplies the raw
+   * d20, the server adds modifiers and judges the total.
+   */
+  allowManualRoll?: boolean;
+  /**
+   * Roll source for the real-game (allowManualRoll=false) path. Defaults to
+   * a real d20 (Math.random-backed). Overridable so tests can inject a
+   * deterministic value instead of stubbing the global RNG.
+   */
+  rollDie?: () => number;
 }
 
 export function PromptModal({
@@ -50,13 +70,35 @@ export function PromptModal({
   onDismiss,
   onLog,
   allowDismiss = true,
+  allowManualRoll = true,
+  rollDie = rollD20,
 }: PromptModalProps) {
   const {
     submitCheck,
     loading: submitCheckLoading,
     error: submitCheckError,
   } = useSubmitCheck();
-  const [rollValue, setRollValue] = useState(10);
+  const [rollValue, setRollValue] = useState(() =>
+    allowManualRoll ? 10 : rollDie()
+  );
+  // Tracks which prompt identity `rollValue` was last rolled for, so the
+  // real-game (allowManualRoll=false) path re-rolls exactly once per new
+  // skill-check prompt — not on every render, and not a second time on
+  // mount (the lazy useState initializer above already covers the first
+  // one). Seeded to the mount-time prompt so that initial roll isn't
+  // immediately discarded and re-rolled by the effect below.
+  const rolledForPromptRef = useRef<InputRequired | null>(
+    !allowManualRoll && prompt?.kind?.case === 'skillCheck' ? prompt : null
+  );
+  useEffect(() => {
+    if (allowManualRoll || prompt?.kind?.case !== 'skillCheck') {
+      return;
+    }
+    if (rolledForPromptRef.current !== prompt) {
+      rolledForPromptRef.current = prompt;
+      setRollValue(rollDie());
+    }
+  }, [prompt, allowManualRoll, rollDie]);
   const [promptResult, setPromptResult] = useState<{
     success: boolean;
     total: number;
@@ -204,32 +246,39 @@ export function PromptModal({
               alignItems: 'center',
             }}
           >
-            <label style={{ fontSize: 12 }}>
-              Roll (1-20){' '}
-              <input
-                type="number"
-                min={1}
-                max={20}
-                step={1}
-                value={rollValue}
-                aria-label="roll value"
-                onChange={(e) =>
-                  setRollValue(
-                    Math.min(
-                      20,
-                      Math.max(1, Math.trunc(Number(e.target.value)))
+            {allowManualRoll ? (
+              <label style={{ fontSize: 12 }}>
+                Roll (1-20){' '}
+                <input
+                  type="number"
+                  min={1}
+                  max={20}
+                  step={1}
+                  value={rollValue}
+                  aria-label="roll value"
+                  onChange={(e) =>
+                    setRollValue(
+                      Math.min(
+                        20,
+                        Math.max(1, Math.trunc(Number(e.target.value)))
+                      )
                     )
-                  )
-                }
-                style={{
-                  width: 60,
-                  background: '#333',
-                  color: '#eee',
-                  border: '1px solid #555',
-                  padding: '2px 4px',
-                }}
-              />
-            </label>
+                  }
+                  style={{
+                    width: 60,
+                    background: '#333',
+                    color: '#eee',
+                    border: '1px solid #555',
+                    padding: '2px 4px',
+                  }}
+                />
+              </label>
+            ) : (
+              <div data-testid="rolled-value" style={{ fontSize: 13 }}>
+                You rolled:{' '}
+                <strong style={{ color: '#aaf' }}>{rollValue}</strong>
+              </div>
+            )}
             <button
               onClick={() => void handleSubmitCheck()}
               disabled={submitCheckLoading}

--- a/src/utils/rollD20.test.ts
+++ b/src/utils/rollD20.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { rollD20 } from './rollD20';
+
+describe('rollD20', () => {
+  it('maps the lowest rng() value to 1', () => {
+    expect(rollD20(() => 0)).toBe(1);
+  });
+
+  it('maps a value just under 1 to 20', () => {
+    expect(rollD20(() => 0.999999)).toBe(20);
+  });
+
+  it('maps a mid-range value to the corresponding face', () => {
+    // Math.floor(0.65 * 20) + 1 = 14
+    expect(rollD20(() => 0.65)).toBe(14);
+  });
+
+  it('stays within [1, 20] across the full rng() input range', () => {
+    for (let i = 0; i < 100; i++) {
+      const value = rollD20(() => i / 100);
+      expect(value).toBeGreaterThanOrEqual(1);
+      expect(value).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('defaults to Math.random when no rng is supplied', () => {
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    try {
+      expect(rollD20()).toBe(11);
+      expect(spy).toHaveBeenCalledOnce();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/utils/rollD20.ts
+++ b/src/utils/rollD20.ts
@@ -1,0 +1,10 @@
+/**
+ * Rolls a fair d20: an integer in [1, 20] inclusive, uniformly distributed.
+ *
+ * Takes an injectable RNG (defaulting to `Math.random`) so callers — chiefly
+ * `PromptModal`'s real-game skill-check roll (rpg-dnd5e-web#597) — can pass a
+ * deterministic source under test instead of stubbing the global.
+ */
+export function rollD20(random: () => number = Math.random): number {
+  return Math.floor(random() * 20) + 1;
+}


### PR DESCRIPTION
## Summary

Closes #597. `PromptModal`'s skill-check branch was a bare `<input type="number">` defaulting to 10 — the player typed their own d20 result and the server accepted it outright. No `Math.random`, no roll, anywhere in the file. This was the playtest harness's determinism input, shipped unchanged onto the real game route when `PromptModal` was extracted for GameView (#440).

The server contract is unchanged and was never the problem: `SkillCheckPrompt{dc, ability, tool}` carries no modifier field, so the client genuinely cannot show a pre-submit total — it just supplies the raw d20 and the server adds ability/tool-proficiency modifiers and judges. The existing post-submit reveal (`rolled {roll}, total {total}, success!/failed.`) is unchanged.

## What changed

- **`src/utils/rollD20.ts`** (new): `rollD20(random = Math.random)` — a fair d20 roll, RNG injectable for tests.
- **`src/components/game/PromptModal.tsx`**: new `allowManualRoll?: boolean` prop (defaults `true`, same harness-first shape #596 used for `allowDismiss`) and `rollDie?: () => number` (defaults to `rollD20`, overridable for tests). When `false`, the skill-check branch rolls a real d20 on each new prompt, shows it (`data-testid="rolled-value"`), and submits exactly that value — no editable input. When `true` (default), the existing typed-input UI is untouched.
- **`src/components/game/EncounterView.tsx`**: passes `allowManualRoll={false}` — the real game route now rolls for real.
- **`PlaytestHarness.tsx`**: unchanged. It doesn't pass `allowManualRoll`, so it keeps the default (`true`) typed-input behavior its ~79 tests depend on for forcing specific rolls.

## Not in scope

`src/concepts/combat-pacing/` (#581) is dice-roll *theater* over an already-server-resolved `AttackResolved` roll — the opposite data direction from a skill check, where the client generates and sends. Left alone; could be reused visually for this later as polish, but no animation was added here.

## Test plan

- [x] `src/utils/rollD20.test.ts` (new) — bounds, RNG mapping, `Math.random` default.
- [x] `src/components/game/EncounterView.test.tsx` — updated the existing skill-check-prompt test (no longer asserts a labeled `roll (1-20)` input) and added 3 new tests under "EncounterView rolls a real d20 for skill checks (rpg-dnd5e-web#597)": no editable `<input>` in the prompt, the rolled value shown equals the value submitted to `SubmitCheck` (RNG pinned via `Math.random` spy, not real output), and the rolled value is always in `[1, 20]`.
- [x] `src/components/playtest/PlaytestHarness.test.tsx` — all 79 existing tests pass **unchanged** (not touched), confirming the harness's typed-roll path is unaffected.
- [x] Full suite: `npx vitest run` → **1287/1287 passed** (74 files).
- [x] `npm run ci-check` → format, lint, typecheck, build, tests all green for this change.

Not verified: a live browser click-through of the locked-door flow. I brought up a dev server in this worktree to check, but its `public/models/synty/*` assets aren't present here (404s on `.glb`/texture loads unrelated to this change — a worktree asset-provisioning gap, not a code issue), so I didn't have a renderable door to click. I didn't want to disturb the already-running session on port 3001. The automated `EncounterView.test.tsx` tests above exercise the identical `stub-click-door` → `InputRequired{skillCheck}` → roll → `SubmitCheck` path through the real (unstubbed) `PromptModal`/`EncounterView` code, which is what gives me confidence here instead.

Also note (per the issue and confirmed with the task owner): ability modifiers are currently stubbed to zero server-side (rpg-api#516, in flight separately) — totals will equal the raw roll until that lands. Not this PR's bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BewLGfsex9kW23pd1NVEea