### PR TITLE
feat(encounter): consume live HexKnowledgeChanged events (#609)

### DIFF
--- a/src/api/encounterStreamDispatch.ts
+++ b/src/api/encounterStreamDispatch.ts
@@ -10,6 +10,7 @@ import type {
   EntityMoved,
   EntityRemoved,
   EntityStabilized,
+  HexKnowledgeChanged,
   InitiativeRolled,
   InputRequiredDelivered,
   ModeChanged,
@@ -63,6 +64,17 @@ export interface EncounterStreamOptions {
    * owns hex/wall knowledge now.
    */
   onDoorOpened?: EncounterStreamHandler<DoorOpened>;
+  /**
+   * rpg-dnd5e-web#609: the only event that moves fog of war (rpg-api-
+   * protos#197). It is a DIFF — a hex/entity absent from the payload is
+   * untouched, never cleared, and a VISIBLE hex's `contents` is total (an
+   * empty list positively means "nobody here", which is how a remembered
+   * occupant disappears on re-sight with no separate forget message). The
+   * web's entire job on receipt is merge-by-position / upsert-by-id; see
+   * useEncounterState's applyEntityKnowledgeBatch + applyHexRecordsMerged
+   * doc comments for the full contract and call order.
+   */
+  onHexKnowledgeChanged?: EncounterStreamHandler<HexKnowledgeChanged>;
   // Wave 2.8: combat events (TURN_BASED mode + attacks + turn cycle).
   /** Authoritative HP update; carries `hp_after` and `amount`. */
   onEntityDamaged?: EncounterStreamHandler<EntityDamaged>;
@@ -177,6 +189,9 @@ export function dispatchEncounterStreamEvent(
     case 'doorOpened':
       options.onDoorOpened?.(payload.value, metadata);
       break;
+    case 'hexKnowledgeChanged':
+      options.onHexKnowledgeChanged?.(payload.value, metadata);
+      break;
     case 'entityDamaged':
       options.onEntityDamaged?.(payload.value, metadata);
       break;
@@ -227,10 +242,10 @@ export function dispatchEncounterStreamEvent(
       break;
     default:
       // Either out-of-current-scope but known to the proto (entityHealed,
-      // hexKnowledgeChanged, dialogue, etc. — the proto defines 28 event
-      // cases; we currently handle 19) OR a genuinely unknown case from a
-      // proto version mismatch. Either way: warn + continue so the stream doesn't
-      // tear down. Add a case arm + callback when the feature lands.
+      // dialogue, etc. — the proto defines 28 event cases; we currently
+      // handle 20) OR a genuinely unknown case from a proto version
+      // mismatch. Either way: warn + continue so the stream doesn't tear
+      // down. Add a case arm + callback when the feature lands.
       // The cast strips the narrowed-to-undefined `case` so we can log it.
       console.warn(
         '[useEncounterStream] unhandled event case:',

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -26,12 +26,12 @@
  * InputRequiredDelivered events, same as every other verb on this stream.
  * DoorOpened is now a pure notification (door identity only,
  * rpg-api-protos#197) — the door's authoritative rendered pose rides the
- * next snapshot's `HexRecord.edges` instead of a parallel reveal event
- * (there is no live per-hex knowledge-change consumption yet, tracked as
- * rpg-dnd5e-web#609). onDoorOpened still flips the matching wall's own kind
- * to DOOR_OPEN locally in useEncounterState (see applyDoorOpened) so the
- * pose updates instantly on the click that caused it, ahead of that next
- * snapshot.
+ * live `HexKnowledgeChanged` stream (rpg-dnd5e-web#609, onHexKnowledgeChanged
+ * below) or the next snapshot's `HexRecord.edges`, instead of a parallel
+ * reveal event. onDoorOpened still flips the matching wall's own kind to
+ * DOOR_OPEN locally in useEncounterState (see applyDoorOpened) so the pose
+ * updates instantly on the click that caused it, ahead of whichever of those
+ * two arrives.
  */
 
 import { create } from '@bufbuild/protobuf';
@@ -412,12 +412,66 @@ export function EncounterView({
       }
     },
     // DoorOpened is a pure notification now (door identity only,
-    // rpg-api-protos#197) — the rendered pose rides the next snapshot's
-    // HexRecord.edges, not a parallel reveal event. HexGrid's door-click
-    // surface still needs a v2-shaped DoorInfo[] (see this file's top
-    // comment) — tracked separately, not this slice.
+    // rpg-api-protos#197) — the rendered pose rides the live
+    // HexKnowledgeChanged stream (onHexKnowledgeChanged below) or the next
+    // snapshot's HexRecord.edges, not a parallel reveal event. HexGrid's
+    // door-click surface still needs a v2-shaped DoorInfo[] (see this file's
+    // top comment) — tracked separately, not this slice.
     onDoorOpened: (e) => {
       encounterState.applyDoorOpened(e.doorEntityId);
+    },
+    // rpg-dnd5e-web#609: the only event that moves fog of war
+    // (rpg-api-protos#197). It is a DIFF — omission means untouched, never
+    // gone — so unlike SnapshotDelivered above this handler MERGES, never
+    // replaces. Order matters: entities are merged into the known-entity
+    // registry FIRST (applyEntityKnowledgeBatch) so applyHexRecordsMerged's
+    // placement resolution — which fails closed against entityMeta, per the
+    // proto's "a placement that resolves against nothing MUST be dropped"
+    // rule — sees this same message's own disclosures already known. See
+    // both reducers' doc comments in useEncounterState.ts for the full
+    // merge-vs-replace contract this handler exists to satisfy.
+    onHexKnowledgeChanged: (e) => {
+      const knowledgeEntries = e.entities.map((entity) => ({
+        entityId: entity.id,
+        type: entity.type,
+        monsterRefId:
+          entity.data?.case === 'monster'
+            ? entity.data.value.monsterRef?.id
+            : undefined,
+        initialHP: entity.hp
+          ? { current: entity.hp.current, max: entity.hp.max }
+          : undefined,
+        initialAC: entity.armorClass,
+        statusEffects: entity.statusEffects,
+        displayName: entity.displayName,
+        classRefId:
+          entity.data?.case === 'character'
+            ? entity.data.value.classRef?.id
+            : undefined,
+        propRefId:
+          entity.data?.case === 'obstacle'
+            ? entity.data.value.obstacleRef?.id
+            : entity.data?.case === 'prop'
+              ? entity.data.value.propRef?.id
+              : undefined,
+        equipment:
+          entity.data?.case === 'character'
+            ? characterEquipmentFrom(entity.data.value)
+            : undefined,
+      }));
+      if (knowledgeEntries.length > 0) {
+        encounterState.applyEntityKnowledgeBatch(knowledgeEntries);
+      }
+
+      encounterState.applyHexRecordsMerged(e.hexes);
+
+      // Walls are additive/idempotent already (applyWallsRevealed); a
+      // REMEMBERED hex carries no edges today (known API-side gap, not
+      // compensated here), so this is a no-op for those.
+      const liveWalls = e.hexes.flatMap((hex) => hex.edges ?? []);
+      if (liveWalls.length > 0) {
+        encounterState.applyWallsRevealed(liveWalls);
+      }
     },
     onStatusApplied: (e) => {
       encounterState.applyStatusApplied(e);

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -288,10 +288,58 @@ export function PlaytestHarness() {
       },
       onDoorOpened: (e) => {
         // DoorOpened is a pure notification now (door identity only,
-        // rpg-api-protos#197) — the rendered pose rides the next snapshot's
-        // HexRecord.edges, not a parallel reveal event.
+        // rpg-api-protos#197) — the rendered pose rides the live
+        // HexKnowledgeChanged stream (onHexKnowledgeChanged below) or the
+        // next snapshot's HexRecord.edges, not a parallel reveal event.
         encounterState.applyDoorOpened(e.doorEntityId);
         addLog(`DoorOpened ${e.doorEntityId}`);
+      },
+      // rpg-dnd5e-web#609: the only event that moves fog of war
+      // (rpg-api-protos#197). It is a DIFF — omission means untouched,
+      // never gone — so unlike SnapshotDelivered above this MERGES, never
+      // replaces. Mirrors EncounterView.tsx's identical wiring; see
+      // useEncounterState's applyEntityKnowledgeBatch / applyHexRecordsMerged
+      // doc comments for the full contract and required call order (entity
+      // meta batch first, so placement resolution below sees this same
+      // message's own disclosures already known).
+      onHexKnowledgeChanged: (e) => {
+        const knowledgeEntries = e.entities.map((entity) => ({
+          entityId: entity.id,
+          type: entity.type,
+          monsterRefId:
+            entity.data?.case === 'monster'
+              ? entity.data.value.monsterRef?.id
+              : undefined,
+          initialHP: entity.hp
+            ? { current: entity.hp.current, max: entity.hp.max }
+            : undefined,
+          initialAC: entity.armorClass,
+          // #462/#491 parity: the harness hydrates statuses/identity from
+          // snapshots the same way EncounterView does; do the same here.
+          statusEffects: entity.statusEffects,
+          displayName: entity.displayName,
+          classRefId:
+            entity.data?.case === 'character'
+              ? entity.data.value.classRef?.id
+              : undefined,
+          // No equipment field: the harness's snapshot hydration (#571)
+          // never wired equipment either, so this stays feature-parity with
+          // that path rather than adding new scope here.
+        }));
+        if (knowledgeEntries.length > 0) {
+          encounterState.applyEntityKnowledgeBatch(knowledgeEntries);
+        }
+
+        encounterState.applyHexRecordsMerged(e.hexes);
+
+        const liveWalls = e.hexes.flatMap((hex) => hex.edges ?? []);
+        if (liveWalls.length > 0) {
+          encounterState.applyWallsRevealed(liveWalls);
+        }
+
+        addLog(
+          `HexKnowledgeChanged hexes=${e.hexes.length} entities=${e.entities.length}`
+        );
       },
       onEntityDamaged: (e) => {
         encounterState.applyEntityDamaged(e);

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -34,7 +34,9 @@ import {
   EncounterMode,
   EntityType,
   HexRecordSchema,
+  HexState,
   InputRequiredSchema,
+  PlacementSchema,
   SkillCheckPromptSchema,
   type StatusEffect,
   TargetKind,
@@ -49,6 +51,7 @@ import { describe, expect, it } from 'vitest';
 import { wallKey } from './dungeonMapGeometry';
 import type {
   CharacterEquipment,
+  EntityKnowledgeEntry,
   LocalEncounterState,
 } from './useEncounterState';
 import {
@@ -58,7 +61,9 @@ import {
   applyEntityAppearedBatch,
   applyEntityDamaged,
   applyEntityDied,
+  applyEntityKnowledgeBatch,
   applyEntityRemoved,
+  applyHexRecordsMerged,
   applyInitiativeRolled,
   applyModeChanged,
   applySnapshotRegionState,
@@ -685,6 +690,198 @@ describe('v1alpha2 reducer additions', () => {
 
       expect(after.walls).toBe(beforeWalls);
       expect(after).toBe(state); // fully idempotent — same top-level reference
+    });
+  });
+
+  describe('live hex knowledge merge (rpg-dnd5e-web#609)', () => {
+    /** Seed a known entity's identity WITHOUT a position — mirrors what
+     * applyEntityKnowledgeBatch does for a live HexKnowledgeChanged's own
+     * `entities` batch, ahead of placement resolution. */
+    function seedKnownEntity(
+      prev: LocalEncounterState,
+      entityId: string,
+      overrides?: Partial<EntityKnowledgeEntry>
+    ): LocalEncounterState {
+      return applyEntityKnowledgeBatch(prev, [
+        {
+          entityId,
+          type: EntityType.MONSTER,
+          monsterRefId: 'goblin',
+          initialHP: undefined,
+          initialAC: undefined,
+          ...overrides,
+        },
+      ]);
+    }
+
+    function makePlacement(entityId: string, facing = 0) {
+      return create(PlacementSchema, { entityId, facing });
+    }
+
+    function makeHexRecord(
+      position: { x: number; y: number; z: number },
+      state: HexState,
+      contents: ReturnType<typeof makePlacement>[] = [],
+      edges: Wall[] = []
+    ) {
+      return create(HexRecordSchema, {
+        position: create(V2PositionSchema, position),
+        state,
+        contents,
+        edges,
+      });
+    }
+
+    describe('applyEntityKnowledgeBatch', () => {
+      it('merges entity meta without creating a position cache entry', () => {
+        const state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+        expect(state.entityMeta.get('goblin-1')?.monsterRefId).toBe('goblin');
+        expect(state.entities.has('goblin-1')).toBe(false);
+      });
+
+      it('upserts by id — a batch mentioning one entity leaves others untouched', () => {
+        let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+        state = seedKnownEntity(state, 'goblin-2');
+        expect(state.entityMeta.get('goblin-1')?.monsterRefId).toBe('goblin');
+        expect(state.entityMeta.get('goblin-2')?.monsterRefId).toBe('goblin');
+        expect(state.entityMeta.size).toBe(2);
+      });
+
+      it('is a no-op on an empty batch (same reference)', () => {
+        const state = createEmptyEncounterState();
+        expect(applyEntityKnowledgeBatch(state, [])).toBe(state);
+      });
+    });
+
+    describe('applyHexRecordsMerged', () => {
+      it('adds new hexes without requiring a prior snapshot', () => {
+        const hex = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE);
+        const after = applyHexRecordsMerged(createEmptyEncounterState(), [hex]);
+        expect(after.revealedHexes.get('0,0,0')).toBe(hex);
+      });
+
+      it('does NOT clear hexes the event does not mention', () => {
+        const entrance = makeTestHex({ x: 0, y: 0, z: 0 }, 'entrance');
+        const chamber = makeTestHex({ x: 1, y: -1, z: 0 }, 'chamber');
+        const seeded = applySnapshotRegionState(
+          createEmptyEncounterState(),
+          'crypt',
+          [],
+          [entrance, chamber]
+        );
+        const newHex = makeHexRecord({ x: 5, y: -3, z: -2 }, HexState.VISIBLE);
+
+        const after = applyHexRecordsMerged(seeded, [newHex]);
+
+        expect(after.revealedHexes.get('0,0,0')).toBe(entrance);
+        expect(after.revealedHexes.get('1,-1,0')).toBe(chamber);
+        expect(after.revealedHexes.get('5,-3,-2')).toBe(newHex);
+        expect(after.revealedHexes.size).toBe(3);
+      });
+
+      it('resolves a placement against a known entity and caches its position', () => {
+        let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+        const hex = makeHexRecord({ x: 2, y: -1, z: -1 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+
+        state = applyHexRecordsMerged(state, [hex]);
+
+        expect(state.entities.get('goblin-1')?.position).toEqual(
+          create(PositionSchema, { x: 2, y: -1, z: -1 })
+        );
+      });
+
+      it('drops a placement whose entityId is not in the known entity set (fail closed)', () => {
+        const hex = makeHexRecord({ x: 2, y: -1, z: -1 }, HexState.VISIBLE, [
+          makePlacement('undisclosed-trap'),
+        ]);
+
+        const state = applyHexRecordsMerged(createEmptyEncounterState(), [hex]);
+
+        expect(state.entities.has('undisclosed-trap')).toBe(false);
+        // The hex record itself is still stored verbatim — the drop only
+        // withholds rendering (the entities position cache), matching the
+        // existing SnapshotDelivered precedent (EncounterView.tsx already
+        // stores a hex's raw contents wholesale while separately filtering
+        // which placements get a position-cache entry).
+        expect(state.revealedHexes.get('2,-1,-1')).toBe(hex);
+      });
+
+      it('re-sight with contents: [] removes a remembered occupant', () => {
+        let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+        const seen = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+        state = applyHexRecordsMerged(state, [seen]);
+        expect(state.entities.has('goblin-1')).toBe(true);
+
+        const emptied = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.VISIBLE,
+          []
+        );
+        state = applyHexRecordsMerged(state, [emptied]);
+
+        expect(state.entities.has('goblin-1')).toBe(false);
+        expect(state.revealedHexes.get('0,0,0')).toBe(emptied);
+      });
+
+      it('does not delete a vacated placement that moved to another hex in the SAME event', () => {
+        let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+        const origin = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+        state = applyHexRecordsMerged(state, [origin]);
+
+        const vacated = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.VISIBLE,
+          []
+        );
+        const arrived = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+        state = applyHexRecordsMerged(state, [vacated, arrived]);
+
+        expect(state.entities.get('goblin-1')?.position).toEqual(
+          create(PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('an empty event changes nothing (same reference)', () => {
+        const state = createEmptyEncounterState();
+        expect(applyHexRecordsMerged(state, [])).toBe(state);
+      });
+
+      it('is idempotent — applying the same event twice leaves state identical', () => {
+        const seeded = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+        const hex = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+
+        const first = applyHexRecordsMerged(seeded, [hex]);
+        const second = applyHexRecordsMerged(first, [hex]);
+
+        expect(second.revealedHexes).toBe(first.revealedHexes);
+        expect(second.entities).toBe(first.entities);
+        expect(second).toEqual(first);
+      });
+
+      it('walls arrive via edges: flattening hex.edges feeds applyWallsRevealed', () => {
+        const wall = makeTestWall({ x: 0, y: 0, z: 0 }, { x: 1, y: -1, z: 0 });
+        const hex = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.VISIBLE,
+          [],
+          [wall]
+        );
+
+        let state = applyHexRecordsMerged(createEmptyEncounterState(), [hex]);
+        state = applyWallsRevealed(state, hex.edges);
+
+        expect(state.walls.get(wallKey(wall))).toBe(wall);
+      });
     });
   });
 });

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -15,7 +15,10 @@
 
 import { create } from '@bufbuild/protobuf';
 import type { Position } from '@kirkdiggler/rpg-api-protos/gen/ts/api/v1alpha1/room_common_pb';
-import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
+import {
+  EntityStateSchema,
+  type EntityState,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type {
   EncounterEnded,
   EntityDamaged,
@@ -42,6 +45,7 @@ import {
   WallSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useCallback, useState } from 'react';
+import { v2PositionToV1 } from '../api/positionConvert';
 import type {
   EquippedMap,
   ItemLike,
@@ -463,6 +467,111 @@ export function applyWallsRevealed(
 }
 
 /**
+ * Merge live HexKnowledgeChanged records into revealedHexes and reconcile
+ * the entity position cache (`entities`) — the merge-path counterpart to
+ * applySnapshotRegionState's full replace. A snapshot is a reconnect resync
+ * (omitted = gone); a live HexKnowledgeChanged is a DIFF (rpg-api-protos#197,
+ * rpg-dnd5e-web#609) — omitted = untouched, never gone. Positions absent
+ * from `hexes` are never consulted below: their previously-cached region
+ * truth AND cached entity positions stand exactly as they were.
+ *
+ * For each position `hexes` DOES mention:
+ *   - The record REPLACES whatever was cached there WHOLESALE, never a
+ *     field-level merge — a VISIBLE record's `contents` is total (an empty
+ *     list is a positive "nobody here"), and a REMEMBERED record already
+ *     carries its complete frozen observation.
+ *   - Every placement's `entityId` resolves against `prev.entityMeta`. Call
+ *     this AFTER merging the same event's `entities` batch in via
+ *     applyEntityKnowledgeBatch, so a same-message disclosure already
+ *     resolves. An entityId that still doesn't resolve is dropped: fail
+ *     closed, never render an undisclosed occupant (neither added to nor
+ *     removed from the position cache).
+ *   - A resolving placement writes (or overwrites) that entityId's cached
+ *     position. This is always treated as an "appear", not a "move" (a
+ *     fresh `create(EntityStateSchema, ...)`, matching
+ *     applyEntityAppearedBatch's own `{ ...entity, ghost: false }` — the
+ *     real hex-by-hex walk animation is EntityMoved's job, handled
+ *     separately by mergeEntityPosition; a knowledge change is never that).
+ *   - An entityId present in the OLD cached record's contents at this
+ *     position but absent from the NEW one — and not re-placed at any OTHER
+ *     position this SAME event (a move within one message) — is removed
+ *     from the position cache. This is how a remembered occupant
+ *     disappears on re-sight: there is no forget message, the arriving
+ *     record simply omits them.
+ *
+ * Idempotent: re-delivering an identical `hexes` array (same HexRecord
+ * object references) is a full no-op — every map returned unchanged.
+ * Exported for testing.
+ */
+export function applyHexRecordsMerged(
+  prev: LocalEncounterState,
+  hexes: HexRecord[]
+): LocalEncounterState {
+  const positioned = hexesWithPosition(hexes);
+  if (positioned.length === 0) return prev;
+
+  let nextRevealedHexes: Map<string, HexRecord> | undefined;
+  for (const hex of positioned) {
+    const key = hexKey(protoPositionToHex(hex.position));
+    if ((nextRevealedHexes ?? prev.revealedHexes).get(key) === hex) continue;
+    if (!nextRevealedHexes) nextRevealedHexes = new Map(prev.revealedHexes);
+    nextRevealedHexes.set(key, hex);
+  }
+  if (!nextRevealedHexes) return prev;
+
+  // Guards the "moved within one event" case: an entityId placed ANYWHERE
+  // in this event's own contents must not also be pruned by the vacate pass
+  // below, even though it's simultaneously absent from wherever it used to
+  // be cached.
+  const placedThisEvent = new Set<string>();
+  for (const hex of positioned) {
+    for (const placement of hex.contents ?? []) {
+      if (prev.entityMeta.has(placement.entityId)) {
+        placedThisEvent.add(placement.entityId);
+      }
+    }
+  }
+
+  let nextEntities: LocalEncounterState['entities'] | undefined;
+  for (const hex of positioned) {
+    const key = hexKey(protoPositionToHex(hex.position));
+    for (const placement of hex.contents ?? []) {
+      if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
+      const position = v2PositionToV1(hex.position);
+      const existing = (nextEntities ?? prev.entities).get(placement.entityId);
+      if (
+        existing?.position?.x === position.x &&
+        existing?.position?.y === position.y &&
+        existing?.position?.z === position.z
+      ) {
+        continue;
+      }
+      if (!nextEntities) nextEntities = new Map(prev.entities);
+      nextEntities.set(
+        placement.entityId,
+        create(EntityStateSchema, { entityId: placement.entityId, position })
+      );
+    }
+    const oldContents = prev.revealedHexes.get(key)?.contents ?? [];
+    for (const oldPlacement of oldContents) {
+      if (placedThisEvent.has(oldPlacement.entityId)) continue;
+      if (!(nextEntities ?? prev.entities).has(oldPlacement.entityId)) {
+        continue;
+      }
+      if (!nextEntities) nextEntities = new Map(prev.entities);
+      nextEntities.delete(oldPlacement.entityId);
+    }
+  }
+
+  return {
+    ...prev,
+    revealedHexes: nextRevealedHexes,
+    revealedHexKeys: new Set(nextRevealedHexes.keys()),
+    entities: nextEntities ?? prev.entities,
+  };
+}
+
+/**
  * Converts one wire-shape StatusEffect into the local EntityStatus shape —
  * shared by both the live StatusApplied path (applyStatusApplied) and the
  * snapshot-hydration path below, since Entity.status_effects and
@@ -582,6 +691,115 @@ export function applyEntityAppearedBatch(
   return {
     ...prev,
     entities: newEntities,
+    entityMeta: newMeta,
+    entityHP: hpChanged ? newHP : prev.entityHP,
+    entityAC: acChanged ? newAC : prev.entityAC,
+    entityStatuses: statusesChanged ? newStatuses : prev.entityStatuses,
+    characterEquipment: equipmentChanged
+      ? newEquipment
+      : prev.characterEquipment,
+  };
+}
+
+/**
+ * Wire-projected entity disclosure from a live HexKnowledgeChanged event
+ * (rpg-dnd5e-web#609) — the merge-path counterpart to the position-carrying
+ * entries applyEntityAppearedBatch takes from a snapshot. Deliberately no
+ * `entity`/position field: HexKnowledgeChanged's Entity message carries no
+ * position of its own (see the proto's own Entity doc comment — "what a
+ * thing IS ... deliberately not where"); placement rides separately on each
+ * HexRecord.contents entry, applied by applyHexRecordsMerged.
+ */
+export interface EntityKnowledgeEntry {
+  entityId: string;
+  type: EntityType;
+  monsterRefId: string | undefined;
+  initialHP: { current: number; max: number } | undefined;
+  initialAC: number | undefined;
+  statusEffects?: StatusEffect[];
+  displayName?: string;
+  classRefId?: string;
+  propRefId?: string;
+  equipment?: CharacterEquipment;
+}
+
+/**
+ * Merge a live HexKnowledgeChanged event's `entities` batch into the known-
+ * entity registry (entityMeta/entityHP/entityAC/entityStatuses/
+ * characterEquipment) WITHOUT touching entity position — mirrors
+ * applyEntityAppearedBatch's per-entity meta projection field-for-field, but
+ * entries carry no position (see EntityKnowledgeEntry's doc comment) and are
+ * upserted, never treated as a full resync: an entity absent from `entries`
+ * keeps whatever entry it already had — unlike the snapshot path, this is a
+ * partial disclosure, not a reconnect resync, so there is nothing to clear.
+ *
+ * Call this BEFORE applyHexRecordsMerged for the same event, so its
+ * placement resolution sees this event's own disclosures already merged
+ * into entityMeta.
+ * Exported for testing.
+ */
+export function applyEntityKnowledgeBatch(
+  prev: LocalEncounterState,
+  entries: EntityKnowledgeEntry[]
+): LocalEncounterState {
+  if (entries.length === 0) return prev;
+  const newMeta = new Map(prev.entityMeta);
+  const newHP = new Map(prev.entityHP);
+  const newAC = new Map(prev.entityAC);
+  const newStatuses = new Map(prev.entityStatuses);
+  const newEquipment = new Map(prev.characterEquipment);
+  let hpChanged = false;
+  let acChanged = false;
+  let statusesChanged = false;
+  let equipmentChanged = false;
+  for (const {
+    entityId,
+    type,
+    monsterRefId,
+    initialHP,
+    initialAC,
+    statusEffects,
+    displayName,
+    classRefId,
+    propRefId,
+    equipment,
+  } of entries) {
+    newMeta.set(entityId, {
+      type,
+      monsterRefId,
+      displayName,
+      classRefId,
+      propRefId,
+    });
+    if (initialHP !== undefined) {
+      newHP.set(entityId, {
+        current: initialHP.current,
+        max: initialHP.max,
+      });
+      hpChanged = true;
+    }
+    if (initialAC !== undefined && initialAC !== 0) {
+      newAC.set(entityId, initialAC);
+      acChanged = true;
+    }
+    if (statusEffects !== undefined) {
+      const converted = statusEffects
+        .map(toEntityStatus)
+        .filter((s): s is EntityStatus => s !== undefined);
+      if (converted.length > 0) {
+        newStatuses.set(entityId, converted);
+      } else {
+        newStatuses.delete(entityId);
+      }
+      statusesChanged = true;
+    }
+    if (equipment !== undefined) {
+      newEquipment.set(entityId, equipment);
+      equipmentChanged = true;
+    }
+  }
+  return {
+    ...prev,
     entityMeta: newMeta,
     entityHP: hpChanged ? newHP : prev.entityHP,
     entityAC: acChanged ? newAC : prev.entityAC,
@@ -1102,6 +1320,20 @@ export interface UseEncounterStateResult {
     }>
   ) => void;
   /**
+   * rpg-dnd5e-web#609 — merge a live HexKnowledgeChanged event's `entities`
+   * batch into the known-entity registry WITHOUT touching position. See
+   * applyEntityKnowledgeBatch's doc comment for the full contract; call
+   * this BEFORE applyHexRecordsMerged for the same event.
+   */
+  applyEntityKnowledgeBatch: (entries: EntityKnowledgeEntry[]) => void;
+  /**
+   * rpg-dnd5e-web#609 — merge live HexKnowledgeChanged hex records into
+   * revealedHexes and reconcile cached entity positions. The merge-path
+   * counterpart to applySnapshotRegionState's full replace — see
+   * applyHexRecordsMerged's doc comment for the full contract.
+   */
+  applyHexRecordsMerged: (hexes: HexRecord[]) => void;
+  /**
    * Wave rpg-dnd5e-web#571 — refresh a character's equipment display
    * fields (and entityAC) after a successful EquipItem/UnequipItem RPC.
    * Optimistic local mirror — see applyCharacterEquipment's doc comment.
@@ -1238,6 +1470,17 @@ export function useEncounterState(): UseEncounterStateResult {
     []
   );
 
+  const applyEntityKnowledgeBatchCallback = useCallback(
+    (entries: EntityKnowledgeEntry[]) => {
+      setState((prev) => applyEntityKnowledgeBatch(prev, entries));
+    },
+    []
+  );
+
+  const applyHexRecordsMergedCallback = useCallback((hexes: HexRecord[]) => {
+    setState((prev) => applyHexRecordsMerged(prev, hexes));
+  }, []);
+
   const applyCharacterEquipmentCallback = useCallback(
     (entityId: string, equipment: CharacterEquipment) => {
       setState((prev) => applyCharacterEquipment(prev, entityId, equipment));
@@ -1328,6 +1571,8 @@ export function useEncounterState(): UseEncounterStateResult {
     applyWallsRevealed: applyWallsRevealedCallback,
     applyDoorOpened: applyDoorOpenedCallback,
     applyEntityAppearedBatch: applyEntityAppearedBatchCallback,
+    applyEntityKnowledgeBatch: applyEntityKnowledgeBatchCallback,
+    applyHexRecordsMerged: applyHexRecordsMergedCallback,
     applyCharacterEquipment: applyCharacterEquipmentCallback,
     applySnapshotTurnState: applySnapshotTurnStateCallback,
     setPendingPrompt: setPendingPromptCallback,


### PR DESCRIPTION
## Summary

Implements #609: the Game Screen now consumes the **live** `HexKnowledgeChanged` event, not just the connect-time snapshot. Previously, opening a door revealed nothing until the next reconnect — the next room rendered black and unwalkable.

**Note on #609's body:** it's written against a superseded design (`GeometryRevealed` promoted via `GeometryAppeared`, viewer-authorized removals). Those messages were deleted in rpg-api-protos#197. The real, current contract is a single event:

```
HexKnowledgeChanged { hexes: HexRecord[], entities: Entity[] }
HexRecord { position, state (VISIBLE | REMEMBERED), terrain, zoneId, edges, contents: Placement[] }
```

- A **VISIBLE** record's `contents` is **total** — `contents: []` positively means the hex is empty. That's how a remembered occupant disappears on re-sight; there's no forget message.
- **Omission is untouched**, never "gone". A hex absent from the event must not be cleared.
- The event is a **DIFF** — merge by position, upsert by id. An empty event changes nothing. Applying the same event twice is a no-op.

## The merge-vs-replace decision

`applySnapshotRegionState` (used for `SnapshotDelivered`) **replaces** `revealedHexes`/`entities` wholesale — correct for a reconnect resync, but calling it with a live diff's 2-3 hexes would wipe the rest of the map. So this adds two **new, separate** merge-path reducers in `useEncounterState.ts` rather than reusing/mutating the snapshot ones:

- **`applyEntityKnowledgeBatch`** — upserts entity identity/HP/AC/statuses/equipment into the known-entity registry (`entityMeta`/`entityHP`/`entityAC`/`entityStatuses`/`characterEquipment`) **without touching position**. The proto's `Entity` message deliberately carries no position of its own ("what a thing IS ... deliberately not where") — position rides separately on each `HexRecord.contents` placement.
- **`applyHexRecordsMerged`** — merges `HexRecord`s into `revealedHexes` by position (untouched positions left alone; a mentioned position is replaced **wholesale**, never field-merged), and reconciles the entity position cache (`entities`):
  - Each placement's `entityId` resolves against `entityMeta` (call `applyEntityKnowledgeBatch` **first** so this same event's own disclosures already resolve). An unresolvable id is **dropped — fail closed**, never rendered.
  - An entityId listed in the OLD cached record's contents at a position but absent from the NEW one — and not re-placed elsewhere in the SAME event (guards a move-within-one-message) — is removed from the position cache. This is the re-sight-removes-occupant behavior.

The hex record itself is still stored verbatim in `revealedHexes` (including any unresolved placement's raw entityId) — only the render-facing position cache is filtered. This mirrors the existing `SnapshotDelivered` handler's own precedent (it already stores hexes wholesale while separately filtering which placements get a position-cache entry).

Walls needed no new reducer: `applyWallsRevealed` was already additive/idempotent, so `hexes.flatMap(h => h.edges ?? [])` feeds it unchanged, same as the snapshot path.

## Changes

- **`src/api/encounterStreamDispatch.ts`** — added `onHexKnowledgeChanged` to `EncounterStreamOptions` + the `case 'hexKnowledgeChanged':` dispatch arm (previously fell through to the "unhandled event" warning).
- **`src/hooks/useEncounterState.ts`** — new `EntityKnowledgeEntry` type + `applyEntityKnowledgeBatch` and `applyHexRecordsMerged` reducers (both exported for testing, both exposed on the hook's return value).
- **`src/components/game/EncounterView.tsx`** — new `onHexKnowledgeChanged` handler: projects `e.entities` into knowledge entries, calls `applyEntityKnowledgeBatch` then `applyHexRecordsMerged(e.hexes)`, then flattens `edges` into `applyWallsRevealed`. Updated the file's stale top comment (previously said "no live per-hex knowledge-change consumption yet, tracked as #609").
- **`src/components/playtest/PlaytestHarness.tsx`** — same wiring, mirrored (no `equipment` field — the harness's snapshot path never hydrated equipment either, so this stays feature-parity rather than adding new scope).

## Tests

Added to `src/hooks/useEncounterState.test.ts` (new `describe('live hex knowledge merge (rpg-dnd5e-web#609)')` block):

- `applyEntityKnowledgeBatch`: merges meta without creating a position entry; upserts by id (leaves other entities untouched); no-op on an empty batch.
- `applyHexRecordsMerged`: adds new hexes with no prior snapshot; **does not clear hexes the event doesn't mention**; resolves a placement against a known entity and caches its position; **drops an unresolvable placement (fail closed)**; **re-sight with `contents: []` removes a remembered occupant**; does not delete a placement that moved to another hex in the same event; **an empty event changes nothing** (same reference); **idempotent** — applying the same event twice leaves state identical; walls arrive via `edges` (flattened into `applyWallsRevealed`).

No existing test encoded the old (superseded) behavior, so nothing needed rewriting — the prior tests only covered `SnapshotDelivered`'s full-replace path, which is untouched by this PR.

## Bar (real output)

```
npx tsc -b --noEmit        → clean, no output
npm run lint                → 0 errors (1 pre-existing warning, unrelated file: useHexMovePath.ts)
npm run format:check        → All matched files use Prettier code style!
npx vitest run              → Test Files 88 passed (88), Tests 1552 passed (1552)
npm run build                → built in 8.17s (pre-existing chunk-size warning only)
```

Pre-push hook's own `ci-check.sh` (format + lint + tsc + build + tests) also passed clean before the push completed.

## Anything not done

- Facing (`Placement.facing`) is not wired to rendering — it isn't consumed anywhere in the codebase yet (character-facing is a separate, not-yet-implemented initiative), so this stays consistent with the existing `SnapshotDelivered` handler, which also ignores it.
- Remembered hexes carrying no `edges` is a known API-side gap (not compensated client-side, per the task).
- `zoneId`/theme are unaffected — `HexKnowledgeChanged` carries no theme/zone fields; those still only ever change via `SnapshotDelivered`, and an unknown zone id on a live-revealed hex already resolves to `undefined` via the existing `regionForHex` fallback (pre-existing, untouched).

Fixes #609.
