### PR TITLE
fix: close door wall run seams

### DIFF
--- a/src/components/hex-grid/syntyHexWallHelpers.ts
+++ b/src/components/hex-grid/syntyHexWallHelpers.ts
@@ -651,6 +651,14 @@ const DOOR_FRAME_RAW_WIDTH = 1.999;
 const DOOR_FRAME_RAW_HEIGHT = 2.5347;
 
 /**
+ * Door frame span along its local X axis after `doorFrameScale` is applied.
+ * This is the calibrated one-hex-edge contract shared by the frame renderer
+ * and connector-run geometry; do not duplicate the raw GLB measurement at
+ * either placement site.
+ */
+export const DOOR_FRAME_CALIBRATED_WIDTH = 1.0;
+
+/**
  * Door frame/leaf height scale (rpg-project#132 follow-up, Kirk's verdict
  * walking the tall-wall default: "at tall walls the door is really really
  * high"). SUPERSEDED design: this used to multiply a `heightRatio`
@@ -676,7 +684,7 @@ export const DOOR_FRAME_FILE = 'SM_Env_Door_Frame_01.glb';
 
 export function doorFrameScale(wallHeight: number): [number, number, number] {
   return [
-    1.0 / DOOR_FRAME_RAW_WIDTH,
+    DOOR_FRAME_CALIBRATED_WIDTH / DOOR_FRAME_RAW_WIDTH,
     wallHeight / DOOR_FRAME_RAW_HEIGHT,
     SYNTY_SCALE,
   ];

--- a/src/hooks/wallRunAdapters.test.ts
+++ b/src/hooks/wallRunAdapters.test.ts
@@ -417,6 +417,37 @@ describe("connectorFallbackSegments (W3 fallback restyle: same category-rule can
 
     expect(fallback.end).toEqual(expected);
     expect(resolved.end).toEqual(expected);
+
+    const afterFallback = connectorFallbackSegments(
+      [cellWall(60, 5), ...anchors(0, 7)],
+      regions,
+      [],
+      [door]
+    )[0]!;
+    const afterResolved = computeWallRuns({
+      regions: [
+        { id: 'left', hexes: rows(58, 59) },
+        { id: 'right', hexes: rows(61, 62) },
+      ],
+      doors: [door],
+    }).connectorRuns[0]!.segments[1]!;
+    const afterCandidateCenter = cubeToWorld(cubeAtColRow(60, 5), HEX_SIZE);
+    const afterLength = Math.hypot(
+      afterCandidateCenter.x - doorCenter.x,
+      afterCandidateCenter.z - doorCenter.z
+    );
+    const afterExpected = {
+      x:
+        doorCenter.x +
+        ((afterCandidateCenter.x - doorCenter.x) / afterLength) *
+          (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+      z:
+        doorCenter.z +
+        ((afterCandidateCenter.z - doorCenter.z) / afterLength) *
+          (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+    };
+    expect(afterFallback.start).toEqual(afterExpected);
+    expect(afterResolved.start).toEqual(afterExpected);
   });
 
   it('excludes a BOUNDARY-EDGE candidate one row beyond the true grid (STILL-BLOCKED regression) even though its column matches a known door', () => {

--- a/src/hooks/wallRunAdapters.test.ts
+++ b/src/hooks/wallRunAdapters.test.ts
@@ -3,7 +3,13 @@
  * W2 "positive category rule" (design.md).
  */
 
-import { cubeToWorld, HEX_SIZE } from '@/components/hex-grid/hexMath';
+import {
+  cubeToWorld,
+  HEX_DIRECTIONS,
+  HEX_SIZE,
+  type CubeCoord,
+} from '@/components/hex-grid/hexMath';
+import { DOOR_FRAME_CALIBRATED_WIDTH } from '@/components/hex-grid/syntyHexWallHelpers';
 import { CUTAWAY_STUB_WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { create } from '@bufbuild/protobuf';
 import {
@@ -372,6 +378,47 @@ describe("connectorFallbackSegments (W3 fallback restyle: same category-rule can
     }
   });
 
