### PR TITLE
feat(hex-grid): author-grid overlay for dictating dungeon-content coordinates

### DIFF
--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -41,6 +41,8 @@ import {
 import { computeWallRuns } from '../../hooks/wallRuns';
 import { WALL_HEIGHT } from '../../rendering/calibrationConstants';
 import { HexGrid } from '../hex-grid';
+import { AuthorGridLegend } from '../hex-grid/AuthorGridLegend';
+import { AuthorGridOverlay } from '../hex-grid/AuthorGridOverlay';
 import {
   cubeToWorld,
   HEX_SIZE,
@@ -452,6 +454,19 @@ export function EncounterMap({
     []
   );
 
+  // Authoring bridge (`?authorGrid=1`): every revealed floor hex's
+  // room-local [col,row] label plus a facing legend, so Kirk can walk a
+  // room and dictate dungeon-content YAML `place:` coordinates directly
+  // instead of hand-deriving them. Same "read the query string once,
+  // default off" convention as litSurfaces/floorPools above. `regions`/
+  // `connectorDoors` are already computed above for wall-run rendering
+  // — this reuses them rather than re-deriving region membership a
+  // second time.
+  const authorGrid = useMemo(
+    () => new URLSearchParams(window.location.search).get('authorGrid') === '1',
+    []
+  );
+
   // Real-dungeon-rendering flag (rpg-dnd5e-web#432 harness-parity). Read
   // once; the game route never mutates the query string mid-session.
   // Default-on: deployed builds bake Synty assets into the image (docker
@@ -559,7 +574,15 @@ export function EncounterMap({
         {perfProbe && (
           <DevPerfProbe windowMs={perfProbe.windowMs} label={perfProbe.label} />
         )}
+        {authorGrid && (
+          <AuthorGridOverlay
+            regions={regions}
+            doors={connectorDoors}
+            hexSize={HEX_SIZE}
+          />
+        )}
       </HexGrid>
+      {authorGrid && <AuthorGridLegend />}
     </div>
   );
 }

--- a/src/components/hex-grid/AuthorGridLegend.tsx
+++ b/src/components/hex-grid/AuthorGridLegend.tsx
@@ -1,0 +1,96 @@
+/**
+ * AuthorGridLegend — `?authorGrid=1`'s facing compass rose: a small,
+ * fixed HUD element (DOM, sibling to the Canvas — same pattern as
+ * TurnOrderOverlay.tsx) giving Kirk the vocabulary to dictate a facing
+ * verbally ("facing 4") while walking a room, before a real rotation
+ * field exists on `place:` entries to capture it mechanically.
+ *
+ * Purely a legend — it renders the SAME six labels in the SAME order
+ * every time (authorGridHelpers.HEX_FACING_LABELS), independent of
+ * region/hex data, so it needs no props. Positioned bottom-left to stay
+ * clear of TurnOrderOverlay (top-center) and EncounterDock (bottom
+ * strip, but this sits above it via a modest bottom offset).
+ */
+
+import type { CSSProperties } from 'react';
+import { HEX_FACING_LABELS } from './authorGridHelpers';
+
+// Angular position for each facing index around the rose, degrees
+// clockwise from "up" on screen — purely a legend layout, not a claim
+// about how these directions map onto the isometric camera's actual
+// view. 0 (E) placed at the right (90deg) so the ring reads like an
+// ordinary compass rather than starting at the top.
+const ANGLE_DEG = [90, 150, 210, 270, 330, 30];
+const RING_RADIUS_PX = 34;
+
+const containerStyle: CSSProperties = {
+  position: 'absolute',
+  left: 12,
+  bottom: 84,
+  padding: '10px 12px',
+  backgroundColor: 'rgba(0, 0, 0, 0.55)',
+  backdropFilter: 'blur(8px)',
+  borderRadius: 10,
+  color: '#e8ecff',
+  fontSize: 11,
+  zIndex: 100,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 6,
+};
+
+const roseStyle: CSSProperties = {
+  position: 'relative',
+  width: RING_RADIUS_PX * 2 + 24,
+  height: RING_RADIUS_PX * 2 + 24,
+};
+
+const centerDotStyle: CSSProperties = {
+  position: 'absolute',
+  left: '50%',
+  top: '50%',
+  width: 6,
+  height: 6,
+  marginLeft: -3,
+  marginTop: -3,
+  borderRadius: '50%',
+  backgroundColor: '#7fd9ff',
+};
+
+function labelStyle(angleDeg: number): CSSProperties {
+  const radians = (angleDeg * Math.PI) / 180;
+  const x = Math.cos(radians) * RING_RADIUS_PX;
+  // Screen Y grows downward; "up" on the rose should be angle 90 by our
+  // own convention above, so subtract to flip.
+  const y = -Math.sin(radians) * RING_RADIUS_PX;
+  return {
+    position: 'absolute',
+    left: `calc(50% + ${x}px)`,
+    top: `calc(50% + ${y}px)`,
+    transform: 'translate(-50%, -50%)',
+    fontWeight: 700,
+    color: '#fff',
+  };
+}
+
+export function AuthorGridLegend() {
+  return (
+    <div style={containerStyle} data-testid="author-grid-legend">
+      <div style={{ opacity: 0.75, letterSpacing: '0.5px' }}>FACING</div>
+      <div style={roseStyle}>
+        <div style={centerDotStyle} />
+        {HEX_FACING_LABELS.map((label, index) => (
+          <div key={label} style={labelStyle(ANGLE_DEG[index]!)}>
+            {index}
+          </div>
+        ))}
+      </div>
+      <div style={{ opacity: 0.75 }}>
+        {HEX_FACING_LABELS.map((label, index) => `${index}=${label}`).join(
+          '  '
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/hex-grid/AuthorGridOverlay.tsx
+++ b/src/components/hex-grid/AuthorGridOverlay.tsx
@@ -1,0 +1,99 @@
+/**
+ * AuthorGridOverlay — `?authorGrid=1` dev-only authoring bridge: renders
+ * every revealed floor hex's room-local [col,row] label (the exact
+ * `place: {at: [col,row]}` coordinates dungeon-content YAML consumes)
+ * plus each room's id, so Kirk can walk a room and dictate placements
+ * without hand-deriving coordinates. All geometry comes from
+ * authorGridHelpers.ts (pure, unit-tested) — this component only renders
+ * it.
+ *
+ * Mounted via HexGrid's own `children` slot (EncounterMap.tsx passes it
+ * conditionally, the same way `?perfProbe` mounts DevPerfProbe) — the
+ * dial-off case is "don't render this element at all," not an internal
+ * early-return, so there's zero cost (no extra hex scan, no mounted
+ * Billboard/Text instances) when the dial is off.
+ *
+ * Billboarded (drei's `<Billboard>`) rather than flat-on-floor: the
+ * camera's isometric angle (CAMERA_OFFSET, calibrationConstants.ts) is
+ * fixed but oblique, so floor-plane text would read foreshortened/
+ * skewed at exactly the angle Kirk needs to read it from — legibility
+ * over "looks painted on," matching this component's whole reason to
+ * exist. `frameloop="demand"` (HexGrid's Canvas) makes Billboard's
+ * per-frame orientation update cheap regardless: it only recomputes on
+ * frames the Canvas actually renders, same as every other per-frame
+ * hook in this codebase (see ClassCharacterModel.tsx's identical note).
+ */
+
+import type { ConnectorDoorInput, RegionInput } from '@/hooks/wallRuns';
+import { Billboard, Text } from '@react-three/drei';
+import { authorGridRooms } from './authorGridHelpers';
+
+export interface AuthorGridOverlayProps {
+  regions: RegionInput[];
+  doors: ConnectorDoorInput[];
+  hexSize: number;
+}
+
+// SyntyHexFloor renders its floor mesh at FLOOR_Y = 0.2 (SyntyHexFloor.tsx)
+// — a label below that sits UNDER the floor surface and never renders.
+// 0.25 clears both that and ShadedHexFloor's y=0 fallback plane with a
+// small, deliberate margin rather than sitting exactly on the surface.
+const LABEL_HEIGHT = 0.25;
+const ROOM_ID_HEIGHT = 0.7; // above head height so it reads as "the room", not "a hex"
+const LABEL_FONT_SIZE = 0.22;
+const ROOM_ID_FONT_SIZE = 0.34;
+const LABEL_COLOR = '#e8ecff';
+const DOOR_ROW_COLOR = '#ffb347'; // dimmer/warmer, not alarming — a hint, not an error
+const ROOM_ID_COLOR = '#7fd9ff';
+const OUTLINE_COLOR = '#000000';
+
+export function AuthorGridOverlay({
+  regions,
+  doors,
+  hexSize,
+}: AuthorGridOverlayProps) {
+  const rooms = authorGridRooms(regions, doors, hexSize);
+  return (
+    <group name="author-grid-overlay">
+      {rooms.map((room) => (
+        <group key={room.regionId}>
+          {room.labels.map((label) => (
+            <Billboard
+              key={label.key}
+              position={[label.world.x, LABEL_HEIGHT, label.world.z]}
+            >
+              <Text
+                fontSize={LABEL_FONT_SIZE}
+                color={label.isDoorRow ? DOOR_ROW_COLOR : LABEL_COLOR}
+                anchorX="center"
+                anchorY="middle"
+                outlineWidth={0.012}
+                outlineColor={OUTLINE_COLOR}
+              >
+                {`${label.localCol},${label.localRow}`}
+              </Text>
+            </Billboard>
+          ))}
+          <Billboard
+            position={[
+              room.labelWorld.x,
+              LABEL_HEIGHT + ROOM_ID_HEIGHT,
+              room.labelWorld.z,
+            ]}
+          >
+            <Text
+              fontSize={ROOM_ID_FONT_SIZE}
+              color={ROOM_ID_COLOR}
+              anchorX="center"
+              anchorY="middle"
+              outlineWidth={0.016}
+              outlineColor={OUTLINE_COLOR}
+            >
+              {room.regionId}
+            </Text>
+          </Billboard>
+        </group>
+      ))}
+    </group>
+  );
+}

--- a/src/components/hex-grid/authorGridHelpers.test.ts
+++ b/src/components/hex-grid/authorGridHelpers.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for authorGridHelpers — the `?authorGrid=1` overlay's pure
+ * geometry. Real reference-tomb-shaped fixture (entrance width 6 ->
+ * connector -> hall width 10, height 8, door at row 4 per
+ * rpg-toolkit's generateDungeonLayout — same widths wallRuns.test.ts
+ * verifies against), so the local [col,row] this module produces is
+ * checked against the SAME real dungeon shape dungeon-content YAML
+ * authors against, not an arbitrary toy rectangle.
+ */
+
+import {
+  cubeAtColRow,
+  type ConnectorDoorInput,
+  type RegionInput,
+} from '@/hooks/wallRuns';
+import { describe, expect, it } from 'vitest';
+import {
+  authorGridRoom,
+  authorGridRooms,
+  doorRowsForRegion,
+  facingDirection,
+  HEX_FACING_LABELS,
+  regionBounds,
+} from './authorGridHelpers';
+import { cubeToWorld, HEX_DIRECTIONS, HEX_SIZE } from './hexMath';
+
+const HEIGHT = 8;
+const DOOR_ROW = 4; // height / 2, per rpg-toolkit's generateDungeonLayout
+const ENTRANCE_WIDTH = 6;
+const HALL_WIDTH = 10;
+const ENTRANCE_CONNECTOR_COL = ENTRANCE_WIDTH; // 6 — reserved, belongs to no region
+const HALL_START_COL = ENTRANCE_CONNECTOR_COL + 1; // 7
+
+function regionCubes(width: number, height: number, offsetX: number) {
+  const hexes = [];
+  for (let col = offsetX; col < offsetX + width; col++) {
+    for (let row = 0; row < height; row++) {
+      hexes.push(cubeAtColRow(col, row));
+    }
+  }
+  return hexes;
+}
+
+const entrance: RegionInput = {
+  id: 'entrance',
+  hexes: regionCubes(ENTRANCE_WIDTH, HEIGHT, 0),
+};
+const hall: RegionInput = {
+  id: 'hall',
+  hexes: regionCubes(HALL_WIDTH, HEIGHT, HALL_START_COL),
+};
+const entranceHallDoor: ConnectorDoorInput = {
+  id: 'reference-tomb-door-entrance-hall',
+  position: cubeAtColRow(ENTRANCE_CONNECTOR_COL, DOOR_ROW),
+};
+
+describe('regionBounds', () => {
+  it('computes col/row extremes from hex membership', () => {
+    expect(regionBounds(entrance.hexes)).toEqual({
+      minCol: 0,
+      maxCol: ENTRANCE_WIDTH - 1,
+      minRow: 0,
+      maxRow: HEIGHT - 1,
+    });
+  });
+
+  it('returns undefined for an empty hex list', () => {
+    expect(regionBounds([])).toBeUndefined();
+  });
+});
+
+describe('doorRowsForRegion', () => {
+  it('marks the door row for the region left of the connector', () => {
+    const bounds = regionBounds(entrance.hexes)!;
+    // entrance's own maxCol (5) + 1 === the connector column (6) the door sits on.
+    expect(doorRowsForRegion(bounds, [entranceHallDoor])).toEqual(
+      new Set([DOOR_ROW])
+    );
+  });
+
+  it('marks the door row for the region right of the connector', () => {
+    const bounds = regionBounds(hall.hexes)!;
+    // hall's own minCol (7) - 1 === the connector column (6) the door sits on.
+    expect(doorRowsForRegion(bounds, [entranceHallDoor])).toEqual(
+      new Set([DOOR_ROW])
+    );
+  });
+
+  it('ignores a door that borders neither region', () => {
+    const farDoor: ConnectorDoorInput = {
+      position: cubeAtColRow(99, DOOR_ROW),
+    };
+    const bounds = regionBounds(entrance.hexes)!;
+    expect(doorRowsForRegion(bounds, [farDoor])).toEqual(new Set());
+  });
+});
+
+describe('authorGridRoom', () => {
+  it("labels the region's own top-left corner hex [0,0]", () => {
+    const room = authorGridRoom(entrance, [entranceHallDoor], HEX_SIZE);
+    const corner = room!.labels.find(
+      (l) => l.localCol === 0 && l.localRow === 0
+    );
+    expect(corner).toBeDefined();
+    expect(corner!.world).toEqual(cubeToWorld(cubeAtColRow(0, 0), HEX_SIZE));
+  });
+
+  it('matches dungeonspec LocalHex{Col,Row} for an interior cell', () => {
+    // A hex at world col/row (9, 3) inside hall (minCol=7, minRow=0) is
+    // local [2, 3] — exactly the {at: [2, 3]} an author would write in
+    // dungeon-content YAML to place something there.
+    const room = authorGridRoom(hall, [entranceHallDoor], HEX_SIZE);
+    const label = room!.labels.find(
+      (l) => l.localCol === 2 && l.localRow === 3
+    );
+    expect(label).toBeDefined();
+    expect(label!.world).toEqual(cubeToWorld(cubeAtColRow(9, 3), HEX_SIZE));
+  });
+
+  it('flags labels on the door row and only that row', () => {
+    const room = authorGridRoom(entrance, [entranceHallDoor], HEX_SIZE);
+    for (const label of room!.labels) {
+      expect(label.isDoorRow).toBe(label.localRow === DOOR_ROW);
+    }
+  });
+
+  it('returns undefined for a region with no hexes', () => {
+    expect(
+      authorGridRoom({ id: 'empty', hexes: [] }, [], HEX_SIZE)
+    ).toBeUndefined();
+  });
+});
+
+describe('authorGridRooms', () => {
+  it('builds one room per non-empty region and skips empty ones', () => {
+    const rooms = authorGridRooms(
+      [entrance, hall, { id: 'unrevealed', hexes: [] }],
+      [entranceHallDoor],
+      HEX_SIZE
+    );
+    expect(rooms.map((r) => r.regionId)).toEqual(['entrance', 'hall']);
+  });
+});
+
+describe('facingDirection', () => {
+  it('numbers HEX_DIRECTIONS 0-5 in order, unmodified', () => {
+    for (let i = 0; i < 6; i++) {
+      expect(facingDirection(i)).toEqual(HEX_DIRECTIONS[i]);
+    }
+  });
+
+  it('wraps both directions so a caller never needs to pre-clamp', () => {
+    expect(facingDirection(6)).toEqual(facingDirection(0));
+    expect(facingDirection(-1)).toEqual(facingDirection(5));
+  });
+
+  it('has a legend label for every direction', () => {
+    expect(HEX_FACING_LABELS).toHaveLength(6);
+  });
+});

--- a/src/components/hex-grid/authorGridHelpers.ts
+++ b/src/components/hex-grid/authorGridHelpers.ts
@@ -1,0 +1,181 @@
+/**
+ * authorGridHelpers — pure geometry for the author-grid overlay
+ * (`?authorGrid=1`): the room-local [col,row] hex labels + facing legend
+ * Kirk uses to walk a room and dictate dungeon-content YAML `place:`
+ * coordinates directly, instead of hand-deriving them from world hexes.
+ * Protocol-agnostic and unit-testable, same split as
+ * wallRuns.ts/wallRunAdapters.ts — this file only knows
+ * `RegionInput`/`ConnectorDoorInput` (already reconstructed from the wire
+ * by EncounterMap.tsx for wall-run computation), never the proto shapes
+ * directly.
+ *
+ * Local [col,row] must match dungeonspec's own `LocalHex{Col,Row}`
+ * EXACTLY (rpg-toolkit encounter/dungeonspec/compile.go:
+ * `LocalHex{Col: at[0], Row: at[1]}`) — col is wallRuns.ts's `hexColumn`
+ * (cube x) minus the region's own `minCol`; row is `hexRow` (parity-
+ * corrected: `z + (x - (x&1))/2`) minus `minRow`. Reuses wallRuns.ts's
+ * already-exported `hexColumn`/`hexRow`/`cubeAtColRow` rather than
+ * re-deriving them; duplicates only the small min/max bounds scan
+ * (wallRuns.ts's own `boundsOf` is private to that module and its doc
+ * comments are all wall-run-specific — cheaper and lower-risk to keep a
+ * small local copy here than to widen that heavily-documented module's
+ * public surface for an unrelated caller).
+ */
+
+import {
+  cubeAtColRow,
+  hexColumn,
+  hexRow,
+  type ConnectorDoorInput,
+  type RegionInput,
+} from '@/hooks/wallRuns';
+import {
+  cubeToWorld,
+  HEX_DIRECTIONS,
+  type CubeCoord,
+  type WorldPos,
+} from './hexMath';
+
+export interface RegionBounds {
+  minCol: number;
+  maxCol: number;
+  minRow: number;
+  maxRow: number;
+}
+
+/** Mirrors wallRuns.ts's private `boundsOf` — see this file's own doc
+ * comment for why this is a small intentional duplication rather than an
+ * import. Exported for testing. */
+export function regionBounds(
+  hexes: readonly CubeCoord[]
+): RegionBounds | undefined {
+  if (hexes.length === 0) return undefined;
+  let minCol = Infinity;
+  let maxCol = -Infinity;
+  let minRow = Infinity;
+  let maxRow = -Infinity;
+  for (const hex of hexes) {
+    const col = hexColumn(hex);
+    const row = hexRow(hex);
+    if (col < minCol) minCol = col;
+    if (col > maxCol) maxCol = col;
+    if (row < minRow) minRow = row;
+    if (row > maxRow) maxRow = row;
+  }
+  return { minCol, maxCol, minRow, maxRow };
+}
+
+/**
+ * Row indices (region-local) that a connector door sits opposite, within
+ * one region's own bounds — "opposite" because a door cell never belongs
+ * to either region's own hex set (`regionInputsFromHexes` excludes
+ * connector cells by construction), so a door can only ever border a
+ * region from its immediately adjacent connector column. Mirrors the same
+ * `col === bounds.minCol - 1` / `col === bounds.maxCol + 1` adjacency
+ * check wallRuns.ts's own connector-siding logic already uses. Returned
+ * as a Set since a wide connector can in principle carry more than one
+ * door cell (stacked doors are not a real content pattern today, but nothing
+ * here assumes there's exactly one).
+ */
+export function doorRowsForRegion(
+  bounds: RegionBounds,
+  doors: readonly ConnectorDoorInput[]
+): Set<number> {
+  const rows = new Set<number>();
+  for (const door of doors) {
+    const col = hexColumn(door.position);
+    if (col !== bounds.minCol - 1 && col !== bounds.maxCol + 1) continue;
+    rows.add(hexRow(door.position) - bounds.minRow);
+  }
+  return rows;
+}
+
+export interface AuthorGridLabel {
+  /** Stable React key — "regionId:col,row". */
+  key: string;
+  world: WorldPos;
+  localCol: number;
+  localRow: number;
+  /** True when this label's row is opposite a connector door — Kirk's
+   * "unplaceable" row (doorway threshold), rendered dimmer/subtler than a
+   * normal label rather than hidden, so the room's row count still reads
+   * correctly at a glance. */
+  isDoorRow: boolean;
+}
+
+export interface AuthorGridRoom {
+  regionId: string;
+  labels: AuthorGridLabel[];
+  /** World position for the room-id corner label — the region's own
+   * (minCol, minRow) corner, i.e. [0,0] in the room's own local space. */
+  labelWorld: WorldPos;
+}
+
+/** One region's full label set, or undefined for an empty region (no
+ * revealed hexes yet — shouldn't happen for a region the wire actually
+ * sent, but `regionBounds` is defensive, so this stays defensive too). */
+export function authorGridRoom(
+  region: RegionInput,
+  doors: readonly ConnectorDoorInput[],
+  hexSize: number
+): AuthorGridRoom | undefined {
+  const bounds = regionBounds(region.hexes);
+  if (!bounds) return undefined;
+  const doorRows = doorRowsForRegion(bounds, doors);
+  const labels: AuthorGridLabel[] = region.hexes.map((hex) => {
+    const localCol = hexColumn(hex) - bounds.minCol;
+    const localRow = hexRow(hex) - bounds.minRow;
+    return {
+      key: `${region.id}:${localCol},${localRow}`,
+      world: cubeToWorld(hex, hexSize),
+      localCol,
+      localRow,
+      isDoorRow: doorRows.has(localRow),
+    };
+  });
+  const labelWorld = cubeToWorld(
+    cubeAtColRow(bounds.minCol, bounds.minRow),
+    hexSize
+  );
+  return { regionId: region.id, labels, labelWorld };
+}
+
+/** Every currently-revealed region's label set, skipping any region with
+ * no hexes yet (see `authorGridRoom`). */
+export function authorGridRooms(
+  regions: readonly RegionInput[],
+  doors: readonly ConnectorDoorInput[],
+  hexSize: number
+): AuthorGridRoom[] {
+  const rooms: AuthorGridRoom[] = [];
+  for (const region of regions) {
+    const room = authorGridRoom(region, doors, hexSize);
+    if (room) rooms.push(room);
+  }
+  return rooms;
+}
+
+/**
+ * Facing legend: numbers hexMath.ts's existing `HEX_DIRECTIONS` order
+ * 0-5 rather than inventing a new one — that array is already the
+ * canonical hex-neighbor order shared with the toolkit
+ * (rpg-toolkit tools/spatial/position.go's own `GetNeighbors` direction
+ * slice: the identical E, NE, NW, W, SW, SE clockwise-from-east
+ * sequence). Facing does nothing mechanically yet — Kirk dictates
+ * "facing 3" during a room walk and it's captured as a YAML comment
+ * until a real rotation field lands on `place:` entries.
+ *
+ * Checked rpg-api-protos, rpg-toolkit, and rpg-api for an existing
+ * facing enum before defining this one: none found as of this writing
+ * (`grep -rniE "facing"` across all three turns up only unrelated
+ * "user-facing" / "room-facing edge" prose, never a direction enum). If
+ * the in-flight fog-of-war/facing work defines one first, THIS numbering
+ * is what needs to reconcile with theirs, not the other way around —
+ * noted here so whoever picks that up finds the reconciliation note
+ * without archaeology.
+ */
+export const HEX_FACING_LABELS = ['E', 'NE', 'NW', 'W', 'SW', 'SE'] as const;
+
+export function facingDirection(index: number): CubeCoord {
+  return HEX_DIRECTIONS[((index % 6) + 6) % 6]!;
+}


### PR DESCRIPTION
## Summary

Closes #644. Adds `?authorGrid=1`, a dial-gated authoring bridge overlay so Kirk can walk a room and dictate `place:` coordinates directly into dungeon-content YAML instead of hand-deriving them:

- **Per-hex labels**: every revealed floor hex renders its room-local `[col,row]` label — the exact coordinates `dungeon-content` YAML `place:` blocks use. World hex → owning region → local coords via the region's own bounds min, reusing `wallRuns.ts`'s already-exported `hexColumn`/`hexRow`/`cubeAtColRow` (the wall-runs work's own col/row↔cube transform) rather than re-deriving it. New pure module `authorGridHelpers.ts` does the geometry (13 unit tests, checked against the real reference-tomb entrance/hall widths the existing `wallRuns.test.ts` fixtures use).
- **Room id**: rendered near each region's own corner (its local `[0,0]`) so a multi-room-visible scene stays unambiguous — "hall 6,3" reads correctly even with two rooms on screen at once.
- **Door row**: the row opposite a connector door (unplaceable — a doorway threshold) renders in a distinct, subtler warm color instead of hidden, so the row count still reads correctly at a glance.
- **Facing legend**: a small compass-rose HUD numbering `hexMath.ts`'s existing `HEX_DIRECTIONS` order 0-5 (E, NE, NW, W, SW, SE — already the canonical hex-neighbor order shared with `rpg-toolkit`'s `tools/spatial/position.go`) rather than inventing a new one. Checked rpg-api-protos/rpg-toolkit/rpg-api for an existing facing enum first — none found. Facing does nothing mechanically yet; documented in `authorGridHelpers.ts` for reconciliation if the in-flight fog-of-war/facing work defines its own numbering first.

`AuthorGridOverlay` mounts via `HexGrid`'s existing `children` slot (same mechanism `?perfProbe`'s `DevPerfProbe` already uses) — zero HexGrid.tsx changes, and zero cost when the dial is off since the component simply isn't mounted, not an internal early-return.

## Verified live

Ran against the real backend (rpg-api on :8080, reference-tomb content) via a fresh character walking into the entrance room with `?authorGrid=1`. Confirmed on screen:
- Per-hex labels `1,1` through `4,6` etc. across the visible floor, matching each hex's actual room-local position
- The door row (local row 4, per reference-tomb's height-8 entrance) rendered in the dimmer warm color across every column in that row, everything else in the normal light color
- The room id ("entrance") rendered near the region's own corner
- The facing legend compass rose (bottom-left), showing `0=E 1=NE 2=NW 3=W 4=SW 5=SE` around a small ring

(First pass had the per-hex labels rendering at y=0.05 — just under `SyntyHexFloor`'s floor mesh at `FLOOR_Y=0.2`, invisible. Caught via live screenshot, not review — fixed to y=0.25.)

## Test plan

- [x] `authorGridHelpers.test.ts` — 13 new unit tests (region bounds, local-coord math against real reference-tomb widths, door-row detection, facing wraparound), all passing
- [x] Full suite: 89 files / 1579 tests passing
- [x] `npm run ci-check` (format/lint/typecheck/build/test) green locally, pre-push hook confirmed
- [x] Live-verified against the real backend as described above

— asset-pipeline agent, on behalf of KirkDiggler
