### PR TITLE
feat(encounter): migrate to v1alpha2 hex-knowledge contract, strip retired geometry events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.113",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.114",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1392,7 +1392,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#0e4e2d77d73a27a24f4a01ada4a015e20d07db66",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#00d690822f7f0489ab6a4fb16f9c95c778908780",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.113",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.114",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",

--- a/src/api/encounterStreamDispatch.test.ts
+++ b/src/api/encounterStreamDispatch.test.ts
@@ -24,9 +24,6 @@ function makeEvent<K extends string, V>(
 const routedCases = [
   ['snapshotDelivered', 'onSnapshotDelivered', { encounter: undefined }],
   ['entityMoved', 'onEntityMoved', { entityId: 'a', actualPath: [] }],
-  ['geometryRevealed', 'onGeometryRevealed', { hexes: [] }],
-  ['entityAppeared', 'onEntityAppeared', { entity: { id: 'g' }, reason: '' }],
-  ['entityDisappeared', 'onEntityDisappeared', { entityId: 'g' }],
   ['doorOpened', 'onDoorOpened', { doorEntityId: 'door-east' }],
   ['entityDamaged', 'onEntityDamaged', { entityId: 'g', amount: 5 }],
   ['statusApplied', 'onStatusApplied', { entityId: 'g', status: {} }],

--- a/src/api/encounterStreamDispatch.ts
+++ b/src/api/encounterStreamDispatch.ts
@@ -5,14 +5,11 @@ import type {
   DoorOpened,
   EncounterEnded,
   EncounterEvent,
-  EntityAppeared,
   EntityDamaged,
   EntityDied,
-  EntityDisappeared,
   EntityMoved,
   EntityRemoved,
   EntityStabilized,
-  GeometryRevealed,
   InitiativeRolled,
   InputRequiredDelivered,
   ModeChanged,
@@ -42,10 +39,11 @@ export type EncounterStreamHandler<T> = (
  * connect + every reconnect). The payload's `encounter` field is empty in
  * slice 1 — DO NOT apply it as state. Treat as a stream-up sync barrier.
  *
- * Cause/effect split: DoorOpened (cause) carries only the door identity in
- * Wave 2.7; the actual reveal data (newly-visible hexes) flows on a parallel
- * GeometryRevealed (effect) event from the toolkit's deliberate two-phase
- * emission. Consumers should subscribe to BOTH; do not try to combine them.
+ * DoorOpened is a pure notification (door identity only, rpg-api-protos#197)
+ * for sound/narration — the old cause/effect split with a parallel
+ * GeometryRevealed (effect) event is retired along with GeometryRevealed
+ * itself (its hex-knowledge role is superseded by the v1alpha2 fog contract,
+ * see rpg-dnd5e-web#609).
  *
  * The same cause/effect split applies for combat: an action emits an umbrella
  * `ActionResolved` (what + economy cost) correlated via the envelope
@@ -58,13 +56,11 @@ export interface EncounterStreamOptions {
   /** slice-1: encounter field is empty; treat as connect-confirm only. */
   onSnapshotDelivered?: EncounterStreamHandler<SnapshotDelivered>;
   onEntityMoved?: EncounterStreamHandler<EntityMoved>;
-  onGeometryRevealed?: EncounterStreamHandler<GeometryRevealed>;
-  onEntityAppeared?: EncounterStreamHandler<EntityAppeared>;
-  onEntityDisappeared?: EncounterStreamHandler<EntityDisappeared>;
   /**
-   * Wave 2.7: door state transitions to open. The event's revealedHexes /
-   * revealedWalls / removedWalls fields are intentionally empty — the
-   * geometry side flows on a separate GeometryRevealed event.
+   * Wave 2.7: door state transitions to open. Pure notification (door
+   * identity only, rpg-api-protos#197) for sound/narration — geometry no
+   * longer rides a parallel event; the fog contract (rpg-dnd5e-web#609)
+   * owns hex/wall knowledge now.
    */
   onDoorOpened?: EncounterStreamHandler<DoorOpened>;
   // Wave 2.8: combat events (TURN_BASED mode + attacks + turn cycle).
@@ -178,15 +174,6 @@ export function dispatchEncounterStreamEvent(
     case 'entityMoved':
       options.onEntityMoved?.(payload.value, metadata);
       break;
-    case 'geometryRevealed':
-      options.onGeometryRevealed?.(payload.value, metadata);
-      break;
-    case 'entityAppeared':
-      options.onEntityAppeared?.(payload.value, metadata);
-      break;
-    case 'entityDisappeared':
-      options.onEntityDisappeared?.(payload.value, metadata);
-      break;
     case 'doorOpened':
       options.onDoorOpened?.(payload.value, metadata);
       break;
@@ -240,9 +227,9 @@ export function dispatchEncounterStreamEvent(
       break;
     default:
       // Either out-of-current-scope but known to the proto (entityHealed,
-      // dialogue, etc. — the proto defines 30 event cases;
-      // we currently handle 22) OR a genuinely unknown case from a proto
-      // version mismatch. Either way: warn + continue so the stream doesn't
+      // hexKnowledgeChanged, dialogue, etc. — the proto defines 28 event
+      // cases; we currently handle 19) OR a genuinely unknown case from a
+      // proto version mismatch. Either way: warn + continue so the stream doesn't
       // tear down. Add a case arm + callback when the feature lands.
       // The cast strips the narrowed-to-undefined `case` so we can log it.
       console.warn(

--- a/src/api/useEncounterStream.integration.test.tsx
+++ b/src/api/useEncounterStream.integration.test.tsx
@@ -1,12 +1,14 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
-import { EntityType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import type { EncounterEvent } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
-import { EncounterMode } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  EncounterMode,
+  type Position,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEncounterState } from '../hooks/useEncounterState';
-import { hexKey, protoPositionToHex } from '../utils/hexCoord';
+import { hexKey } from '../utils/hexCoord';
 import { createFakeStream, type FakeStream } from './fakeEncounterStream';
 import { v2PositionToV1 } from './positionConvert';
 
@@ -39,16 +41,51 @@ afterEach(() => {
  * Test harness — exactly mirrors LobbyView's v2 wiring (Task 7.3) so the
  * integration test exercises the same callback graph the production code uses.
  * Returns the encounter state directly for assertions.
+ *
+ * v1alpha2 hex-knowledge contract (rpg-api-protos#197): entities and walls
+ * no longer arrive via live per-entity/per-geometry events (EntityAppeared/
+ * EntityDisappeared/GeometryRevealed are gone) — both now ride only on
+ * SnapshotDelivered, mirroring EncounterView.tsx's real wiring exactly:
+ * entity position comes from a hex's `contents` (an entity says only what
+ * it is, not where), and walls come from flattening every hex's `edges`
+ * (not a flat `Space.walls` list anymore).
  */
 function useTestHarness(encounterId: string) {
   const state = useEncounterState();
   useEncounterStream(encounterId, 'alice', {
     onSnapshotDelivered: (e) => {
+      const hexes = e.encounter?.space?.hexes ?? [];
       state.applySnapshotRegionState(
         e.encounter?.space?.theme ?? '',
         e.encounter?.space?.zones ?? [],
-        e.encounter?.space?.hexes ?? []
+        hexes
       );
+      const positionByEntityId = new Map<string, Position>();
+      for (const hex of hexes) {
+        if (!hex.position) continue;
+        for (const placement of hex.contents ?? []) {
+          positionByEntityId.set(placement.entityId, hex.position);
+        }
+      }
+      const entityEntries = (e.encounter?.space?.entities ?? [])
+        .filter((entity) => positionByEntityId.has(entity.id))
+        .map((entity) => ({
+          entity: create(EntityStateSchema, {
+            entityId: entity.id,
+            position: v2PositionToV1(positionByEntityId.get(entity.id)!),
+          }),
+          type: entity.type,
+          monsterRefId: undefined,
+          initialHP: undefined,
+          initialAC: undefined,
+        }));
+      if (entityEntries.length > 0) {
+        state.applyEntityAppearedBatch(entityEntries);
+      }
+      const walls = hexes.flatMap((hex) => hex.edges ?? []);
+      if (walls.length > 0) {
+        state.applyWallsRevealed(walls);
+      }
     },
     onEntityMoved: (e) => {
       // rpg-dnd5e-web#542: mirrors EncounterView.tsx's real wiring — pass
@@ -61,26 +98,6 @@ function useTestHarness(encounterId: string) {
           v2PositionToV1(last),
           e.actualPath.map(v2PositionToV1)
         );
-    },
-    onGeometryRevealed: (e) => {
-      state.applyHexesRevealed(e.hexes);
-    },
-    onEntityAppeared: (e) => {
-      if (!e.entity || !e.entity.position) return;
-      const stub = create(EntityStateSchema, {
-        entityId: e.entity.id,
-        position: v2PositionToV1(e.entity.position),
-        entityType: EntityType.UNSPECIFIED,
-      });
-      state.applyEntityAppeared(stub);
-    },
-    onEntityDisappeared: (e) => {
-      if (e.lastKnownPosition) {
-        state.applyEntityDisappeared(
-          e.entityId,
-          protoPositionToHex(e.lastKnownPosition)
-        );
-      }
     },
     onDoorOpened: (e) => {
       state.applyDoorOpened(e.doorEntityId);
@@ -108,14 +125,22 @@ describe('useEncounterStream + useEncounterState — integration', () => {
   it('EntityMoved teleports the entity to last hex of actual_path', async () => {
     const { result } = renderHook(() => useTestHarness('enc-1'));
 
-    // Stream up
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-
-    // Seed alice via EntityAppeared so subsequent move has a target
+    // Stream up, seeding alice via the snapshot's hex `contents` (entity
+    // position now rides the occupied hex, not the entity itself).
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'alice', position: { x: 0, y: 0, z: 0 }, reason: '' },
+        makeEvent('snapshotDelivered', {
+          encounter: {
+            space: {
+              entities: [{ id: 'alice', type: 1 }],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'alice' }],
+                },
+              ],
+            },
+          },
         })
       )
     );
@@ -153,65 +178,7 @@ describe('useEncounterStream + useEncounterState — integration', () => {
     });
   });
 
-  it('EntityDisappeared marks ghost and updates position to last_known', async () => {
-    const { result } = renderHook(() => useTestHarness('enc-1'));
-
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'goblin', position: { x: 1, y: -1, z: 0 } },
-        })
-      )
-    );
-    act(() =>
-      fake.push(
-        makeEvent('entityDisappeared', {
-          entityId: 'goblin',
-          lastKnownPosition: { x: 3, y: -2, z: -1 },
-        })
-      )
-    );
-
-    await waitFor(() => {
-      const g = result.current.entities.get('goblin');
-      expect(g?.ghost).toBe(true);
-      // applyEntityDisappeared uses create(PositionSchema) which adds $typeName;
-      // individual field assertions avoid proto-branding false negatives.
-      expect(g?.position?.x).toBe(3);
-      expect(g?.position?.y).toBe(-2);
-      expect(g?.position?.z).toBe(-1);
-    });
-  });
-
-  it('GeometryRevealed adds to revealedHexes set', async () => {
-    const { result } = renderHook(() => useTestHarness('enc-1'));
-
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    // GeometryRevealed.hexes is Hex[]; each Hex wraps a Position via .position.
-    act(() =>
-      fake.push(
-        makeEvent('geometryRevealed', {
-          hexes: [
-            { position: { x: 5, y: -3, z: -2 }, terrain: 0 },
-            { position: { x: 6, y: -3, z: -3 }, terrain: 0 },
-          ],
-          walls: [],
-        })
-      )
-    );
-
-    await waitFor(() => {
-      expect(
-        result.current.revealedHexes.has(hexKey({ q: 5, r: -3, s: -2 }))
-      ).toBe(true);
-      expect(
-        result.current.revealedHexes.has(hexKey({ q: 6, r: -3, s: -3 }))
-      ).toBe(true);
-    });
-  });
-
-  it('replaces snapshot region truth and merges incremental hex zone identity', async () => {
+  it('replaces snapshot region truth across reconnects', async () => {
     const { result } = renderHook(() => useTestHarness('enc-1'));
 
     act(() =>
@@ -224,16 +191,12 @@ describe('useEncounterStream + useEncounterState — integration', () => {
                 { id: 'entrance', name: 'Entrance', archetype: 'entrance' },
                 { id: 'chamber', name: 'Chamber', archetype: 'chamber' },
               ],
-              hexes: [{ position: { x: 0, y: 0, z: 0 }, zoneId: 'entrance' }],
+              hexes: [
+                { position: { x: 0, y: 0, z: 0 }, zoneId: 'entrance' },
+                { position: { x: 1, y: -1, z: 0 }, zoneId: 'chamber' },
+              ],
             },
           },
-        })
-      )
-    );
-    act(() =>
-      fake.push(
-        makeEvent('geometryRevealed', {
-          hexes: [{ position: { x: 1, y: -1, z: 0 }, zoneId: 'chamber' }],
         })
       )
     );
@@ -274,11 +237,10 @@ describe('useEncounterStream + useEncounterState — integration', () => {
     });
   });
 
-  it('DoorOpened + GeometryRevealed flow into both openDoors and revealedHexes (cause/effect split)', async () => {
-    // Wave 2.7: the toolkit emits DoorOpened (cause, no hex data) and a
-    // parallel GeometryRevealed (effect, with newly-visible hexes). The two
-    // reducers must update independently — door state on one, hex set on the
-    // other — without either swallowing the other.
+  it('DoorOpened marks the door open in openDoors', async () => {
+    // rpg-api-protos#197: DoorOpened is now a pure notification (door
+    // identity only) — the world-changing geometry no longer rides a
+    // parallel event, it arrives on the next snapshot's HexRecord.edges.
     const { result } = renderHook(() => useTestHarness('enc-1'));
 
     act(() => fake.push(makeEvent('snapshotDelivered', {})));
@@ -286,102 +248,57 @@ describe('useEncounterStream + useEncounterState — integration', () => {
       fake.push(
         makeEvent('doorOpened', {
           doorEntityId: 'door-east',
-          revealedHexes: [],
-          revealedWalls: [],
-          removedWalls: [],
-        })
-      )
-    );
-    act(() =>
-      fake.push(
-        makeEvent('geometryRevealed', {
-          hexes: [{ position: { x: 4, y: -2, z: -2 } }],
         })
       )
     );
 
     await waitFor(() => {
       expect(result.current.openDoors.has('door-east')).toBe(true);
-      expect(
-        result.current.revealedHexes.has(hexKey({ q: 4, r: -2, s: -2 }))
-      ).toBe(true);
     });
   });
 
-  it('appear → move → disappear → appear sequence settles cleanly', async () => {
+  it('snapshot walls flatten from every hex edges into the sticky wall map', async () => {
+    // rpg-api-protos#197: walls no longer ride a flat Space.walls list —
+    // each hex carries its own boundary segments as `edges`. This exercises
+    // the real production remap (EncounterView.tsx/PlaytestHarness.tsx),
+    // not just applyWallsRevealed in isolation.
     const { result } = renderHook(() => useTestHarness('enc-1'));
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'mover', position: { x: 0, y: 0, z: 0 } },
+        makeEvent('snapshotDelivered', {
+          encounter: {
+            space: {
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  edges: [
+                    {
+                      from: { x: 0, y: 0, z: 0 },
+                      to: { x: 1, y: -1, z: 0 },
+                      kind: 1,
+                    },
+                  ],
+                },
+                {
+                  position: { x: 1, y: -1, z: 0 },
+                  edges: [
+                    {
+                      from: { x: 1, y: -1, z: 0 },
+                      to: { x: 2, y: -2, z: 0 },
+                      kind: 1,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
         })
       )
     );
-    await waitFor(() => {
-      expect(result.current.entities.get('mover')?.ghost).toBeFalsy();
-    });
 
-    act(() =>
-      fake.push(
-        makeEvent('entityMoved', {
-          entityId: 'mover',
-          actualPath: [
-            { x: 0, y: 0, z: 0 },
-            { x: 1, y: -1, z: 0 },
-          ],
-        })
-      )
-    );
     await waitFor(() => {
-      // v2PositionToV1 uses create(PositionSchema) which adds $typeName;
-      // individual field assertions avoid proto-branding false negatives.
-      const pos = result.current.entities.get('mover')?.position;
-      expect(pos?.x).toBe(1);
-      expect(pos?.y).toBe(-1);
-      expect(pos?.z).toBe(0);
-    });
-
-    act(() =>
-      fake.push(
-        makeEvent('entityDisappeared', {
-          entityId: 'mover',
-          lastKnownPosition: { x: 2, y: -1, z: -1 },
-        })
-      )
-    );
-    await waitFor(() => {
-      const m = result.current.entities.get('mover');
-      expect(m?.ghost).toBe(true);
-      // applyEntityDisappeared uses create(PositionSchema) which adds $typeName;
-      // individual field assertions avoid proto-branding false negatives.
-      expect(m?.position?.x).toBe(2);
-      expect(m?.position?.y).toBe(-1);
-      expect(m?.position?.z).toBe(-1);
-    });
-
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'mover', position: { x: 5, y: -3, z: -2 } },
-        })
-      )
-    );
-    await waitFor(() => {
-      const m = result.current.entities.get('mover');
-      expect(m?.ghost).toBeFalsy();
-      // v2PositionToV1 uses create(PositionSchema) which adds $typeName;
-      // individual field assertions avoid proto-branding false negatives.
-      expect(m?.position?.x).toBe(5);
-      expect(m?.position?.y).toBe(-3);
-      expect(m?.position?.z).toBe(-2);
-      // rpg-dnd5e-web#542: the earlier move's movePath/moveSeq must NOT
-      // survive the disappear→reappear round-trip — a revive that kept
-      // them would make HexEntity's useHexMovePath think a fresh move
-      // just started on reconnect, animating a walk from nowhere.
-      expect(m?.movePath).toBeUndefined();
-      expect(m?.moveSeq).toBeUndefined();
+      expect(result.current.walls.size).toBe(2);
     });
   });
 

--- a/src/api/useEncounterStream.integration.test.tsx
+++ b/src/api/useEncounterStream.integration.test.tsx
@@ -54,10 +54,19 @@ function useTestHarness(encounterId: string) {
   const state = useEncounterState();
   useEncounterStream(encounterId, 'alice', {
     onSnapshotDelivered: (e) => {
-      const hexes = e.encounter?.space?.hexes ?? [];
+      // Mirrors EncounterView.tsx/PlaytestHarness.tsx: the slice-1 stream-up
+      // sync barrier delivers a SnapshotDelivered with no `encounter` at
+      // all, and that must be a no-op — NOT a clear of existing region/
+      // entity/wall state. Guarding here (rather than relying on the `?.`
+      // chains below) is load-bearing, not cosmetic: without it, an
+      // encounter-less snapshot would call applySnapshotRegionState with
+      // '', [], [] and wipe out theme/zones/hexes that production would
+      // have left untouched.
+      if (!e.encounter) return;
+      const hexes = e.encounter.space?.hexes ?? [];
       state.applySnapshotRegionState(
-        e.encounter?.space?.theme ?? '',
-        e.encounter?.space?.zones ?? [],
+        e.encounter.space?.theme ?? '',
+        e.encounter.space?.zones ?? [],
         hexes
       );
       const positionByEntityId = new Map<string, Position>();
@@ -67,7 +76,7 @@ function useTestHarness(encounterId: string) {
           positionByEntityId.set(placement.entityId, hex.position);
         }
       }
-      const entityEntries = (e.encounter?.space?.entities ?? [])
+      const entityEntries = (e.encounter.space?.entities ?? [])
         .filter((entity) => positionByEntityId.has(entity.id))
         .map((entity) => ({
           entity: create(EntityStateSchema, {

--- a/src/components/game/EncounterMap.test.tsx
+++ b/src/components/game/EncounterMap.test.tsx
@@ -11,11 +11,11 @@
 import { create } from '@bufbuild/protobuf';
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import {
-  HexSchema,
+  HexRecordSchema,
   PositionSchema,
   WallKind,
   WallSchema,
-  type Hex,
+  type HexRecord,
   type Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { render } from '@testing-library/react';
@@ -44,8 +44,8 @@ function doorWall(id: string): Wall {
   });
 }
 
-function revealedHex(x: number, y: number, z: number, zoneId = ''): Hex {
-  return create(HexSchema, {
+function revealedHex(x: number, y: number, z: number, zoneId = ''): HexRecord {
+  return create(HexRecordSchema, {
     position: create(PositionSchema, { x, y, z }),
     zoneId,
   });
@@ -63,7 +63,9 @@ function baseProps() {
   return {
     entities,
     entityMeta: new Map(),
-    revealedHexes: new Map<string, Hex>([['0,0,0', revealedHex(0, 0, 0)]]),
+    revealedHexes: new Map<string, HexRecord>([
+      ['0,0,0', revealedHex(0, 0, 0)],
+    ]),
     walls: new Map<string, Wall>([['door-1', doorWall('door-1')]]),
     entityHP: new Map(),
     initiativeOrder: [],

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -24,7 +24,7 @@
 
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type {
-  Hex,
+  HexRecord,
   Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useMemo } from 'react';
@@ -77,15 +77,16 @@ export interface EncounterMapProps {
   /** v1alpha2 identity metadata (type, monsterRefId) keyed by entityId. */
   entityMeta: Map<string, EntityMeta>;
   /**
-   * Per-hex reveal map ("x,y,z" cube-coord keys -> the full wire `Hex`,
-   * including `zoneId`) from useEncounterState's `state.revealedHexes`.
+   * Per-hex reveal map ("x,y,z" cube-coord keys -> the full wire
+   * `HexRecord`, including `zoneId`) from useEncounterState's
+   * `state.revealedHexes`.
    * Dungeon-walls redesign (rpg-project#133): `zoneId` is what lets this
    * component reconstruct each room's hex membership
    * (wallRunAdapters.regionInputsFromHexes) for envelope/connector run
    * computation — a plain key `Set` (pre-#133) can't carry that. Floor-tile
    * synthesis below only needs the key set, derived internally.
    */
-  revealedHexes: Map<string, Hex>;
+  revealedHexes: Map<string, HexRecord>;
   /** Sticky revealed walls, keyed by wallKey, from Space.walls/GeometryRevealed.walls. Renders as [] when the server sends none. */
   walls: Map<string, Wall>;
   /** Per-entity HP — marks monsters dead (HP <= 0) so HexGrid renders their corpse. */

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -87,7 +87,7 @@ export interface EncounterMapProps {
    * synthesis below only needs the key set, derived internally.
    */
   revealedHexes: Map<string, HexRecord>;
-  /** Sticky revealed walls, keyed by wallKey, from Space.walls/GeometryRevealed.walls. Renders as [] when the server sends none. */
+  /** Sticky revealed walls, keyed by wallKey, flattened from each revealed hex's `HexRecord.edges` (rpg-api-protos#197 — walls now ride per-hex rather than a flat `Space.walls` list). Renders as [] when the server sends none. */
   walls: Map<string, Wall>;
   /** Per-entity HP — marks monsters dead (HP <= 0) so HexGrid renders their corpse. */
   entityHP: Map<string, { current: number; max: number }>;

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -310,22 +310,22 @@ describe('EncounterView resume-after-refresh entity resolution (#444)', () => {
         makeEvent('snapshotDelivered', {
           encounter: {
             space: {
+              // resolveMyEntityId reads this roster directly off the wire
+              // event (case/playerId match) — it never consumes placement,
+              // so these entities are deliberately left unplaced (no hexes).
               entities: [
                 {
                   id: 'char-alice-resolved',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   data: { case: 'character', value: { playerId: 'alice' } },
                 },
                 {
                   id: 'char-bob',
-                  position: { x: 1, y: 0, z: -1 },
                   type: EntityType.CHARACTER,
                   data: { case: 'character', value: { playerId: 'bob' } },
                 },
                 {
                   id: 'goblin-1',
-                  position: { x: 2, y: 0, z: -2 },
                   type: EntityType.MONSTER,
                   data: {
                     case: 'monster',
@@ -362,7 +362,6 @@ describe('EncounterView resume-after-refresh entity resolution (#444)', () => {
               entities: [
                 {
                   id: 'char-alice-resolved',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   data: { case: 'character', value: { playerId: 'alice' } },
                 },
@@ -407,7 +406,6 @@ describe('EncounterView ignores interaction before entityId resolves (#461 Copil
               entities: [
                 {
                   id: 'goblin-1',
-                  position: { x: 2, y: 0, z: -2 },
                   type: EntityType.MONSTER,
                   data: {
                     case: 'monster',
@@ -703,7 +701,6 @@ describe('EncounterView renders condition badges hydrated from the snapshot (#46
               entities: [
                 {
                   id: 'char-bob',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   data: { case: 'character', value: { playerId: 'bob' } },
                   statusEffects: [
@@ -716,6 +713,12 @@ describe('EncounterView renders condition badges hydrated from the snapshot (#46
                       displayName: 'Raging',
                     },
                   ],
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-bob' }],
                 },
               ],
             },
@@ -759,10 +762,15 @@ describe('EncounterView renders condition badges hydrated from the snapshot (#46
               entities: [
                 {
                   id: 'char-bob',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   data: { case: 'character', value: { playerId: 'bob' } },
                   statusEffects: [],
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-bob' }],
                 },
               ],
             },
@@ -1415,7 +1423,6 @@ describe('EncounterView equip/unequip (rpg-dnd5e-web#571)', () => {
               entities: [
                 {
                   id: 'char-alice',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   data: {
                     case: 'character',
@@ -1466,6 +1473,12 @@ describe('EncounterView equip/unequip (rpg-dnd5e-web#571)', () => {
                       mainHandDamage: '1d8 slashing',
                     },
                   },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-alice' }],
                 },
               ],
             },
@@ -1580,7 +1593,6 @@ describe('EncounterView combat pacing', () => {
               entities: [
                 {
                   id: 'char-alice-resolved',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   data: { case: 'character', value: { playerId: 'alice' } },
                 },
@@ -1680,9 +1692,14 @@ describe('EncounterView combat pacing', () => {
               entities: [
                 {
                   id: 'char-alice',
-                  position: { x: 0, y: 0, z: 0 },
                   type: EntityType.CHARACTER,
                   hp: { current: 20, max: 20, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-alice' }],
                 },
               ],
             },
@@ -1818,12 +1835,17 @@ describe('EncounterView combat pacing', () => {
               entities: [
                 {
                   id: 'goblin-1',
-                  position: { x: 1, y: 0, z: -1 },
                   type: EntityType.MONSTER,
                   data: {
                     case: 'monster',
                     value: { monsterRef: { id: 'goblin' } },
                   },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 1, y: 0, z: -1 },
+                  contents: [{ entityId: 'goblin-1' }],
                 },
               ],
             },

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -23,10 +23,15 @@
  * handleDoorClick below fires `useInteract`'s `Interact(encounterId,
  * doorId, 'open')`; the world-changing effects (open/reveal, or a
  * skill-check prompt for a locked door) flow back as DoorOpened/
- * GeometryRevealed/InputRequiredDelivered events, same as every other verb
- * on this stream. onDoorOpened also flips the matching wall's own kind to
- * DOOR_OPEN in useEncounterState (see applyDoorOpened) so the pose updates
- * immediately, without waiting on a walls-bearing GeometryRevealed.
+ * InputRequiredDelivered events, same as every other verb on this stream.
+ * DoorOpened is now a pure notification (door identity only,
+ * rpg-api-protos#197) — the door's authoritative rendered pose rides the
+ * next snapshot's `HexRecord.edges` instead of a parallel reveal event
+ * (there is no live per-hex knowledge-change consumption yet, tracked as
+ * rpg-dnd5e-web#609). onDoorOpened still flips the matching wall's own kind
+ * to DOOR_OPEN locally in useEncounterState (see applyDoorOpened) so the
+ * pose updates instantly on the click that caused it, ahead of that next
+ * snapshot.
  */
 
 import { create } from '@bufbuild/protobuf';
@@ -37,6 +42,7 @@ import type {
   AvailableAction,
   CharacterData,
   Entity,
+  Position,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
@@ -58,7 +64,6 @@ import { useCombatLog } from '../../hooks/useCombatLog';
 import type { CharacterEquipment } from '../../hooks/useEncounterState';
 import { useEncounterState } from '../../hooks/useEncounterState';
 import { errorMessage } from '../../utils/combatFormat';
-import { protoPositionToHex } from '../../utils/hexCoord';
 import {
   actionKey,
   targetKindNeedsPrompt,
@@ -306,17 +311,33 @@ export function EncounterView({
           e.encounter.mode,
           e.encounter.turnState
         );
+        const hexes = e.encounter.space?.hexes ?? [];
         encounterState.applySnapshotRegionState(
           e.encounter.space?.theme ?? '',
           e.encounter.space?.zones ?? [],
-          e.encounter.space?.hexes ?? []
+          hexes
         );
+        // v1alpha2 hex-knowledge contract (rpg-api-protos#197): Entity no
+        // longer carries its own position — a hex states occupancy, an
+        // entity says only what it is. Build a one-shot reverse index
+        // (entityId -> the hex's position) from this snapshot's authoritative
+        // `contents` before mapping entities, and rebuild it from scratch
+        // every snapshot rather than merging into a prior index — `contents`
+        // is total for a visible hex, so a stale carried-over placement could
+        // resurrect an entity the current snapshot no longer places anywhere.
+        const positionByEntityId = new Map<string, Position>();
+        for (const hex of hexes) {
+          if (!hex.position) continue;
+          for (const placement of hex.contents ?? []) {
+            positionByEntityId.set(placement.entityId, hex.position);
+          }
+        }
         const entityEntries = (e.encounter.space?.entities ?? [])
-          .filter((entity) => entity.position !== undefined)
+          .filter((entity) => positionByEntityId.has(entity.id))
           .map((entity) => ({
             entity: create(EntityStateSchema, {
               entityId: entity.id,
-              position: v2PositionToV1(entity.position!),
+              position: v2PositionToV1(positionByEntityId.get(entity.id)!),
             }),
             type: entity.type,
             monsterRefId:
@@ -365,7 +386,11 @@ export function EncounterView({
         if (entityEntries.length > 0) {
           encounterState.applyEntityAppearedBatch(entityEntries);
         }
-        const walls = e.encounter.space?.walls ?? [];
+        // v1alpha2 hex-knowledge contract: walls no longer ride a flat
+        // Space.walls list — each hex carries its own boundary segments as
+        // `edges`. The data moved, not disappeared, so this flattens the
+        // same shape applyWallsRevealed already expects.
+        const walls = hexes.flatMap((hex) => hex.edges ?? []);
         if (walls.length > 0) {
           encounterState.applyWallsRevealed(walls);
         }
@@ -386,69 +411,13 @@ export function EncounterView({
         );
       }
     },
-    onGeometryRevealed: (e) => {
-      encounterState.applyHexesRevealed(e.hexes);
-      const walls = e.walls ?? [];
-      if (walls.length > 0) {
-        encounterState.applyWallsRevealed(walls);
-      }
-    },
-    // Cause/effect split (mirrors PlaytestHarness): DoorOpened only carries
-    // the door identity — the newly-visible geometry rides the parallel
-    // GeometryRevealed above. State-only for now: HexGrid's door-click
+    // DoorOpened is a pure notification now (door identity only,
+    // rpg-api-protos#197) — the rendered pose rides the next snapshot's
+    // HexRecord.edges, not a parallel reveal event. HexGrid's door-click
     // surface still needs a v2-shaped DoorInfo[] (see this file's top
     // comment) — tracked separately, not this slice.
     onDoorOpened: (e) => {
       encounterState.applyDoorOpened(e.doorEntityId);
-    },
-    onEntityAppeared: (e) => {
-      if (!e.entity || !e.entity.position) return;
-      const stub = create(EntityStateSchema, {
-        entityId: e.entity.id,
-        position: v2PositionToV1(e.entity.position),
-      });
-      encounterState.applyEntityAppeared(stub);
-      const monsterRefId =
-        e.entity.data?.case === 'monster'
-          ? e.entity.data.value.monsterRef?.id
-          : undefined;
-      const initialHP = e.entity.hp
-        ? { current: e.entity.hp.current, max: e.entity.hp.max }
-        : undefined;
-      const classRefId =
-        e.entity.data?.case === 'character'
-          ? e.entity.data.value.classRef?.id
-          : undefined;
-      // See the matching onSnapshotDelivered comment above — same
-      // obstacle_ref/prop_ref -> propRefId derivation for the live
-      // (non-snapshot) appearance path.
-      const propRefId =
-        e.entity.data?.case === 'obstacle'
-          ? e.entity.data.value.obstacleRef?.id
-          : e.entity.data?.case === 'prop'
-            ? e.entity.data.value.propRef?.id
-            : undefined;
-      encounterState.applyEntityMeta(
-        e.entity.id,
-        e.entity.type,
-        monsterRefId,
-        initialHP,
-        e.entity.armorClass,
-        e.entity.displayName,
-        classRefId,
-        propRefId,
-        e.entity.data?.case === 'character'
-          ? characterEquipmentFrom(e.entity.data.value)
-          : undefined
-      );
-    },
-    onEntityDisappeared: (e) => {
-      if (e.lastKnownPosition) {
-        encounterState.applyEntityDisappeared(
-          e.entityId,
-          protoPositionToHex(e.lastKnownPosition)
-        );
-      }
     },
     onStatusApplied: (e) => {
       encounterState.applyStatusApplied(e);
@@ -759,8 +728,10 @@ export function EncounterView({
   // (take_action.go). Dropping the response therefore soft-locked the
   // player: the prompt persists server-side, so every later verb is refused
   // with "resolve the pending prompt before issuing another action" while
-  // nothing is on screen to resolve. The world-changing half (door opens,
-  // hexes reveal) still flows as DoorOpened/GeometryRevealed events.
+  // nothing is on screen to resolve. The world-changing half still flows
+  // over the stream: DoorOpened (door identity, pure notification since
+  // rpg-api-protos#197) plus the next snapshot's HexRecord.edges for the
+  // newly-visible geometry — there is no parallel reveal event anymore.
   const handleDoorClick = async (doorId: string) => {
     try {
       const response = await interact(encounterId, doorId, 'open');

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -31,6 +31,51 @@ function makeEvent(caseName: string, value: unknown): EncounterEvent {
   return { event: { case: caseName, value } } as unknown as EncounterEvent;
 }
 
+/**
+ * rpg-api-protos#197: entities no longer arrive via a live EntityAppeared
+ * event, and an Entity no longer carries its own position — position comes
+ * from whichever hex's `contents` lists the entity's id. This builds a
+ * SnapshotDelivered payload that seeds one or more entities the same way
+ * PlaytestHarness.tsx's real onSnapshotDelivered reads it: one hex per
+ * entity (by default; pass a shared `position` to co-locate them), each
+ * hex's `contents` pointing back at the entity.
+ */
+function snapshotWithEntities(
+  entities: Array<{
+    id: string;
+    position?: { x: number; y: number; z: number };
+    type?: number;
+    hp?: { current: number; max: number };
+    armorClass?: number;
+    monsterRefId?: string;
+    classRefId?: string;
+    displayName?: string;
+  }>
+): EncounterEvent {
+  return makeEvent('snapshotDelivered', {
+    encounter: {
+      space: {
+        entities: entities.map((e) => ({
+          id: e.id,
+          type: e.type ?? 1, // ENTITY_TYPE_CHARACTER
+          hp: e.hp,
+          armorClass: e.armorClass,
+          displayName: e.displayName,
+          data: e.monsterRefId
+            ? { case: 'monster', value: { monsterRef: { id: e.monsterRefId } } }
+            : e.classRefId
+              ? { case: 'character', value: { classRef: { id: e.classRefId } } }
+              : undefined,
+        })),
+        hexes: entities.map((e) => ({
+          position: e.position ?? { x: 0, y: 0, z: 0 },
+          contents: [{ entityId: e.id }],
+        })),
+      },
+    },
+  });
+}
+
 // vi.hoisted so the mock factory can close over the refs before imports run
 // The concrete signature for setReactionReadyFn is intentionally permissive
 // so the mock.calls tuple types preserve the request object — matches the
@@ -175,21 +220,10 @@ describe('PlaytestHarness', () => {
     expect(screen.getByText(/dev-encounter/)).toBeTruthy();
   });
 
-  it('shows entity in table after EntityAppeared event', async () => {
+  it('shows entity in table after snapshot seeds it', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: {
-            id: 'char-alice',
-            position: { x: 0, y: 0, z: 0 },
-            reason: '',
-          },
-        })
-      )
-    );
+    act(() => fake.push(snapshotWithEntities([{ id: 'char-alice' }])));
 
     await waitFor(() => {
       expect(screen.getByText('char-alice')).toBeTruthy();
@@ -199,18 +233,7 @@ describe('PlaytestHarness', () => {
   it('updates entity row after EntityMoved event', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: {
-            id: 'char-alice',
-            position: { x: 0, y: 0, z: 0 },
-            reason: '',
-          },
-        })
-      )
-    );
+    act(() => fake.push(snapshotWithEntities([{ id: 'char-alice' }])));
     await waitFor(() => expect(screen.getByText('char-alice')).toBeTruthy());
 
     act(() =>
@@ -235,17 +258,7 @@ describe('PlaytestHarness', () => {
     render(<PlaytestHarness />);
 
     // Seed entity with position so the Move button becomes enabled
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: {
-            id: 'char-alice',
-            position: { x: 0, y: 0, z: 0 },
-          } as unknown as EntityState,
-        })
-      )
-    );
+    act(() => fake.push(snapshotWithEntities([{ id: 'char-alice' }])));
 
     await waitFor(() => {
       const btn = screen.getByRole('button', { name: /move there/i });
@@ -279,14 +292,7 @@ describe('PlaytestHarness', () => {
 
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
-        })
-      )
-    );
+    act(() => fake.push(snapshotWithEntities([{ id: 'char-alice' }])));
 
     await waitFor(() => {
       const btn = screen.getByRole('button', { name: /move there/i });
@@ -370,9 +376,6 @@ describe('PlaytestHarness', () => {
       fake.push(
         makeEvent('doorOpened', {
           doorEntityId: 'door-east',
-          revealedHexes: [],
-          revealedWalls: [],
-          removedWalls: [],
         })
       )
     );
@@ -383,11 +386,10 @@ describe('PlaytestHarness', () => {
     expect(screen.getByText(/Open doors \(1\):.*door-east/)).toBeTruthy();
   });
 
-  it('logs both DoorOpened and GeometryRevealed independently (cause/effect split)', async () => {
-    // Wave 2.7: the toolkit emits the cause (DoorOpened, no hexes) and the
-    // effect (GeometryRevealed, with hexes) as two separate events. The
-    // harness must surface both in the log; the dispatcher must not collapse
-    // them.
+  it('logs DoorOpened as a pure notification', async () => {
+    // rpg-api-protos#197: DoorOpened is now door identity only — the
+    // world-changing geometry no longer rides a parallel event, it arrives
+    // on the next snapshot's HexRecord.edges instead.
     render(<PlaytestHarness />);
 
     act(() => fake.push(makeEvent('snapshotDelivered', {})));
@@ -395,26 +397,12 @@ describe('PlaytestHarness', () => {
       fake.push(
         makeEvent('doorOpened', {
           doorEntityId: 'door-east',
-          revealedHexes: [],
-          revealedWalls: [],
-          removedWalls: [],
-        })
-      )
-    );
-    act(() =>
-      fake.push(
-        makeEvent('geometryRevealed', {
-          hexes: [
-            { position: { x: 1, y: -1, z: 0 } },
-            { position: { x: 2, y: -2, z: 0 } },
-          ],
         })
       )
     );
 
     await waitFor(() => {
       expect(screen.getByText(/DoorOpened door-east/i)).toBeTruthy();
-      expect(screen.getByText(/GeometryRevealed 2 hex/i)).toBeTruthy();
     });
   });
 
@@ -626,15 +614,14 @@ describe('PlaytestHarness', () => {
 
   it('renders HP in entities table row after EntityDamaged event', async () => {
     // HP is now shown inline in the entities table, not a separate HP table.
-    // goblin-1 must appear first (EntityAppeared) so it has a row in the table.
+    // goblin-1 must appear first (via the snapshot) so it has a row in the table.
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
-        })
+        snapshotWithEntities([
+          { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
+        ])
       )
     );
     act(() =>
@@ -836,12 +823,11 @@ describe('PlaytestHarness', () => {
   it('shows HP inline in entities table after EntityDamaged (fix #398)', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
-        })
+        snapshotWithEntities([
+          { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
+        ])
       )
     );
     act(() =>
@@ -860,21 +846,20 @@ describe('PlaytestHarness', () => {
     });
   });
 
-  it('shows entity type in entities table after EntityAppeared with v1alpha2 entity type (fix #397)', async () => {
+  it('shows entity type in entities table from the snapshot with v1alpha2 entity type (fix #397)', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    // Send an EntityAppeared event with a monster entity carrying type + data
+    // Seed a monster entity carrying type + monster ref via the snapshot.
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: {
+        snapshotWithEntities([
+          {
             id: 'goblin-1',
             type: 2, // EntityType.MONSTER = 2 in v1alpha2
             position: { x: 1, y: 0, z: -1 },
-            data: { case: 'monster', value: { monsterRef: { id: 'goblin' } } },
+            monsterRefId: 'goblin',
           },
-        })
+        ])
       )
     );
 
@@ -883,20 +868,19 @@ describe('PlaytestHarness', () => {
     });
   });
 
-  it('seeds HP in entities table from EntityAppeared initial hp (fix #397 + #398)', async () => {
+  it('seeds HP in entities table from the snapshot initial hp (fix #397 + #398)', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: {
+        snapshotWithEntities([
+          {
             id: 'goblin-1',
             type: 2,
             position: { x: 1, y: 0, z: -1 },
             hp: { current: 7, max: 7 },
           },
-        })
+        ])
       )
     );
 
@@ -909,20 +893,13 @@ describe('PlaytestHarness', () => {
   it('highlights active actor row distinctly from local player row (fix #400)', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
-    // Seed both entities
+    // Seed both entities via a single snapshot.
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
-        })
-      )
-    );
-    act(() =>
-      fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
-        })
+        snapshotWithEntities([
+          { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
+          { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
+        ])
       )
     );
     act(() =>
@@ -1301,12 +1278,11 @@ describe('PlaytestHarness', () => {
   it('removes entity from table after EntityRemoved event', async () => {
     render(<PlaytestHarness />);
 
-    act(() => fake.push(makeEvent('snapshotDelivered', {})));
     act(() =>
       fake.push(
-        makeEvent('entityAppeared', {
-          entity: { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
-        })
+        snapshotWithEntities([
+          { id: 'goblin-1', position: { x: 1, y: 0, z: -1 } },
+        ])
       )
     );
 
@@ -1870,23 +1846,20 @@ describe('PlaytestHarness', () => {
       // the click as an attack target.
       act(() =>
         fake.push(
-          makeEvent('entityAppeared', {
-            entity: {
+          snapshotWithEntities([
+            {
               id: 'goblin-1',
               type: 2, // MONSTER
               position: { x: 1, y: -1, z: 0 },
-              data: {
-                case: 'monster',
-                value: { monsterRef: { id: 'goblin' } },
-              },
+              monsterRefId: 'goblin',
             },
-          })
+          ])
         )
       );
 
-      // Wait for the entity to land in state. EntityAppeared shows up in
-      // both the event log and the dev-panel entity table, so use
-      // findAllByText to settle without a uniqueness assertion.
+      // Wait for the entity to land in state. It shows up in both the
+      // event log and the dev-panel entity table, so use findAllByText to
+      // settle without a uniqueness assertion.
       await waitFor(() => {
         const matches = screen.queryAllByText(/goblin-1/);
         expect(matches.length).toBeGreaterThan(0);
@@ -1925,13 +1898,13 @@ describe('PlaytestHarness', () => {
       // a selection.
       act(() =>
         fake.push(
-          makeEvent('entityAppeared', {
-            entity: {
+          snapshotWithEntities([
+            {
               id: 'char-bob',
               type: 1, // CHARACTER
               position: { x: 2, y: -2, z: 0 },
             },
-          })
+          ])
         )
       );
 
@@ -1954,22 +1927,18 @@ describe('PlaytestHarness', () => {
 
     it('map entity click after EncounterEnded does NOT dispatch attack', async () => {
       render(<PlaytestHarness />);
-      act(() => fake.push(makeEvent('snapshotDelivered', {})));
       // Seed goblin-1 BEFORE ending so the click target exists in
       // entityMeta and the encounter-ended branch is reached.
       act(() =>
         fake.push(
-          makeEvent('entityAppeared', {
-            entity: {
+          snapshotWithEntities([
+            {
               id: 'goblin-1',
               type: 2,
               position: { x: 1, y: -1, z: 0 },
-              data: {
-                case: 'monster',
-                value: { monsterRef: { id: 'goblin' } },
-              },
+              monsterRefId: 'goblin',
             },
-          })
+          ])
         )
       );
       act(() =>
@@ -2213,14 +2182,7 @@ describe('PlaytestHarness', () => {
   describe('status effect rendering (#430)', () => {
     it('renders a Hidden status badge on the entity table row after StatusApplied', async () => {
       render(<PlaytestHarness />);
-      act(() => fake.push(makeEvent('snapshotDelivered', {})));
-      act(() =>
-        fake.push(
-          makeEvent('entityAppeared', {
-            entity: { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
-          })
-        )
-      );
+      act(() => fake.push(snapshotWithEntities([{ id: 'char-alice' }])));
       act(() =>
         fake.push(
           makeEvent('statusApplied', {
@@ -2245,12 +2207,11 @@ describe('PlaytestHarness', () => {
     // either the helper or the helped ally) must see it too.
     it('renders a Helped status badge on a non-local-player entity (third-party visibility)', async () => {
       render(<PlaytestHarness />);
-      act(() => fake.push(makeEvent('snapshotDelivered', {})));
       act(() =>
         fake.push(
-          makeEvent('entityAppeared', {
-            entity: { id: 'char-fighter', position: { x: 1, y: 0, z: -1 } },
-          })
+          snapshotWithEntities([
+            { id: 'char-fighter', position: { x: 1, y: 0, z: -1 } },
+          ])
         )
       );
       act(() =>
@@ -2283,14 +2244,7 @@ describe('PlaytestHarness', () => {
   describe('status removal + death-save arc (#433)', () => {
     it('clears the status badge after StatusRemoved for the matching source', async () => {
       render(<PlaytestHarness />);
-      act(() => fake.push(makeEvent('snapshotDelivered', {})));
-      act(() =>
-        fake.push(
-          makeEvent('entityAppeared', {
-            entity: { id: 'char-alice', position: { x: 0, y: 0, z: 0 } },
-          })
-        )
-      );
+      act(() => fake.push(snapshotWithEntities([{ id: 'char-alice' }])));
       act(() =>
         fake.push(
           makeEvent('statusApplied', {

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,7 +1,10 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
-import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import type {
+  AvailableAction,
+  Position,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
   EntityType,
@@ -17,13 +20,9 @@ import { useInteract } from '../../api/useInteract';
 import { useMoveEntity } from '../../api/useMoveEntity';
 import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useTakeAction } from '../../api/useTakeAction';
-import {
-  hexesWithPosition,
-  useEncounterState,
-} from '../../hooks/useEncounterState';
+import { useEncounterState } from '../../hooks/useEncounterState';
 import { errorMessage, formatSourceRefs } from '../../utils/combatFormat';
 import { getConditionDisplay } from '../../utils/conditionIcons';
-import { protoPositionToHex } from '../../utils/hexCoord';
 import { PromptModal } from '../game/PromptModal';
 import { StatusBadgeList } from '../ui/StatusBadgeList';
 import { ActionMenu } from './ActionMenu';
@@ -205,19 +204,35 @@ export function PlaytestHarness() {
             e.encounter.mode,
             e.encounter.turnState
           );
+          const hexes = e.encounter.space?.hexes ?? [];
           encounterState.applySnapshotRegionState(
             e.encounter.space?.theme ?? '',
             e.encounter.space?.zones ?? [],
-            e.encounter.space?.hexes ?? []
+            hexes
           );
+          // v1alpha2 hex-knowledge contract (rpg-api-protos#197): Entity no
+          // longer carries its own position — a hex states occupancy, an
+          // entity says only what it is. Build a one-shot reverse index
+          // (entityId -> the hex's position) from this snapshot's
+          // authoritative `contents` before mapping entities, rebuilt from
+          // scratch every snapshot (mirrors EncounterView.tsx) rather than
+          // merged into a prior index, since `contents` is total for a
+          // visible hex.
+          const positionByEntityId = new Map<string, Position>();
+          for (const hex of hexes) {
+            if (!hex.position) continue;
+            for (const placement of hex.contents ?? []) {
+              positionByEntityId.set(placement.entityId, hex.position);
+            }
+          }
           // Seed entities from the snapshot's space entities list in a single
           // batch setState call to avoid N intermediate renders for N entities.
           const entityEntries = (e.encounter.space?.entities ?? [])
-            .filter((entity) => entity.position !== undefined)
+            .filter((entity) => positionByEntityId.has(entity.id))
             .map((entity) => ({
               entity: create(EntityStateSchema, {
                 entityId: entity.id,
-                position: v2PositionToV1(entity.position!),
+                position: v2PositionToV1(positionByEntityId.get(entity.id)!),
               }),
               type: entity.type,
               monsterRefId:
@@ -244,7 +259,11 @@ export function PlaytestHarness() {
           if (entityEntries.length > 0) {
             encounterState.applyEntityAppearedBatch(entityEntries);
           }
-          const walls = e.encounter.space?.walls ?? [];
+          // v1alpha2 hex-knowledge contract: walls no longer ride a flat
+          // Space.walls list — each hex carries its own boundary segments as
+          // `edges`. The data moved, not disappeared, so this flattens the
+          // same shape applyWallsRevealed already expects.
+          const walls = hexes.flatMap((hex) => hex.edges ?? []);
           if (walls.length > 0) {
             encounterState.applyWallsRevealed(walls);
           }
@@ -267,61 +286,10 @@ export function PlaytestHarness() {
         const pos = last ? `(${last.x},${last.y},${last.z})` : '(no path)';
         addLog(`EntityMoved ${e.entityId} → ${pos}`);
       },
-      onGeometryRevealed: (e) => {
-        const revealedHexes = hexesWithPosition(e.hexes);
-        encounterState.applyHexesRevealed(revealedHexes);
-        const walls = e.walls ?? [];
-        if (walls.length > 0) {
-          encounterState.applyWallsRevealed(walls);
-        }
-        addLog(`GeometryRevealed ${revealedHexes.length} hex(es)`);
-      },
-      onEntityAppeared: (e) => {
-        if (!e.entity || !e.entity.position) return;
-        // Create a v1alpha1 stub for positional tracking in the entities Map.
-        // The v1alpha2 Entity fields (type, hp, MonsterData) flow separately
-        // into entityMeta and entityHP via applyEntityMeta below.
-        const stub = create(EntityStateSchema, {
-          entityId: e.entity.id,
-          position: v2PositionToV1(e.entity.position),
-        });
-        encounterState.applyEntityAppeared(stub);
-        // Store v1alpha2 identity metadata and seed initial HP + AC.
-        const monsterRefId =
-          e.entity.data?.case === 'monster'
-            ? e.entity.data.value.monsterRef?.id
-            : undefined;
-        const initialHP = e.entity.hp
-          ? { current: e.entity.hp.current, max: e.entity.hp.max }
-          : undefined;
-        const classRefId =
-          e.entity.data?.case === 'character'
-            ? e.entity.data.value.classRef?.id
-            : undefined;
-        encounterState.applyEntityMeta(
-          e.entity.id,
-          e.entity.type,
-          monsterRefId,
-          initialHP,
-          e.entity.armorClass,
-          e.entity.displayName,
-          classRefId
-        );
-        addLog(`EntityAppeared ${e.entity.id}`);
-      },
-      onEntityDisappeared: (e) => {
-        if (e.lastKnownPosition) {
-          encounterState.applyEntityDisappeared(
-            e.entityId,
-            protoPositionToHex(e.lastKnownPosition)
-          );
-        }
-        addLog(`EntityDisappeared ${e.entityId}`);
-      },
       onDoorOpened: (e) => {
-        // Cause/effect split: DoorOpened only carries the door identity in
-        // Wave 2.7; the newly-visible hexes flow on a parallel
-        // GeometryRevealed event handled above. Log both lines independently.
+        // DoorOpened is a pure notification now (door identity only,
+        // rpg-api-protos#197) — the rendered pose rides the next snapshot's
+        // HexRecord.edges, not a parallel reveal event.
         encounterState.applyDoorOpened(e.doorEntityId);
         addLog(`DoorOpened ${e.doorEntityId}`);
       },

--- a/src/components/playtest/PlaytestMap.tsx
+++ b/src/components/playtest/PlaytestMap.tsx
@@ -19,7 +19,9 @@
  * - `floorTiles` is synthesized from `revealedHexes` plus every entity's
  *   current cell. Without an entity-cell fallback the local player can't
  *   move from the seeded fallback position before the first
- *   `GeometryRevealed` event lands.
+ *   `SnapshotDelivered` places them (there is no live per-hex reveal event
+ *   after rpg-api-protos#197 — hex/entity knowledge now arrives on
+ *   snapshot only, until rpg-dnd5e-web#609 consumes HexKnowledgeChanged).
  *
  * - `movementRemaining` defaults to 30 ft. The harness is a verification
  *   tool — the server is the source of truth for movement budget and will
@@ -74,7 +76,9 @@ export interface PlaytestMapProps {
   >;
   /**
    * v1alpha2 identity metadata (type, monsterRefId) keyed by entityId.
-   * Populated by `applyEntityMeta` from EntityAppeared events.
+   * Populated by `applyEntityAppearedBatch` from each SnapshotDelivered
+   * entity's fields (rpg-api-protos#197 retired the live per-entity
+   * EntityAppeared event; entities now arrive only via snapshot).
    */
   entityMeta: Map<string, EntityMeta>;
   /**
@@ -83,9 +87,10 @@ export interface PlaytestMapProps {
    */
   revealedHexes: Set<string>;
   /**
-   * Sticky revealed walls, keyed by `wallKey`, from `Space.walls` (snapshot)
-   * merged with `GeometryRevealed.walls` (delta). Degrades to an empty map
-   * — and no walls render — when the server sends none.
+   * Sticky revealed walls, keyed by `wallKey`, flattened from each revealed
+   * hex's `HexRecord.edges` (rpg-api-protos#197 — walls now ride per-hex
+   * rather than a flat `Space.walls` list). Degrades to an empty map — and
+   * no walls render — when the server sends none.
    */
   walls: Map<string, Wall>;
   /**
@@ -116,7 +121,7 @@ export interface PlaytestMapProps {
   myEntityId: string;
   /**
    * Optional fallback position for the local player before the first
-   * EntityAppeared event lands (the dev-seeded encounter). Used only when
+   * SnapshotDelivered places them (the dev-seeded encounter). Used only when
    * the local player isn't present in `entities` yet.
    */
   fallbackPosition?: { x: number; y: number; z: number };

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -577,68 +577,6 @@ describe('v1alpha2 reducer additions', () => {
     });
   });
 
-  describe('applyEntityAppeared', () => {
-    it('adds a new entity at first-visible position with ghost cleared', () => {
-      const prev = createEmptyEncounterState();
-      const entity = makeTestEntity('goblin-1', { x: 3, y: -2, z: -1 });
-      const after = seedEntity(prev, entity);
-      const stored = after.entities.get('goblin-1');
-      expect(stored).toBeDefined();
-      expect(stored?.ghost).toBeFalsy();
-      expect(stored?.position?.x).toBe(3);
-      expect(stored?.position?.y).toBe(-2);
-      expect(stored?.position?.z).toBe(-1);
-    });
-
-    it('clears the ghost flag on a previously-disappeared entity', () => {
-      const entity = makeTestEntity('alice', { x: 0, y: 0, z: 0 });
-      const withEntity = seedEntity(createEmptyEncounterState(), entity);
-      const ghosted = applyEntityDisappeared(withEntity, 'alice', {
-        q: 1,
-        r: -1,
-        s: 0,
-      });
-      expect(ghosted.entities.get('alice')?.ghost).toBe(true);
-
-      const reappeared = seedEntity(
-        ghosted,
-        makeTestEntity('alice', { x: 5, y: -3, z: -2 })
-      );
-      expect(reappeared.entities.get('alice')?.ghost).toBeFalsy();
-    });
-  });
-
-  describe('applyEntityDisappeared', () => {
-    it('keeps entity in store, sets ghost=true, updates position to last_known', () => {
-      const entity = makeTestEntity('bob', { x: 0, y: 0, z: 0 });
-      const prev = seedEntity(createEmptyEncounterState(), entity);
-      const after = applyEntityDisappeared(prev, 'bob', {
-        q: 4,
-        r: -2,
-        s: -2,
-      });
-      const stored = after.entities.get('bob');
-      expect(stored?.ghost).toBe(true);
-      expect(stored?.position?.x).toBe(4);
-      expect(stored?.position?.y).toBe(-2);
-      expect(stored?.position?.z).toBe(-2);
-    });
-
-    it('is a no-op if the entity is not in state (defensive)', () => {
-      const prev = createEmptyEncounterState();
-      const after = applyEntityDisappeared(prev, 'unknown', {
-        q: 0,
-        r: 0,
-        s: 0,
-      });
-      expect(after.entities.size).toBe(0);
-      // Reference identity preserved on no-op — matches mergeEntityPosition's
-      // pattern; prevents needless React re-renders if a stream loop fires
-      // EntityDisappeared for an entity we never saw.
-      expect(after).toBe(prev);
-    });
-  });
-
   describe('applyDoorOpened', () => {
     it('adds the door entity id to openDoors', () => {
       const prev = createEmptyEncounterState();
@@ -669,12 +607,13 @@ describe('v1alpha2 reducer additions', () => {
       expect(prev.openDoors.size).toBe(0);
     });
 
-    it('does not touch revealedHexes (cause/effect split)', () => {
-      // The toolkit emits DoorOpened (cause) and GeometryRevealed (effect)
-      // as two events. applyDoorOpened only updates door state; the hex
-      // reveal flows through applyHexesRevealed independently.
-      let state = createEmptyEncounterState();
-      state = applyHexesRevealed(state, [makeTestHex({ x: 1, y: -1, z: 0 })]);
+    it('does not touch revealedHexes', () => {
+      let state = applySnapshotRegionState(
+        createEmptyEncounterState(),
+        '',
+        [],
+        [makeTestHex({ x: 1, y: -1, z: 0 })]
+      );
       const beforeOpen = state.revealedHexes;
       state = applyDoorOpened(state, 'door-east');
       expect(state.revealedHexes).toBe(beforeOpen);
@@ -746,38 +685,6 @@ describe('v1alpha2 reducer additions', () => {
 
       expect(after.walls).toBe(beforeWalls);
       expect(after).toBe(state); // fully idempotent — same top-level reference
-    });
-  });
-
-  describe('appear/disappear sequences', () => {
-    it('survives appeared → moved → disappeared → appeared cleanly', () => {
-      let state = createEmptyEncounterState();
-      state = seedEntity(state, makeTestEntity('mover', { x: 0, y: 0, z: 0 }));
-      expect(state.entities.get('mover')?.ghost).toBeFalsy();
-
-      state = mergeEntityPosition(
-        state,
-        'mover',
-        create(PositionSchema, { x: 1, y: -1, z: 0 })
-      );
-      expect(state.entities.get('mover')?.position?.x).toBe(1);
-      expect(state.entities.get('mover')?.position?.y).toBe(-1);
-      expect(state.entities.get('mover')?.position?.z).toBe(0);
-
-      state = applyEntityDisappeared(state, 'mover', { q: 2, r: -1, s: -1 });
-      expect(state.entities.get('mover')?.ghost).toBe(true);
-      expect(state.entities.get('mover')?.position?.x).toBe(2);
-      expect(state.entities.get('mover')?.position?.y).toBe(-1);
-      expect(state.entities.get('mover')?.position?.z).toBe(-1);
-
-      state = seedEntity(
-        state,
-        makeTestEntity('mover', { x: 5, y: -3, z: -2 })
-      );
-      expect(state.entities.get('mover')?.ghost).toBeFalsy();
-      expect(state.entities.get('mover')?.position?.x).toBe(5);
-      expect(state.entities.get('mover')?.position?.y).toBe(-3);
-      expect(state.entities.get('mover')?.position?.z).toBe(-2);
     });
   });
 });
@@ -1232,218 +1139,6 @@ describe('Wave 2.8 combat reducers', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Wave 2.8 display fixes (#397, #399)
-// ---------------------------------------------------------------------------
-
-describe('applyEntityMetaFromAppeared', () => {
-  it('stores type and monsterRefId for a monster entity', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      undefined,
-      undefined
-    );
-    const meta = after.entityMeta.get('goblin-1');
-    expect(meta?.type).toBe(EntityType.MONSTER);
-    expect(meta?.monsterRefId).toBe('goblin');
-  });
-
-  it('stores type without monsterRefId for a character entity', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'char-alice',
-      EntityType.CHARACTER,
-      undefined,
-      undefined,
-      undefined
-    );
-    const meta = after.entityMeta.get('char-alice');
-    expect(meta?.type).toBe(EntityType.CHARACTER);
-    expect(meta?.monsterRefId).toBeUndefined();
-  });
-
-  it('stores propRefId for an obstacle/prop entity (rpg-dnd5e-web#528)', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'obstacle-1',
-      EntityType.OBSTACLE,
-      undefined,
-      undefined,
-      undefined,
-      'Barrel',
-      undefined,
-      'barrel'
-    );
-    const meta = after.entityMeta.get('obstacle-1');
-    expect(meta?.propRefId).toBe('barrel');
-  });
-
-  it('stores displayName and classRefId when provided (rpg-dnd5e-web#491)', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'char-alice',
-      EntityType.CHARACTER,
-      undefined,
-      undefined,
-      undefined,
-      'Alice',
-      'rogue'
-    );
-    const meta = after.entityMeta.get('char-alice');
-    expect(meta?.displayName).toBe('Alice');
-    expect(meta?.classRefId).toBe('rogue');
-  });
-
-  it('seeds entityHP when initialHP is provided', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      { current: 7, max: 7 },
-      undefined
-    );
-    expect(after.entityHP.get('goblin-1')).toEqual({ current: 7, max: 7 });
-  });
-
-  it('does not touch entityHP when initialHP is undefined', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      undefined,
-      undefined
-    );
-    expect(after.entityHP.size).toBe(0);
-  });
-
-  it('overwrites existing meta on re-appear (server is authoritative)', () => {
-    let state = createEmptyEncounterState();
-    state = applyEntityMetaFromAppeared(
-      state,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      undefined,
-      undefined
-    );
-    state = applyEntityMetaFromAppeared(
-      state,
-      'goblin-1',
-      EntityType.MONSTER,
-      'hobgoblin',
-      { current: 11, max: 11 },
-      undefined
-    );
-    expect(state.entityMeta.get('goblin-1')?.monsterRefId).toBe('hobgoblin');
-    expect(state.entityHP.get('goblin-1')).toEqual({ current: 11, max: 11 });
-  });
-
-  it('does not mutate the previous state', () => {
-    const prev = createEmptyEncounterState();
-    applyEntityMetaFromAppeared(
-      prev,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      { current: 5, max: 7 },
-      undefined
-    );
-    expect(prev.entityMeta.size).toBe(0);
-    expect(prev.entityHP.size).toBe(0);
-  });
-
-  it('preserves other entity meta entries', () => {
-    let state = createEmptyEncounterState();
-    state = applyEntityMetaFromAppeared(
-      state,
-      'char-alice',
-      EntityType.CHARACTER,
-      undefined,
-      undefined,
-      undefined
-    );
-    state = applyEntityMetaFromAppeared(
-      state,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      undefined,
-      undefined
-    );
-    expect(state.entityMeta.size).toBe(2);
-    expect(state.entityMeta.get('char-alice')?.type).toBe(EntityType.CHARACTER);
-    expect(state.entityMeta.get('goblin-1')?.type).toBe(EntityType.MONSTER);
-  });
-
-  it('seeds entityAC from v2 Entity.armor_class', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'char-charli',
-      EntityType.CHARACTER,
-      undefined,
-      { current: 12, max: 12 },
-      15
-    );
-    expect(after.entityAC.get('char-charli')).toBe(15);
-  });
-
-  it('does not touch entityAC when initialAC is undefined', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'char-charli',
-      EntityType.CHARACTER,
-      undefined,
-      undefined,
-      undefined
-    );
-    expect(after.entityAC.has('char-charli')).toBe(false);
-  });
-
-  it('seeds characterEquipment when equipment is provided (rpg-dnd5e-web#571)', () => {
-    const prev = createEmptyEncounterState();
-    const equipment = testEquipment();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'char-aldric',
-      EntityType.CHARACTER,
-      undefined,
-      undefined,
-      undefined,
-      'Sir Aldric',
-      'fighter',
-      undefined,
-      equipment
-    );
-    expect(after.characterEquipment.get('char-aldric')).toBe(equipment);
-  });
-
-  it('does not touch characterEquipment when equipment is undefined', () => {
-    const prev = createEmptyEncounterState();
-    const after = applyEntityMetaFromAppeared(
-      prev,
-      'goblin-1',
-      EntityType.MONSTER,
-      'goblin',
-      undefined,
-      undefined
-    );
-    expect(after.characterEquipment.size).toBe(0);
-  });
-});
-
 describe('applySnapshotTurnState', () => {
   it('sets initiativeOrder, activeEntityId, round, and mode from snapshot turn state', () => {
     const prev = createEmptyEncounterState();
@@ -1768,10 +1463,17 @@ describe('applyEntityAppearedBatch', () => {
   });
 
   it('sets ghost=false on all batch entities', () => {
-    // applyEntityAppearedBatch should clear ghost just like applyEntityAppeared
+    // applyEntityAppearedBatch clears ghost on revive — there is no longer a
+    // live disappear event, so the ghost precondition is built directly here.
     const entity = makeTestEntity('mover', { x: 0, y: 0, z: 0 });
     let state = seedEntity(createEmptyEncounterState(), entity);
-    state = applyEntityDisappeared(state, 'mover', { q: 1, r: -1, s: 0 });
+    const ghostedEntities = new Map(state.entities);
+    ghostedEntities.set('mover', {
+      ...state.entities.get('mover')!,
+      ghost: true,
+      position: create(PositionSchema, { x: 1, y: -1, z: 0 }),
+    });
+    state = { ...state, entities: ghostedEntities };
     expect(state.entities.get('mover')?.ghost).toBe(true);
 
     state = applyEntityAppearedBatch(state, [
@@ -2298,14 +2000,15 @@ describe('applyCharacterEquipment', () => {
 
   it('leaves entityAC untouched when armorClassDetail is undefined', () => {
     let prev = createEmptyEncounterState();
-    prev = applyEntityMetaFromAppeared(
-      prev,
-      'char-aldric',
-      EntityType.CHARACTER,
-      undefined,
-      undefined,
-      18
-    );
+    prev = applyEntityAppearedBatch(prev, [
+      {
+        entity: makeTestEntity('char-aldric', { x: 0, y: 0, z: 0 }),
+        type: EntityType.CHARACTER,
+        monsterRefId: undefined,
+        initialHP: undefined,
+        initialAC: 18,
+      },
+    ]);
     const after = applyCharacterEquipment(
       prev,
       'char-aldric',

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -33,7 +33,7 @@ import {
   EconomySlot,
   EncounterMode,
   EntityType,
-  HexSchema,
+  HexRecordSchema,
   InputRequiredSchema,
   SkillCheckPromptSchema,
   type StatusEffect,
@@ -46,21 +46,19 @@ import {
   ZoneSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
-import { hexKey } from '../utils/hexCoord';
 import { wallKey } from './dungeonMapGeometry';
-import type { CharacterEquipment } from './useEncounterState';
+import type {
+  CharacterEquipment,
+  LocalEncounterState,
+} from './useEncounterState';
 import {
   applyCharacterEquipment,
   applyDoorOpened,
   applyEncounterEnded,
-  applyEntityAppeared,
   applyEntityAppearedBatch,
   applyEntityDamaged,
   applyEntityDied,
-  applyEntityDisappeared,
-  applyEntityMetaFromAppeared,
   applyEntityRemoved,
-  applyHexesRevealed,
   applyInitiativeRolled,
   applyModeChanged,
   applySnapshotRegionState,
@@ -125,7 +123,7 @@ function makeTestHex(
   position: { x: number; y: number; z: number },
   zoneId = ''
 ) {
-  return create(HexSchema, {
+  return create(HexRecordSchema, {
     position: create(V2PositionSchema, position),
     zoneId,
   });
@@ -133,6 +131,29 @@ function makeTestHex(
 
 function makeTestZone(id: string, archetype = '') {
   return create(ZoneSchema, { id, name: id, archetype });
+}
+
+/**
+ * Test-only scaffolding: seed a single entity into state the same way
+ * `applyEntityAppearedBatch` does in production (the sole entity-population
+ * path now that entities arrive only via SnapshotDelivered — there is no
+ * live per-entity appear event). Mirrors the old `applyEntityAppeared`
+ * singular reducer's "add/revive entity, clear ghost flag" semantics for
+ * tests that just need an entity in state before exercising something else.
+ */
+function seedEntity(
+  prev: LocalEncounterState,
+  entity: EntityState
+): LocalEncounterState {
+  return applyEntityAppearedBatch(prev, [
+    {
+      entity,
+      type: EntityType.UNSPECIFIED,
+      monsterRefId: undefined,
+      initialHP: undefined,
+      initialAC: undefined,
+    },
+  ]);
 }
 
 describe('createEmptyEncounterState', () => {
@@ -163,7 +184,7 @@ describe('createEmptyEncounterState', () => {
 
 describe('mergeEntityPosition', () => {
   it('updates position of an existing entity', () => {
-    const prev = applyEntityAppeared(
+    const prev = seedEntity(
       createEmptyEncounterState(),
       create(EntityStateSchema, { entityId: 'char-1' })
     );
@@ -181,7 +202,7 @@ describe('mergeEntityPosition', () => {
       currentHitPoints: 12,
       maxHitPoints: 20,
     });
-    const prev = applyEntityAppeared(createEmptyEncounterState(), seeded);
+    const prev = seedEntity(createEmptyEncounterState(), seeded);
 
     const newPos = create(PositionSchema, { x: 5, y: -3, z: -2 });
     const next = mergeEntityPosition(prev, 'char-1', newPos);
@@ -193,7 +214,7 @@ describe('mergeEntityPosition', () => {
   });
 
   it('returns prev unchanged when entity is not present', () => {
-    const prev = applyEntityAppeared(
+    const prev = seedEntity(
       createEmptyEncounterState(),
       create(EntityStateSchema, { entityId: 'char-1' })
     );
@@ -206,7 +227,7 @@ describe('mergeEntityPosition', () => {
   });
 
   it('does not mutate the previous state', () => {
-    const prev = applyEntityAppeared(
+    const prev = seedEntity(
       createEmptyEncounterState(),
       create(EntityStateSchema, { entityId: 'char-1' })
     );
@@ -224,7 +245,7 @@ describe('mergeEntityPosition', () => {
   // (see the field's doc comment on LocalEncounterState.entities).
   describe('path (rpg-dnd5e-web#542)', () => {
     it('stashes the path as movePath and bumps moveSeq from undefined to 1', () => {
-      const prev = applyEntityAppeared(
+      const prev = seedEntity(
         createEmptyEncounterState(),
         create(EntityStateSchema, { entityId: 'char-1' })
       );
@@ -241,7 +262,7 @@ describe('mergeEntityPosition', () => {
     });
 
     it('increments moveSeq on each subsequent genuine move', () => {
-      const prev = applyEntityAppeared(
+      const prev = seedEntity(
         createEmptyEncounterState(),
         create(EntityStateSchema, { entityId: 'char-1' })
       );
@@ -259,7 +280,7 @@ describe('mergeEntityPosition', () => {
     });
 
     it('bumps moveSeq again for a same-destination move (e.g. bounced off a wall)', () => {
-      const prev = applyEntityAppeared(
+      const prev = seedEntity(
         createEmptyEncounterState(),
         create(EntityStateSchema, { entityId: 'char-1' })
       );
@@ -272,7 +293,7 @@ describe('mergeEntityPosition', () => {
     });
 
     it('leaves movePath/moveSeq untouched when path is omitted (pre-#542 call sites)', () => {
-      const prev = applyEntityAppeared(
+      const prev = seedEntity(
         createEmptyEncounterState(),
         create(EntityStateSchema, { entityId: 'char-1' })
       );
@@ -287,7 +308,7 @@ describe('mergeEntityPosition', () => {
     });
 
     it('leaves movePath/moveSeq untouched when path is an empty array', () => {
-      const prev = applyEntityAppeared(
+      const prev = seedEntity(
         createEmptyEncounterState(),
         create(EntityStateSchema, { entityId: 'char-1' })
       );
@@ -424,31 +445,32 @@ describe('v1alpha2 reducer additions', () => {
       expect(before.revealedHexes.size).toBe(0);
     });
 
-    it('merges incremental hex identity and replaces it only on the next snapshot', () => {
+    it('replaces prior region truth wholesale on a second snapshot (reconnect)', () => {
       const entrance = makeTestZone('entrance', 'entrance');
       const chamber = makeTestZone('chamber', 'chamber');
       const entranceHex = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
       const chamberHex = makeTestHex({ x: 1, y: -1, z: 0 }, 'chamber');
-      const seeded = applySnapshotRegionState(
+      const first = applySnapshotRegionState(
         createEmptyEncounterState(),
         'crypt',
         [entrance, chamber],
-        [entranceHex]
+        [entranceHex, chamberHex]
       );
-      const revealed = applyHexesRevealed(seeded, [chamberHex]);
-      const replacement = applySnapshotRegionState(
-        revealed,
+
+      const second = applySnapshotRegionState(
+        first,
         'cave',
         [chamber],
         [chamberHex]
       );
 
-      expect(revealed.revealedHexes.get('0,0,0')).toBe(entranceHex);
-      expect(revealed.revealedHexes.get('1,-1,0')).toBe(chamberHex);
-      expect(seeded.revealedHexes.has('1,-1,0')).toBe(false);
-      expect(replacement.theme).toBe('cave');
-      expect(replacement.revealedHexes.has('0,0,0')).toBe(false);
-      expect(replacement.zones.has('entrance')).toBe(false);
+      expect(second.theme).toBe('cave');
+      expect(second.zones.has('entrance')).toBe(false);
+      expect(second.revealedHexes.has('0,0,0')).toBe(false);
+      expect(second.revealedHexes.get('1,-1,0')).toBe(chamberHex);
+      // The first snapshot's own result is untouched by the second call.
+      expect(first.theme).toBe('crypt');
+      expect(first.revealedHexes.has('0,0,0')).toBe(true);
     });
 
     it('returns only server metadata for missing and unknown zone data', () => {
@@ -477,63 +499,12 @@ describe('v1alpha2 reducer additions', () => {
     });
   });
 
-  describe('applyHexesRevealed', () => {
+  describe('hexesWithPosition', () => {
     it('filters malformed hexes before they reach reveal merges or harness logs', () => {
       const positioned = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
-      const malformed = create(HexSchema, { zoneId: 'chamber' });
+      const malformed = create(HexRecordSchema, { zoneId: 'chamber' });
 
       expect(hexesWithPosition([positioned, malformed])).toEqual([positioned]);
-    });
-
-    it('adds hexes to revealedHexes without dropping existing reveals', () => {
-      const prev = createEmptyEncounterState();
-      const after1 = applyHexesRevealed(prev, [
-        makeTestHex({ x: 0, y: 0, z: 0 }),
-      ]);
-      expect(after1.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))).toBe(true);
-
-      const after2 = applyHexesRevealed(after1, [
-        makeTestHex({ x: 1, y: -1, z: 0 }),
-      ]);
-      expect(after2.revealedHexes.has(hexKey({ q: 0, r: 0, s: 0 }))).toBe(true);
-      expect(after2.revealedHexes.has(hexKey({ q: 1, r: -1, s: 0 }))).toBe(
-        true
-      );
-    });
-
-    it('is idempotent on duplicate hexes', () => {
-      const hex = makeTestHex({ x: 2, y: -1, z: -1 }, 'chamber');
-      const prev = applyHexesRevealed(createEmptyEncounterState(), [hex]);
-      const after = applyHexesRevealed(prev, [hex]);
-      expect(after.revealedHexes.size).toBe(1);
-      expect(after).toBe(prev);
-    });
-
-    it('keeps reveal-key identity for metadata-only updates and replaces it for new coordinates', () => {
-      const entrance = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
-      const seeded = applyHexesRevealed(createEmptyEncounterState(), [
-        entrance,
-      ]);
-      const originalMap = seeded.revealedHexes;
-      const originalKeys = seeded.revealedHexKeys;
-      const chamber = makeTestHex({ x: 0, y: 0, z: 0 }, 'chamber');
-
-      const metadataUpdated = applyHexesRevealed(seeded, [chamber]);
-
-      expect(metadataUpdated.revealedHexes).not.toBe(originalMap);
-      expect(metadataUpdated.revealedHexes.get('0,0,0')).toBe(chamber);
-      expect(metadataUpdated.revealedHexKeys).toBe(originalKeys);
-      expect(seeded.revealedHexes.get('0,0,0')).toBe(entrance);
-
-      const withNewCoordinate = applyHexesRevealed(metadataUpdated, [
-        makeTestHex({ x: 1, y: -1, z: 0 }, 'corridor'),
-      ]);
-
-      expect(withNewCoordinate.revealedHexKeys).not.toBe(originalKeys);
-      expect(withNewCoordinate.revealedHexKeys).toEqual(
-        new Set(['0,0,0', '1,-1,0'])
-      );
-      expect(metadataUpdated.revealedHexKeys).toBe(originalKeys);
     });
   });
 
@@ -610,7 +581,7 @@ describe('v1alpha2 reducer additions', () => {
     it('adds a new entity at first-visible position with ghost cleared', () => {
       const prev = createEmptyEncounterState();
       const entity = makeTestEntity('goblin-1', { x: 3, y: -2, z: -1 });
-      const after = applyEntityAppeared(prev, entity);
+      const after = seedEntity(prev, entity);
       const stored = after.entities.get('goblin-1');
       expect(stored).toBeDefined();
       expect(stored?.ghost).toBeFalsy();
@@ -621,10 +592,7 @@ describe('v1alpha2 reducer additions', () => {
 
     it('clears the ghost flag on a previously-disappeared entity', () => {
       const entity = makeTestEntity('alice', { x: 0, y: 0, z: 0 });
-      const withEntity = applyEntityAppeared(
-        createEmptyEncounterState(),
-        entity
-      );
+      const withEntity = seedEntity(createEmptyEncounterState(), entity);
       const ghosted = applyEntityDisappeared(withEntity, 'alice', {
         q: 1,
         r: -1,
@@ -632,7 +600,7 @@ describe('v1alpha2 reducer additions', () => {
       });
       expect(ghosted.entities.get('alice')?.ghost).toBe(true);
 
-      const reappeared = applyEntityAppeared(
+      const reappeared = seedEntity(
         ghosted,
         makeTestEntity('alice', { x: 5, y: -3, z: -2 })
       );
@@ -643,7 +611,7 @@ describe('v1alpha2 reducer additions', () => {
   describe('applyEntityDisappeared', () => {
     it('keeps entity in store, sets ghost=true, updates position to last_known', () => {
       const entity = makeTestEntity('bob', { x: 0, y: 0, z: 0 });
-      const prev = applyEntityAppeared(createEmptyEncounterState(), entity);
+      const prev = seedEntity(createEmptyEncounterState(), entity);
       const after = applyEntityDisappeared(prev, 'bob', {
         q: 4,
         r: -2,
@@ -784,10 +752,7 @@ describe('v1alpha2 reducer additions', () => {
   describe('appear/disappear sequences', () => {
     it('survives appeared → moved → disappeared → appeared cleanly', () => {
       let state = createEmptyEncounterState();
-      state = applyEntityAppeared(
-        state,
-        makeTestEntity('mover', { x: 0, y: 0, z: 0 })
-      );
+      state = seedEntity(state, makeTestEntity('mover', { x: 0, y: 0, z: 0 }));
       expect(state.entities.get('mover')?.ghost).toBeFalsy();
 
       state = mergeEntityPosition(
@@ -805,7 +770,7 @@ describe('v1alpha2 reducer additions', () => {
       expect(state.entities.get('mover')?.position?.y).toBe(-1);
       expect(state.entities.get('mover')?.position?.z).toBe(-1);
 
-      state = applyEntityAppeared(
+      state = seedEntity(
         state,
         makeTestEntity('mover', { x: 5, y: -3, z: -2 })
       );
@@ -1805,7 +1770,7 @@ describe('applyEntityAppearedBatch', () => {
   it('sets ghost=false on all batch entities', () => {
     // applyEntityAppearedBatch should clear ghost just like applyEntityAppeared
     const entity = makeTestEntity('mover', { x: 0, y: 0, z: 0 });
-    let state = applyEntityAppeared(createEmptyEncounterState(), entity);
+    let state = seedEntity(createEmptyEncounterState(), entity);
     state = applyEntityDisappeared(state, 'mover', { q: 1, r: -1, s: 0 });
     expect(state.entities.get('mover')?.ghost).toBe(true);
 
@@ -2115,7 +2080,7 @@ describe('Wave 2.9 setPendingPromptReducer', () => {
     it('does not remove entity from entities map', () => {
       let state = createEmptyEncounterState();
       const entity = create(EntityStateSchema, { entityId: 'goblin-1' });
-      state = applyEntityAppeared(state, entity);
+      state = seedEntity(state, entity);
       const event: EntityDied = {
         entityId: 'goblin-1',
       } as unknown as EntityDied;
@@ -2128,7 +2093,7 @@ describe('Wave 2.9 setPendingPromptReducer', () => {
     it('removes an existing entity from the entities map', () => {
       let state = createEmptyEncounterState();
       const entity = create(EntityStateSchema, { entityId: 'goblin-1' });
-      state = applyEntityAppeared(state, entity);
+      state = seedEntity(state, entity);
       expect(state.entities.has('goblin-1')).toBe(true);
 
       const event: EntityRemoved = {
@@ -2152,11 +2117,11 @@ describe('Wave 2.9 setPendingPromptReducer', () => {
 
     it('does not remove other entities when one is removed', () => {
       let state = createEmptyEncounterState();
-      state = applyEntityAppeared(
+      state = seedEntity(
         state,
         create(EntityStateSchema, { entityId: 'goblin-1' })
       );
-      state = applyEntityAppeared(
+      state = seedEntity(
         state,
         create(EntityStateSchema, { entityId: 'goblin-2' })
       );

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -14,10 +14,7 @@
  */
 
 import { create } from '@bufbuild/protobuf';
-import {
-  PositionSchema,
-  type Position,
-} from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
+import type { Position } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type {
   EncounterEnded,
@@ -31,7 +28,7 @@ import type {
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import type {
-  Hex,
+  HexRecord,
   InputRequired,
   StatusEffect,
   TurnState,
@@ -64,7 +61,8 @@ export interface EntityHP {
 }
 
 /**
- * v1alpha2 entity identity metadata, populated from EntityAppeared.entity.
+ * v1alpha2 entity identity metadata, populated from SnapshotDelivered's
+ * per-entity batch (see `applyEntityAppearedBatch`).
  * Carries type and monster ref id so the harness can label entity rows without
  * storing the full v1alpha2 Entity proto alongside the v1alpha1 EntityState.
  */
@@ -141,9 +139,9 @@ export interface LocalEncounterState {
    * `movePath`/`moveSeq` (rpg-dnd5e-web#542): the real hex-by-hex route from
    * the most recent genuine `EntityMoved`/`MovementCompletedEvent`, set ONLY
    * by `mergeEntityPosition` (the sole reducer `onEntityMoved` feeds) — never
-   * by `applyEntityAppeared`/`applyEntityAppearedBatch` (initial placement,
-   * revive-from-ghost), which replace the whole entity record with a fresh
-   * `{...entity, ghost: false}` off the wire and so naturally clear both
+   * by `applyEntityAppearedBatch` (initial placement, revive-from-ghost),
+   * which replaces the whole entity record with a fresh
+   * `{...entity, ghost: false}` off the wire and so naturally clears both
    * fields back to undefined. This is what lets HexEntity's movement
    * interpolation key off "a real move just happened" without a separate
    * boolean: `moveSeq` only ever advances on a genuine move, so watching it
@@ -158,7 +156,7 @@ export interface LocalEncounterState {
     EntityState & { ghost?: boolean; movePath?: Position[]; moveSeq?: number }
   >;
   /** v1alpha2-revealed hexes, keyed by stable cube coordinate. */
-  revealedHexes: Map<string, Hex>;
+  revealedHexes: Map<string, HexRecord>;
   /** Compatibility projection for existing undifferentiated floor consumers. */
   revealedHexKeys: Set<string>;
   /** Server-authored dungeon-wide visual family, absent when unspecified. */
@@ -200,10 +198,10 @@ export interface LocalEncounterState {
   entityStatuses: Map<string, EntityStatus[]>;
   /**
    * v1alpha2 entity identity metadata keyed by entity id. Populated by
-   * `applyEntityMetaFromAppeared` (reducer) / `applyEntityMeta` (hook callback)
-   * from EntityAppeared.entity fields. Carries type and monster ref id; kept
-   * separate from the v1alpha1 EntityState store so neither v1 nor v2 entity
-   * shapes need to import the other.
+   * `applyEntityAppearedBatch` from each SnapshotDelivered entity's fields.
+   * Carries type and monster ref id; kept separate from the v1alpha1
+   * EntityState store so neither v1 nor v2 entity shapes need to import the
+   * other.
    */
   entityMeta: Map<string, EntityMeta>;
   /**
@@ -387,10 +385,12 @@ export function mergeEntityPosition(
  * filter keeps stream reducers and harness diagnostics consistent.
  */
 export function hexesWithPosition(
-  hexes: Hex[]
-): Array<Hex & { position: NonNullable<Hex['position']> }> {
+  hexes: HexRecord[]
+): Array<HexRecord & { position: NonNullable<HexRecord['position']> }> {
   return hexes.filter(
-    (hex): hex is Hex & { position: NonNullable<Hex['position']> } =>
+    (
+      hex
+    ): hex is HexRecord & { position: NonNullable<HexRecord['position']> } =>
       hex.position !== undefined
   );
 }
@@ -404,9 +404,9 @@ export function applySnapshotRegionState(
   prev: LocalEncounterState,
   theme: string,
   zones: Zone[],
-  hexes: Hex[]
+  hexes: HexRecord[]
 ): LocalEncounterState {
-  const revealedHexes = new Map<string, Hex>();
+  const revealedHexes = new Map<string, HexRecord>();
   for (const hex of hexesWithPosition(hexes)) {
     revealedHexes.set(hexKey(protoPositionToHex(hex.position)), hex);
   }
@@ -416,39 +416,6 @@ export function applySnapshotRegionState(
     zones: new Map(zones.map((zone) => [zone.id, zone])),
     revealedHexes,
     revealedHexKeys: new Set(revealedHexes.keys()),
-  };
-}
-
-/**
- * Merge newly revealed wire hexes without dropping previously revealed zone
- * identity. A malformed incremental record with no zone ID cannot erase an
- * existing record for that coordinate; the next snapshot remains the explicit
- * server-authoritative replacement boundary.
- * Exported for testing.
- */
-export function applyHexesRevealed(
-  prev: LocalEncounterState,
-  hexes: Hex[]
-): LocalEncounterState {
-  let revealedHexes: Map<string, Hex> | undefined;
-  let revealedHexKeys: Set<string> | undefined;
-  for (const hex of hexesWithPosition(hexes)) {
-    const key = hexKey(protoPositionToHex(hex.position));
-    const existing = (revealedHexes ?? prev.revealedHexes).get(key);
-    const next = !hex.zoneId && existing ? existing : hex;
-    if (existing === next) continue;
-    if (!revealedHexes) revealedHexes = new Map(prev.revealedHexes);
-    revealedHexes.set(key, next);
-    if (!existing) {
-      if (!revealedHexKeys) revealedHexKeys = new Set(prev.revealedHexKeys);
-      revealedHexKeys.add(key);
-    }
-  }
-  if (!revealedHexes) return prev;
-  return {
-    ...prev,
-    revealedHexes,
-    revealedHexKeys: revealedHexKeys ?? prev.revealedHexKeys,
   };
 }
 
@@ -496,22 +463,6 @@ export function applyWallsRevealed(
 }
 
 /**
- * Add or revive an entity in the store at its first-visible position.
- * Clears the ghost flag unconditionally — the entity is now visible.
- * Overwrites any prior entry with the same entityId (e.g. a ghosted entity
- * that just re-entered the player's line of sight).
- * Exported for testing.
- */
-export function applyEntityAppeared(
-  prev: LocalEncounterState,
-  entity: EntityState
-): LocalEncounterState {
-  const newEntities = new Map(prev.entities);
-  newEntities.set(entity.entityId, { ...entity, ghost: false });
-  return { ...prev, entities: newEntities };
-}
-
-/**
  * Converts one wire-shape StatusEffect into the local EntityStatus shape —
  * shared by both the live StatusApplied path (applyStatusApplied) and the
  * snapshot-hydration path below, since Entity.status_effects and
@@ -536,9 +487,12 @@ function toEntityStatus(effect: StatusEffect): EntityStatus | undefined {
 /**
  * Apply a batch of entity appearances — each carrying both the v1alpha1
  * positional stub AND v1alpha2 meta (type, monsterRefId, initialHP, initialAC) — in a
- * single state update. Use this instead of calling applyEntityAppeared +
- * applyEntityMeta per entity in a loop (which triggers N intermediate renders
- * and N Map clone operations for N entities).
+ * single state update. This is the sole entity-population path: entities
+ * arrive only via SnapshotDelivered now (there is no live per-entity
+ * appear/disappear event), so a single batch call per snapshot replaces what
+ * used to be a per-entity loop over separate appear + meta reducers (which
+ * would trigger N intermediate renders and N Map clone operations for N
+ * entities anyway).
  *
  * statusEffects (rpg-dnd5e-web#462) seeds entityStatuses per entity when
  * present: SnapshotDelivered is a full resync, so each entity's status list
@@ -639,70 +593,6 @@ export function applyEntityAppearedBatch(
 }
 
 /**
- * Record v1alpha2 entity identity metadata from an EntityAppeared event.
- *
- * Stores type and (for monsters) monsterRef.id in `entityMeta` so the harness
- * can render a type column and monster identifier without storing the full
- * v1alpha2 Entity proto. Also seeds `entityHP` and `entityAC` when the entity
- * carries those values — this populates HP/AC in the entities table before any
- * damage events land.
- *
- * Idempotent on a same-entity / same-meta re-appear: the meta entry is always
- * overwritten (the server's word is authoritative). Exported for testing.
- */
-export function applyEntityMetaFromAppeared(
-  prev: LocalEncounterState,
-  entityId: string,
-  type: EntityType,
-  monsterRefId: string | undefined,
-  initialHP: { current: number; max: number } | undefined,
-  initialAC: number | undefined,
-  displayName?: string,
-  classRefId?: string,
-  propRefId?: string,
-  equipment?: CharacterEquipment
-): LocalEncounterState {
-  const newMeta = new Map(prev.entityMeta);
-  newMeta.set(entityId, {
-    type,
-    monsterRefId,
-    displayName,
-    classRefId,
-    propRefId,
-  });
-
-  const hasHP = initialHP !== undefined;
-  const hasAC = initialAC !== undefined && initialAC !== 0;
-  const hasEquipment = equipment !== undefined;
-
-  if (!hasHP && !hasAC && !hasEquipment) {
-    return { ...prev, entityMeta: newMeta };
-  }
-
-  const newHP = hasHP ? new Map(prev.entityHP) : prev.entityHP;
-  if (hasHP) {
-    newHP.set(entityId, { current: initialHP!.current, max: initialHP!.max });
-  }
-  const newAC = hasAC ? new Map(prev.entityAC) : prev.entityAC;
-  if (hasAC) {
-    newAC.set(entityId, initialAC!);
-  }
-  const newEquipment = hasEquipment
-    ? new Map(prev.characterEquipment)
-    : prev.characterEquipment;
-  if (hasEquipment) {
-    newEquipment.set(entityId, equipment!);
-  }
-  return {
-    ...prev,
-    entityMeta: newMeta,
-    entityHP: newHP,
-    entityAC: newAC,
-    characterEquipment: newEquipment,
-  };
-}
-
-/**
  * Apply v1alpha2 encounter mode + turn state from a SnapshotDelivered event.
  * Updates `mode`, `initiativeOrder`, `activeEntityId`, and `round` from the
  * snapshot without touching HP / doors / hexes (those flow only via delta
@@ -756,32 +646,6 @@ export function applySnapshotTurnState(
     // TurnStateChanged push. Stored verbatim; web computes nothing.
     turnState,
   };
-}
-
-/**
- * Mark an entity as ghosted (no longer visible) and update its position to
- * the last known hex. Renders ghosts at the last place the player saw them.
- * No-op if the entity is not currently tracked (defensive guard).
- * Exported for testing.
- */
-export function applyEntityDisappeared(
-  prev: LocalEncounterState,
-  entityId: string,
-  lastKnown: CubeHexCoord
-): LocalEncounterState {
-  const existing = prev.entities.get(entityId);
-  if (!existing) return prev;
-  const newEntities = new Map(prev.entities);
-  newEntities.set(entityId, {
-    ...existing,
-    ghost: true,
-    position: create(PositionSchema, {
-      x: lastKnown.q,
-      y: lastKnown.r,
-      z: lastKnown.s,
-    }),
-  });
-  return { ...prev, entities: newEntities };
 }
 
 /**
@@ -1209,34 +1073,12 @@ export interface UseEncounterStateResult {
   applySnapshotRegionState: (
     theme: string,
     zones: Zone[],
-    hexes: Hex[]
+    hexes: HexRecord[]
   ) => void;
-  /** Merge newly revealed wire hexes (additive, identity-preserving). */
-  applyHexesRevealed: (hexes: Hex[]) => void;
   /** Add walls to the sticky wall map, keyed by `wallKey` (additive, idempotent) */
   applyWallsRevealed: (walls: Wall[]) => void;
-  /** Add or revive an entity at its first-visible position, clearing ghost */
-  applyEntityAppeared: (entity: EntityState) => void;
-  /** Mark entity as ghosted at last known position; no-op if not tracked */
-  applyEntityDisappeared: (entityId: string, lastKnown: CubeHexCoord) => void;
   /** Mark a door entity as open; idempotent. */
   applyDoorOpened: (doorEntityId: string) => void;
-  /**
-   * Store v1alpha2 entity identity metadata from EntityAppeared.entity.
-   * Also seeds entityHP from entity.hp and entityAC from entity.armor_class.
-   * Call after applyEntityAppeared so the v1alpha1 stub and v2 meta are both stored.
-   */
-  applyEntityMeta: (
-    entityId: string,
-    type: EntityType,
-    monsterRefId: string | undefined,
-    initialHP: { current: number; max: number } | undefined,
-    initialAC: number | undefined,
-    displayName?: string,
-    classRefId?: string,
-    propRefId?: string,
-    equipment?: CharacterEquipment
-  ) => void;
   /**
    * Apply a batch of entity appearances in a single state update to avoid N
    * intermediate renders when seeding multiple entities from a snapshot.
@@ -1362,64 +1204,19 @@ export function useEncounterState(): UseEncounterStateResult {
   }, []);
 
   const applySnapshotRegionStateCallback = useCallback(
-    (theme: string, zones: Zone[], hexes: Hex[]) => {
+    (theme: string, zones: Zone[], hexes: HexRecord[]) => {
       setState((prev) => applySnapshotRegionState(prev, theme, zones, hexes));
     },
     []
   );
 
-  const applyHexesRevealedCallback = useCallback((hexes: Hex[]) => {
-    setState((prev) => applyHexesRevealed(prev, hexes));
-  }, []);
-
   const applyWallsRevealedCallback = useCallback((walls: Wall[]) => {
     setState((prev) => applyWallsRevealed(prev, walls));
   }, []);
 
-  const applyEntityAppearedCallback = useCallback((entity: EntityState) => {
-    setState((prev) => applyEntityAppeared(prev, entity));
-  }, []);
-
-  const applyEntityDisappearedCallback = useCallback(
-    (entityId: string, lastKnown: CubeHexCoord) => {
-      setState((prev) => applyEntityDisappeared(prev, entityId, lastKnown));
-    },
-    []
-  );
-
   const applyDoorOpenedCallback = useCallback((doorEntityId: string) => {
     setState((prev) => applyDoorOpened(prev, doorEntityId));
   }, []);
-
-  const applyEntityMetaCallback = useCallback(
-    (
-      entityId: string,
-      type: EntityType,
-      monsterRefId: string | undefined,
-      initialHP: { current: number; max: number } | undefined,
-      initialAC: number | undefined,
-      displayName?: string,
-      classRefId?: string,
-      propRefId?: string,
-      equipment?: CharacterEquipment
-    ) => {
-      setState((prev) =>
-        applyEntityMetaFromAppeared(
-          prev,
-          entityId,
-          type,
-          monsterRefId,
-          initialHP,
-          initialAC,
-          displayName,
-          classRefId,
-          propRefId,
-          equipment
-        )
-      );
-    },
-    []
-  );
 
   const applyEntityAppearedBatchCallback = useCallback(
     (
@@ -1528,12 +1325,8 @@ export function useEncounterState(): UseEncounterStateResult {
     applyEntityPositionUpdate,
     reset,
     applySnapshotRegionState: applySnapshotRegionStateCallback,
-    applyHexesRevealed: applyHexesRevealedCallback,
     applyWallsRevealed: applyWallsRevealedCallback,
-    applyEntityAppeared: applyEntityAppearedCallback,
-    applyEntityDisappeared: applyEntityDisappearedCallback,
     applyDoorOpened: applyDoorOpenedCallback,
-    applyEntityMeta: applyEntityMetaCallback,
     applyEntityAppearedBatch: applyEntityAppearedBatchCallback,
     applyCharacterEquipment: applyCharacterEquipmentCallback,
     applySnapshotTurnState: applySnapshotTurnStateCallback,

--- a/src/hooks/wallRunAdapters.test.ts
+++ b/src/hooks/wallRunAdapters.test.ts
@@ -7,7 +7,7 @@ import { cubeToWorld, HEX_SIZE } from '@/components/hex-grid/hexMath';
 import { CUTAWAY_STUB_WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { create } from '@bufbuild/protobuf';
 import {
-  HexSchema,
+  HexRecordSchema,
   PositionSchema,
   WallKind,
   WallSchema,
@@ -35,7 +35,7 @@ import {
 } from './wallRuns';
 
 function hex(x: number, y: number, z: number, zoneId = '') {
-  return create(HexSchema, {
+  return create(HexRecordSchema, {
     position: create(PositionSchema, { x, y, z }),
     zoneId,
   });
@@ -82,7 +82,7 @@ describe('regionInputsFromHexes', () => {
   });
 
   it('excludes hexes with no position', () => {
-    const positionless = create(HexSchema, { zoneId: 'entrance' });
+    const positionless = create(HexRecordSchema, { zoneId: 'entrance' });
     const regions = regionInputsFromHexes([positionless]);
     expect(regions).toHaveLength(0);
   });

--- a/src/hooks/wallRunAdapters.ts
+++ b/src/hooks/wallRunAdapters.ts
@@ -1,6 +1,6 @@
 /**
  * wallRunAdapters — the W2 seam between the real wire shapes
- * (`Hex`/`Wall` v1alpha2 protos) and wallRuns.ts's pure, protocol-agnostic
+ * (`HexRecord`/`Wall` v1alpha2 protos) and wallRuns.ts's pure, protocol-agnostic
  * `RegionInput`/`ConnectorDoorInput` inputs, plus the "positive category
  * rule" that decides what the LEGACY per-cell renderer (SyntyHexWall) still
  * draws once envelope/connector runs take over the boundary (rpg-project#133
@@ -23,7 +23,7 @@ import {
 import { isDoorWallKind } from '@/components/hex-grid/syntyHexWallHelpers';
 import { connectorPartitionHeight } from '@/components/hex-grid/wallRunMeshHelpers';
 import {
-  type Hex,
+  type HexRecord,
   type Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
@@ -46,7 +46,9 @@ import {
  * connector/door cell, which never carries a region tag by construction)
  * are excluded entirely; they contribute to no region's envelope.
  */
-export function regionInputsFromHexes(hexes: Iterable<Hex>): RegionInput[] {
+export function regionInputsFromHexes(
+  hexes: Iterable<HexRecord>
+): RegionInput[] {
   const byZone = new Map<string, CubeCoord[]>();
   for (const hex of hexes) {
     if (!hex.zoneId || !hex.position) continue;


### PR DESCRIPTION
## Summary

The v1alpha2 encounter proto contract changed (rpg-api-protos#197/#198, now pinned at v0.1.114): `GeometryRevealed`, `EntityAppeared`, `EntityDisappeared`, `Hex`, `Entity.position`, `Space.walls`, and `DoorOpened.revealed*` were all removed outright, replaced by `HexRecord` (`position`/`state`/`terrain`/`zoneId`/`edges`/`contents`) delivered only on `SnapshotDelivered`.

**This is a strip plus two source remaps, not a pure strip** — rendering keeps working rather than going dark where the data simply moved:

- **Walls**: `Space.walls` is gone; walls now ride each hex's own `edges`. Both snapshot readers (`EncounterView.tsx`, `PlaytestHarness.tsx`) now build the wall list via `hexes.flatMap(h => h.edges ?? [])`. `state.walls`, `applyWallsRevealed`, and the whole `EncounterMap` wall-computation pipeline (envelope/connector runs, legacy walls, door frames) are unchanged — only the source expression moved.
- **Entity position**: `Entity` no longer carries its own position — a hex's `contents: Placement[]` states occupancy. Both snapshot readers now build a one-shot reverse index (`entityId -> hex.position`) from the snapshot's `contents`, rebuilt fresh every snapshot (never merged into a prior index — `contents` is total for a visible hex, so a stale carried-over placement could resurrect an entity the current snapshot no longer places anywhere). Entities with no placement are dropped rather than guessed at (fail closed).

**Genuinely dead code removed, not remapped:** the `onGeometryRevealed`/`onEntityAppeared`/`onEntityDisappeared` stream handlers and the `applyHexesRevealed`/`applyEntityAppeared`/`applyEntityDisappeared`/`applyEntityMetaFromAppeared` reducers they alone fed (verified no other caller for any of them — `applyEntityAppearedBatch` is the sole surviving entity-population path, fed only by `SnapshotDelivered`). `DoorOpened` survives as a pure notification (door identity only) — its rendered pose now comes from the next snapshot's `edges` rather than a parallel reveal event.

`Hex` → `HexRecord` retyped everywhere the still-alive `SnapshotDelivered` path feeds it (`useEncounterState.ts`, `EncounterMap.tsx`, `wallRunAdapters.ts`) — same field names, mechanical.

## The real risk surface: 18 test failures compiled fine

This is the thing a diff alone won't show: **the type system did not catch the contract change** for most of the entity-seeding path. Test fixtures across `EncounterView.test.tsx`, `PlaytestHarness.test.tsx`, and `useEncounterStream.integration.test.tsx` set `entities[].position` directly with no matching `hexes[].contents` placement — that's valid-looking, loosely-typed event-literal JS (these files' own `makeEvent` helpers cast through `unknown`), so nothing failed to compile. The entities just silently never seeded at runtime. Only fixtures whose assertions actually depended on entity-dependent rendering (a badge, an HP cell, a click target) caught it; several others were fixed even though their assertions happened to still pass either way, since they were fixtures quietly no longer doing what they claimed to demonstrate.

Fixed by threading position through `hexes[].contents` in every affected fixture, narrowing 2 tests whose "cause/effect split" premise no longer exists (`DoorOpened` + a parallel `GeometryRevealed` — now just `DoorOpened` on its own), and deleting tests that exist only to verify a removed live event (equivalent coverage already exists at the unit level in `useEncounterState.test.ts` for entity ghost/revive semantics, e.g. `movePath`/`moveSeq` reset on re-appear via `applyEntityAppearedBatch`).

## typecheck script

`typecheck` flipped from `tsc --noEmit` to `tsc -b --noEmit` (rpg-dnd5e-web#640). The old form was a no-op on this repo's root `tsconfig.json` (`"files": []` with only project references, and no `-b`) — it silently type-checked **zero files** and always exited 0, regardless of real errors. `tsc -b --noEmit` is confirmed clean on `origin/development`, with no other pre-existing errors surfacing on this base (the two known pre-existing errors from `main`'s stranded fog-of-war concept don't apply here — see below).

## Known intentional gap

Remembered (not-currently-visible) hexes carry no `edges` by design until the API side stores observations (rpg-toolkit#851) — previously-explored areas will render wall-less until then. This is an API-side consequence, not a bug, and not this PR's job to compensate for with client-side wall memory.

## `src/concepts/fog-of-war/`

Does not exist on `origin/development` (main-only, landed via #611) and is completely untouched by this PR. A follow-up is queued separately to fix the two pre-existing `tsc -b` errors that surface once `development` batches into `main` and picks up both the fog concept and this proto bump together (adapter.ts's `Hex`→`HexRecord` swap, and a pre-existing `doorRotationOverrides` prop mismatch from #611 that the old no-op typecheck let through) — tracked as a follow-up PR against `main`, not part of this change.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npm run lint` — 0 errors (1 pre-existing, unrelated warning in `useHexMovePath.ts`)
- [x] `npm run format:check` — clean
- [x] `npm run build` — succeeds, theme-CSS combat-HUD guard passes
- [x] `npx vitest run` — 1540/1540 passing across 88 files

— asset-pipeline agent, on behalf of KirkDiggler
