### PR TITLE
release: fog-of-war follow-ups (#651 VISIBLE precedence, #638 wall seams)

### DIFF
--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -15,6 +15,7 @@ import {
   EconomySlot,
   EncounterMode,
   EntityType,
+  HexState,
   TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
@@ -102,6 +103,7 @@ vi.mock('./EncounterMap', () => ({
     myEntityId: string;
     openDoorIds?: string[];
     theme?: string;
+    entities: Map<string, { position?: { x: number; y: number; z: number } }>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (entityId: string) => void;
     onDoorClick?: (doorId: string) => void;
@@ -113,6 +115,12 @@ vi.mock('./EncounterMap', () => ({
       data-my-entity-id={props.myEntityId}
       data-open-door-ids={(props.openDoorIds ?? []).join(',')}
       data-theme={props.theme ?? ''}
+      // rpg-dnd5e-web#651: expose the resolved entity->position cache so
+      // tests can assert VISIBLE-over-REMEMBERED precedence without
+      // reaching into Three.js internals.
+      data-entity-positions={JSON.stringify(
+        [...props.entities.entries()].map(([id, e]) => [id, e.position])
+      )}
     >
       <button
         data-testid="stub-move"
@@ -375,6 +383,93 @@ describe('EncounterView resume-after-refresh entity resolution (#444)', () => {
 
     const stub = screen.getByTestId('encounter-map-stub');
     expect(stub.getAttribute('data-my-entity-id')).toBe('char-explicit');
+  });
+});
+
+describe('EncounterView snapshot position resolution: VISIBLE beats REMEMBERED (rpg-dnd5e-web#651)', () => {
+  // Real regression: rpg-api#732 restates a mover's WHOLE known set (visible
+  // + remembered) on every move, so this snapshot's own `hexes` array
+  // legitimately carries the SAME entity in both a REMEMBERED hex (their
+  // just-vacated one, still listing them per HexRecord's frozen-observation
+  // contract) and a VISIBLE hex (where they actually are now) in one event.
+  // The old reverse-index loop resolved plain array order, so whichever hex
+  // sorted last silently won — this pins that the VISIBLE one always wins,
+  // in both orderings.
+  function snapshotWith(hexes: unknown[]) {
+    return {
+      encounter: {
+        space: {
+          entities: [
+            {
+              id: 'goblin-1',
+              type: EntityType.MONSTER,
+              data: {
+                case: 'monster',
+                value: { monsterRef: { id: 'goblin' } },
+              },
+            },
+          ],
+          hexes,
+        },
+      },
+    };
+  }
+
+  const rememberedOrigin = {
+    position: { x: 0, y: 0, z: 0 },
+    state: HexState.REMEMBERED,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+  const visibleDestination = {
+    position: { x: 1, y: -1, z: 0 },
+    state: HexState.VISIBLE,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts LAST in the snapshot', async () => {
+    render(
+      <EncounterView encounterId="enc-1" playerId="alice" onBack={() => {}} />
+    );
+
+    await act(async () => {
+      hoisted.fakeRef.current?.push(
+        makeEvent(
+          'snapshotDelivered',
+          snapshotWith([visibleDestination, rememberedOrigin])
+        )
+      );
+      await Promise.resolve();
+    });
+
+    const stub = screen.getByTestId('encounter-map-stub');
+    const positions = JSON.parse(
+      stub.getAttribute('data-entity-positions')!
+    ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+    const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+    expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
+  });
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts FIRST in the snapshot', async () => {
+    render(
+      <EncounterView encounterId="enc-1" playerId="alice" onBack={() => {}} />
+    );
+
+    await act(async () => {
+      hoisted.fakeRef.current?.push(
+        makeEvent(
+          'snapshotDelivered',
+          snapshotWith([rememberedOrigin, visibleDestination])
+        )
+      );
+      await Promise.resolve();
+    });
+
+    const stub = screen.getByTestId('encounter-map-stub');
+    const positions = JSON.parse(
+      stub.getAttribute('data-entity-positions')!
+    ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+    const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+    expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
   });
 });
 

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -42,7 +42,6 @@ import type {
   AvailableAction,
   CharacterData,
   Entity,
-  Position,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
@@ -62,7 +61,10 @@ import { useTakeAction } from '../../api/useTakeAction';
 import { useUnequipItem } from '../../api/useUnequipItem';
 import { useCombatLog } from '../../hooks/useCombatLog';
 import type { CharacterEquipment } from '../../hooks/useEncounterState';
-import { useEncounterState } from '../../hooks/useEncounterState';
+import {
+  positionByEntityIdFromHexes,
+  useEncounterState,
+} from '../../hooks/useEncounterState';
 import { errorMessage } from '../../utils/combatFormat';
 import {
   actionKey,
@@ -325,13 +327,11 @@ export function EncounterView({
         // every snapshot rather than merging into a prior index — `contents`
         // is total for a visible hex, so a stale carried-over placement could
         // resurrect an entity the current snapshot no longer places anywhere.
-        const positionByEntityId = new Map<string, Position>();
-        for (const hex of hexes) {
-          if (!hex.position) continue;
-          for (const placement of hex.contents ?? []) {
-            positionByEntityId.set(placement.entityId, hex.position);
-          }
-        }
+        // positionByEntityIdFromHexes (rpg-dnd5e-web#651) resolves VISIBLE
+        // over REMEMBERED for an entity present in both, regardless of
+        // `hexes`' own array order — see its doc comment for why a plain
+        // per-hex loop here corrupted the mover's own position on reconnect.
+        const positionByEntityId = positionByEntityIdFromHexes(hexes);
         const entityEntries = (e.encounter.space?.entities ?? [])
           .filter((entity) => positionByEntityId.has(entity.id))
           .map((entity) => ({

--- a/src/components/hex-grid/WallRunMesh.tsx
+++ b/src/components/hex-grid/WallRunMesh.tsx
@@ -88,6 +88,23 @@ const NOMINAL_PIECE_WIDTH = 1.0;
 const RUN_WALL_PIVOT_RATIO =
   RUN_WALL_VARIANT.rawMinX / RUN_WALL_VARIANT.rawWidth;
 
+/**
+ * Overlap grown onto each side of every tiled wall piece (rpg-dnd5e-web
+ * #634: Kirk's tall-wall-default walk found visible air gaps between
+ * adjacent wall segments, worse in the lower half). Root-caused via an
+ * isolated two-tile render (measuring the ACTUAL rendered silhouette, not
+ * just the theoretical bounding box, which already met flush with zero
+ * gap by construction — see `tileWallSegment`'s own `overlapMargin` doc
+ * comment): `RUN_WALL_VARIANT`'s ("plain," this run tiling's only
+ * variant — this file's own doc comment on why) authored edge silhouette
+ * is a deliberately irregular rock-cut profile, not a flat rectangle, and
+ * recedes inward from its own bounding box by up to ~0.05 world units in
+ * its lower ~60% specifically (measured directly against the real GLB).
+ * 0.08 comfortably covers that measured worst case with margin to spare,
+ * without visibly bulging the seam.
+ */
+const RUN_WALL_TILE_OVERLAP_MARGIN = 0.08;
+
 function FloorSkirtBox({
   segment,
   remembered = false,
@@ -146,7 +163,8 @@ function TiledWallRun({
         segment,
         NOMINAL_PIECE_WIDTH,
         RUN_WALL_PIVOT_RATIO,
-        facing
+        facing,
+        RUN_WALL_TILE_OVERLAP_MARGIN
       ),
     [segment, facing]
   );

--- a/src/components/hex-grid/wallRunMeshHelpers.test.ts
+++ b/src/components/hex-grid/wallRunMeshHelpers.test.ts
@@ -310,6 +310,152 @@ describe('tileWallSegment (W3: real Synty pieces tiled along a run, design.md/pl
       }
     });
   });
+
+  describe('overlapMargin (issue #634 regression: "air gaps between adjacent wall segments at the tall default")', () => {
+    // Root-caused via an isolated two-tile render (not the theoretical
+    // bounding box, which is already provably gap-free by construction —
+    // see the pivotRatio tests above): RUN_WALL_VARIANT's ("plain"
+    // Wall_Half) authored edge silhouette is a deliberately irregular,
+    // rock-cut profile, not a flat rectangle, and recedes inward from its
+    // own bbox by varying amounts at different heights (measured: up to
+    // ~0.05 unit in the lower ~60% of the panel). overlapMargin grows each
+    // tile's rendered bbox symmetrically so adjacent tiles OVERLAP instead
+    // of meeting exactly flush, self-covering the irregular edge — same
+    // class of fix as envelopeCornerOverlapMargin (wallRuns.ts) already
+    // uses for room corners.
+    const MEASURED_PIVOT_RATIO = -0.1174 / 2.672; // RUN_WALL_VARIANT's real pivotRatio
+    const rawWidth = 2.672;
+    const rawMinX = -0.1174;
+
+    it('default overlapMargin (0) is byte-identical to omitting the parameter entirely', () => {
+      const omitted = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO
+      );
+      const explicitZero = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        undefined,
+        0
+      );
+      expect(explicitZero).toEqual(omitted);
+    });
+
+    it('a non-zero margin grows the RENDERED pieceWidth by exactly 2*overlapMargin, leaving count and inter-tile spacing untouched', () => {
+      const noMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO
+      );
+      const withMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 4, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        undefined,
+        0.08
+      );
+      expect(withMargin).toHaveLength(noMargin.length);
+      for (let i = 0; i < withMargin.length; i++) {
+        expect(withMargin[i]!.pieceWidth).toBeCloseTo(
+          noMargin[i]!.pieceWidth + 0.16,
+          9
+        );
+      }
+      // Margin is a constant offset applied uniformly to every tile's
+      // origin (same relationship the pivotRatio tests above prove for
+      // pivotRatio itself) — never a per-tile stretch/squeeze, so
+      // consecutive origins stay exactly `pieceWidth` (the TRUE slot
+      // width) apart regardless of margin.
+      for (let i = 1; i < withMargin.length; i++) {
+        expect(
+          withMargin[i]!.position.x - withMargin[i - 1]!.position.x
+        ).toBeCloseTo(1.0, 9);
+      }
+    });
+
+    it('closes the measured real-world gap: adjacent tiles’ actual (bbox-corrected) rendered edges OVERLAP by exactly 2*overlapMargin instead of meeting flush — reproduces the exact hand-derived numbers this issue was root-caused against', () => {
+      const overlapMargin = 0.08;
+      const pieces = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        undefined,
+        overlapMargin
+      );
+      expect(pieces).toHaveLength(2);
+
+      const tsx0 = pieces[0]!.pieceWidth / rawWidth;
+      const bboxMin0 = pieces[0]!.position.x + rawMinX * tsx0;
+      const bboxMax0 = pieces[0]!.position.x + (rawMinX + rawWidth) * tsx0;
+      expect(bboxMin0).toBeCloseTo(-overlapMargin, 9); // -0.08
+      expect(bboxMax0).toBeCloseTo(1 + overlapMargin, 9); // 1.08
+
+      const tsx1 = pieces[1]!.pieceWidth / rawWidth;
+      const bboxMin1 = pieces[1]!.position.x + rawMinX * tsx1;
+      const bboxMax1 = pieces[1]!.position.x + (rawMinX + rawWidth) * tsx1;
+      expect(bboxMin1).toBeCloseTo(1 - overlapMargin, 9); // 0.92
+      expect(bboxMax1).toBeCloseTo(2 + overlapMargin, 9); // 2.08
+
+      // The seam itself: piece 0's rendered right edge now sits PAST
+      // piece 1's rendered left edge by exactly 2*overlapMargin — an
+      // overlap, not a flush meet (margin=0 gives exactly 0 here, per
+      // the test below).
+      expect(bboxMax0 - bboxMin1).toBeCloseTo(2 * overlapMargin, 9);
+    });
+
+    it('WITHOUT the margin (margin=0), the same two tiles meet exactly flush — proves the overlap test above is not vacuous', () => {
+      const pieces = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO
+      );
+      const tsx0 = pieces[0]!.pieceWidth / rawWidth;
+      const bboxMax0 = pieces[0]!.position.x + (rawMinX + rawWidth) * tsx0;
+      const tsx1 = pieces[1]!.pieceWidth / rawWidth;
+      const bboxMin1 = pieces[1]!.position.x + rawMinX * tsx1;
+      expect(bboxMax0 - bboxMin1).toBeCloseTo(0, 9);
+    });
+
+    it('the origin-shift sign convention holds for a flipped run too (facing forces a 180deg flip): margin still applies as a constant per-tile offset, added (not subtracted) per the flipped branch’s own sign convention', () => {
+      const facingOpposingNaive = { x: 0, z: -1 }; // forces a flip for dir=(2,0)
+      const noMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        facingOpposingNaive
+      );
+      const withMargin = tileWallSegment(
+        { start: { x: 0, z: 0 }, end: { x: 2, z: 0 } },
+        1.0,
+        MEASURED_PIVOT_RATIO,
+        facingOpposingNaive,
+        0.08
+      );
+      // Same constant-offset relationship as the non-flipped case: margin
+      // never changes inter-tile spacing.
+      for (let i = 1; i < withMargin.length; i++) {
+        expect(
+          withMargin[i]!.position.x - withMargin[i - 1]!.position.x
+        ).toBeCloseTo(1.0, 9);
+      }
+      // Reproduces the exact hand-derived flipped-formula shift:
+      // marginTerm = overlapMargin*(1+2*pivotRatio), ADDED for the
+      // flipped branch — opposite sign from the non-flipped branch above,
+      // matching the existing sign-flip convention between the two
+      // branches of the origin formula.
+      const marginTerm = 0.08 * (1 + 2 * MEASURED_PIVOT_RATIO);
+      expect(withMargin[0]!.position.x).toBeCloseTo(
+        noMargin[0]!.position.x + marginTerm,
+        9
+      );
+      expect(withMargin[1]!.position.x).toBeCloseTo(
+        noMargin[1]!.position.x + marginTerm,
+        9
+      );
+    });
+  });
 });
 
 describe("facingCorrectedRotationY (round-2 W3/W4 fix: tileWallSegment's rotationY is a pure function of the run's own direction, with no notion of \"outward\" — hall's left/right sides share one direction pair and top/bottom share another, so within each pair the SAME rotationY got computed for both despite opposite outward normals; exactly one of each pair always ended up showing its flat, undecorated back outward, verified against the real reference-tomb fixture: 2 of hall's 4 sides failed)", () => {

--- a/src/components/hex-grid/wallRunMeshHelpers.ts
+++ b/src/components/hex-grid/wallRunMeshHelpers.ts
@@ -147,7 +147,31 @@ export function tileWallSegment(
    * caller) skips the correction entirely, keeping the original
    * direction-only rotationY unchanged.
    */
-  facing?: WorldPos
+  facing?: WorldPos,
+  /**
+   * Extra width (world units) grown symmetrically onto EACH side of
+   * every tile's rendered bounding box, so adjacent tiles OVERLAP by this
+   * amount instead of meeting exactly edge-to-edge (rpg-dnd5e-web#634:
+   * Kirk's tall-wall-default walk found visible air gaps between
+   * adjacent wall segments, worse in the lower half). Root cause,
+   * confirmed via an isolated two-tile render measuring the actual
+   * rendered silhouette (not just the theoretical bounding box, which
+   * DOES meet flush with zero gap by construction — the exact-tiling math
+   * itself was never wrong): this pack's wall panels are authored with a
+   * deliberately irregular, rough-hewn rock-cut edge silhouette, not a
+   * flat rectangular one — the edge recedes inward from the piece's own
+   * bounding box by varying amounts at different heights (measured: ~0.01
+   * unit near the top, up to ~0.05 unit in the lower ~60% of this pack's
+   * "plain" variant specifically), so two tiles placed exactly
+   * bbox-to-bbox leave a real gap wherever BOTH neighbors' edges recede
+   * at the same height. Same class of fix as `envelopeCornerOverlapMargin`
+   * (wallRuns.ts) already uses for room CORNERS — deliberately overlapping
+   * geometry to self-cover an irregular/non-mitered seam rather than
+   * trying to author a perfectly complementary edge profile. Default 0
+   * preserves the exact pre-fix tiling math (and every existing test
+   * asserting on it) for any caller that doesn't pass a value.
+   */
+  overlapMargin = 0
 ): TiledPiece[] {
   const dx = segment.end.x - segment.start.x;
   const dz = segment.end.z - segment.start.z;
@@ -155,6 +179,11 @@ export function tileWallSegment(
   if (length < WALL_RUN_LENGTH_EPSILON) return [];
 
   const count = Math.max(1, Math.round(length / nominalPieceWidth));
+  // `pieceWidth` stays the TRUE, non-overlapping slot width — it's what
+  // determines `count` and where each tile's own slot boundary sits, so
+  // the run's overall coverage/spacing is completely unaffected by
+  // `overlapMargin`. Only the RENDERED width (returned per piece, below)
+  // grows.
   const pieceWidth = length / count;
   const naiveRotationY = Math.atan2(-dz, dx);
   const rotationY = facing
@@ -177,6 +206,17 @@ export function tileWallSegment(
   const flipped = rotationY !== naiveRotationY;
   const ux = dx / length;
   const uz = dz / length;
+  const renderedWidth = pieceWidth + 2 * overlapMargin;
+  // Growing the rendered width by `overlapMargin` on each side shifts
+  // where the origin needs to land relative to the (unchanged) slot
+  // boundary — re-deriving the SAME "scaled bbox lands flush at
+  // [i,i+1]*pieceWidth" relationship the comment below already explains,
+  // just solved for a bbox that now lands at
+  // [i*pieceWidth - overlapMargin, (i+1)*pieceWidth + overlapMargin]
+  // instead. Reduces to the original `marginTerm = 0` exactly when
+  // `overlapMargin = 0`, so every existing caller (and test) is
+  // byte-identical.
+  const marginTerm = overlapMargin * (1 + 2 * pivotRatio);
 
   const pieces: TiledPiece[] = [];
   for (let i = 0; i < count; i++) {
@@ -189,15 +229,15 @@ export function tileWallSegment(
     // formulas below agree exactly at pivotRatio = -0.5, which is also
     // how this was verified).
     const originDist = flipped
-      ? pieceWidth * (i + pivotRatio + 1)
-      : pieceWidth * (i - pivotRatio);
+      ? pieceWidth * (i + pivotRatio + 1) + marginTerm
+      : pieceWidth * (i - pivotRatio) - marginTerm;
     pieces.push({
       position: {
         x: segment.start.x + ux * originDist,
         z: segment.start.z + uz * originDist,
       },
       rotationY,
-      pieceWidth,
+      pieceWidth: renderedWidth,
     });
   }
   return pieces;

--- a/src/components/playtest/PlaytestHarness.test.tsx
+++ b/src/components/playtest/PlaytestHarness.test.tsx
@@ -11,6 +11,7 @@ import type {
 import {
   EconomySlot,
   EncounterMode,
+  HexState,
   TargetKind,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
@@ -121,6 +122,7 @@ vi.mock('./PlaytestMap', () => ({
     myEntityId: string;
     isMyTurn: boolean;
     fallbackPosition?: { x: number; y: number; z: number };
+    entities: Map<string, { position?: { x: number; y: number; z: number } }>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (id: string) => void;
   }) => (
@@ -136,6 +138,12 @@ vi.mock('./PlaytestMap', () => ({
           ? `${props.fallbackPosition.x},${props.fallbackPosition.y},${props.fallbackPosition.z}`
           : '(none)'
       }
+      // rpg-dnd5e-web#651: expose the resolved entity->position cache so
+      // tests can assert VISIBLE-over-REMEMBERED precedence without
+      // reaching into Three.js internals.
+      data-entity-positions={JSON.stringify(
+        [...props.entities.entries()].map(([id, e]) => [id, e.position])
+      )}
     >
       <button
         data-testid="map-simulate-move"
@@ -2349,6 +2357,76 @@ describe('PlaytestHarness', () => {
       await waitFor(() => {
         expect(screen.getByText(/Stabilized char-alice/i)).toBeTruthy();
       });
+    });
+  });
+});
+
+describe('PlaytestHarness snapshot position resolution: VISIBLE beats REMEMBERED (rpg-dnd5e-web#651)', () => {
+  // Same real regression as EncounterView.test.tsx's identically-named
+  // describe block: rpg-api#732 restates a mover's WHOLE known set (visible
+  // + remembered) on every move, so a single snapshot's `hexes` can
+  // legitimately carry the SAME entity in both a REMEMBERED hex (their
+  // just-vacated one) and a VISIBLE hex (where they actually are). Both
+  // call sites shared one (previously buggy) reverse-index loop; this pins
+  // the harness's own copy the same way.
+  const rememberedOrigin = {
+    position: { x: 0, y: 0, z: 0 },
+    state: HexState.REMEMBERED,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+  const visibleDestination = {
+    position: { x: 1, y: -1, z: 0 },
+    state: HexState.VISIBLE,
+    contents: [{ entityId: 'goblin-1', facing: 0 }],
+  };
+
+  function snapshotWith(hexes: unknown[]) {
+    return makeEvent('snapshotDelivered', {
+      encounter: {
+        space: {
+          entities: [
+            {
+              id: 'goblin-1',
+              type: 2, // ENTITY_TYPE_MONSTER
+              data: {
+                case: 'monster',
+                value: { monsterRef: { id: 'goblin' } },
+              },
+            },
+          ],
+          hexes,
+        },
+      },
+    });
+  }
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts LAST in the snapshot', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(snapshotWith([visibleDestination, rememberedOrigin])));
+
+    await waitFor(() => {
+      const stub = screen.getByTestId('playtest-map-stub');
+      const positions = JSON.parse(
+        stub.getAttribute('data-entity-positions')!
+      ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+      const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+      expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
+    });
+  });
+
+  it('resolves to the VISIBLE hex when the REMEMBERED record sorts FIRST in the snapshot', async () => {
+    render(<PlaytestHarness />);
+
+    act(() => fake.push(snapshotWith([rememberedOrigin, visibleDestination])));
+
+    await waitFor(() => {
+      const stub = screen.getByTestId('playtest-map-stub');
+      const positions = JSON.parse(
+        stub.getAttribute('data-entity-positions')!
+      ) as Array<[string, { x: number; y: number; z: number } | undefined]>;
+      const goblinPosition = positions.find(([id]) => id === 'goblin-1')?.[1];
+      expect(goblinPosition).toMatchObject({ x: 1, y: -1, z: 0 });
     });
   });
 });

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -1,10 +1,7 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
-import type {
-  AvailableAction,
-  Position,
-} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import type { AvailableAction } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
   EntityType,
@@ -20,7 +17,10 @@ import { useInteract } from '../../api/useInteract';
 import { useMoveEntity } from '../../api/useMoveEntity';
 import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useTakeAction } from '../../api/useTakeAction';
-import { useEncounterState } from '../../hooks/useEncounterState';
+import {
+  positionByEntityIdFromHexes,
+  useEncounterState,
+} from '../../hooks/useEncounterState';
 import { errorMessage, formatSourceRefs } from '../../utils/combatFormat';
 import { getConditionDisplay } from '../../utils/conditionIcons';
 import { PromptModal } from '../game/PromptModal';
@@ -215,16 +215,12 @@ export function PlaytestHarness() {
           // entity says only what it is. Build a one-shot reverse index
           // (entityId -> the hex's position) from this snapshot's
           // authoritative `contents` before mapping entities, rebuilt from
-          // scratch every snapshot (mirrors EncounterView.tsx) rather than
-          // merged into a prior index, since `contents` is total for a
-          // visible hex.
-          const positionByEntityId = new Map<string, Position>();
-          for (const hex of hexes) {
-            if (!hex.position) continue;
-            for (const placement of hex.contents ?? []) {
-              positionByEntityId.set(placement.entityId, hex.position);
-            }
-          }
+          // scratch every snapshot rather than merged into a prior index,
+          // since `contents` is total for a visible hex.
+          // positionByEntityIdFromHexes (rpg-dnd5e-web#651, shared with
+          // EncounterView.tsx) resolves VISIBLE over REMEMBERED for an
+          // entity present in both, regardless of `hexes`' own array order.
+          const positionByEntityId = positionByEntityIdFromHexes(hexes);
           // Seed entities from the snapshot's space entities list in a single
           // batch setState call to avoid N intermediate renders for N entities.
           const entityEntries = (e.encounter.space?.entities ?? [])

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -78,6 +78,7 @@ import {
   hexesWithPosition,
   knowledgeStateForPosition,
   mergeEntityPosition,
+  positionByEntityIdFromHexes,
   regionForHex,
   setPendingPromptReducer,
   setReactionReadyLocalReducer,
@@ -882,6 +883,187 @@ describe('v1alpha2 reducer additions', () => {
         state = applyWallsRevealed(state, hex.edges);
 
         expect(state.walls.get(wallKey(wall))).toBe(wall);
+      });
+
+      describe('VISIBLE-over-REMEMBERED position precedence (rpg-dnd5e-web#651)', () => {
+        // rpg-api#732 started restating a mover's WHOLE known set (visible +
+        // remembered) on every move, so an entity — very often the mover
+        // themselves — can legitimately appear in a fresh VISIBLE record
+        // AND a stale REMEMBERED record within the exact same event. The
+        // old single-pass loop resolved placements in plain array order, so
+        // whichever record happened to sort last silently won; these tests
+        // pin that a VISIBLE placement always wins, regardless of order.
+        it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts LAST', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const visible = makeHexRecord(
+            { x: 1, y: -1, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1')]
+          );
+          const remembered = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+
+          state = applyHexRecordsMerged(state, [visible, remembered]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 1, y: -1, z: 0 })
+          );
+        });
+
+        it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts FIRST', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const remembered = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+          const visible = makeHexRecord(
+            { x: 1, y: -1, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1')]
+          );
+
+          state = applyHexRecordsMerged(state, [remembered, visible]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 1, y: -1, z: 0 })
+          );
+        });
+
+        it('still resolves a position for an entity present ONLY in a REMEMBERED record this event — its frozen last-observed hex, so it renders as a memory (rpg-dnd5e-web#650) rather than vanishing', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const remembered = makeHexRecord(
+            { x: 3, y: -2, z: -1 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+
+          state = applyHexRecordsMerged(state, [remembered]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 3, y: -2, z: -1 })
+          );
+        });
+
+        it('a move sequence (visible A, then remembered A + visible B in the next event) leaves the entity at B, not A', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const atA = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+            makePlacement('goblin-1'),
+          ]);
+          state = applyHexRecordsMerged(state, [atA]);
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 0, y: 0, z: 0 })
+          );
+
+          // The mover walks from A to B: A demotes to REMEMBERED (still
+          // listing goblin-1's old placement, per HexRecord's own "frozen
+          // observation" contract) and B becomes newly VISIBLE with
+          // goblin-1 now placed there — both arrive in the SAME event, as
+          // rpg-api#732's full restatement does on every move.
+          const rememberedA = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.REMEMBERED,
+            [makePlacement('goblin-1')]
+          );
+          const visibleB = makeHexRecord(
+            { x: 1, y: -1, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1')]
+          );
+          state = applyHexRecordsMerged(state, [rememberedA, visibleB]);
+
+          expect(state.entities.get('goblin-1')?.position).toEqual(
+            create(PositionSchema, { x: 1, y: -1, z: 0 })
+          );
+        });
+      });
+    });
+
+    describe('positionByEntityIdFromHexes (rpg-dnd5e-web#651)', () => {
+      // The full-resync snapshot-hydration counterpart to
+      // applyHexRecordsMerged's VISIBLE-over-REMEMBERED precedence above —
+      // same rule, same bug shape, shared by EncounterView.tsx and
+      // PlaytestHarness.tsx's onSnapshotDelivered instead of each keeping
+      // its own (previously identical, previously broken) copy.
+      it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts LAST', () => {
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+        const remembered = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+
+        const positions = positionByEntityIdFromHexes([visible, remembered]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('resolves to the VISIBLE position when the REMEMBERED record for the same entity sorts FIRST', () => {
+        const remembered = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1'),
+        ]);
+
+        const positions = positionByEntityIdFromHexes([remembered, visible]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('still resolves a position for an entity present ONLY in a REMEMBERED record — its frozen last-observed hex, so a reconnect still renders it as a memory (rpg-dnd5e-web#650) instead of dropping it', () => {
+        const remembered = makeHexRecord(
+          { x: 3, y: -2, z: -1 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+
+        const positions = positionByEntityIdFromHexes([remembered]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 3, y: -2, z: -1 })
+        );
+      });
+
+      it('a move sequence (visible A / remembered A + visible B, all in one hex list) resolves to B, not A', () => {
+        const rememberedA = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1')]
+        );
+        const visibleB = makeHexRecord(
+          { x: 1, y: -1, z: 0 },
+          HexState.VISIBLE,
+          [makePlacement('goblin-1')]
+        );
+
+        const positions = positionByEntityIdFromHexes([rememberedA, visibleB]);
+
+        expect(positions.get('goblin-1')).toEqual(
+          create(V2PositionSchema, { x: 1, y: -1, z: 0 })
+        );
+      });
+
+      it('ignores contents on a hex with no position (defensive)', () => {
+        const positionless = create(HexRecordSchema, {
+          state: HexState.VISIBLE,
+          contents: [create(PlacementSchema, { entityId: 'goblin-1' })],
+        });
+
+        const positions = positionByEntityIdFromHexes([positionless]);
+
+        expect(positions.has('goblin-1')).toBe(false);
       });
     });
 

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -401,6 +401,56 @@ export function hexesWithPosition(
 }
 
 /**
+ * Build a position index (entityId -> the hex position that currently
+ * places it) from a full hex list, honoring VISIBLE-over-REMEMBERED
+ * precedence for an entity present in both (rpg-dnd5e-web#651). Shared by
+ * both full-resync snapshot hydration sites (EncounterView.tsx's and
+ * PlaytestHarness.tsx's `onSnapshotDelivered`) — this exact reverse-index
+ * pattern was independently duplicated in both ("mirrors EncounterView.tsx"
+ * read the harness's own prior comment), and both copies had the same
+ * bug: iterating hexes in plain array order and letting whichever record
+ * for an entity sorted last silently win, with no regard for `hex.state`.
+ * Extracted here so the precedence rule can't drift out of sync between
+ * them, or between them and `applyHexRecordsMerged`'s own live-merge
+ * version of the same rule below.
+ *
+ * An entity present ONLY in REMEMBERED records (never VISIBLE in this same
+ * hex list) still resolves to a position — its last-observed one. That is
+ * deliberate, not a gap: HexRecord's own contract says a remembered
+ * placement "resolves against the viewer's known entity set... because a
+ * remembered occupant still needs something to render as," and a snapshot
+ * (a reconnect resync) carries a viewer's FULL accumulated knowledge —
+ * VISIBLE and REMEMBERED together — so excluding remembered-only entities
+ * here would make a previously-seen-but-now-out-of-sight monster/prop
+ * vanish across a reconnect instead of rendering as the frozen memory
+ * rpg-dnd5e-web#650 built for. What this function guarantees is narrower
+ * and is the actual bug fix: a REMEMBERED placement can never override a
+ * VISIBLE one for the same entity, in either array order.
+ */
+export function positionByEntityIdFromHexes(
+  hexes: HexRecord[]
+): Map<string, NonNullable<HexRecord['position']>> {
+  const positioned = hexesWithPosition(hexes);
+  const positions = new Map<string, NonNullable<HexRecord['position']>>();
+  const claimedByVisible = new Set<string>();
+  for (const hex of positioned) {
+    if (hex.state !== HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      claimedByVisible.add(placement.entityId);
+      positions.set(placement.entityId, hex.position);
+    }
+  }
+  for (const hex of positioned) {
+    if (hex.state === HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      if (claimedByVisible.has(placement.entityId)) continue;
+      positions.set(placement.entityId, hex.position);
+    }
+  }
+  return positions;
+}
+
+/**
  * Replace region metadata from the server's snapshot. A reconnect snapshot is
  * authoritative, so omitted theme/zones/hexes clear stale local values.
  * Exported for testing.
@@ -510,12 +560,27 @@ export function applyWallsRevealed(
  *     resolves. An entityId that still doesn't resolve is dropped: fail
  *     closed, never render an undisclosed occupant (neither added to nor
  *     removed from the position cache).
- *   - A resolving placement writes (or overwrites) that entityId's cached
- *     position. This is always treated as an "appear", not a "move" (a
- *     fresh `create(EntityStateSchema, ...)`, matching
- *     applyEntityAppearedBatch's own `{ ...entity, ghost: false }` — the
- *     real hex-by-hex walk animation is EntityMoved's job, handled
- *     separately by mergeEntityPosition; a knowledge change is never that).
+ *   - VISIBLE-over-REMEMBERED precedence (rpg-dnd5e-web#651): an entity can
+ *     legitimately appear in TWO records within the SAME event — the newly
+ *     VISIBLE hex it just moved to, and a REMEMBERED hex that still lists
+ *     it (a remembered record retains its frozen observation until
+ *     something re-derives it — that's the entire point of "remembered").
+ *     Resolving placements in plain array order let whichever hex happened
+ *     to sort last silently win, so a stale REMEMBERED placement could
+ *     revert a fresh VISIBLE position — this is what corrupted the MOVER's
+ *     own cached position on nearly every move once rpg-api#732 started
+ *     restating the mover's whole known set (visible + remembered) on
+ *     every step: wrong position -> excluded from `visibleEntities`
+ *     (rendered as a frozen memory of themselves) -> missing from
+ *     `visibleTurnOrder` -> "my move did nothing until I clicked twice."
+ *     Placements are now resolved in two passes instead of one: every
+ *     VISIBLE placement first (always wins), then REMEMBERED placements
+ *     fill in only entities no VISIBLE record claimed this event — which
+ *     is exactly the legitimate "only ever seen from afar, now out of
+ *     sight" case #650 needs to still resolve to a position so it renders
+ *     as a memory (HexRecord's own doc comment: a remembered placement
+ *     "resolves against the viewer's known entity set... because a
+ *     remembered occupant still needs something to render as").
  *   - An entityId present in the OLD cached record's contents at this
  *     position but absent from the NEW one — and not re-placed at any OTHER
  *     position this SAME event (a move within one message) — is removed
@@ -557,25 +622,54 @@ export function applyHexRecordsMerged(
   }
 
   let nextEntities: LocalEncounterState['entities'] | undefined;
+  const setPosition = (entityId: string, position: Position) => {
+    const existing = (nextEntities ?? prev.entities).get(entityId);
+    if (
+      existing?.position?.x === position.x &&
+      existing?.position?.y === position.y &&
+      existing?.position?.z === position.z
+    ) {
+      return;
+    }
+    if (!nextEntities) nextEntities = new Map(prev.entities);
+    nextEntities.set(
+      entityId,
+      create(EntityStateSchema, { entityId, position })
+    );
+  };
+
+  // Pass 1: every VISIBLE placement this event. Always wins — set
+  // unconditionally, regardless of what a REMEMBERED record for the same
+  // entity says (processed in pass 2 below).
+  const claimedByVisibleThisEvent = new Set<string>();
   for (const hex of positioned) {
-    const key = hexKey(protoPositionToHex(hex.position));
+    if (hex.state !== HexState.VISIBLE) continue;
     for (const placement of hex.contents ?? []) {
       if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
-      const position = v2PositionToV1(hex.position);
-      const existing = (nextEntities ?? prev.entities).get(placement.entityId);
-      if (
-        existing?.position?.x === position.x &&
-        existing?.position?.y === position.y &&
-        existing?.position?.z === position.z
-      ) {
-        continue;
-      }
-      if (!nextEntities) nextEntities = new Map(prev.entities);
-      nextEntities.set(
-        placement.entityId,
-        create(EntityStateSchema, { entityId: placement.entityId, position })
-      );
+      claimedByVisibleThisEvent.add(placement.entityId);
+      setPosition(placement.entityId, v2PositionToV1(hex.position));
     }
+  }
+  // Pass 2: REMEMBERED placements — only for entities no VISIBLE record
+  // claimed this event. A REMEMBERED record's own placement is otherwise
+  // exactly as authoritative as a VISIBLE one (it's the frozen truth of
+  // what this position held), it just never gets to override a fresher
+  // sighting from the same event.
+  for (const hex of positioned) {
+    if (hex.state === HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      if (claimedByVisibleThisEvent.has(placement.entityId)) continue;
+      if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
+      setPosition(placement.entityId, v2PositionToV1(hex.position));
+    }
+  }
+
+  // Vacate pass: an entity that used to sit at a position this event
+  // updates, and isn't re-placed anywhere else this event, is gone from the
+  // cache. Reads only `prev.revealedHexes` (untouched by the two passes
+  // above), so its own ordering relative to them doesn't matter.
+  for (const hex of positioned) {
+    const key = hexKey(protoPositionToHex(hex.position));
     const oldContents = prev.revealedHexes.get(key)?.contents ?? [];
     for (const oldPlacement of oldContents) {
       if (placedThisEvent.has(oldPlacement.entityId)) continue;


### PR DESCRIPTION
## Summary

Two commits landed on `development` after PR #653 (\`development\` → \`main\`, "release: viewer-scoped Fog of War") was squash-merged, which severed ancestry between the branches — `main`'s squash commit has a single parent, so `development` is not recorded as an ancestor. A direct merge of `main` into `development` (or vice versa) produces spurious diffs from the stale merge-base rather than clean per-commit history.

This PR cherry-picks the two `development`-only commits directly onto `main` instead:

- `b8cc7ea` — fix: VISIBLE hex placement must win over REMEMBERED for entity position (#651)
- `ab821bb` — fix(hex-grid): close tile-seam air gaps in wall runs at the tall default (#638)

Both cherry-picked with **zero conflicts** — verified precondition: `main`'s blobs for every file each commit touches were byte-identical to that commit's own parent state, so each cherry-pick's diff applies cleanly.

An earlier attempt to reconcile the branches via `git merge -X ours` was abandoned: it silently reintroduced an unused `Position` type import in `EncounterView.tsx` / `PlaytestHarness.tsx` (git's line-based 3-way merge, using the true (stale) merge-base, saw only `main` touching an import that `development` had net-zero'd across two of its own commits). Cherry-pick avoids this entirely, since each commit's own diff already includes #651's removal of that import. Confirmed here: no stray `Position` import in either file, and `git diff origin/development` for both is empty.

After this PR merges, `development` will be recut from `main` (Kirk's call — not part of this PR).

## Verification

- `git diff --name-only origin/development` from this branch: exactly the 22 main-only fog-of-war concept-bundle files (5 playtest-evidence PNGs, `src/App.tsx`, 16 `src/concepts/**` files) — nothing outside that set, confirming full reconciliation.
- `npx tsc -b --noEmit` — pass
- `npm run lint` — pass (0 errors, 1 pre-existing unrelated warning)
- `npx vitest run` — 97 test files / 1643 tests passed
- `npm run build` — pass
- Pre-push `ci-check.sh` hook (format/lint/typecheck/build/tests) — all green

## Test plan

- [x] Cherry-picks applied with zero conflicts
- [x] Branch reconciles cleanly against `development` (only expected concept-bundle diff remains)
- [x] No stray unused import from the earlier abandoned merge approach
- [x] Full local check suite green

— asset-pipeline agent, on behalf of KirkDiggler