### PR TITLE
Fix: VISIBLE hex placement must win over REMEMBERED for entity position

### DIFF
--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -15,6 +15,7 @@ import {
   EconomySlot,
   EncounterMode,
   EntityType,
+  HexState,
   TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
@@ -102,6 +103,7 @@ vi.mock('./EncounterMap', () => ({
     myEntityId: string;
     openDoorIds?: string[];
     theme?: string;
+    entities: Map<string, { position?: { x: number; y: number; z: number } }>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (entityId: string) => void;
     onDoorClick?: (doorId: string) => void;
@@ -113,6 +115,12 @@ vi.mock('./EncounterMap', () => ({
       data-my-entity-id={props.myEntityId}
       data-open-door-ids={(props.openDoorIds ?? []).join(',')}
       data-theme={props.theme ?? ''}
+      // rpg-dnd5e-web#651: expose the resolved entity->position cache so
+      // tests can assert VISIBLE-over-REMEMBERED precedence without
+      // reaching into Three.js internals.
+      data-entity-positions={JSON.stringify(
+        [...props.entities.entries()].map(([id, e]) => [id, e.position])
+      )}
     >
       <button
         data-testid="stub-move"
@@ -375,6 +383,93 @@ describe('EncounterView resume-after-refresh entity resolution (#444)', () => {
 
     const stub = screen.getByTestId('encounter-map-stub');
     expect(stub.getAttribute('data-my-entity-id')).toBe('char-explicit');
+  });
+});
+
+describe('EncounterView snapshot position resolution: VISIBLE beats REMEMBERED (rpg-dnd5e-web#651)', () => {
+  // Real regression: rpg-api#732 restates a mover's WHOLE known set (visible
+  // + remembered) on every move, so this snapshot's own `hexes` array
+  // legitimately carries the SAME entity in both a REMEMBERED hex (their
+  // just-vacated one, still listing them per HexRecord's frozen-observation
+  // contract) and a VISIBLE hex (where they actually are now) in one event.
+  // The old reverse-index loop resolved plain array order, so whichever hex
+  // sorted last silently won — this pins that the VISIBLE one always wins,
+  // in both orderings.
+  function snapshotWith(hexes: unknown[]) {
+    return {
+      encounter: {
+        space: {
+          entities: [
+            {
+              id: 'goblin-1',
+              type: EntityType.MONSTER,
+              data: {
+                case: 'monster',
+                value: { monsterRef: { id: 'goblin' } },
+              },
+            },
+          ],
+          hexes,
+        },
+      },
+    };
+  }
+
+  const rememberedOrigin = {
+    position: { x: 0, y: 0, z: 0 },
+    state: HexState.REMEMBERED,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+  const visibleDestination = {
+    position: { x: 1, y: -1, z: 0 },
+    state: HexState.VISIBLE,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts LAST in the snapshot', async () => {
+    render(
+      <EncounterView encounterId="enc-1" playerId="alice" onBack={() => {}} />
+    );
+
+    await act(async () => {
+      hoisted.fakeRef.current?.push(
+        makeEvent(
+          'snapshotDelivered',
+          snapshotWith([visibleDestination, rememberedOrigin])
+        )
+      );
+      await Promise.resolve();
+    });
+
+    const stub = screen.getByTestId('encounter-map-stub');
+    const positions = JSON.parse(
+      stub.getAttribute('data-entity-positions')!
+    ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+    const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+    expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
+  });
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts FIRST in the snapshot', async () => {
+    render(
+      <EncounterView encounterId="enc-1" playerId="alice" onBack={() => {}} />
+    );
+
+    await act(async () => {
+      hoisted.fakeRef.current?.push(
+        makeEvent(
+          'snapshotDelivered',
+          snapshotWith([rememberedOrigin, visibleDestination])
+        )
+      );
+      await Promise.resolve();
+    });
+
+    const stub = screen.getByTestId('encounter-map-stub');
+    const positions = JSON.parse(
+      stub.getAttribute('data-entity-positions')!
+    ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+    const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+    expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
   });
 });
 

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -42,7 +42,6 @@ import type {
   AvailableAction,
   CharacterData,
   Entity,
-  Position,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
@@ -62,7 +61,10 @@ import { useTakeAction } from '../../api/useTakeAction';
 import { useUnequipItem } from '../../api/useUnequipItem';
 import { useCombatLog } from '../../hooks/useCombatLog';
 import type { CharacterEquipment } from '../../hooks/useEncounterState';
-import { useEncounterState } from '../../hooks/useEncounterState';
+import {
+  positionByEntityIdFromHexes,
+  useEncounterState,
+} from '../../hooks/useEncounterState';
 import { errorMessage } from '../../utils/combatFormat';
 import {
   actionKey,
@@ -325,13 +327,11 @@ export function EncounterView({
         // every snapshot rather than merging into a prior index — `contents`
         // is total for a visible hex, so a stale carried-over placement could
         // resurrect an entity the current snapshot no longer places anywhere.
-        const positionByEntityId = new Map<string, Position>();
-        for (const hex of hexes) {
-          if (!hex.position) continue;
-          for (const placement of hex.contents ?? []) {
-            positionByEntityId.set(placement.entityId, hex.position);
-          }
-        }
+        // positionByEntityIdFromHexes (rpg-dnd5e-web#651) resolves VISIBLE
+        // over REMEMBERED for an entity present in both, regardless of
+        // `hexes`' own array order — see its doc comment for why a plain
+        // per-hex loop here corrupted the mover's own position on reconnect.
+        const positionByEntityId = positionByEntityIdFromHexes(hexes);
         const entityEntries = (e.encounter.space?.entities ?? [])
           .filter((entity) => positionByEntityId.has(entity.id))
           .map((entity) => ({

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -11,6 +11,7 @@ import type {
 import {
   EconomySlot,
   EncounterMode,
+  HexState,
   TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
@@ -121,6 +122,7 @@ vi.mock('./PlaytestMap', () => ({
     myEntityId: string;
     isMyTurn: boolean;
     fallbackPosition?: { x: number; y: number; z: number };
+    entities: Map<string, { position?: { x: number; y: number; z: number } }>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (id: string) => void;
   }) => (
@@ -136,6 +138,12 @@ vi.mock('./PlaytestMap', () => ({
           ? `${props.fallbackPosition.x},${props.fallbackPosition.y},${props.fallbackPosition.z}`
           : '(none)'
       }
+      // rpg-dnd5e-web#651: expose the resolved entity->position cache so
+      // tests can assert VISIBLE-over-REMEMBERED precedence without
+      // reaching into Three.js internals.
+      data-entity-positions={JSON.stringify(
+        [...props.entities.entries()].map(([id, e]) => [id, e.position])
+      )}
     >
       <button
         data-testid="map-simulate-move"
@@ -2349,6 +2357,76 @@ describe('PlaytestHarness', () => {
       await waitFor(() => {
         expect(screen.getByText(/Stabilized char-alice/i)).toBeTruthy();
       });
+    });
+  });
+});
+
+describe('PlaytestHarness snapshot position resolution: VISIBLE beats REMEMBERED (rpg-dnd5e-web#651)', () => {
+  // Same real regression as EncounterView.test.tsx's identically-named
+  // describe block: rpg-api#732 restates a mover's WHOLE known set (visible
+  // + remembered) on every move, so a single snapshot's `hexes` can
+  // legitimately carry the SAME entity in both a REMEMBERED hex (their
+  // just-vacated one) and a VISIBLE hex (where they actually are). Both
+  // call sites shared one (previously buggy) reverse-index loop; this pins
+  // the harness's own copy the same way.
+  const rememberedOrigin = {
+    position: { x: 0, y: 0, z: 0 },
+    state: HexState.REMEMBERED,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+  const visibleDestination = {
+    position: { x: 1, y: -1, z: 0 },
+    state: HexState.VISIBLE,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+
+  function snapshotWith(hexes: unknown[]) {
+    return makeEvent('snapshotDelivered', {
+      encounter: {
+        space: {
+          entities: [
+            {
+              id: 'goblin-1',
+              type: 2, // ENTITY_TYPE_MONSTER
+              data: {
+                case: 'monster',
+                value: { monsterRef: { id: 'goblin' } },
+              },
+            },
+          ],
+          hexes,
+        },
+      },
+    });
+  }
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts LAST in the snapshot', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(snapshotWith([visibleDestination, rememberedOrigin])));
+
+    await waitFor(() => {
+      const stub = screen.getByTestId('playtest-map-stub');
+      const positions = JSON.parse(
+        stub.getAttribute('data-entity-positions')!
+      ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+      const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+      expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
+    });
+  });
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts FIRST in the snapshot', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(snapshotWith([rememberedOrigin, visibleDestination])));
+
+    await waitFor(() => {
+      const stub = screen.getByTestId('playtest-map-stub');
+      const positions = JSON.parse(
+        stub.getAttribute('data-entity-positions')!
+      ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+      const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+      expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
     });
   });
 });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,10 +1,7 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
-import type {
-  AvailableAction,
-  Position,
-} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
   EntityType,
@@ -20,7 +17,10 @@ import { useInteract } from '../../api/useInteract';
 import { useMoveEntity } from '../../api/useMoveEntity';
 import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useTakeAction } from '../../api/useTakeAction';
-import { useEncounterState } from '../../hooks/useEncounterState';
+import {
+  positionByEntityIdFromHexes,
+  useEncounterState,
+} from '../../hooks/useEncounterState';
 import { errorMessage, formatSourceRefs } from '../../utils/combatFormat';
 import { getConditionDisplay } from '../../utils/conditionIcons';
 import { PromptModal } from '../game/PromptModal';
@@ -215,16 +215,12 @@ export function PlaytestHarness() {
           // entity says only what it is. Build a one-shot reverse index
           // (entityId -> the hex's position) from this snapshot's
           // authoritative `contents` before mapping entities, rebuilt from
-          // scratch every snapshot (mirrors EncounterView.tsx) rather than
-          // merged into a prior index, since `contents` is total for a
-          // visible hex.
-          const positionByEntityId = new Map<string, Position>();
-          for (const hex of hexes) {
-            if (!hex.position) continue;
-            for (const placement of hex.contents ?? []) {
-              positionByEntityId.set(placement.entityId, hex.position);
-            }
-          }
+          // scratch every snapshot rather than merged into a prior index,
+          // since `contents` is total for a visible hex.
+          // positionByEntityIdFromHexes (rpg-dnd5e-web#651, shared with
+          // EncounterView.tsx) resolves VISIBLE over REMEMBERED for an
+          // entity present in both, regardless of `hexes`' own array order.
+          const positionByEntityId = positionByEntityIdFromHexes(hexes);
           // Seed entities from the snapshot's space entities list in a single
           // batch setState call to avoid N intermediate renders for N entities.
           const entityEntries = (e.encounter.space?.entities ?? [])

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -78,6 +78,7 @@ import {
   hexesWithPosition,
   knowledgeStateForPosition,
   mergeEntityPosition,
+  positionByEntityIdFromHexes,
   regionForHex,
   setPendingPromptReducer,
   setReactionReadyLocalReducer,
@@ -882,6 +883,187 @@ describe('v1alpha2 reducer additions', () => {
         state = applyWallsRevealed(state, hex.edges);
 
         expect(state.walls.get(wallKey(wall))).toBe(wall);
+      });
+
+      describe('VISIBLE-over-REMEMBERED position precedence (rpg-dnd5e-web#651)', () => {
+        // rpg-api#732 started restating a mover's WHOLE known set (visible +
+        // remembered) on every move, so an entity — very often the mover
+        // themselves — can legitimately appear in a fresh VISIBLE record
+        // AND a stale REMEMBERED record within the exact same event. The
+        // old single-pass loop resolved placements in plain array order, so
+        // whichever record happened to sort last silently won; these tests
+        // pin that a VISIBLE placement always wins, regardless of order.
+        it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts LAST', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const visible = makeHexRecord(
+            { x: 1, y: -1, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1')]
+          );
+          const remembered = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+
+          state = applyHexRecordsMerged(state, [visible, remembered]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 1, y: -1, z: 0 })
+          );
+        });
+
+        it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts FIRST', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const remembered = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+          const visible = makeHexRecord(
+            { x: 1, y: -1, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1')]
+          );
+
+          state = applyHexRecordsMerged(state, [remembered, visible]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 1, y: -1, z: 0 })
+          );
+        });
+
+        it('still resolves a position for an entity present ONLY in a REMEMBERED record this event — its frozen last-observed hex, so it renders as a memory (rpg-dnd5e-web#650) rather than vanishing', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const remembered = makeHexRecord(
+            { x: 3, y: -2, z: -1 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+
+          state = applyHexRecordsMerged(state, [remembered]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 3, y: -2, z: -1 })
+          );
+        });
+
+        it('a move sequence (visible A, then remembered A + visible B in the next event) leaves the entity at B, not A', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const atA = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+            makePlacement('goblin-1'),
+          ]);
+          state = applyHexRecordsMerged(state, [atA]);
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 0, y: 0, z: 0 })
+          );
+
+          // The mover walks from A to B: A demotes to REMEMBERED (still
+          // listing goblin-1's old placement, per HexRecord's own "frozen
+          // observation" contract) and B becomes newly VISIBLE with
+          // goblin-1 now placed there — both arrive in the SAME event, as
+          // rpg-api#732's full restatement does on every move.
+          const rememberedA = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+          const visibleB = makeHexRecord(
+            { x: 1, y: -1, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1')]
+          );
+          state = applyHexRecordsMerged(state, [rememberedA, visibleB]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 1, y: -1, z: 0 })
+          );
+        });
+      });
+    });
+
+    describe('positionByEntityIdFromHexes (rpg-dnd5e-web#651)', () => {
+      // The full-resync snapshot-hydration counterpart to
+      // applyHexRecordsMerged's VISIBLE-over-REMEMBERED precedence above —
+      // same rule, same bug shape, shared by EncounterView.tsx and
+      // PlaytestHarness.tsx's onSnapshotDelivered instead of each keeping
+      // its own (previously identical, previously broken) copy.
+      it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts LAST', () => {
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+        const remembered = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+
+        const positions = positionByEntityIdFromHexes([visible, remembered]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts FIRST', () => {
+        const remembered = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+
+        const positions = positionByEntityIdFromHexes([remembered, visible]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('still resolves a position for an entity present ONLY in a REMEMBERED record — its frozen last-observed hex, so a reconnect still renders it as a memory (rpg-dnd5e-web#650) instead of dropping it', () => {
+        const remembered = makeHexRecord(
+          { x: 3, y: -2, z: -1 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+
+        const positions = positionByEntityIdFromHexes([remembered]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 3, y: -2, z: -1 })
+        );
+      });
+
+      it('a move sequence (visible A / remembered A + visible B, all in one hex list) resolves to B, not A', () => {
+        const rememberedA = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+        const visibleB = makeHexRecord(
+          { x: 1, y: -1, z: 0 },
+          HexState.VISIBLE,
+          [makePlacement('goblin-1')]
+        );
+
+        const positions = positionByEntityIdFromHexes([rememberedA, visibleB]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('ignores contents on a hex with no position (defensive)', () => {
+        const positionless = create(HexRecordSchema, {
+          state: HexState.VISIBLE,
+          contents: [create(PlacementSchema, { entityId: 'goblin-1' })],
+        });
+
+        const positions = positionByEntityIdFromHexes([positionless]);
+
+        expect(positions.has('goblin-1')).toBe(false);
       });
     });
 

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -401,6 +401,56 @@ export function hexesWithPosition(
 }
 
 /**
+ * Build a position index (entityId -> the hex position that currently
+ * places it) from a full hex list, honoring VISIBLE-over-REMEMBERED
+ * precedence for an entity present in both (rpg-dnd5e-web#651). Shared by
+ * both full-resync snapshot hydration sites (EncounterView.tsx's and
+ * PlaytestHarness.tsx's `onSnapshotDelivered`) — this exact reverse-index
+ * pattern was independently duplicated in both ("mirrors EncounterView.tsx"
+ * read the harness's own prior comment), and both copies had the same
+ * bug: iterating hexes in plain array order and letting whichever record
+ * for an entity sorted last silently win, with no regard for `hex.state`.
+ * Extracted here so the precedence rule can't drift out of sync between
+ * them, or between them and `applyHexRecordsMerged`'s own live-merge
+ * version of the same rule below.
+ *
+ * An entity present ONLY in REMEMBERED records (never VISIBLE in this same
+ * hex list) still resolves to a position — its last-observed one. That is
+ * deliberate, not a gap: HexRecord's own contract says a remembered
+ * placement "resolves against the viewer's known entity set... because a
+ * remembered occupant still needs something to render as," and a snapshot
+ * (a reconnect resync) carries a viewer's FULL accumulated knowledge —
+ * VISIBLE and REMEMBERED together — so excluding remembered-only entities
+ * here would make a previously-seen-but-now-out-of-sight monster/prop
+ * vanish across a reconnect instead of rendering as the frozen memory
+ * rpg-dnd5e-web#650 built for. What this function guarantees is narrower
+ * and is the actual bug fix: a REMEMBERED placement can never override a
+ * VISIBLE one for the same entity, in either array order.
+ */
+export function positionByEntityIdFromHexes(
+  hexes: HexRecord[]
+): Map<string, NonNullable<HexRecord['position']>> {
+  const positioned = hexesWithPosition(hexes);
+  const positions = new Map<string, NonNullable<HexRecord['position']>>();
+  const claimedByVisible = new Set<string>();
+  for (const hex of positioned) {
+    if (hex.state !== HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      claimedByVisible.add(placement.entityId);
+      positions.set(placement.entityId, hex.position);
+    }
+  }
+  for (const hex of positioned) {
+    if (hex.state === HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      if (claimedByVisible.has(placement.entityId)) continue;
+      positions.set(placement.entityId, hex.position);
+    }
+  }
+  return positions;
+}
+
+/**
  * Replace region metadata from the server's snapshot. A reconnect snapshot is
  * authoritative, so omitted theme/zones/hexes clear stale local values.
  * Exported for testing.
@@ -510,12 +560,27 @@ export function applyWallsRevealed(
  *     resolves. An entityId that still doesn't resolve is dropped: fail
  *     closed, never render an undisclosed occupant (neither added to nor
  *     removed from the position cache).
- *   - A resolving placement writes (or overwrites) that entityId's cached
- *     position. This is always treated as an "appear", not a "move" (a
- *     fresh `create(EntityStateSchema, ...)`, matching
- *     applyEntityAppearedBatch's own `{ ...entity, ghost: false }` — the
- *     real hex-by-hex walk animation is EntityMoved's job, handled
- *     separately by mergeEntityPosition; a knowledge change is never that).
+ *   - VISIBLE-over-REMEMBERED precedence (rpg-dnd5e-web#651): an entity can
+ *     legitimately appear in TWO records within the SAME event — the newly
+ *     VISIBLE hex it just moved to, and a REMEMBERED hex that still lists
+ *     it (a remembered record retains its frozen observation until
+ *     something re-derives it — that's the entire point of "remembered").
+ *     Resolving placements in plain array order let whichever hex happened
+ *     to sort last silently win, so a stale REMEMBERED placement could
+ *     revert a fresh VISIBLE position — this is what corrupted the MOVER's
+ *     own cached position on nearly every move once rpg-api#732 started
+ *     restating the mover's whole known set (visible + remembered) on
+ *     every step: wrong position -> excluded from `visibleEntities`
+ *     (rendered as a frozen memory of themselves) -> missing from
+ *     `visibleTurnOrder` -> "my move did nothing until I clicked twice."
+ *     Placements are now resolved in two passes instead of one: every
+ *     VISIBLE placement first (always wins), then REMEMBERED placements
+ *     fill in only entities no VISIBLE record claimed this event — which
+ *     is exactly the legitimate "only ever seen from afar, now out of
+ *     sight" case #650 needs to still resolve to a position so it renders
+ *     as a memory (HexRecord's own doc comment: a remembered placement
+ *     "resolves against the viewer's known entity set... because a
+ *     remembered occupant still needs something to render as").
  *   - An entityId present in the OLD cached record's contents at this
  *     position but absent from the NEW one — and not re-placed at any OTHER
  *     position this SAME event (a move within one message) — is removed
@@ -557,25 +622,54 @@ export function applyHexRecordsMerged(
   }
 
   let nextEntities: LocalEncounterState['entities'] | undefined;
+  const setPosition = (entityId: string, position: Position) => {
+    const existing = (nextEntities ?? prev.entities).get(entityId);
+    if (
+      existing?.position?.x === position.x &&
+      existing?.position?.y === position.y &&
+      existing?.position?.z === position.z
+    ) {
+      return;
+    }
+    if (!nextEntities) nextEntities = new Map(prev.entities);
+    nextEntities.set(
+      entityId,
+      create(EntityStateSchema, { entityId, position })
+    );
+  };
+
+  // Pass 1: every VISIBLE placement this event. Always wins — set
+  // unconditionally, regardless of what a REMEMBERED record for the same
+  // entity says (processed in pass 2 below).
+  const claimedByVisibleThisEvent = new Set<string>();
   for (const hex of positioned) {
-    const key = hexKey(protoPositionToHex(hex.position));
+    if (hex.state !== HexState.VISIBLE) continue;
     for (const placement of hex.contents ?? []) {
       if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
-      const position = v2PositionToV1(hex.position);
-      const existing = (nextEntities ?? prev.entities).get(placement.entityId);
-      if (
-        existing?.position?.x === position.x &&
-        existing?.position?.y === position.y &&
-        existing?.position?.z === position.z
-      ) {
-        continue;
-      }
-      if (!nextEntities) nextEntities = new Map(prev.entities);
-      nextEntities.set(
-        placement.entityId,
-        create(EntityStateSchema, { entityId: placement.entityId, position })
-      );
+      claimedByVisibleThisEvent.add(placement.entityId);
+      setPosition(placement.entityId, v2PositionToV1(hex.position));
     }
+  }
+  // Pass 2: REMEMBERED placements — only for entities no VISIBLE record
+  // claimed this event. A REMEMBERED record's own placement is otherwise
+  // exactly as authoritative as a VISIBLE one (it's the frozen truth of
+  // what this position held), it just never gets to override a fresher
+  // sighting from the same event.
+  for (const hex of positioned) {
+    if (hex.state === HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      if (claimedByVisibleThisEvent.has(placement.entityId)) continue;
+      if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
+      setPosition(placement.entityId, v2PositionToV1(hex.position));
+    }
+  }
+
+  // Vacate pass: an entity that used to sit at a position this event
+  // updates, and isn't re-placed anywhere else this event, is gone from the
+  // cache. Reads only `prev.revealedHexes` (untouched by the two passes
+  // above), so its own ordering relative to them doesn't matter.
+  for (const hex of positioned) {
+    const key = hexKey(protoPositionToHex(hex.position));
     const oldContents = prev.revealedHexes.get(key)?.contents ?? [];
     for (const oldPlacement of oldContents) {
       if (placedThisEvent.has(oldPlacement.entityId)) continue;


### PR DESCRIPTION
## Summary

Real gameplay regression Kirk hit: clicking to move rendered the fog update immediately, but the character didn't actually move until a second click; turn order went wrong; he got attacked but couldn't see the monster. All three trace to one root cause in the entity position index.

**Root cause**: an entity can legitimately appear in TWO hex records within the same `HexKnowledgeChanged` event — the newly-VISIBLE hex it just moved to, and a REMEMBERED hex that still lists it (a remembered record retains its frozen observation; that's the entire point of "remembered"). Both `applyHexRecordsMerged` (the live-merge path) and a reverse-index loop duplicated identically in `EncounterView.tsx`/`PlaytestHarness.tsx` (snapshot hydration) resolved placements in plain array order, with **no check of `hex.state`**. Whichever hex happened to sort last silently won. A stale REMEMBERED placement could therefore revert a fresh VISIBLE position — most visibly on the **mover's own entity**: wrong position → excluded from `HexGrid`'s `visibleEntities` (rendered as a frozen memory of themselves) → missing from `visibleTurnOrder` → exactly Kirk's three symptoms.

## Fix

- **`src/hooks/useEncounterState.ts`** — `applyHexRecordsMerged` now resolves placements in two passes: every VISIBLE placement first (always wins, unconditionally), then REMEMBERED placements fill in only entities no VISIBLE record claimed *this event*. Order-independent. An entity present in a REMEMBERED hex only (never VISIBLE in that event) still resolves to a position — its frozen last-observed one — because that's required for it to render as the memory rpg-dnd5e-web#650 built for; HexRecord's own contract says a remembered placement "resolves against the viewer's known entity set... because a remembered occupant still needs something to render as."
- **`src/hooks/useEncounterState.ts`** — new shared `positionByEntityIdFromHexes(hexes)` implements the identical precedence for the snapshot-hydration path, replacing the byte-identical (and identically broken) reverse-index loop that `EncounterView.tsx` and `PlaytestHarness.tsx` had each independently duplicated (the harness's own old comment literally said "mirrors EncounterView.tsx"). One implementation now, not two that can silently drift apart again.
- Both call sites updated to use the shared helper; the now-unused local `Position` type imports were removed.

## Test plan

- [x] `npx tsc -b --noEmit`
- [x] `npm run lint` (0 errors; 1 pre-existing unrelated warning in `useHexMovePath.ts`)
- [x] `npm run format:check`
- [x] `npx vitest run` — 1607 passed, 91 files
- [x] `npm run build`

New tests pin exactly the bar this bug needs, at two levels:

**Reducer/helper level** (`useEncounterState.test.ts`, both for `applyHexRecordsMerged` and for `positionByEntityIdFromHexes`):
- an entity present in a VISIBLE hex and a REMEMBERED hex resolves to the VISIBLE position regardless of array order (tested both orderings)
- an entity present only in a REMEMBERED hex still resolves — to that frozen position, not to nothing (see the "fix" section above for why exclusion would be wrong, not a gap)
- a move sequence (visible A → remembered A + visible B, same event) resolves to B, not A

**Through the real components** (new describe blocks in `EncounterView.test.tsx` and `PlaytestHarness.test.tsx`): mount the real component, push a `snapshotDelivered` event whose `hexes` carry the mover in both a REMEMBERED and a VISIBLE record (both array orderings), and assert the entity ends up at the VISIBLE position via the real `onSnapshotDelivered` handler — not just the isolated helper.

## Live verification (real gameplay) — partial, with an honest caveat

Built a throwaway character (`?playerId=posfix`), drove Home → Lobby → Ready → Start into a real encounter on my own `npm run dev -- --port 3022`, and drove real `MoveEntity` calls (via the same `EncounterMap.onMove` prop a real click ultimately calls — RPC and stream both real, only the pixel-level raycast is skipped) while inspecting the live React state and the raw stream events.

**What I could confirm**: the fix logic is correct and match the reducer/component test evidence above.

**What I could NOT cleanly confirm live, and why** — this surfaced something worth flagging directly rather than glossing over: my local `rpg-api:local` Docker image (not something this PR touches or can fix) has a **separate, server-side staleness bug** in its `HexKnowledgeChanged` restatement-on-move. Direct evidence, captured via this repo's own stream-event dev logging (`streamLogging.ts`):

- Move issued from `(8,-11,3)` to `(9,-12,3)`.
- `entityMoved` arrives (sequence 25) correctly reporting the new position.
- `hexKnowledgeChanged` arrives **in the same sequence (25)** — 431 hexes, but the hex at the *old* position `(8,-11,3)` is still listed with `state: VISIBLE` and the mover's own placement — contradicting the move that just happened in that same transaction. The mover is not placed at `(9,-12,3)` in this event or the next one (sequence 26, 26 newly-visible hexes) either.

Since this event genuinely says "the mover is VISIBLE at the old position," my client fix (VISIBLE always wins) correctly keeps them there — the client is being told something false by a trusted source, and no client-side precedence rule can distinguish that from a real, fresh sighting.

I traced this to source: `main`'s `rpg-api` doesn't implement `HexKnowledgeChanged`-on-move at all yet (only `feat/724-hex-knowledge` and `feat/remembered-transitions` do — my local `rpg-api:local` image is evidently built from one of those branches, likely mid-lineage). The move-restatement feature itself is `feat/remembered-transitions` commit `97625a9` (**Kirk's own commit, today**) — `translateMoveEventWithData` in `internal/handlers/dnd5e/v2/encounter/translate.go`, line ~291: `enc, err := encounter.LoadFromData(ctx, data, broker)` then `enc.KnownHexes(viewer)`. My data is consistent with `data`/`KnownHexes(viewer)` being read before the move's own view-recompute has settled, inside the same event-publish chain — i.e. a likely ordering race in that rpg-api commit itself, unrelated to and not fixable from this PR. Flagging with the exact evidence rather than either hiding it or trying to route around it client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzdG4UCKmpJCDgh9ipiqXF
