### PR TITLE
feat(devtools): log streamed messages, not just the iterator (#648)

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,152 @@
+import type { StreamResponse, UnaryResponse } from '@connectrpc/connect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loggingInterceptor } from './client';
+
+/** Minimal fake req satisfying what loggingInterceptor actually reads
+ * (service.typeName, method.name, message) — cast past the rest of
+ * Connect's UnaryRequest/StreamRequest shape, same convention
+ * encounterStreamDispatch.test.ts's makeEvent() fixture uses. */
+function makeFakeReq(overrides?: { stream?: boolean }) {
+  return {
+    stream: overrides?.stream ?? false,
+    service: { typeName: 'test.Service' },
+    method: { name: 'TestMethod' },
+    message: { hello: 'world' },
+  } as unknown as Parameters<ReturnType<typeof loggingInterceptor>>[0];
+}
+
+async function* fromArray<T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) yield item;
+}
+
+describe('loggingInterceptor', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  describe('in development mode', () => {
+    beforeEach(() => {
+      vi.stubEnv('MODE', 'development');
+    });
+
+    it('behaves exactly as before for a unary response: logs it, returns it unchanged', async () => {
+      const unaryResponse = {
+        stream: false,
+        message: { ok: true },
+        service: { typeName: 'test.Service' },
+        header: new Headers(),
+        trailer: new Headers(),
+        method: { name: 'TestMethod' },
+      } as unknown as UnaryResponse;
+      const next = vi.fn().mockResolvedValue(unaryResponse);
+
+      const result = await loggingInterceptor(next)(makeFakeReq());
+
+      // Same reference — a unary response is passed through untouched, not
+      // wrapped or cloned, exactly like before this change.
+      expect(result).toBe(unaryResponse);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('🔵 Request: test.Service.TestMethod'),
+        { hello: 'world' }
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('🟢 Response: test.Service.TestMethod'),
+        { ok: true }
+      );
+    });
+
+    it('wraps a stream response so its messages are logged, still yielding every message', async () => {
+      const messages = [{ a: 1 }, { a: 2 }];
+      const streamResponse = {
+        stream: true,
+        message: fromArray(messages),
+        service: { typeName: 'test.Service' },
+        header: new Headers(),
+        trailer: new Headers(),
+        method: { name: 'TestMethod' },
+      } as unknown as StreamResponse;
+      const next = vi.fn().mockResolvedValue(streamResponse);
+
+      const result = (await loggingInterceptor(next)(
+        makeFakeReq({ stream: true })
+      )) as StreamResponse;
+
+      expect(result.message).not.toBe(streamResponse.message);
+      const received: unknown[] = [];
+      for await (const message of result.message) {
+        received.push(message);
+      }
+      expect(received).toEqual(messages);
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Stream opened: test.Service.TestMethod')
+      );
+    });
+  });
+
+  describe('outside development mode', () => {
+    beforeEach(() => {
+      vi.stubEnv('MODE', 'production');
+    });
+
+    it('logs nothing for a unary response', async () => {
+      const unaryResponse = {
+        stream: false,
+        message: { ok: true },
+        service: { typeName: 'test.Service' },
+        header: new Headers(),
+        trailer: new Headers(),
+        method: { name: 'TestMethod' },
+      } as unknown as UnaryResponse;
+      const next = vi.fn().mockResolvedValue(unaryResponse);
+
+      const result = await loggingInterceptor(next)(makeFakeReq());
+
+      expect(result).toBe(unaryResponse);
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs nothing for a stream response and leaves it completely unwrapped', async () => {
+      const messages = [{ a: 1 }, { a: 2 }];
+      const streamResponse = {
+        stream: true,
+        message: fromArray(messages),
+        service: { typeName: 'test.Service' },
+        header: new Headers(),
+        trailer: new Headers(),
+        method: { name: 'TestMethod' },
+      } as unknown as StreamResponse;
+      const next = vi.fn().mockResolvedValue(streamResponse);
+
+      const result = await loggingInterceptor(next)(
+        makeFakeReq({ stream: true })
+      );
+
+      // Same reference — not wrapped at all when not in development, so
+      // there is zero overhead/behavior change in production.
+      expect(result).toBe(streamResponse);
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs nothing on error, but still rethrows', async () => {
+      const next = vi.fn().mockRejectedValue(new Error('boom'));
+
+      await expect(loggingInterceptor(next)(makeFakeReq())).rejects.toThrow(
+        'boom'
+      );
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -8,6 +8,7 @@ import { CharacterService as CharacterServiceV2 } from '@kirkdiggler/rpg-api-pro
 import { EncounterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 
 import { getDiscordToken, getPlayerId } from './auth';
+import { wrapStreamResponseForLogging } from './streamLogging';
 
 // Get API host from environment - handle Discord Activity proxy
 const isDiscordActivity = window.location.hostname.includes('discordsays.com');
@@ -39,8 +40,10 @@ const authInterceptor: Interceptor = (next) => async (req) => {
   return next(req);
 };
 
-// Logging interceptor for debugging
-const loggingInterceptor: Interceptor = (next) => async (req) => {
+// Logging interceptor for debugging. Exported (only) so it can be unit
+// tested directly against fake `next` responses — not intended as a public
+// API for other modules to import interceptors from.
+export const loggingInterceptor: Interceptor = (next) => async (req) => {
   const startTime = Date.now();
   const methodName = `${req.service.typeName}.${req.method.name}`;
 
@@ -52,6 +55,19 @@ const loggingInterceptor: Interceptor = (next) => async (req) => {
   try {
     const response = await next(req);
     const duration = Date.now() - startTime;
+
+    // Server streams: `response.message` is an AsyncIterable, not a
+    // message — logging it directly (the `else` branch below) only ever
+    // shows the iterator object once, at open, and never a single event.
+    // wrapStreamResponseForLogging replaces it with a lazy logging
+    // generator (see its own doc comment for why this must not buffer).
+    if (response.stream) {
+      if (import.meta.env.MODE === 'development') {
+        return wrapStreamResponseForLogging(methodName, response);
+      }
+      return response;
+    }
+
     if (import.meta.env.MODE === 'development') {
       console.log(
         `🟢 Response: ${methodName} (${duration}ms)`,

--- a/src/api/streamLogging.test.ts
+++ b/src/api/streamLogging.test.ts
@@ -1,0 +1,176 @@
+import type { StreamResponse } from '@connectrpc/connect';
+import { HexState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { wrapStreamResponseForLogging } from './streamLogging';
+
+/** Builds a minimal fake source AsyncIterable from a plain array — mirrors
+ * how a real transport hands the interceptor an AsyncIterable of decoded
+ * messages. */
+async function* fromArray<T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+/** Same duck-typed EncounterEvent shape encounterStreamDispatch.test.ts's
+ * makeEvent() fixture uses ({ event: { case, value } }) — streamLogging
+ * only ever duck-types this shape, never imports the real EncounterEvent
+ * type, so a plain object is a faithful fixture. */
+function makeEncounterEventLike(caseName: string, value: unknown) {
+  return { event: { case: caseName, value } };
+}
+
+function makeStreamResponse<T>(message: AsyncIterable<T>): StreamResponse {
+  return {
+    stream: true,
+    message,
+    service: { typeName: 'test.Service' },
+    header: new Headers(),
+    trailer: new Headers(),
+    method: { name: 'TestStream' },
+  } as unknown as StreamResponse;
+}
+
+/** Drains an AsyncIterable into an array, for order/content assertions. */
+async function drain<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iterable) {
+    out.push(item);
+  }
+  return out;
+}
+
+describe('wrapStreamResponseForLogging', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('yields every message in order, unmodified', async () => {
+    const messages = [
+      makeEncounterEventLike('entityMoved', { entityId: 'a' }),
+      makeEncounterEventLike('doorOpened', { doorEntityId: 'door-east' }),
+      makeEncounterEventLike('turnEnded', { entityId: 'a' }),
+    ];
+    const response = makeStreamResponse(fromArray(messages));
+
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+    const received = await drain(wrapped.message);
+
+    expect(received).toEqual(messages);
+  });
+
+  it('logs one line per message, in order, with an increasing index', async () => {
+    const messages = [
+      makeEncounterEventLike('entityMoved', { entityId: 'a' }),
+      makeEncounterEventLike('doorOpened', { doorEntityId: 'door-east' }),
+    ];
+    const response = makeStreamResponse(fromArray(messages));
+
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+    await drain(wrapped.message);
+
+    // Stream-open + 2 messages + stream-end = 4 log lines.
+    expect(logSpy).toHaveBeenCalledTimes(4);
+    expect(logSpy.mock.calls[0][0]).toContain('Stream opened: Svc.Method');
+    expect(logSpy.mock.calls[1][0]).toMatch(
+      /Svc\.Method #1 \+\d+ms entityMoved/
+    );
+    expect(logSpy.mock.calls[1][1]).toBe(messages[0]);
+    expect(logSpy.mock.calls[2][0]).toMatch(
+      /Svc\.Method #2 \+\d+ms doorOpened/
+    );
+    expect(logSpy.mock.calls[2][1]).toBe(messages[1]);
+    expect(logSpy.mock.calls[3][0]).toContain('Stream ended: Svc.Method');
+    expect(logSpy.mock.calls[3][0]).toContain('2 messages');
+  });
+
+  it('does not buffer — messages are only pulled from the source as the consumer asks for them', async () => {
+    let producedCount = 0;
+    async function* countingSource() {
+      for (let i = 0; i < 3; i++) {
+        producedCount++;
+        yield makeEncounterEventLike('entityMoved', { entityId: `e${i}` });
+      }
+    }
+    const response = makeStreamResponse(countingSource());
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+
+    const iterator = wrapped.message[Symbol.asyncIterator]();
+    await iterator.next();
+    // Only the first message should have been pulled from the underlying
+    // source — a buffering implementation would have drained all 3 eagerly.
+    expect(producedCount).toBe(1);
+
+    await iterator.next();
+    expect(producedCount).toBe(2);
+  });
+
+  it('summarizes hexKnowledgeChanged as hex count / visible-vs-remembered split / entity count', async () => {
+    const hexKnowledgeEvent = makeEncounterEventLike('hexKnowledgeChanged', {
+      hexes: [
+        { state: HexState.VISIBLE },
+        { state: HexState.VISIBLE },
+        { state: HexState.REMEMBERED },
+      ],
+      entities: [{ id: 'goblin-1' }],
+    });
+    const response = makeStreamResponse(fromArray([hexKnowledgeEvent]));
+
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+    await drain(wrapped.message);
+
+    const messageLine = logSpy.mock.calls[1][0] as string;
+    expect(messageLine).toContain(
+      'hexKnowledgeChanged 3 hexes (2 visible, 1 remembered), 1 entities'
+    );
+  });
+
+  it('falls back to the plain case name for a message with no case set', async () => {
+    const response = makeStreamResponse(
+      fromArray([{ event: { case: undefined } }])
+    );
+
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+    await drain(wrapped.message);
+
+    expect(logSpy.mock.calls[1][0]).toContain('(no case set)');
+  });
+
+  it('falls back to no summary label for a non-EncounterEvent-shaped message', async () => {
+    const response = makeStreamResponse(fromArray([{ foo: 'bar' }]));
+
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+    await drain(wrapped.message);
+
+    // No case label, but the method/index/elapsed prefix and the raw
+    // message (as the last console.log argument) are still present.
+    expect(logSpy.mock.calls[1][0]).toMatch(
+      /^🟣 Stream: Svc\.Method #1 \+\d+ms$/
+    );
+    expect(logSpy.mock.calls[1][1]).toEqual({ foo: 'bar' });
+  });
+
+  it('logs and rethrows when the underlying stream errors — never swallows it', async () => {
+    async function* failingSource() {
+      yield makeEncounterEventLike('entityMoved', { entityId: 'a' });
+      throw new Error('boom');
+    }
+    const response = makeStreamResponse(failingSource());
+    const wrapped = wrapStreamResponseForLogging('Svc.Method', response);
+
+    await expect(drain(wrapped.message)).rejects.toThrow('boom');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('Stream error: Svc.Method');
+    expect(errorSpy.mock.calls[0][0]).toContain('1 messages');
+  });
+});

--- a/src/api/streamLogging.ts
+++ b/src/api/streamLogging.ts
@@ -1,0 +1,144 @@
+/**
+ * Per-message logging for Connect server-streaming RPCs.
+ *
+ * client.ts's loggingInterceptor logs unary requests/responses in full, but
+ * is blind to streams: for a `StreamResponse`, `response.message` is an
+ * `AsyncIterable`, not a message — so the interceptor previously logged the
+ * iterator object once, at stream open, and never saw a single event. That
+ * is why live `StreamEncounter` events (fog reveals, entity moves, ...) were
+ * invisible in devtools while ordinary unary calls were fully visible.
+ *
+ * `wrapStreamResponseForLogging` replaces `response.message` with an async
+ * generator that logs each message as it passes through, plus stream
+ * open/end/error, while staying fully lazy — it never buffers, so streaming
+ * behavior (backpressure, cancellation via the request's AbortSignal) is
+ * unchanged. `for await...of` inside the wrapper's generator body forwards
+ * `.return()`/`.throw()` from the consumer straight into the underlying
+ * iterable per the language spec, so early teardown (e.g.
+ * useEncounterStream's abort-on-unmount) still propagates correctly.
+ *
+ * Split out of client.ts (rather than inlined in the interceptor) so that
+ * file stays small/readable and the summarization logic below — in
+ * particular making `hexKnowledgeChanged` genuinely useful, since it's the
+ * event read most — lives in one, independently testable place.
+ */
+import type { StreamResponse } from '@connectrpc/connect';
+import { HexState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+
+interface OneofEnvelope {
+  case: string | undefined;
+  value?: unknown;
+}
+
+/** Duck-types a proto oneof accessor shape ({ case, value }) at `field` —
+ * generic-safe: works for ANY message that happens to carry a oneof named
+ * `field` (EncounterEvent's `event` today), never assumes the message IS
+ * one. */
+function oneofEnvelope(
+  message: unknown,
+  field: string
+): OneofEnvelope | undefined {
+  if (!message || typeof message !== 'object') return undefined;
+  const envelope = (message as Record<string, unknown>)[field];
+  if (!envelope || typeof envelope !== 'object') return undefined;
+  if (!('case' in envelope)) return undefined;
+  return envelope as OneofEnvelope;
+}
+
+/**
+ * Summarizes a HexKnowledgeChanged payload as hex count, the VISIBLE vs
+ * REMEMBERED split, and entity count — e.g. "12 hexes (9 visible, 3
+ * remembered), 2 entities" — rather than a bare object dump. This is the
+ * highest-traffic event on the encounter stream and the hardest to scan
+ * without this: "reveals arrive, un-reveals don't" is immediate from this
+ * one line instead of a console hunt through nested hex arrays.
+ *
+ * Defensive on shape (`value` is `unknown` off the duck-typed oneof) —
+ * falls back to a bare case-name label if `hexes`/`entities` aren't arrays.
+ */
+function summarizeHexKnowledgeChanged(value: unknown): string {
+  if (!value || typeof value !== 'object') return 'hexKnowledgeChanged';
+  const hexes = (value as { hexes?: unknown }).hexes;
+  const entities = (value as { entities?: unknown }).entities;
+  if (!Array.isArray(hexes) || !Array.isArray(entities)) {
+    return 'hexKnowledgeChanged';
+  }
+  const visible = hexes.filter(
+    (hex) => (hex as { state?: unknown }).state === HexState.VISIBLE
+  ).length;
+  const remembered = hexes.filter(
+    (hex) => (hex as { state?: unknown }).state === HexState.REMEMBERED
+  ).length;
+  return `hexKnowledgeChanged ${hexes.length} hexes (${visible} visible, ${remembered} remembered), ${entities.length} entities`;
+}
+
+/**
+ * Summarizes one streamed message for the per-line log label: the oneof
+ * case name for an EncounterEvent-shaped message (`payload.case` — e.g.
+ * "entityMoved") since the case is the thing you actually scan for, a
+ * richer summary for `hexKnowledgeChanged` specifically (see
+ * summarizeHexKnowledgeChanged), and an empty label for anything that
+ * doesn't duck-type as one (a plain-message stream — the full object still
+ * follows as the log's last argument regardless).
+ */
+function summarizeStreamMessage(message: unknown): string {
+  const envelope = oneofEnvelope(message, 'event');
+  if (!envelope) return '';
+  if (envelope.case === undefined) return '(no case set)';
+  if (envelope.case === 'hexKnowledgeChanged') {
+    return summarizeHexKnowledgeChanged(envelope.value);
+  }
+  return envelope.case;
+}
+
+/**
+ * Wraps a StreamResponse's `message` AsyncIterable so each message is
+ * logged as it passes through, plus stream open/end/error. `methodName`
+ * should already be formatted the same way as the unary request/response
+ * logs (`${service.typeName}.${method.name}`) for a consistent devtools
+ * view. Returns a NEW response object (the input is not mutated) whose
+ * `message` is the logging-wrapped generator — every other field is passed
+ * through verbatim.
+ *
+ * Callers gate this behind `import.meta.env.MODE === 'development'`
+ * themselves (see client.ts) — this function always logs when called, so
+ * it must never run in production.
+ */
+export function wrapStreamResponseForLogging<Res extends StreamResponse>(
+  methodName: string,
+  response: Res
+): Res {
+  const openedAt = Date.now();
+  console.log(`🟣 Stream opened: ${methodName}`);
+
+  async function* logged() {
+    let index = 0;
+    try {
+      for await (const message of response.message) {
+        index++;
+        const elapsedMs = Date.now() - openedAt;
+        const label = summarizeStreamMessage(message);
+        console.log(
+          `🟣 Stream: ${methodName} #${index} +${elapsedMs}ms${
+            label ? ` ${label}` : ''
+          }`,
+          message
+        );
+        yield message;
+      }
+      const elapsedMs = Date.now() - openedAt;
+      console.log(
+        `⚪ Stream ended: ${methodName} (${index} messages, ${elapsedMs}ms)`
+      );
+    } catch (err) {
+      const elapsedMs = Date.now() - openedAt;
+      console.error(
+        `🔴 Stream error: ${methodName} (${index} messages, ${elapsedMs}ms)`,
+        err
+      );
+      throw err;
+    }
+  }
+
+  return { ...response, message: logged() };
+}


### PR DESCRIPTION
## Summary

Fixes #648: `client.ts`'s `loggingInterceptor` logged every unary request/response but was blind to server streams — `response.message` for a `StreamResponse` is an `AsyncIterable`, not a message, so the interceptor logged the iterator object once at stream open and never saw a single event afterward. That's why live `StreamEncounter` events (fog reveals, entity moves, ...) were invisible in devtools while ordinary calls were fully visible — diagnosing #609 required a hand-added, hand-removed `console.log`.

## Where I put it, and why

New module: **`src/api/streamLogging.ts`**, imported by `client.ts` rather than inlined there. `client.ts` today is small and purely transport wiring (auth interceptor, logging interceptor, client construction) — the streamed-message summarization logic, especially the `hexKnowledgeChanged`-specific summary, is enough independent logic (and needs its own focused unit tests) that folding it into `client.ts` would bloat the one file that's currently easy to read end-to-end. `client.ts` itself only grew by ~15 lines: a branch on `response.stream` that calls out to `wrapStreamResponseForLogging`.

## What it does

`wrapStreamResponseForLogging(methodName, response)`:
- Logs `🟣 Stream opened: <method>` immediately.
- Replaces `response.message` with an async generator that, for each message pulled through by the consumer: logs `🟣 Stream: <method> #<index> +<elapsedMs>ms <summary>` (full message object as the log's last argument, so it stays expandable in devtools) — **then yields the message unmodified**.
- Logs `⚪ Stream ended: <method> (<n> messages, <ms>ms)` when the source completes, or `🔴 Stream error: <method> (<n> messages, <ms>ms)` + rethrows when it doesn't (so a silently-dying stream, e.g. an `AbortError`, is now visible instead of vanishing).
- **Summary**: for an `EncounterEvent`-shaped message (duck-typed via a `{ event: { case, value } }` check — this module never hard-imports `EncounterEvent`, so it stays generic for any current/future server-streaming RPC), logs the oneof case name (e.g. `entityMoved`) rather than dumping the object, since the case is what you actually scan for. `hexKnowledgeChanged` gets a richer summary — hex count, VISIBLE-vs-REMEMBERED split, entity count, e.g. `hexKnowledgeChanged 12 hexes (9 visible, 3 remembered), 2 entities` — since it's the highest-traffic, hardest-to-scan event on the encounter stream. Anything that doesn't duck-type as an EncounterEvent falls back to no summary label (just method/index/elapsed); the full object is still logged.
- **Stays lazy**: the wrapper is an async generator that pulls from `response.message` one item at a time inside its own `for await...of` — it never buffers ahead. Early consumer teardown (`.return()`, e.g. `useEncounterStream`'s abort-on-unmount) and thrown errors both propagate through to the underlying iterable via standard generator semantics, so cancellation and backpressure are unchanged.
- Gated in `client.ts` (not inside the wrapper) behind the existing `import.meta.env.MODE === 'development'` check — in any other mode, a stream response is returned completely untouched (same reference), zero overhead, exactly like before this change.

`loggingInterceptor` is now exported from `client.ts` (only) so it can be unit-tested directly against fake `next` responses, without spinning up a real transport.

## Tests

**`src/api/streamLogging.test.ts`** (7 tests): yields every message in order/unmodified; logs one line per message with an increasing index + stream open/end lines; **does not buffer** (a counting source proves only 1 message is pulled per `.next()`, never all 3 eagerly); `hexKnowledgeChanged` summarized correctly; falls back to `(no case set)` for an unset oneof case; falls back to no summary label (method/index/elapsed only) for a non-EncounterEvent-shaped message; logs and **rethrows** (never swallows) a mid-stream error.

**`src/api/client.test.ts`** (5 tests): in development mode — a unary response is logged and returned **unchanged (same reference)**, proving it "behaves exactly as before"; a stream response is wrapped and still yields every message. Outside development mode — nothing logs for a unary response, nothing logs for a stream response **and it's returned completely unwrapped (same reference)**, and an error still rethrows silently (no console noise) — proving the `MODE` gate holds for every path.

## Bar (real output)

```
npx tsc -b --noEmit        → clean, no output
npm run lint                 → 0 errors (1 pre-existing warning, unrelated file: src/components/hex-grid/useHexMovePath.ts)
npm run format:check         → All matched files use Prettier code style!
npx vitest run               → Test Files 90 passed (90), Tests 1564 passed (1564)
npm run build                  → built in 8.17s (pre-existing chunk-size warning only)
```
Pre-push hook's own `ci-check.sh` (format + lint + tsc + build + tests) also passed clean before the push completed.

## Anything not done / could not do honestly

Nothing withheld. One judgment call worth flagging explicitly: I exported `loggingInterceptor` from `client.ts` (it was previously module-private) purely so it's directly unit-testable — it's not intended as a public API surface for other modules to build on, just a test seam. Said so in the code comment at the export site.

Fixes #648.
