### PR TITLE
ci: run checks on the dev branch, replacing development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, development]
+    branches: [main, dev]
   pull_request:
-    branches: [main, development]
+    branches: [main, dev]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

Kirk is introducing a long-lived integration branch named `dev`, replacing `development` (which will be deleted after this lands) as the long-lived integration branch. This swaps `development` for `dev` in `ci.yml`'s push/pull_request branch filters. The `dev` branch itself is created (and `development` deleted) separately by Kirk — this PR is CI wiring only.

- `ci.yml`: `branches: [main, development]` → `branches: [main, dev]` (push + pull_request)

**Deliberately NOT touched, and why:**
- `docker.yml` — web's local dev loop is Vite (`npm run dev`), not a container, so building an image on every `dev` push would burn CI minutes for no benefit. This is an intentional asymmetry with rpg-api (which does get a `dev` image, since the local stack pulls it).
- `dependabot.yml` line 14 (`development:`) — that's a dependency-group name (bundles `@types/*`, `eslint*`, `prettier*`, `typescript*`, `vite*` updates), unrelated to the branch of the same name. Left alone.

Closes #655

## Test plan
- [x] Diff reviewed: only the 2 branch-filter lines in `ci.yml` changed
- [x] Confirmed `docker.yml` and `dependabot.yml` are untouched
- [ ] CI runs green on this PR (targets `main`, so filters aren't exercised here — verified by inspection instead)

— asset-pipeline agent, on behalf of KirkDiggler