+  it('terminates a one-sided fallback at the same calibrated frame envelope as its resolved ConnectorRun successor', () => {
+    const door = { id: 'door-1', position: cubeAtColRow(60, 4) };
+    const fallback = connectorFallbackSegments(
+      [cellWall(60, 3), ...anchors(0, 7)],
+      regions,
+      [],
+      [door]
+    )[0]!;
+    const rows = (minCol: number, maxCol: number): CubeCoord[] => {
+      const hexes: CubeCoord[] = [];
+      for (let col = minCol; col <= maxCol; col++) {
+        for (let row = 0; row <= 7; row++) hexes.push(cubeAtColRow(col, row));
+      }
+      return hexes;
+    };
+    const resolved = computeWallRuns({
+      regions: [
+        { id: 'left', hexes: rows(58, 59) },
+        { id: 'right', hexes: rows(61, 62) },
+      ],
+      doors: [door],
+    }).connectorRuns[0]!.segments[0]!;
+    const doorCenter = cubeToWorld(door.position, HEX_SIZE);
+    const candidateCenter = cubeToWorld(cubeAtColRow(60, 3), HEX_SIZE);
+    const length = Math.hypot(
+      doorCenter.x - candidateCenter.x,
+      doorCenter.z - candidateCenter.z
+    );
+    const towardDoor = {
+      x: (doorCenter.x - candidateCenter.x) / length,
+      z: (doorCenter.z - candidateCenter.z) / length,
+    };
+    const expected = {
+      x: doorCenter.x - towardDoor.x * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+      z: doorCenter.z - towardDoor.z * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+    };
+
+    expect(fallback.end).toEqual(expected);
+    expect(resolved.end).toEqual(expected);
+  });
+
   it('excludes a BOUNDARY-EDGE candidate one row beyond the true grid (STILL-BLOCKED regression) even though its column matches a known door', () => {
     const offGridBoundaryEdge = edgeWall(59, 7, 60, 8);
     const doors = [{ id: 'door-1', position: cubeAtColRow(60, 4) }];
@@ -611,6 +658,37 @@ describe('connectorDoorPlanes (rpg-project#132 connector-single-wall follow-up, 
     // door (not a coincidental fixture artifact).
     expect(hexColumn(doorHex)).toBe(6);
     expect(hexRow(doorHex)).toBe(4);
+  });
+
+  it('keeps the calibrated connector plane stable for all six wire passage orientations and closed/open/locked states', () => {
+    const doorHex = cubeAtColRow(6, 4);
+    const planes = HEX_DIRECTIONS.map((direction, index) => {
+      const kind = [
+        WallKind.DOOR_CLOSED,
+        WallKind.DOOR_OPEN,
+        WallKind.DOOR_LOCKED,
+      ][index % 3]!;
+      const wireDoor = wall(
+        doorHex.x,
+        doorHex.y,
+        doorHex.z,
+        doorHex.x + direction.x,
+        doorHex.y + direction.y,
+        doorHex.z + direction.z,
+        kind,
+        `door-${index}`
+      );
+      const input = connectorDoorInputsFromWalls([wireDoor]);
+      return connectorDoorPlanes(input, HEX_SIZE).get(`door-${index}`)!;
+    });
+
+    // The production adapter intentionally ignores the arbitrary passage
+    // edge: all states/orientations place the frame on the same connector
+    // column plane from the door cell itself.
+    for (const plane of planes) {
+      expect(plane.position).toEqual(cubeToWorld(doorHex, HEX_SIZE));
+      expect(plane.rotationY).toBeCloseTo(planes[0]!.rotationY, 9);
+    }
   });
 });
 

