### PR TITLE
Render remembered fog-of-war knowledge (floor, walls, entities)

### DIFF
--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -37,6 +37,7 @@ import {
   connectorFallbackSegments,
   legacyRenderWalls,
   regionInputsFromHexes,
+  rememberedHexKeysFromRecords,
 } from '../../hooks/wallRunAdapters';
 import { computeWallRuns } from '../../hooks/wallRuns';
 import { WALL_HEIGHT } from '../../rendering/calibrationConstants';
@@ -208,6 +209,17 @@ export function EncounterMap({
     () => regionInputsFromHexes(revealedHexes.values()),
     [revealedHexes]
   );
+  // Fog-of-war render state (rpg-dnd5e-web#605/#609): every REMEMBERED
+  // hex's own key (floor) plus every REMEMBERED hex's edges' own `from` key
+  // (walls) — HexGrid's `rememberedFloorHexKeys`/`rememberedWallHexKeys`
+  // shape, fed straight through below. HexGrid already owns all the actual
+  // charcoal tinting, click/hover/path suppression, and remembered-run
+  // derivation (`rememberedWallRunIds`) once it has these two sets; this is
+  // the only place on this route that was missing them.
+  const rememberedHexKeys = useMemo(
+    () => rememberedHexKeysFromRecords(revealedHexes.values()),
+    [revealedHexes]
+  );
   const connectorDoors = useMemo(
     () => connectorDoorInputsFromWalls(wallList),
     [wallList]
@@ -278,17 +290,22 @@ export function EncounterMap({
       entities,
       entityMeta,
       entityHP,
-      entityStatuses
+      entityStatuses,
+      revealedHexes
     );
     if (devPropDemoKeys.length === 0) return base;
     const anchor = (base.find((e) => e.entityId === myEntityId) ?? base[0])
       ?.position;
+    // Dev prop-demo entities are synthetic and always "here" — they never
+    // get a knowledgeState (undefined, i.e. rendered live), same as every
+    // other field buildDevPropDemoEntities doesn't set.
     return [...base, ...buildDevPropDemoEntities(devPropDemoKeys, anchor)];
   }, [
     entities,
     entityMeta,
     entityHP,
     entityStatuses,
+    revealedHexes,
     devPropDemoKeys,
     myEntityId,
   ]);
@@ -504,8 +521,10 @@ export function EncounterMap({
     >
       <HexGrid
         floorTiles={floorTiles}
+        rememberedFloorHexKeys={rememberedHexKeys.floorKeys}
         entities={renderableEntities}
         walls={wallList}
+        rememberedWallHexKeys={rememberedHexKeys.wallKeys}
         legacySyntyWalls={legacySyntyWalls}
         envelopeRuns={wallRunsResult.envelopeRuns}
         envelopeCorners={wallRunsResult.envelopeCorners}

--- a/src/components/hex-grid/HexEntity.test.tsx
+++ b/src/components/hex-grid/HexEntity.test.tsx
@@ -121,3 +121,41 @@ describe('remembered entities are inert', () => {
     expect(handlerCount(renderer, 'onClick')).toBe(0);
   });
 });
+
+describe('remembered entities look like a memory (rpg-dnd5e-web#605/#609)', () => {
+  // An obstacle with no obstacleType/propRefId resolves no prop variant
+  // (obstaclePropKeys.ts), so HexEntity falls back to the plain capsule —
+  // the same fallback a real pillar/prop renders through whenever its GLB
+  // hasn't synced (HexGrid's ErrorBoundary lineage), so this capsule path
+  // is not a toy case.
+  function capsuleMaterial(
+    renderer: Awaited<ReturnType<typeof ReactThreeTestRenderer.create>>
+  ) {
+    const mesh = renderer.scene.findAllByType('Mesh')[0] as unknown as {
+      instance: THREE.Mesh;
+    };
+    return mesh.instance.material as THREE.MeshStandardMaterial;
+  }
+
+  it('tints a remembered obstacle capsule with the shared crypt-memory color', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <HexEntity {...base} type="obstacle" knowledgeState="remembered" />
+    );
+    // '#805ad5' (COLORS.obstacle.default) multiplied by CRYPT_MEMORY_COLOR
+    // '#465366' is exactly CRYPT_MEMORY_COLOR's own hex — matches
+    // cloneCryptMaterials' `color.multiply(CRYPT_MEMORY_COLOR)` when the
+    // fallback capsule is built directly from cryptHex rather than routed
+    // through that helper; either way the visible result is the same
+    // shared memory tint.
+    const color = capsuleMaterial(renderer).color;
+    expect(`#${color.getHexString()}`).toBe('#465366');
+  });
+
+  it('renders a live (non-remembered) obstacle capsule in its normal color, unchanged', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <HexEntity {...base} type="obstacle" />
+    );
+    const color = capsuleMaterial(renderer).color;
+    expect(`#${color.getHexString()}`).toBe('#805ad5');
+  });
+});

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -607,7 +607,7 @@ export function HexEntity({
       {...(withInteraction ? interactionProps : {})}
     >
       <meshStandardMaterial
-        color={color}
+        color={remembered ? cryptHex : color}
         emissive={selected ? color : '#000000'}
         emissiveIntensity={selected ? 0.2 : 0}
       />
@@ -629,6 +629,7 @@ export function HexEntity({
             variant={propVariant}
             position={[0, 0, 0]}
             rotationY={propRotationY}
+            remembered={remembered}
           />
         </ErrorBoundary>
       </Suspense>

--- a/src/components/hex-grid/PropModel.test.tsx
+++ b/src/components/hex-grid/PropModel.test.tsx
@@ -160,3 +160,55 @@ describe('PropModel renderScale (rpg-game-assets#36 wave-1, issue #623 fast-foll
     expect(outerGroupScale(renderer)).toBeCloseTo(SYNTY_SCALE * 2);
   });
 });
+
+describe('PropModel remembered tinting (rpg-dnd5e-web#605/#609)', () => {
+  function meshMaterials(renderer: {
+    scene: { findAllByType: (t: string) => unknown[] };
+  }): THREE.MeshStandardMaterial[] {
+    return renderer.scene
+      .findAllByType('Mesh')
+      .map(
+        (n) =>
+          (n as { instance: THREE.Mesh }).instance
+            .material as THREE.MeshStandardMaterial
+      );
+  }
+
+  it('leaves the parent mesh untinted when remembered is omitted — every pre-existing caller, unchanged', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <PropModel variant={BASE_VARIANT} position={[0, 0, 0]} />
+    );
+    const [material] = meshMaterials(renderer);
+    expect(`#${material!.color.getHexString()}`).toBe('#ffffff');
+  });
+
+  it('tints the parent mesh with the shared crypt-memory color when remembered', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <PropModel variant={BASE_VARIANT} position={[0, 0, 0]} remembered />
+    );
+    const [material] = meshMaterials(renderer);
+    // White (the mock's default MeshStandardMaterial color) multiplied by
+    // CRYPT_MEMORY_COLOR is exactly CRYPT_MEMORY_COLOR itself.
+    expect(`#${material!.color.getHexString()}`).toBe('#465366');
+  });
+
+  it('tints every companion mesh alongside the parent when remembered — a remembered candle prop does not leave its flame at full brightness', async () => {
+    const variant: PropVariant = {
+      ...BASE_VARIANT,
+      companions: [
+        {
+          name: 'SM_Prop_Candles_01_Particle',
+          file: 'props/SM_Prop_Candles_01_Particle.glb',
+        },
+      ],
+    };
+    const renderer = await ReactThreeTestRenderer.create(
+      <PropModel variant={variant} position={[0, 0, 0]} remembered />
+    );
+    const materials = meshMaterials(renderer);
+    expect(materials).toHaveLength(2);
+    for (const material of materials) {
+      expect(`#${material.color.getHexString()}`).toBe('#465366');
+    }
+  });
+});

