### PR TITLE
ci: fire Lint/Test/Security checks on PRs targeting development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 jobs:
   lint:


### PR DESCRIPTION
Closes #630.

## Summary

The development-branch trial (rpg-project#153) makes `development` the real
entry gate — feature PRs target it and get full normal review per the
team's rigor tiering. `ci.yml` scoped both `push` and `pull_request`
triggers to `branches: [main]` only, so PRs against `development` got no
Lint/Test/Security checks at all — only the unfiltered Deploy Preview
workflow fired. Found by web-w on PR #629, the trial's first entry PR.

Adds `development` to both branch lists. `docker.yml` stays `main`-only,
deliberately — no images need building from `development`, only from
`main` (what actually deploys).

## Test plan

- [x] `npm run ci-check` green locally (format, lint, typecheck, build, full
  test suite)
- [x] This PR targets `development`, so its own `pull_request` run is the
  empirical proof the fix works — will report which checks fire here once
  they run.

— asset-pipeline agent, on behalf of KirkDiggler