### PR TITLE
Fix racial traits modal layout and empty-state rendering

### DIFF
--- a/src/character/creation/RaceSelectionModal.test.tsx
+++ b/src/character/creation/RaceSelectionModal.test.tsx
@@ -1,0 +1,66 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  RaceInfoSchema,
+  RacialTraitSchema,
+  type RaceInfo,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RaceSelectionModal } from './RaceSelectionModal';
+
+const hoisted = vi.hoisted(() => ({
+  useListRaces: vi.fn(),
+}));
+
+vi.mock('../../api/hooks', () => ({
+  useListRaces: hoisted.useListRaces,
+}));
+
+function race(name: string, traits: RaceInfo['traits']): RaceInfo {
+  return create(RaceInfoSchema, { name, traits });
+}
+
+function renderModal(races: RaceInfo[]) {
+  hoisted.useListRaces.mockReturnValue({
+    data: races,
+    loading: false,
+    error: null,
+  });
+
+  render(<RaceSelectionModal isOpen onClose={vi.fn()} onSelect={vi.fn()} />);
+}
+
+describe('RaceSelectionModal racial traits', () => {
+  it('keeps populated traits in the existing collapsible disclosure without an inner scrollbar', async () => {
+    renderModal([
+      race('Elf', [
+        create(RacialTraitSchema, {
+          name: 'Darkvision',
+          description: 'You can see in dim light within 60 feet of you.',
+        }),
+      ]),
+    ]);
+
+    const disclosure = screen.getByRole('button', { name: /racial traits/i });
+    expect(disclosure).toBeTruthy();
+    expect(screen.getByText('Darkvision')).toBeTruthy();
+
+    const traitContainer = screen.getByText('Darkvision').parentElement
+      ?.parentElement as HTMLDivElement;
+    expect(traitContainer.style.overflowY).toBe('');
+    expect(traitContainer.style.maxHeight).toBe('');
+
+    fireEvent.click(disclosure);
+    await waitFor(() => {
+      expect(screen.queryByText('Darkvision')).toBeNull();
+    });
+  });
+
+  it('omits the entire racial traits disclosure and fallback for Human with no traits', () => {
+    renderModal([race('Human', [])]);
+
+    expect(screen.queryByRole('button', { name: /racial traits/i })).toBeNull();
+    expect(screen.queryByText('Racial Traits')).toBeNull();
+    expect(screen.queryByText('No racial traits available')).toBeNull();
+  });
+});

--- a/src/character/creation/RaceSelectionModal.tsx
+++ b/src/character/creation/RaceSelectionModal.tsx
@@ -783,19 +783,17 @@ export function RaceSelectionModal({
             })()}
 
             {/* Racial Traits */}
-            <CollapsibleSection title="Racial Traits" defaultOpen={true}>
-              <div
-                style={{
-                  maxHeight: '140px',
-                  overflowY: 'auto',
-                  padding: '8px',
-                  backgroundColor: bgSecondary,
-                  borderRadius: '6px',
-                  border: `1px solid ${borderPrimary}`,
-                }}
-              >
-                {currentRaceData.traits && currentRaceData.traits.length > 0 ? (
-                  currentRaceData.traits.map((trait, i) => (
+            {currentRaceData.traits.length > 0 && (
+              <CollapsibleSection title="Racial Traits" defaultOpen={true}>
+                <div
+                  style={{
+                    padding: '8px',
+                    backgroundColor: bgSecondary,
+                    borderRadius: '6px',
+                    border: `1px solid ${borderPrimary}`,
+                  }}
+                >
+                  {currentRaceData.traits.map((trait, i) => (
                     <div key={i} style={{ marginBottom: '8px' }}>
                       <div
                         style={{
@@ -848,14 +846,10 @@ export function RaceSelectionModal({
                           </div>
                         )}
                     </div>
-                  ))
-                ) : (
-                  <div style={{ color: textMuted, fontSize: '14px' }}>
-                    No racial traits available
-                  </div>
-                )}
-              </div>
-            </CollapsibleSection>
+                  ))}
+                </div>
+              </CollapsibleSection>
+            )}
 
             {/* Proficiencies - RaceInfo no longer has proficiencies field - they come through choices now */}
           </div>


### PR DESCRIPTION
## Summary
- remove the Racial Traits inner scroll container so populated traits flow through the modal scroll
- omit the Racial Traits disclosure entirely when the selected race has no traits
- add RTL coverage for populated and empty racial-trait responses

Closes #675

## Tests
- `npx vitest run src/character/creation/RaceSelectionModal.test.tsx`
- `npm run ci-check`

## Live evidence
Local preview: `http://127.0.0.1:3004/?playerId=web-675-evidence` (VITE_API_HOST=`http://localhost:8080`). Real local character creation against the local API captured:
- `/tmp/rpg-web-675-evidence/elf-desktop.png` and `elf-discord.png`: populated Elf traits; computed trait-container `overflow-y: visible`, `max-height: none`
- `/tmp/rpg-web-675-evidence/human-desktop.png` and `human-discord.png`: Human has no Racial Traits disclosure or fallback
- `/tmp/rpg-web-675-evidence/evidence.json`: viewport and DOM assertions

— asset-pipeline agent, on behalf of KirkDiggler