### PR TITLE
fix(hex-grid): close tile-seam air gaps in wall runs at the tall default

### DIFF
--- a/src/components/hex-grid/WallRunMesh.tsx
+++ b/src/components/hex-grid/WallRunMesh.tsx
@@ -88,6 +88,23 @@ const NOMINAL_PIECE_WIDTH = 1.0;
 const RUN_WALL_PIVOT_RATIO =
   RUN_WALL_VARIANT.rawMinX / RUN_WALL_VARIANT.rawWidth;
 
+/**
+ * Overlap grown onto each side of every tiled wall piece (rpg-dnd5e-web
+ * #634: Kirk's tall-wall-default walk found visible air gaps between
+ * adjacent wall segments, worse in the lower half). Root-caused via an
+ * isolated two-tile render (measuring the ACTUAL rendered silhouette, not
+ * just the theoretical bounding box, which already met flush with zero
+ * gap by construction — see `tileWallSegment`'s own `overlapMargin` doc
+ * comment): `RUN_WALL_VARIANT`'s ("plain," this run tiling's only
+ * variant — this file's own doc comment on why) authored edge silhouette
+ * is a deliberately irregular rock-cut profile, not a flat rectangle, and
+ * recedes inward from its own bounding box by up to ~0.05 world units in
+ * its lower ~60% specifically (measured directly against the real GLB).
+ * 0.08 comfortably covers that measured worst case with margin to spare,
+ * without visibly bulging the seam.
+ */
+const RUN_WALL_TILE_OVERLAP_MARGIN = 0.08;
+
 function FloorSkirtBox({
   segment,
   remembered = false,
@@ -146,7 +163,8 @@ function TiledWallRun({
         segment,
         NOMINAL_PIECE_WIDTH,
         RUN_WALL_PIVOT_RATIO,
-        facing
+        facing,
+        RUN_WALL_TILE_OVERLAP_MARGIN
       ),
     [segment, facing]
   );

--- a/src/components/hex-grid/wallRunMeshHelpers.test.ts
+++ b/src/components/hex-grid/wallRunMeshHelpers.test.ts
@@ -310,6 +310,152 @@ describe('tileWallSegment (W3: real Synty pieces tiled along a run, design.md/pl
       }
     });
   });