--- a/src/components/hex-grid/PropModel.tsx
+++ b/src/components/hex-grid/PropModel.tsx
@@ -54,16 +54,29 @@
  * SYNTY_SCALE, not derived from `footprintHexes`. See that field's own doc
  * comment in propManifest.ts for why it exists and how its value was
  * picked.
+ *
+ * Remembered tinting (rpg-dnd5e-web#605/#609): `remembered` applies the
+ * SAME shared crypt-memory material treatment ClassCharacterModel.tsx uses
+ * for player/monster models (`cloneCryptMaterials`, sceneKnowledge.ts) — a
+ * frozen prop reads as memory identically to a frozen character, rather
+ * than a second approximation. This was exactly the follow-up this file's
+ * own header comment flagged ("no material clone/dispose effect is needed
+ * unless a future slice adds per-instance tinting... the pattern to
+ * follow"). Each companion mesh (e.g. candles' flame pieces) gets the same
+ * treatment independently, so a remembered candle prop doesn't leave its
+ * flame glowing at full brightness.
  */
 
 import { SYNTY_SCALE } from '@/rendering/calibrationConstants';
 import { useGLTF } from '@react-three/drei';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
 import {
   PROPS_MODEL_BASE,
   type PropCompanion,
   type PropVariant,
 } from './propManifest';
+import { cloneCryptMaterials } from './sceneKnowledge';
 
 export interface PropModelProps {
   variant: PropVariant;
@@ -71,6 +84,45 @@ export interface PropModelProps {
    * caller — see HexEntity.tsx's cubeToWorld usage). */
   position: [number, number, number];
   rotationY?: number;
+  /** Render as the viewer's frozen last observation (rpg-dnd5e-web#605/
+   * #609) — the same shared crypt-memory material tint
+   * ClassCharacterModel.tsx applies to player/monster models. Defaults
+   * false, matching every caller before this prop existed. */
+  remembered?: boolean;
+}
+
+/** Snapshot each mesh's original (untinted) material once per `object`
+ * identity, then apply (or remove) the shared crypt-memory tint when
+ * `remembered` toggles — same "snapshot once, tint as a separate effect"
+ * split ClassCharacterModel.tsx uses, so neither a fresh clone/mount nor a
+ * remembered toggle can compound a tint onto an already-tinted material.
+ * Shared by both the parent variant and each companion mesh below. */
+function useRememberedTint(object: THREE.Object3D, remembered: boolean) {
+  const originalMaterials = useMemo(() => {
+    const map = new Map<THREE.Mesh, THREE.Material | THREE.Material[]>();
+    object.traverse((child) => {
+      if (child instanceof THREE.Mesh) map.set(child, child.material);
+    });
+    return map;
+  }, [object]);
+
+  useEffect(() => {
+    if (!remembered) {
+      originalMaterials.forEach((mat, mesh) => {
+        mesh.material = mat;
+      });
+      return () => {};
+    }
+    const created: THREE.Material[] = [];
+    originalMaterials.forEach((mat, mesh) => {
+      const crypt = cloneCryptMaterials(mat);
+      (Array.isArray(crypt) ? crypt : [crypt]).forEach((m) => created.push(m));
+      mesh.material = crypt;
+    });
+    return () => {
+      created.forEach((mat) => mat.dispose());
+    };
+  }, [originalMaterials, remembered]);
 }
 
 /** One companion mesh, loaded/cloned independently of its parent (its own
@@ -78,9 +130,16 @@ export interface PropModelProps {
  * transform of its own — the parent `<group>` in `PropModel` below
  * supplies position/rotation/scale for both the parent variant and every
  * companion alike, so a companion always sits at its parent's anchor. */
-function PropCompanionModel({ companion }: { companion: PropCompanion }) {
+function PropCompanionModel({
+  companion,
+  remembered,
+}: {
+  companion: PropCompanion;
+  remembered: boolean;
+}) {
   const { scene } = useGLTF(PROPS_MODEL_BASE + companion.file);
   const cloned = useMemo(() => scene.clone(true), [scene]);
+  useRememberedTint(cloned, remembered);
   return <primitive object={cloned} />;
 }
 
@@ -88,9 +147,11 @@ export function PropModel({
   variant,
   position,
   rotationY = 0,
+  remembered = false,
 }: PropModelProps) {
   const { scene } = useGLTF(PROPS_MODEL_BASE + variant.file);
   const cloned = useMemo(() => scene.clone(true), [scene]);
+  useRememberedTint(cloned, remembered);
 
   return (
     <group
@@ -100,7 +161,11 @@ export function PropModel({
     >
       <primitive object={cloned} />
       {variant.companions?.map((companion) => (
-        <PropCompanionModel key={companion.file} companion={companion} />
+        <PropCompanionModel
+          key={companion.file}
+          companion={companion}
+          remembered={remembered}
+        />
       ))}
     </group>
   );

--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -12,6 +12,8 @@ import { create } from '@bufbuild/protobuf';
 import type { EntityState } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import {
   EntityType,
+  HexRecordSchema,
+  HexState,
   PositionSchema,
   WallKind,
   WallSchema,
@@ -347,6 +349,92 @@ describe('buildRenderableEntities', () => {
     ]);
     const list = buildRenderableEntities(entities, new Map(), new Map());
     expect(list).toHaveLength(0);
+  });
+
+  describe('knowledgeState (rpg-dnd5e-web#605/#609)', () => {
+    it('leaves knowledgeState undefined when revealedHexes is omitted (PlaytestMap harness, byte-identical to pre-fog behavior)', () => {
+      const entities = new Map([
+        ['char-alice', makeEntityState('char-alice', { x: 0, y: 0, z: 0 })],
+      ]);
+      const meta = new Map<string, EntityMeta>([
+        ['char-alice', { type: EntityType.CHARACTER, monsterRefId: undefined }],
+      ]);
+
+      const list = buildRenderableEntities(entities, meta, new Map());
+      expect(list[0]?.knowledgeState).toBeUndefined();
+    });
+
+    it("marks an entity 'remembered' when its position's hex record is HEX_STATE_REMEMBERED", () => {
+      const entities = new Map([
+        ['goblin-1', makeEntityState('goblin-1', { x: 1, y: -1, z: 0 })],
+      ]);
+      const meta = new Map<string, EntityMeta>([
+        ['goblin-1', { type: EntityType.MONSTER, monsterRefId: 'goblin' }],
+      ]);
+      const revealedHexes = new Map([
+        [
+          '1,-1,0',
+          create(HexRecordSchema, {
+            position: create(PositionSchema, { x: 1, y: -1, z: 0 }),
+            state: HexState.REMEMBERED,
+          }),
+        ],
+      ]);
+
+      const list = buildRenderableEntities(
+        entities,
+        meta,
+        new Map(),
+        undefined,
+        revealedHexes
+      );
+      expect(list[0]?.knowledgeState).toBe('remembered');
+    });
+
+    it("marks an entity 'visible' when its position's hex record is HEX_STATE_VISIBLE", () => {
+      const entities = new Map([
+        ['char-alice', makeEntityState('char-alice', { x: 0, y: 0, z: 0 })],
+      ]);
+      const meta = new Map<string, EntityMeta>([
+        ['char-alice', { type: EntityType.CHARACTER, monsterRefId: undefined }],
+      ]);
+      const revealedHexes = new Map([
+        [
+          '0,0,0',
+          create(HexRecordSchema, {
+            position: create(PositionSchema, { x: 0, y: 0, z: 0 }),
+            state: HexState.VISIBLE,
+          }),
+        ],
+      ]);
+
+      const list = buildRenderableEntities(
+        entities,
+        meta,
+        new Map(),
+        undefined,
+        revealedHexes
+      );
+      expect(list[0]?.knowledgeState).toBe('visible');
+    });
+
+    it("falls back to 'visible' when revealedHexes has no record for the entity's position", () => {
+      const entities = new Map([
+        ['char-alice', makeEntityState('char-alice', { x: 5, y: -5, z: 0 })],
+      ]);
+      const meta = new Map<string, EntityMeta>([
+        ['char-alice', { type: EntityType.CHARACTER, monsterRefId: undefined }],
+      ]);
+
+      const list = buildRenderableEntities(
+        entities,
+        meta,
+        new Map(),
+        undefined,
+        new Map()
+      );
+      expect(list[0]?.knowledgeState).toBe('visible');
+    });
   });
 });
 

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -16,10 +16,15 @@ import {
   PositionSchema,
   WallKind,
   WallSchema,
+  type HexRecord,
   type Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import type { AbsoluteFloorTile } from '../../hooks/dungeonMapGeometry';
-import type { EntityMeta, EntityStatus } from '../../hooks/useEncounterState';
+import {
+  knowledgeStateForPosition,
+  type EntityMeta,
+  type EntityStatus,
+} from '../../hooks/useEncounterState';
 import { CUTAWAY_TALL_WALL_HEIGHT } from '../../rendering/calibrationConstants';
 import {
   coordToKey,
@@ -28,6 +33,7 @@ import {
   HEX_SIZE,
   type CubeCoord,
 } from '../hex-grid/hexMath';
+import type { SceneKnowledgeState } from '../hex-grid/sceneKnowledge';
 
 /**
  * Render shape consumed by HexGrid for each entity on the map.
@@ -68,6 +74,14 @@ export interface RenderableEntity {
   /** Monotonic counter bumped only by a genuine move — see
    * `useEncounterState.ts`'s `mergeEntityPosition` doc comment. */
   moveSeq?: number;
+  /** Fog-of-war render state (rpg-dnd5e-web#605/#609) — 'remembered' drives
+   * HexGrid's charcoal tint and click/hover/path suppression for an entity
+   * standing in a hex the viewer no longer has line of sight to. Undefined
+   * (every caller that doesn't pass `revealedHexes` to
+   * `buildRenderableEntities` below, i.e. PlaytestMap's harness route,
+   * which has no per-hex `HexRecord.state` to resolve against) renders
+   * exactly like 'visible' — HexGrid's own `isRemembered` default. */
+  knowledgeState?: SceneKnowledgeState;
 }
 
 /** Checks for a status whose source ref id is "unconscious" — the only
@@ -141,6 +155,13 @@ export function entityTypeToDisplay(
  * callers/tests that don't track conditions keep compiling — an empty
  * statuses map is a legitimate real state (isDowned simply stays false),
  * not a stand-in for a required argument callers must now all supply.
+ *
+ * `revealedHexes` (optional, rpg-dnd5e-web#605/#609): the real route's
+ * per-hex `HexRecord` map, used to resolve each entity's `knowledgeState`
+ * via `knowledgeStateForPosition`. Omitted (PlaytestMap's harness, which
+ * only tracks a bare revealed-position `Set`, never real `HexRecord.state`)
+ * leaves every entity's `knowledgeState` undefined — byte-identical to
+ * before this parameter existed.
  */
 export function buildRenderableEntities(
   entities: Map<
@@ -153,7 +174,8 @@ export function buildRenderableEntities(
   >,
   entityMeta: Map<string, EntityMeta>,
   entityHP: Map<string, { current: number; max: number }>,
-  entityStatuses: Map<string, EntityStatus[]> | undefined = new Map()
+  entityStatuses: Map<string, EntityStatus[]> | undefined = new Map(),
+  revealedHexes?: Map<string, HexRecord>
 ): RenderableEntity[] {
   const result: RenderableEntity[] = [];
   for (const [id, entity] of entities.entries()) {
@@ -170,14 +192,15 @@ export function buildRenderableEntities(
     const displayName = meta?.monsterRefId
       ? `${id} (${meta.monsterRefId})`
       : id;
+    const position = {
+      x: entity.position.x ?? 0,
+      y: entity.position.y ?? 0,
+      z: entity.position.z ?? 0,
+    };
     result.push({
       entityId: id,
       name: displayName,
-      position: {
-        x: entity.position.x ?? 0,
-        y: entity.position.y ?? 0,
-        z: entity.position.z ?? 0,
-      },
+      position,
       type: entityTypeToDisplay(meta?.type),
       isDead,
       isGhost: entity.ghost === true,
@@ -187,6 +210,9 @@ export function buildRenderableEntities(
       propRefId: meta?.propRefId,
       movePath: entity.movePath,
       moveSeq: entity.moveSeq,
+      knowledgeState: revealedHexes
+        ? knowledgeStateForPosition(revealedHexes, position)
+        : undefined,
     });
   }
   return result;

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -76,6 +76,7 @@ import {
   applyWallsRevealed,
   createEmptyEncounterState,
   hexesWithPosition,
+  knowledgeStateForPosition,
   mergeEntityPosition,
   regionForHex,
   setPendingPromptReducer,
@@ -881,6 +882,32 @@ describe('v1alpha2 reducer additions', () => {
         state = applyWallsRevealed(state, hex.edges);
 
         expect(state.walls.get(wallKey(wall))).toBe(wall);
+      });
+    });
+
+    describe('knowledgeStateForPosition (rpg-dnd5e-web#605/#609)', () => {
+      it("returns 'remembered' for a position whose hex record is HEX_STATE_REMEMBERED", () => {
+        const hex = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.REMEMBERED);
+        const revealedHexes = new Map([['1,-1,0', hex]]);
+
+        expect(
+          knowledgeStateForPosition(revealedHexes, { x: 1, y: -1, z: 0 })
+        ).toBe('remembered');
+      });
+
+      it("returns 'visible' for a position whose hex record is HEX_STATE_VISIBLE", () => {
+        const hex = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE);
+        const revealedHexes = new Map([['0,0,0', hex]]);
+
+        expect(
+          knowledgeStateForPosition(revealedHexes, { x: 0, y: 0, z: 0 })
+        ).toBe('visible');
+      });
+
+      it("falls back to 'visible' for a position with no hex record at all", () => {
+        expect(
+          knowledgeStateForPosition(new Map(), { x: 9, y: -9, z: 0 })
+        ).toBe('visible');
       });
     });
   });

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -41,6 +41,7 @@ import type {
 import {
   EncounterMode,
   EntityType,
+  HexState,
   WallKind,
   WallSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
@@ -437,6 +438,29 @@ export function regionForHex(
     theme: state.theme,
     zone: hex?.zoneId ? state.zones.get(hex.zoneId) : undefined,
   };
+}
+
+/**
+ * Fog-of-war knowledge state for a position (rpg-dnd5e-web#605/#609):
+ * a REMEMBERED hex record renders frozen/charcoal (sceneKnowledge.ts's
+ * `SceneKnowledgeState` — kept as a plain literal union here rather than
+ * importing that type, so this state-layer module stays independent of the
+ * render-layer one), everything else — a VISIBLE record, or no record at
+ * all — renders live.
+ *
+ * A position with no matching hex record falls back to 'visible' rather
+ * than fail-closed hiding: `applyHexRecordsMerged` only ever caches an
+ * entity's position from a hex record's own `contents`, so a real entity
+ * should always resolve here — this is a defensive default for a position
+ * this genuinely cannot resolve (e.g. a synthetic/dev-only entity), not an
+ * expected miss.
+ */
+export function knowledgeStateForPosition(
+  revealedHexes: Map<string, HexRecord>,
+  position: { x: number; y: number; z: number }
+): 'visible' | 'remembered' {
+  const hex = revealedHexes.get(hexKey(protoPositionToHex(position)));
+  return hex?.state === HexState.REMEMBERED ? 'remembered' : 'visible';
 }
 
 /**

--- a/src/hooks/wallRunAdapters.test.ts
+++ b/src/hooks/wallRunAdapters.test.ts
@@ -8,6 +8,7 @@ import { CUTAWAY_STUB_WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { create } from '@bufbuild/protobuf';
 import {
   HexRecordSchema,
+  HexState,
   PositionSchema,
   WallKind,
   WallSchema,
@@ -23,6 +24,7 @@ import {
   connectorRunDoorRotations,
   legacyRenderWalls,
   regionInputsFromHexes,
+  rememberedHexKeysFromRecords,
 } from './wallRunAdapters';
 import {
   computeWallRuns,
@@ -34,10 +36,19 @@ import {
   type RegionInput,
 } from './wallRuns';
 
-function hex(x: number, y: number, z: number, zoneId = '') {
+function hex(
+  x: number,
+  y: number,
+  z: number,
+  zoneId = '',
+  state: HexState = HexState.UNSPECIFIED,
+  edges: Wall[] = []
+) {
   return create(HexRecordSchema, {
     position: create(PositionSchema, { x, y, z }),
     zoneId,
+    state,
+    edges,
   });
 }
 
@@ -85,6 +96,45 @@ describe('regionInputsFromHexes', () => {
     const positionless = create(HexRecordSchema, { zoneId: 'entrance' });
     const regions = regionInputsFromHexes([positionless]);
     expect(regions).toHaveLength(0);
+  });
+});
+
+describe('rememberedHexKeysFromRecords (rpg-dnd5e-web#605/#609)', () => {
+  it("collects a REMEMBERED record's own key into floorKeys", () => {
+    const hexes = [
+      hex(0, 0, 0, 'entrance', HexState.VISIBLE),
+      hex(1, -1, 0, 'entrance', HexState.REMEMBERED),
+    ];
+    const { floorKeys } = rememberedHexKeysFromRecords(hexes);
+    expect(floorKeys.has('1,-1,0')).toBe(true);
+    expect(floorKeys.has('0,0,0')).toBe(false);
+  });
+
+  it("collects a REMEMBERED record's own edges by their own `from` key into wallKeys", () => {
+    const edge = wall(1, -1, 0, 2, -2, 0, WallKind.SOLID);
+    const hexes = [hex(1, -1, 0, 'entrance', HexState.REMEMBERED, [edge])];
+    const { wallKeys } = rememberedHexKeysFromRecords(hexes);
+    expect(wallKeys.has('1,-1,0')).toBe(true);
+  });
+
+  it('contributes no wall key for a REMEMBERED record with no edges (known server-side gap)', () => {
+    const hexes = [hex(1, -1, 0, 'entrance', HexState.REMEMBERED, [])];
+    const { wallKeys } = rememberedHexKeysFromRecords(hexes);
+    expect(wallKeys.size).toBe(0);
+  });
+
+  it("ignores a VISIBLE record's edges entirely", () => {
+    const edge = wall(0, 0, 0, 1, -1, 0, WallKind.SOLID);
+    const hexes = [hex(0, 0, 0, 'entrance', HexState.VISIBLE, [edge])];
+    const { floorKeys, wallKeys } = rememberedHexKeysFromRecords(hexes);
+    expect(floorKeys.size).toBe(0);
+    expect(wallKeys.size).toBe(0);
+  });
+
+  it('returns empty sets for no hexes', () => {
+    const { floorKeys, wallKeys } = rememberedHexKeysFromRecords([]);
+    expect(floorKeys.size).toBe(0);
+    expect(wallKeys.size).toBe(0);
   });
 });
 

--- a/src/hooks/wallRunAdapters.ts
+++ b/src/hooks/wallRunAdapters.ts
@@ -23,6 +23,7 @@ import {
 import { isDoorWallKind } from '@/components/hex-grid/syntyHexWallHelpers';
 import { connectorPartitionHeight } from '@/components/hex-grid/wallRunMeshHelpers';
 import {
+  HexState,
   type HexRecord,
   type Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
@@ -65,6 +66,45 @@ export function regionInputsFromHexes(
     }
   }
   return Array.from(byZone, ([id, coordHexes]) => ({ id, hexes: coordHexes }));
+}
+
+/**
+ * Remembered-hex key sets, in HexGrid's own `rememberedFloorHexKeys`/
+ * `rememberedWallHexKeys` shape (rpg-dnd5e-web#605/#609's
+ * `HexState.REMEMBERED`) — the same VISIBLE/REMEMBERED partition
+ * the fog-of-war CONCEPT's adapter already proved and had signed off
+ * visually (`src/concepts/fog-of-war/adapter.ts`'s `toHexGridProps`),
+ * reused here on the real route's `HexRecord[]` rather than re-derived.
+ *
+ * Floor: every REMEMBERED record's own key (`coordToKey(hex.position)`).
+ *
+ * Walls: keyed by each edge's OWN `from`, NOT the record's position —
+ * matches HexGrid's own lookup (`rememberedWallHexKeys?.has(wallKey-ish
+ * "x,y,z")` against `Wall.from`, see HexGrid.tsx's `visibleWalls`/
+ * `shadedWalls`). Keying by the record instead would silently mislabel any
+ * edge authored against a neighbour.
+ *
+ * A REMEMBERED record's `edges` arrives empty today (known server-side
+ * gap: remembered hexes carry no edges yet, so a remembered room currently
+ * renders with no walls at all rather than shaded ones) — this still
+ * contributes the correct entry once that gap closes, rather than needing a
+ * second pass then.
+ */
+export function rememberedHexKeysFromRecords(hexes: Iterable<HexRecord>): {
+  floorKeys: Set<string>;
+  wallKeys: Set<string>;
+} {
+  const floorKeys = new Set<string>();
+  const wallKeys = new Set<string>();
+  for (const hex of hexes) {
+    if (hex.state !== HexState.REMEMBERED || !hex.position) continue;
+    floorKeys.add(coordToKey(hex.position));
+    for (const edge of hex.edges) {
+      if (!edge.from) continue;
+      wallKeys.add(coordToKey(edge.from));
+    }
+  }
+  return { floorKeys, wallKeys };
 }
 
 /**


### PR DESCRIPTION
## Summary

The game route received fog-of-war knowledge (`HexRecord.state`: VISIBLE/REMEMBERED) over the wire, stored it, and then dropped it — `EncounterMap.tsx` never fed `HexGrid`'s existing `rememberedFloorHexKeys`/`rememberedWallHexKeys`/entity `knowledgeState` props, so a hex that left line of sight rendered exactly like the old pre-fog behavior (nothing changed) instead of going charcoal.

This PR wires that up, reusing the fog-of-war **concept**'s proven contract (`src/concepts/fog-of-war/adapter.ts`, already signed off visually) rather than inventing a second one:

- **`src/hooks/wallRunAdapters.ts`** — new `rememberedHexKeysFromRecords(hexes)`: partitions revealed `HexRecord[]` into `{ floorKeys, wallKeys }` exactly like the concept adapter (floor keyed by the REMEMBERED record's own position; walls keyed by each REMEMBERED record's edges' own `from`). `HexGrid` already derives all the actual charcoal tinting, click/hover/path suppression, and remembered-wall-run classification internally once given these two sets — this was the only missing piece on the floor/wall side.
- **`src/hooks/useEncounterState.ts`** — new `knowledgeStateForPosition(revealedHexes, position)`: resolves whether the hex at a position is currently VISIBLE or REMEMBERED, returning HexGrid's `'visible' | 'remembered'` vocabulary.
- **`src/components/playtest/playtestMapHelpers.ts`** — `buildRenderableEntities` takes an optional `revealedHexes` param and now sets `RenderableEntity.knowledgeState` from it. Omitted (PlaytestMap's harness, which only tracks a bare position `Set`, never real `HexRecord.state`) leaves `knowledgeState` undefined — byte-identical to before.
- **`src/components/game/EncounterMap.tsx`** — the only real estate change: computes `rememberedHexKeys` via the new adapter and passes `rememberedFloorHexKeys`/`rememberedWallHexKeys` to `HexGrid`, and passes `revealedHexes` into `buildRenderableEntities`.

### Gap found while verifying live (fixed in this PR too)

Driving a real character through Home → Lobby → Ready → Start and walking behind a pillar surfaced that `HexEntity.tsx`'s obstacle/prop rendering path never applied the remembered crypt-memory tint that player/monster models already had via `ClassCharacterModel`'s `cloneCryptMaterials`. A remembered pillar/prop rendered at full brightness — not inert-and-shadowed as the design calls for. Fixed:

- **`src/components/hex-grid/PropModel.tsx`** — new `remembered` prop, using the exact same shared `cloneCryptMaterials` treatment (snapshot-original-materials-once, tint-as-a-separate-effect) `ClassCharacterModel.tsx` already uses. Applies to companion meshes too (e.g. a remembered candle's flame no longer glows at full brightness). This is literally the follow-up this file's own header comment flagged: *"no material clone/dispose effect is needed unless a future slice adds per-instance tinting... the pattern to follow."*
- **`src/components/hex-grid/HexEntity.tsx`** — the obstacle capsule fallback (used whenever a prop's GLB hasn't synced, via the same ErrorBoundary lineage as everything else in this file) now uses `cryptHex` when remembered, matching every other fallback in this file. `<PropModel>` now receives `remembered={remembered}`.

### Semantics preserved

- Unexplored = absent from the map entirely (unchanged, still renders black).
- VISIBLE = current truth, rendered live.
- REMEMBERED = frozen last observation, charcoal; not clickable/hoverable/targetable/pathable (`HexGrid`'s pre-existing `isRemembered`/`entityClickHandler` machinery — unchanged, just now actually fed).
- Remembered content is never reconciled against live state — it's whatever `HexRecord.contents` said at merge time (`useEncounterState.applyHexRecordsMerged`, unchanged).
- **Known server-side gap, not compensated for client-side**: a REMEMBERED record currently carries no `edges`, so a remembered room renders with no walls today. `rememberedHexKeysFromRecords` is still correct once that gap closes (it reads `hex.edges` directly), it just usually finds none to contribute right now.

## Verified live (real gameplay, not just unit tests)

Built a throwaway character (`?playerId=pillarwalker`, a distinct id — `alice`/`test-player` were taken) through the real character-creation wizard, then drove Home → Lobby → Ready → Start into a real freshly-generated encounter, on my own `npm run dev -- --port 3021` (Synty assets aren't synced in this dev checkout, so it renders through `ShadedHexFloor`/`ShadedHexWall`/the obstacle capsule fallback — the same fallback path production falls back to on a missing GLB, so this is a real, load-bearing render path, not a toy one).

Walked the character (via the real `MoveEntity` RPC / server-validated path — not simulated) until a pillar (`obstacle-pillars-3`, a `dnd5e:props:pillar` obstacle) left line of sight. Confirmed via the live React tree:

- `HexGrid`'s own `entities` prop: `obstacle-pillars-3` → `knowledgeState: "remembered"`, every other pillar/entity still `"visible"`.
- `HexGrid`'s own `rememberedFloorHexKeys`/`rememberedWallHexKeys` props: non-empty (45 floor hexes, 3 wall hexes) once fog state existed to feed them.

And visually: the remembered pillar rendered dark navy (the shared crypt-memory tint) while five other still-visible pillars stayed bright purple in the same frame, and a wall run in the newly-remembered area picked up the same dark tint against every other (still plain gray) wall. Floor charcoal tinting is the same `rememberedFloorHexKeys` prop feeding `ShadedHexFloor`'s pre-existing `CRYPT_MEMORY_COLOR` override (unmodified code) — verified via the prop count, not a distinguishable screenshot crop, since the base shaded-floor gray and the charcoal tint are close in this renderer.

Screenshots captured during this session live under this job's scratch dir (not embeddable here — no image-hosting step in this flow, per this repo's own recent-PR convention of describing rather than embedding): initial spawn (all pillars bright, no remembered state yet) vs. post-walk (one pillar dark, others unchanged) are the before/after pair; happy to paste them into a PR comment on request.

**Honest caveat**: I could not get real per-hex directional wall geometry (Synty pieces) into frame for this specific verification since this local checkout has no synced Synty assets — the shaded-renderer fallback path is what got exercised, not `SyntyHexWall`/`SyntyHexFloor`/`WallRunMesh`'s real modular-piece rendering. Those consume the exact same `rememberedFloorHexKeys`/`rememberedWallHexKeys`/`rememberedWallRunIds` props (`HexGrid.tsx`, unmodified by this PR) as the shaded fallback, so the wiring is identical, but I have not visually confirmed the Synty-piece charcoal look specifically.

## Test plan

- [x] `npx tsc -b --noEmit`
- [x] `npm run lint` (0 errors; 1 pre-existing unrelated warning in `useHexMovePath.ts`)
- [x] `npm run format:check`
- [x] `npx vitest run` — 1594 passed, 91 files (new coverage: `wallRunAdapters.test.ts` for `rememberedHexKeysFromRecords`, `useEncounterState.test.ts` for `knowledgeStateForPosition`, `playtestMapHelpers.test.ts` for `buildRenderableEntities`'s new `knowledgeState` param, `HexEntity.test.tsx`/`PropModel.test.tsx` for the crypt-tint fix)
- [x] `npm run build`
- [x] Live verification via a real Home → Lobby → Ready → Start playthrough (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdG4UCKmpJCDgh9ipiqXF