--- a/src/hooks/wallRunAdapters.ts
+++ b/src/hooks/wallRunAdapters.ts
@@ -459,16 +459,20 @@ function candidateToFallbackSegment(
     const outerHalfRow = Math.hypot(dx, dz) / 2;
     // Match connectorRunForDoor's exact frame-envelope termination while
     // this column is still represented by individual fallback cells.
-    return {
-      start: {
-        x: center.x - towardDoor.x * outerHalfRow,
-        z: center.z - towardDoor.z * outerHalfRow,
-      },
-      end: {
-        x: doorCenter.x - towardDoor.x * halfFrame,
-        z: doorCenter.z - towardDoor.z * halfFrame,
-      },
+    const outer = {
+      x: center.x - towardDoor.x * outerHalfRow,
+      z: center.z - towardDoor.z * outerHalfRow,
     };
+    const frameEnvelope = {
+      x: doorCenter.x - towardDoor.x * halfFrame,
+      z: doorCenter.z - towardDoor.z * halfFrame,
+    };
+    // Preserve the ordinary increasing-row segment direction on both
+    // sides of the door. It keeps fallback tile orientation identical to
+    // the pre-fix path while changing only the inner endpoint.
+    return row < hexRow(doorAtAdjacentRow.position)
+      ? { start: outer, end: frameEnvelope }
+      : { start: frameEnvelope, end: outer };
   }
   return {
     start: { x: center.x - dx / 2, z: center.z - dz / 2 },

--- a/src/hooks/wallRunAdapters.ts
+++ b/src/hooks/wallRunAdapters.ts
@@ -20,7 +20,10 @@ import {
   type CubeCoord,
   type WorldPos,
 } from '@/components/hex-grid/hexMath';
-import { isDoorWallKind } from '@/components/hex-grid/syntyHexWallHelpers';
+import {
+  DOOR_FRAME_CALIBRATED_WIDTH,
+  isDoorWallKind,
+} from '@/components/hex-grid/syntyHexWallHelpers';
 import { connectorPartitionHeight } from '@/components/hex-grid/wallRunMeshHelpers';
 import {
   HexState,
@@ -433,7 +436,8 @@ export function legacyRenderWalls(
  */
 function candidateToFallbackSegment(
   candidate: CubeCoord,
-  hexSize: number
+  hexSize: number,
+  doorAtAdjacentRow: ConnectorDoorInput | undefined
 ): WallRunSegment {
   const col = hexColumn(candidate);
   const row = hexRow(candidate);
@@ -441,6 +445,31 @@ function candidateToFallbackSegment(
   const next = cubeToWorld(cubeAtColRow(col, row + 1), hexSize);
   const dx = next.x - center.x;
   const dz = next.z - center.z;
+  const halfFrame = DOOR_FRAME_CALIBRATED_WIDTH / 2;
+  if (doorAtAdjacentRow) {
+    const doorCenter = cubeToWorld(doorAtAdjacentRow.position, hexSize);
+    const distance = Math.hypot(
+      doorCenter.x - center.x,
+      doorCenter.z - center.z
+    );
+    const towardDoor = {
+      x: (doorCenter.x - center.x) / distance,
+      z: (doorCenter.z - center.z) / distance,
+    };
+    const outerHalfRow = Math.hypot(dx, dz) / 2;
+    // Match connectorRunForDoor's exact frame-envelope termination while
+    // this column is still represented by individual fallback cells.
+    return {
+      start: {
+        x: center.x - towardDoor.x * outerHalfRow,
+        z: center.z - towardDoor.z * outerHalfRow,
+      },
+      end: {
+        x: doorCenter.x - towardDoor.x * halfFrame,
+        z: doorCenter.z - towardDoor.z * halfFrame,
+      },
+    };
+  }
   return {
     start: { x: center.x - dx / 2, z: center.z - dz / 2 },
     end: { x: center.x + dx / 2, z: center.z + dz / 2 },
@@ -482,6 +511,13 @@ export function connectorFallbackSegments(
 
   const segments: WallRunSegment[] = [];
   const seenCandidateKeys = new Set<string>();
+  const doorByColumnRow = new Map<string, ConnectorDoorInput>();
+  for (const door of doors) {
+    doorByColumnRow.set(
+      `${hexColumn(door.position)},${hexRow(door.position)}`,
+      door
+    );
+  }
   for (const wall of walls) {
     const category = categorizeWall(
       wall,
@@ -494,7 +530,14 @@ export function connectorFallbackSegments(
     const key = coordToKey(category.candidate);
     if (seenCandidateKeys.has(key)) continue;
     seenCandidateKeys.add(key);
-    segments.push(candidateToFallbackSegment(category.candidate, hexSize));
+    const candidateCol = hexColumn(category.candidate);
+    const candidateRow = hexRow(category.candidate);
+    const doorAtAdjacentRow =
+      doorByColumnRow.get(`${candidateCol},${candidateRow - 1}`) ??
+      doorByColumnRow.get(`${candidateCol},${candidateRow + 1}`);
+    segments.push(
+      candidateToFallbackSegment(category.candidate, hexSize, doorAtAdjacentRow)
+    );
   }
   return segments;
 }

--- a/src/hooks/wallRuns.test.ts
+++ b/src/hooks/wallRuns.test.ts
@@ -23,6 +23,7 @@ import {
   type CubeCoord,
   type WorldPos,
 } from '@/components/hex-grid/hexMath';
+import { DOOR_FRAME_CALIBRATED_WIDTH } from '@/components/hex-grid/syntyHexWallHelpers';
 import { describe, expect, it } from 'vitest';
 import {
   REAL_LOOK_LAB_DOORS,
@@ -1747,4 +1748,48 @@ describe('computeWallRuns — widening propagation across a 3+ room chain (gate 
       distance(tombBottom.start, stuckAtRow4)
     );
   });
+});
+
+describe('computeWallRuns — door-frame junctions (#635)', () => {
+  it.each([
+    { height: 4, doorRow: 1, label: 'short connector' },
+    { height: 12, doorRow: 6, label: 'long connector' },
+  ])(
+    '$label terminates both wall halves at the calibrated frame envelope without crossing the door center',
+    ({ height, doorRow }) => {
+      const doorCol = 2;
+      const regions: RegionInput[] = [
+        { id: 'left', hexes: regionCubes(2, height, 0) },
+        { id: 'right', hexes: regionCubes(2, height, 3) },
+      ];
+      const door = {
+        id: `door-${height}`,
+        position: cubeAtColRow(doorCol, doorRow),
+      };
+      const run = computeWallRuns({ regions, doors: [door] }).connectorRuns[0]!;
+      const [beforeDoor, afterDoor] = run.segments;
+      const center = cubeToWorld(door.position, HEX_SIZE);
+      const next = cubeToWorld(cubeAtColRow(doorCol, doorRow + 1), HEX_SIZE);
+      const length = Math.hypot(next.x - center.x, next.z - center.z);
+      const direction = {
+        x: (next.x - center.x) / length,
+        z: (next.z - center.z) / length,
+      };
+      const along = (point: WorldPos) =>
+        (point.x - center.x) * direction.x + (point.z - center.z) * direction.z;
+
+      // Prior geometry ended these at +/-sqrt(3) (the adjacent row centers),
+      // leaving the reported 1.15-unit daylight gap after #634's 0.08 tile
+      // overlap. The renderer now overlaps this exact frame envelope by 0.08.
+      const halfFrame = DOOR_FRAME_CALIBRATED_WIDTH / 2;
+      expect(along(beforeDoor!.end)).toBeCloseTo(-halfFrame, 9);
+      expect(along(afterDoor!.start)).toBeCloseTo(halfFrame, 9);
+      expect(Math.abs(along(beforeDoor!.end))).toBeLessThan(1);
+      expect(Math.abs(along(afterDoor!.start))).toBeLessThan(1);
+
+      // Nearest endpoints are outside, never through, the door center.
+      expect(along(beforeDoor!.end)).toBeLessThan(0);
+      expect(along(afterDoor!.start)).toBeGreaterThan(0);
+    }
+  );
 });

--- a/src/hooks/wallRuns.ts
+++ b/src/hooks/wallRuns.ts
@@ -82,6 +82,7 @@ import {
   type CubeCoord,
   type WorldPos,
 } from '@/components/hex-grid/hexMath';
+import { DOOR_FRAME_CALIBRATED_WIDTH } from '@/components/hex-grid/syntyHexWallHelpers';
 
 /** One region's stable id and the set of hex cells the wire currently
  * reports as belonging to it (Space.hexes filtered by zoneId === region
@@ -1171,6 +1172,13 @@ function connectorRunForDoor(
   const facing = unitDirection(doorWorld, boundsCenter(boundsB, hexSize));
 
   const segments: WallRunSegment[] = [];
+  // The frame is centered on the door cell and calibrated to a one-edge
+  // span. Terminating at the adjacent row center leaves a 1.15-unit visual
+  // hole even after WallRunMesh's existing #634 tile overlap; terminate at
+  // the frame's outer envelope instead. WallRunMesh then applies its normal
+  // 0.08 overlap into this boundary, so the rendered wall self-covers the
+  // irregular panel/frame junction without changing ordinary wall tiling.
+  const doorFrameHalfSpan = DOOR_FRAME_CALIBRATED_WIDTH / 2;
 
   // regionA sits on the LOWER-column side of this connector (always —
   // connectorRegionsForDoor's own convention), so its relevant corners are
@@ -1202,8 +1210,9 @@ function connectorRunForDoor(
   // guarantees it), so the candidate list is never empty.
   if (doorRow > minRow) {
     const rawStart = worldAt(minRow);
-    const rawEnd = worldAt(doorRow - 1);
-    const dir = unitDirection(rawStart, rawEnd);
+    // Anchor to the door cell rather than rawEnd: a one-row half-run has
+    // rawStart === rawEnd but still needs the connector column direction.
+    const dir = unitDirection(rawStart, doorWorld);
     const nearTargets: WorldPos[] = [];
     if (boundsA.minRow === minRow)
       nearTargets.push(regionACorners.get('topRight')!);
@@ -1216,13 +1225,16 @@ function connectorRunForDoor(
         x: rawStart.x - dir.x * nearExtension,
         z: rawStart.z - dir.z * nearExtension,
       },
-      end: rawEnd,
+      end: {
+        x: doorWorld.x - dir.x * doorFrameHalfSpan,
+        z: doorWorld.z - dir.z * doorFrameHalfSpan,
+      },
     });
   }
   if (doorRow < maxRow) {
-    const rawStart = worldAt(doorRow + 1);
     const rawEnd = worldAt(maxRow);
-    const dir = unitDirection(rawStart, rawEnd);
+    // Symmetric door-cell anchor keeps a one-row half-run non-degenerate.
+    const dir = unitDirection(doorWorld, rawEnd);
     const farTargets: WorldPos[] = [];
     if (boundsA.maxRow === maxRow)
       farTargets.push(regionACorners.get('bottomRight')!);
@@ -1231,7 +1243,10 @@ function connectorRunForDoor(
     const farExtension =
       distancePastPoint(rawEnd, farTargets) + envelopeCornerOverlapMargin;
     segments.push({
-      start: rawStart,
+      start: {
+        x: doorWorld.x + dir.x * doorFrameHalfSpan,
+        z: doorWorld.z + dir.z * doorFrameHalfSpan,
+      },
       end: {
         x: rawEnd.x + dir.x * farExtension,
         z: rawEnd.z + dir.z * farExtension,


### PR DESCRIPTION
## Summary
- terminate resolved connector wall halves at the calibrated outer door-frame envelope, where the existing #634 0.08 tile overlap carries the rendered wall into the frame
- give adjacent-row fallback segments the identical frame-envelope termination, preserving one-sided/frontier → resolved geometry
- cover short and long runs, both fallback junctions, six wire passage orientations, closed/open/locked states, and fallback parity with production geometry/adapters

Closes #635

## Evidence
- `npm run test:run -- src/hooks/wallRuns.test.ts src/hooks/wallRunAdapters.test.ts src/components/hex-grid/wallRunMeshHelpers.test.ts` — 3 files, 143 tests passed
- Regression discrimination: restoring adjacent-row-center endpoints made both new short/long #635 cases fail at `±1.7320508075688772` vs the required calibrated `±0.5`.
- `npm run ci-check` — passed (format, lint, typecheck, build, tests).
- Visual harness: inspected the fresh worktree and its `public/` tree; the required environment GLBs (`SM_Env_Door_Frame_01.glb` / `SM_Env_Wall_Half_01.glb`) are not present, so this checkout cannot honestly produce or inspect a rendered seam image. No asset-contract change is required: the fix uses the existing calibrated frame scale and preserves #634 tile overlap.

## Scope
Render geometry only; no server/game-state computation or asset conversion changes.

— asset-pipeline agent, on behalf of KirkDiggler