+
+  describe('overlapMargin (issue #634 regression: "air gaps between adjacent wall segments at the tall default")', () => {
+    // Root-caused via an isolated two-tile render (not the theoretical
+    // bounding box, which is already provably gap-free by construction —
+    // see the pivotRatio tests above): RUN_WALL_VARIANT's ("plain"
+    // Wall_Half) authored edge silhouette is a deliberately irregular,
+    // rock-cut profile, not a flat rectangle, and recedes inward from its
+    // own bbox by varying amounts at different heights (measured: up to
+    // ~0.05 unit in the lower ~60% of the panel). overlapMargin grows each
+    // tile's rendered bbox symmetrically so adjacent tiles OVERLAP instead
+    // of meeting exactly flush, self-covering the irregular edge — same
+    // class of fix as envelopeCornerOverlapMargin (wallRuns.ts) already
+    // uses for room corners.
+    const MEASURED_PIVOT_RATIO = -0.1174 / 2.672; // RUN_WALL_VARIANT's real pivotRatio
+    const rawWidth = 2.672;
+    const rawMinX = -0.1174;
+
+    it('default overlapMargin (0) is byte-identical to omitting the parameter entirely', () => {
+      const omitted = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO
+      );
+      const explicitZero = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        undefined,
+        0
+      );
+      expect(explicitZero).toEqual(omitted);
+    });
+
+    it('a non-zero margin grows the RENDERED pieceWidth by exactly 2*overlapMargin, leaving count and inter-tile spacing untouched', () => {
+      const noMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO
+      );
+      const withMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        undefined,
+        0.08
+      );
+      expect(withMargin).toHaveLength(noMargin.length);
+      for (let i = 0; i < withMargin.length; i++) {
+        expect(withMargin[i]!.pieceWidth).toBeCloseTo(
+          noMargin[i]!.pieceWidth + 0.16,
+          9
+        );
+      }
+      // Margin is a constant offset applied uniformly to every tile's
+      // origin (same relationship the pivotRatio tests above prove for
+      // pivotRatio itself) — never a per-tile stretch/squeeze, so
+      // consecutive origins stay exactly `pieceWidth` (the TRUE slot
+      // width) apart regardless of margin.
+      for (let i = 1; i < withMargin.length; i++) {
+        expect(
+          withMargin[i]!.position.x - withMargin[i - 1]!.position.x
+        ).toBeCloseTo(1.0, 9);
+      }
+    });
+
+    it('closes the measured real-world gap: adjacent tiles’ actual (bbox-corrected) rendered edges OVERLAP by exactly 2*overlapMargin instead of meeting flush — reproduces the exact hand-derived numbers this issue was root-caused against', () => {
+      const overlapMargin = 0.08;
+      const pieces = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        undefined,
+        overlapMargin
+      );
+      expect(pieces).toHaveLength(2);
+
+      const tsx0 = pieces[0]!.pieceWidth / rawWidth;
+      const bboxMin0 = pieces[0]!.position.x + rawMinX * tsx0;
+      const bboxMax0 = pieces[0]!.position.x + (rawMinX + rawWidth) * tsx0;
+      expect(bboxMin0).toBeCloseTo(-overlapMargin, 9); // -0.08
+      expect(bboxMax0).toBeCloseTo(1 + overlapMargin, 9); // 1.08
+
+      const tsx1 = pieces[1]!.pieceWidth / rawWidth;
+      const bboxMin1 = pieces[1]!.position.x + rawMinX * tsx1;
+      const bboxMax1 = pieces[1]!.position.x + (rawMinX + rawWidth) * tsx1;
+      expect(bboxMin1).toBeCloseTo(1 - overlapMargin, 9); // 0.92
+      expect(bboxMax1).toBeCloseTo(2 + overlapMargin, 9); // 2.08
+
+      // The seam itself: piece 0's rendered right edge now sits PAST
+      // piece 1's rendered left edge by exactly 2*overlapMargin — an
+      // overlap, not a flush meet (margin=0 gives exactly 0 here, per
+      // the test below).
+      expect(bboxMax0 - bboxMin1).toBeCloseTo(2 * overlapMargin, 9);
+    });
+
+    it('WITHOUT the margin (margin=0), the same two tiles meet exactly flush — proves the overlap test above is not vacuous', () => {
+      const pieces = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO
+      );
+      const tsx0 = pieces[0]!.pieceWidth / rawWidth;
+      const bboxMax0 = pieces[0]!.position.x + (rawMinX + rawWidth) * tsx0;
+      const tsx1 = pieces[1]!.pieceWidth / rawWidth;
+      const bboxMin1 = pieces[1]!.position.x + rawMinX * tsx1;
+      expect(bboxMax0 - bboxMin1).toBeCloseTo(0, 9);
+    });
+
+    it('the origin-shift sign convention holds for a flipped run too (facing forces a 180deg flip): margin still applies as a constant per-tile offset, added (not subtracted) per the flipped branch’s own sign convention', () => {
+      const facingOpposingNaive = { x: 0, z: -1 }; // forces a flip for dir=(2,0)
+      const noMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        facingOpposingNaive
+      );
+      const withMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        facingOpposingNaive,
+        0.08
+      );
+      // Same constant-offset relationship as the non-flipped case: margin
+      // never changes inter-tile spacing.
+      for (let i = 1; i < withMargin.length; i++) {
+        expect(
+          withMargin[i]!.position.x - withMargin[i - 1]!.position.x
+        ).toBeCloseTo(1.0, 9);
+      }
+      // Reproduces the exact hand-derived flipped-formula shift:
+      // marginTerm = overlapMargin*(1+2*pivotRatio), ADDED for the
+      // flipped branch — opposite sign from the non-flipped branch above,
+      // matching the existing sign-flip convention between the two
+      // branches of the origin formula.
+      const marginTerm = 0.08 * (1 + 2 * MEASURED_PIVOT_RATIO);
+      expect(withMargin[0]!.position.x).toBeCloseTo(
+        noMargin[0]!.position.x + marginTerm,
+        9
+      );
+      expect(withMargin[1]!.position.x).toBeCloseTo(
+        noMargin[1]!.position.x + marginTerm,
+        9
+      );
+    });
+  });
 });
 
 describe("facingCorrectedRotationY (round-2 W3/W4 fix: tileWallSegment's rotationY is a pure function of the run's own direction, with no notion of \"outward\" — hall's left/right sides share one direction pair and top/bottom share another, so within each pair the SAME rotationY got computed for both despite opposite outward normals; exactly one of each pair always ended up showing its flat, undecorated back outward, verified against the real reference-tomb fixture: 2 of hall's 4 sides failed)", () => {

--- a/src/components/hex-grid/wallRunMeshHelpers.ts
+++ b/src/components/hex-grid/wallRunMeshHelpers.ts
@@ -147,7 +147,31 @@ export function tileWallSegment(
    * caller) skips the correction entirely, keeping the original
    * direction-only rotationY unchanged.
    */
-  facing?: WorldPos
+  facing?: WorldPos,
+  /**
+   * Extra width (world units) grown symmetrically onto EACH side of
+   * every tile's rendered bounding box, so adjacent tiles OVERLAP by this
+   * amount instead of meeting exactly edge-to-edge (rpg-dnd5e-web#634:
+   * Kirk's tall-wall-default walk found visible air gaps between
+   * adjacent wall segments, worse in the lower half). Root cause,
+   * confirmed via an isolated two-tile render measuring the actual
+   * rendered silhouette (not just the theoretical bounding box, which
+   * DOES meet flush with zero gap by construction — the exact-tiling math
+   * itself was never wrong): this pack's wall panels are authored with a
+   * deliberately irregular, rough-hewn rock-cut edge silhouette, not a
+   * flat rectangular one — the edge recedes inward from the piece's own
+   * bounding box by varying amounts at different heights (measured: ~0.01
+   * unit near the top, up to ~0.05 unit in the lower ~60% of this pack's
+   * "plain" variant specifically), so two tiles placed exactly
+   * bbox-to-bbox leave a real gap wherever BOTH neighbors' edges recede
+   * at the same height. Same class of fix as `envelopeCornerOverlapMargin`
+   * (wallRuns.ts) already uses for room CORNERS — deliberately overlapping
+   * geometry to self-cover an irregular/non-mitered seam rather than
+   * trying to author a perfectly complementary edge profile. Default 0
+   * preserves the exact pre-fix tiling math (and every existing test
+   * asserting on it) for any caller that doesn't pass a value.
+   */
+  overlapMargin = 0
 ): TiledPiece[] {
   const dx = segment.end.x - segment.start.x;
   const dz = segment.end.z - segment.start.z;
@@ -155,6 +179,11 @@ export function tileWallSegment(
   if (length < WALL_RUN_LENGTH_EPSILON) return [];
 
   const count = Math.max(1, Math.round(length / nominalPieceWidth));
+  // `pieceWidth` stays the TRUE, non-overlapping slot width — it's what
+  // determines `count` and where each tile's own slot boundary sits, so
+  // the run's overall coverage/spacing is completely unaffected by
+  // `overlapMargin`. Only the RENDERED width (returned per piece, below)
+  // grows.
   const pieceWidth = length / count;
   const naiveRotationY = Math.atan2(-dz, dx);
   const rotationY = facing
@@ -177,6 +206,17 @@ export function tileWallSegment(
   const flipped = rotationY !== naiveRotationY;
   const ux = dx / length;
   const uz = dz / length;
+  const renderedWidth = pieceWidth + 2 * overlapMargin;
+  // Growing the rendered width by `overlapMargin` on each side shifts
+  // where the origin needs to land relative to the (unchanged) slot
+  // boundary — re-deriving the SAME "scaled bbox lands flush at
+  // [i,i+1]*pieceWidth" relationship the comment below already explains,
+  // just solved for a bbox that now lands at
+  // [i*pieceWidth - overlapMargin, (i+1)*pieceWidth + overlapMargin]
+  // instead. Reduces to the original `marginTerm = 0` exactly when
+  // `overlapMargin = 0`, so every existing caller (and test) is
+  // byte-identical.
+  const marginTerm = overlapMargin * (1 + 2 * pivotRatio);
 
   const pieces: TiledPiece[] = [];
   for (let i = 0; i < count; i++) {
@@ -189,15 +229,15 @@ export function tileWallSegment(
     // formulas below agree exactly at pivotRatio = -0.5, which is also
     // how this was verified).
     const originDist = flipped
-      ? pieceWidth * (i + pivotRatio + 1)
-      : pieceWidth * (i - pivotRatio);
+      ? pieceWidth * (i + pivotRatio + 1) + marginTerm
+      : pieceWidth * (i - pivotRatio) - marginTerm;
     pieces.push({
       position: {
         x: segment.start.x + ux * originDist,
         z: segment.start.z + uz * originDist,
       },
       rotationY,
-      pieceWidth,
+      pieceWidth: renderedWidth,
     });
   }
   return pieces;


### PR DESCRIPTION
## Summary

Closes #634. Kirk's :3011 walk at the new tall `wallHeight` default found
visible air gaps between adjacent tiled wall segments, worse in the lower
half. Per the "root-cause with an isolated two-tile render before fixing"
process, this was root-caused (not patched) before any fix landed.

## Root cause

The tiling math in `tileWallSegment` places adjacent tiles' **bounding
boxes** exactly flush — proven gap-free by hand-derivation and already
covered by the existing `pivotRatio` regression tests. The gap is real,
but it comes from a different source: `RUN_WALL_VARIANT` ("plain"
`SM_Env_Wall_Half_01.glb`, the dominant tiled piece, weight 3) is authored
with a deliberately irregular, rock-cut edge silhouette, not a flat
rectangle. Measured directly against the real GLB (isolated two-tile
Playwright render, orthographic front-on camera, exact production baking
pipeline): the edge recedes inward from its own bounding box by up to
**~0.05 world units** in the panel's lower ~60%, near-zero at the top —
matching Kirk's "worse in the lower half" report exactly. The absolute
gap doesn't scale with `wallHeight` (only Y stretches; the tiling math is
X-direction), but tall walls give the eye far more vertical surface to
notice it on.

Other variants were checked too: "broken" (`SM_Env_Wall_Broken_Edge_01`)
has a much larger (~0.55 unit) gap that's a deliberate "damaged" thematic
feature, not a tiling artifact — judged out of scope. "alcove"
(pivotRatio exactly -0.5, genuinely centered) already tiles cleanly.

## Fix

Adds an `overlapMargin` parameter to `tileWallSegment` that grows each
tile's *rendered* width symmetrically by a fixed amount on each side
(true slot width/count/spacing unchanged), with a derived origin-shift
term so the grown bounding boxes land flush-with-overlap instead of
flush-with-a-gap. Same class of fix as `envelopeCornerOverlapMargin`
(`wallRuns.ts`) already uses for room corners — deliberately overlapping
geometry to self-cover an irregular seam. Default `0` preserves the exact
pre-fix behavior for every existing caller/test. `WallRunMesh.tsx` wires
in a measured `0.08` (comfortably covers the ~0.05 worst case).

## Test plan

- [x] New regression suite (5 cases): default-preserving, `pieceWidth`
      growth by exactly `2*overlapMargin`, the overlap magnitude
      reproducing the exact hand-derived numbers, a flush-at-zero-margin
      control, and the flipped-run sign convention
- [x] Full existing suite unaffected: 1571/1571 tests pass
- [x] `tsc --noEmit`, `eslint`, `npm run ci-check` all clean
- [x] Isolated two-tile render: gap measured and closed to 0px at the
      exact `overlapMargin=0.08` value shipped here
- [x] Live-verified against the real `wall-lab` dungeon content (not just
      the synthetic scene) — walked into the encounter, checked both a
      near/stub wall run and the tall door-adjacent wall run; both render
      as continuous, gap-free surfaces under this fix

— asset-pipeline agent, on behalf of KirkDiggler