### PR TITLE
fix(hex-grid): default walls tall+uniform, door height targets wall height directly

### DIFF
--- a/src/components/hex-grid/SyntyHexWall.test.tsx
+++ b/src/components/hex-grid/SyntyHexWall.test.tsx
@@ -300,32 +300,53 @@ describe('SyntyHexWall spaceTheme (rpg-dnd5e-web#558 real-route theme consumptio
   });
 });
 
-describe('doorFrameScale / doorLeafScale (rpg-project#132 wall-height dial: "the height of the walls might be a little low" — door frame/leaf rise the SAME proportion the wall-height dial does, not independently)', () => {
-  it('at heightRatio=1 (the default wallHeight, no override), height is exactly the old flat SYNTY_SCALE — byte-identical to pre-dial behavior', () => {
-    expect(doorFrameScale(1)[1]).toBe(SYNTY_SCALE);
-    expect(doorLeafScale(1)[1]).toBe(SYNTY_SCALE);
+describe('doorFrameScale / doorLeafScale (rpg-project#132 follow-up, Kirk\'s verdict walking the tall-wall default: "at tall walls the door is really really high" — door height must target wallHeight DIRECTLY, not multiply a ratio onto the door\'s own legacy baseline)', () => {
+  // SM_Env_Door_Frame_01's own measured raw height at scale=1 (Box3
+  // read — see doorFrameScale's own doc comment for the measurement
+  // provenance; same convention as wallVariantScale's tests hardcoding
+  // WALL_VARIANTS' own known raw dimensions rather than importing a
+  // private module constant).
+  const DOOR_FRAME_RAW_HEIGHT = 2.5347;
+
+  it("targets wallHeight directly: frame height scale * its own raw height equals wallHeight almost exactly (the frame's top edge lands at the wall height, no ratio compounding)", () => {
+    const wallHeight = 2.4;
+    const [, sy] = doorFrameScale(wallHeight);
+    expect(sy * DOOR_FRAME_RAW_HEIGHT).toBeCloseTo(wallHeight, 5);
   });
 
-  it('scales height by the ratio, leaving width/depth (X/Z) untouched — only height is what "the wall is a little low" is about', () => {
-    const ratio = 1.5;
-    const frame = doorFrameScale(ratio);
-    const leaf = doorLeafScale(ratio);
-    expect(frame[1]).toBeCloseTo(SYNTY_SCALE * ratio, 9);
-    expect(leaf[1]).toBeCloseTo(SYNTY_SCALE * ratio, 9);
-    // X (width) and Z (depth/thickness) are the SAME regardless of ratio.
-    const frameAtDefault = doorFrameScale(1);
-    const leafAtDefault = doorLeafScale(1);
-    expect(frame[0]).toBe(frameAtDefault[0]);
-    expect(frame[2]).toBe(frameAtDefault[2]);
-    expect(leaf[0]).toBe(leafAtDefault[0]);
-    expect(leaf[2]).toBe(leafAtDefault[2]);
+  it("the leaf scales by the SAME per-height-unit factor as the frame (not its own raw height) — preserves the leaf's authored ~97% proportion within the frame at any wallHeight", () => {
+    const wallHeight = 2.4;
+    const [, frameSy] = doorFrameScale(wallHeight);
+    const [, leafSy] = doorLeafScale(wallHeight);
+    expect(leafSy).toBeCloseTo(frameSy, 9);
   });
 
-  it('a wallHeight override translates to the correct ratio (wallHeight / WALL_HEIGHT) — e.g. wallHeight=1.2 at the default WALL_HEIGHT=0.8 gives ratio 1.5', () => {
-    const wallHeight = 1.2;
-    const ratio = wallHeight / WALL_HEIGHT;
-    expect(ratio).toBeCloseTo(1.5, 9);
-    expect(doorFrameScale(ratio)[1]).toBeCloseTo(SYNTY_SCALE * 1.5, 9);
+  it('scaling is linear in wallHeight — doubling wallHeight exactly doubles the height scale for both pieces, proving a direct target rather than a ratio against a fixed baseline', () => {
+    const [, sy1] = doorFrameScale(1.2);
+    const [, sy2] = doorFrameScale(2.4);
+    expect(sy2).toBeCloseTo(sy1 * 2, 9);
+    const [, leafSy1] = doorLeafScale(1.2);
+    const [, leafSy2] = doorLeafScale(2.4);
+    expect(leafSy2).toBeCloseTo(leafSy1 * 2, 9);
+  });
+
+  it('leaves width/depth (X/Z) untouched regardless of wallHeight — only height tracks the wall now', () => {
+    const frameLow = doorFrameScale(0.8);
+    const frameHigh = doorFrameScale(12.4);
+    expect(frameLow[0]).toBe(frameHigh[0]);
+    expect(frameLow[2]).toBe(frameHigh[2]);
+    const leafLow = doorLeafScale(0.8);
+    const leafHigh = doorLeafScale(12.4);
+    expect(leafLow[0]).toBe(leafHigh[0]);
+    expect(leafLow[2]).toBe(leafHigh[2]);
+  });
+
+  it('does NOT compound the door\'s old oversized-relative-to-0.8 baseline — at the OLD default (WALL_HEIGHT was 0.8), frame height scale is far below the historical flat SYNTY_SCALE, proving this is no longer "SYNTY_SCALE times a ratio"', () => {
+    const [, sy] = doorFrameScale(0.8);
+    // Old formula would have been exactly SYNTY_SCALE (0.75) at the old
+    // default; the new formula targets 0.8 directly against the frame's
+    // own ~2.53 raw height instead, landing well under that.
+    expect(sy).toBeLessThan(SYNTY_SCALE);
   });
 });
 

--- a/src/components/hex-grid/SyntyHexWall.tsx
+++ b/src/components/hex-grid/SyntyHexWall.tsx
@@ -182,16 +182,14 @@ export function SyntyHexWall({
             id !== undefined ? doorPlaneOverrides?.get(id) : undefined;
           const rotationY = plane?.rotationY ?? edge.rotationY;
           const framePosition = plane?.position ?? edge.mid;
-          // Door frame/leaf height rises the SAME proportion the wall-height
-          // dial moves its effective height away from the calibrated
-          // default — 1.0 (no-op) at the default, so every existing caller
-          // is byte-identical (doorFrameScale/doorLeafScale's own doc
-          // comments). `doorHeights` (cutaway prototype) overrides THIS
-          // door's own effective height ahead of the global `wallHeight`
-          // when present.
+          // Door frame/leaf height targets `effectiveDoorHeight` directly
+          // (doorFrameScale/doorLeafScale's own doc comments — rpg-project#132
+          // follow-up, Kirk's verdict: door height must equal wall height,
+          // not scale a legacy ratio). `doorHeights` (cutaway prototype)
+          // overrides THIS door's own effective height ahead of the global
+          // `wallHeight` when present.
           const effectiveDoorHeight =
             (id !== undefined ? doorHeights?.get(id) : undefined) ?? wallHeight;
-          const doorHeightRatio = effectiveDoorHeight / WALL_HEIGHT;
           // The leaf's pivot sits at one end of the edge, like the wall
           // pieces (this file's own doc comment) — `edge.a` is exactly
           // `edge.mid` offset by half the edge's own length, along the
@@ -235,7 +233,7 @@ export function SyntyHexWall({
                 file={DOOR_FRAME_FILE}
                 position={framePosition}
                 rotationY={rotationY}
-                scale={doorFrameScale(doorHeightRatio)}
+                scale={doorFrameScale(effectiveDoorHeight)}
                 remembered={isRemembered}
               />
               <GlbInstance
@@ -245,7 +243,7 @@ export function SyntyHexWall({
                   rotationY +
                   (visualState === 'open' ? DOOR_OPEN_ROTATION_OFFSET : 0)
                 }
-                scale={doorLeafScale(doorHeightRatio)}
+                scale={doorLeafScale(effectiveDoorHeight)}
                 tint={visualState === 'locked' ? LOCKED_DOOR_TINT : undefined}
                 remembered={isRemembered}
               />

--- a/src/components/hex-grid/WallRunMesh.tsx
+++ b/src/components/hex-grid/WallRunMesh.tsx
@@ -37,7 +37,7 @@ import type {
   EnvelopeRun,
   WallRunSegment,
 } from '@/hooks/wallRuns';
-import { SYNTY_SCALE } from '@/rendering/calibrationConstants';
+import { SYNTY_SCALE, WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { Suspense, useMemo } from 'react';
 import type * as THREE from 'three';
 import { GlbInstance } from './GlbInstance';
@@ -254,8 +254,6 @@ export interface WallRunMeshProps {
   spaceTheme?: WallTheme;
 }
 
-const DEFAULT_WALL_HEIGHT = 0.8; // matches calibrationConstants.WALL_HEIGHT
-
 /**
  * Renders every envelope run, connector run segment, and connector
  * fallback segment as tiled real Synty wall pieces. Own Suspense boundary
@@ -293,7 +291,7 @@ export function WallRunMesh({
   fallbackSegments = [],
   rememberedEnvelopeRegionIds,
   rememberedConnectorDoorIds,
-  wallHeight = DEFAULT_WALL_HEIGHT,
+  wallHeight = WALL_HEIGHT,
   wallCutaway = false,
   playerPosition,
   spaceTheme,

--- a/src/components/hex-grid/syntyHexWallHelpers.ts
+++ b/src/components/hex-grid/syntyHexWallHelpers.ts
@@ -643,38 +643,63 @@ export function fittingScale(
   ];
 }
 
-// SM_Env_Door_Frame_01's own local-space bounding width at scale=1, pivot
-// centered (see SyntyHexWall.tsx's own historical DOOR_FRAME_RAW_WIDTH
-// comment for the measurement provenance).
+// SM_Env_Door_Frame_01's own local-space bounding width/height at scale=1
+// (measured directly off the GLB via a live Box3.setFromObject read —
+// same technique WallVariant's own rawWidth/rawHeight use; pivot already
+// sits at floor level, confirmed by the same measurement).
 const DOOR_FRAME_RAW_WIDTH = 1.999;
+const DOOR_FRAME_RAW_HEIGHT = 2.5347;
 
 /**
- * Door frame height/leaf height scale — historically a flat SYNTY_SCALE
- * (a "human-scale feature, not clamped to the short game wall height"),
- * now scaled by the SAME ratio the `wallHeight` dial applies to every
- * other wall piece (Kirk's live-walk ask, rpg-project#132 wall-height
- * dial: "the height of the walls might be a little low" — walls, door
- * frame, and fittings should all rise TOGETHER when that dial changes, not
- * just the run boxes). `heightRatio` is `wallHeight / WALL_HEIGHT` (the
- * calibrated default) — 1.0 at the default wallHeight, so this is
- * byte-identical to the old flat SYNTY_SCALE for every caller that
- * doesn't pass an override. Width/depth (X/Z) are deliberately
- * untouched — door WIDTH still fits the edge exactly, and depth/thickness
- * still matches the wall's own SYNTY_SCALE convention; only height is
- * what "the wall is a little low" is about.
+ * Door frame/leaf height scale (rpg-project#132 follow-up, Kirk's verdict
+ * walking the tall-wall default: "at tall walls the door is really really
+ * high"). SUPERSEDED design: this used to multiply a `heightRatio`
+ * (`wallHeight / WALL_HEIGHT`) onto the door's own historical flat-
+ * `SYNTY_SCALE` baseline — a baseline already sized to stand proud of the
+ * OLD 0.8 knee-wall (a deliberately human-scale feature, "not clamped to
+ * the short game wall height"), so as `WALL_HEIGHT` rose to 2.4 the door
+ * compounded an already-oversized starting point instead of tracking the
+ * wall, rendering far taller than the wall itself.
+ *
+ * Now targets `wallHeight` DIRECTLY — the same "scale = wallHeight /
+ * rawHeight" pattern `wallVariantScale`/`fittingScale` already use for
+ * wall panels/fittings — so the frame's own top edge lands almost
+ * exactly at `wallHeight` (no separate margin term needed:
+ * `DOOR_FRAME_RAW_HEIGHT` already measures the frame's own authored
+ * proportions, so "frame reads as slightly recessed into the wall" falls
+ * out of the asset itself, not this formula). Width/depth (X/Z) stay
+ * untouched — door WIDTH still fits the edge exactly, depth/thickness
+ * still matches the wall's own `SYNTY_SCALE` convention; only height
+ * tracks the wall now.
  */
 export const DOOR_FRAME_FILE = 'SM_Env_Door_Frame_01.glb';
 
-export function doorFrameScale(heightRatio: number): [number, number, number] {
-  return [1.0 / DOOR_FRAME_RAW_WIDTH, SYNTY_SCALE * heightRatio, SYNTY_SCALE];
+export function doorFrameScale(wallHeight: number): [number, number, number] {
+  return [
+    1.0 / DOOR_FRAME_RAW_WIDTH,
+    wallHeight / DOOR_FRAME_RAW_HEIGHT,
+    SYNTY_SCALE,
+  ];
 }
 
-// SM_Env_Door_01 is 1.3236 wide at scale 1 (pivot at one end, like the wall
-// piece) — 1.3236 * 0.75 = 0.9927, a near-perfect fit against a 1.0 edge.
+// SM_Env_Door_01 is 1.3236 wide, 2.4557 tall at scale 1 (pivot at one end
+// like the wall piece, floor-level base) — 1.3236 * 0.75 = 0.9927, a
+// near-perfect fit against a 1.0 edge.
 export const DOOR_LEAF_FILE = 'SM_Env_Door_01.glb';
 
-export function doorLeafScale(heightRatio: number): [number, number, number] {
-  return [SYNTY_SCALE, SYNTY_SCALE * heightRatio, SYNTY_SCALE];
+/**
+ * Leaf height scale uses the SAME per-height-unit factor the frame uses
+ * (`wallHeight / DOOR_FRAME_RAW_HEIGHT` — NOT the leaf's own raw height)
+ * — "leaf proportional within frame" (Kirk's verdict): the leaf's raw
+ * height is already ~97% of the frame's (2.4557 / 2.5347), authored to
+ * sit just inside the frame's opening without poking through the top
+ * lintel. Scaling both pieces by the FRAME's own factor preserves that
+ * authored ratio at any `wallHeight` — scaling the leaf by
+ * `wallHeight / (its own raw height)` instead would make it exactly as
+ * tall as the frame, losing the margin the asset was built with.
+ */
+export function doorLeafScale(wallHeight: number): [number, number, number] {
+  return [SYNTY_SCALE, wallHeight / DOOR_FRAME_RAW_HEIGHT, SYNTY_SCALE];
 }
 
 /**

--- a/src/rendering/calibrationConstants.ts
+++ b/src/rendering/calibrationConstants.ts
@@ -29,8 +29,17 @@ export const SYNTY_SCALE = 0.75;
  * demo, for calibrating Synty wall/door pieces to match — was independently
  * re-declared as `const WALL_HEIGHT = 0.8` in ShadedHexWall.tsx,
  * HexWall.tsx, and SyntyRoomDemo.tsx.
+ *
+ * 2.4 is the DEFAULT the real route actually renders at (rpg-project#132,
+ * Kirk's verdict walking the merged wall-height/cutaway build: "the higher
+ * walls look nice... we can just pan around" — camera rotation makes tall
+ * uniform walls preferable to the old 0.8 knee-wall "game board" look, and
+ * cutaway stubs stay OPT-IN only, never a default). The old 0.8 value and
+ * the `?wallHeight=`/`?wallCutaway=1` dials this constant still feeds are
+ * unchanged — this bump only changes what every caller gets with NO query
+ * params at all.
  */
-export const WALL_HEIGHT = 0.8;
+export const WALL_HEIGHT = 2.4;
 
 /**
  * The game Canvas's own fixed camera position offset (HexGrid.tsx's


### PR DESCRIPTION
## Summary

Kirk's verdicts from walking the merged wall-height/cutaway build (PR #626):

1. **Default walls go tall + uniform**: `WALL_HEIGHT` default 0.8 -> 2.4, cutaway stubs stay OFF by default ("the camera can pan/rotate... the higher walls look nice"). The `?wallHeight=`/`?wallCutaway=1` dials are exactly as built, opt-in overrides only — this changes what every caller gets with NO query params at all. Also removed `WallRunMesh.tsx`'s own duplicate `DEFAULT_WALL_HEIGHT = 0.8` local constant (calibrationConstants.ts's header already flagged this as the one remaining un-consolidated re-declaration) — it now imports the shared constant directly, so there's a single source of truth.

2. **Door height now targets wall height directly**, not a ratio against the door's own legacy baseline. The old formula multiplied `wallHeight / WALL_HEIGHT` onto a door historically sized to stand proud of the 0.8 knee-wall (a deliberate "human-scale feature, not clamped to the short game wall height") — as `WALL_HEIGHT` rose to 2.4 that ratio compounded an already-oversized starting point, rendering "really really high" per Kirk's live walk. Retargeted `doorFrameScale`/`doorLeafScale` to the same `scale = wallHeight / rawHeight` pattern `wallVariantScale`/`fittingScale` already use for wall panels/fittings — measured the door frame/leaf GLBs' own raw bounding boxes directly (live `Box3.setFromObject` read) to get the true `rawHeight`, same technique `WallVariant`'s own measurements used. The leaf scales by the SAME per-height-unit factor as the frame (not its own raw height), preserving its authored ~97%-of-frame proportion at any `wallHeight`.

Scope stays exactly these two changes, per the issue.

Closes #628 (sub-issue of rpg-project#132 umbrella).

## Evidence

Live-verified on the wall-lab instance across the full range — new default (no params, uniform 2.4), legacy 0.8 via the dial, and the `?wallHeight=12.4` extreme. The door tracks the wall's own height proportionally at every point instead of ballooning past it. Composite: `/home/kirk/.claude/jobs/4adc1192/tmp/cutaway-shots/door-height-fix-evidence.png`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint .` clean
- [x] Full suite: 1566/1566 tests passing (rewrote the `doorFrameScale`/`doorLeafScale` unit tests for the new absolute-target design — old ratio-based assertions no longer apply)
- [x] `npm run ci-check` green
- [x] Live-verified door close-up at default (0.8 legacy vs 2.4 new default) + the `?wallHeight=` dial extreme, per the issue's own process ask

Entry review: this is a clean retarget (door height = wallHeight, single formula change) — no growth beyond the two verdicts' stated scope.

— asset-pipeline agent, on behalf of KirkDiggler