### PR TITLE
feat(dungeon-builder): Kirk verdicts -- hex-true is the only board, comments demoted

### DIFF
--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -18,12 +18,7 @@ import {
   totalColumns,
 } from './boardGeometry';
 import type { DungeonDoc } from './dungeonYaml';
-import {
-  BOARD_HEX_SIZE,
-  cellCenter,
-  cellCorners,
-  type LayoutMode,
-} from './hexLayout';
+import { BOARD_HEX_SIZE, cellCenter, cellCorners } from './hexLayout';
 import {
   BOSS_COLOR,
   MONSTER_COLOR,
@@ -35,7 +30,6 @@ import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 interface BoardProps {
   floorPlan: FloorPlan;
   doc: DungeonDoc;
-  layoutMode: LayoutMode;
   selectedPalette: PaletteSelection | null;
   selectedPlacement: PlacementSelection | null;
   selectedConnectorIndex: number | null;
@@ -84,7 +78,6 @@ function shortLabel(ref: string, isBoss: boolean): string {
 export function Board({
   floorPlan,
   doc,
-  layoutMode,
   selectedPalette,
   selectedPlacement,
   selectedConnectorIndex,
@@ -122,8 +115,8 @@ export function Board({
     const room = roomAtColumn(floorPlan, col);
     const connector = connectorAtColumn(floorPlan, col);
     for (let row = 0; row < floorPlan.height; row++) {
-      const center = cellCenter(layoutMode, col, row);
-      const corners = cellCorners(layoutMode, center, BOARD_HEX_SIZE - 1.5);
+      const center = cellCenter(col, row);
+      const corners = cellCorners(center, BOARD_HEX_SIZE - 1.5);
       corners.forEach(([x, y]) => trackExtent(x, y));
       const points = corners
         .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
@@ -243,8 +236,8 @@ export function Board({
   // honesty mechanism elsewhere in this concept exists to avoid. See
   // CONTRACT.md.
   const trackCellExtent = (col: number, row: number) => {
-    const center = cellCenter(layoutMode, col, row);
-    cellCorners(layoutMode, center, BOARD_HEX_SIZE - 1.5).forEach(([x, y]) =>
+    const center = cellCenter(col, row);
+    cellCorners(center, BOARD_HEX_SIZE - 1.5).forEach(([x, y]) =>
       trackExtent(x, y)
     );
   };
@@ -252,7 +245,7 @@ export function Board({
   for (const wall of doc.walls) {
     trackCellExtent(wall.from[0], wall.from[1]);
     trackCellExtent(wall.to[0], wall.to[1]);
-    const center = cellCenter(layoutMode, wall.from[0], wall.from[1]);
+    const center = cellCenter(wall.from[0], wall.from[1]);
     const isDoor = wall.kind === 'door';
     // Same orange/cream distinction the creation board's own wall
     // rendering and the 3D preview's wall boxes already use for solid
@@ -298,8 +291,8 @@ export function Board({
   }
   for (const [holeCol, holeRow] of doc.holes) {
     trackCellExtent(holeCol, holeRow);
-    const center = cellCenter(layoutMode, holeCol, holeRow);
-    const corners = cellCorners(layoutMode, center, BOARD_HEX_SIZE - 1.5).map(
+    const center = cellCenter(holeCol, holeRow);
+    const corners = cellCorners(center, BOARD_HEX_SIZE - 1.5).map(
       ([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`
     );
     structuralOverlay.push(
@@ -316,7 +309,7 @@ export function Board({
   }
   if (doc.start) {
     trackCellExtent(doc.start[0], doc.start[1]);
-    const center = cellCenter(layoutMode, doc.start[0], doc.start[1]);
+    const center = cellCenter(doc.start[0], doc.start[1]);
     structuralOverlay.push(
       <g key="dialect-start" pointerEvents="none">
         <circle
@@ -344,7 +337,7 @@ export function Board({
   }
   if (doc.end) {
     trackCellExtent(doc.end[0], doc.end[1]);
-    const center = cellCenter(layoutMode, doc.end[0], doc.end[1]);
+    const center = cellCenter(doc.end[0], doc.end[1]);
     structuralOverlay.push(
       <g key="dialect-end" pointerEvents="none">
         <circle
@@ -378,7 +371,7 @@ export function Board({
     room.place.forEach((p, index) => {
       const absCol = fpRoom.startColumn + p.at[0];
       const row = p.at[1];
-      const center = cellCenter(layoutMode, absCol, row);
+      const center = cellCenter(absCol, row);
       const sel: PlacementSelection = { roomId: room.id, index };
       const isSelected =
         !!selectedPlacement &&
@@ -417,7 +410,7 @@ export function Board({
     if (room.boss) {
       const absCol = fpRoom.startColumn + room.boss.at[0];
       const row = room.boss.at[1];
-      const center = cellCenter(layoutMode, absCol, row);
+      const center = cellCenter(absCol, row);
       const sel: PlacementSelection = { roomId: room.id, boss: true };
       const isSelected =
         !!selectedPlacement &&
@@ -456,7 +449,7 @@ export function Board({
 
   // Room labels + entrance marker.
   const labels: ReactElement[] = floorPlan.rooms.map((r) => {
-    const top = cellCenter(layoutMode, r.startColumn, 0);
+    const top = cellCenter(r.startColumn, 0);
     return (
       <text
         key={`label-${r.id}`}
@@ -477,7 +470,6 @@ export function Board({
   let entranceMarker: ReactElement | null = null;
   if (floorPlan.entrance) {
     const center = cellCenter(
-      layoutMode,
       floorPlan.entrance.column,
       floorPlan.entrance.row
     );
@@ -529,8 +521,7 @@ export function Board({
     const boardPt = ctm ? pt.matrixTransform(ctm.inverse()) : { x: 0, y: 0 };
     const { absCol, row, room } = nearestCell(
       { x: boardPt.x, y: boardPt.y },
-      floorPlan,
-      layoutMode
+      floorPlan
     );
     setDragging(null);
     if (!room) {

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -108,12 +108,27 @@ Both are now settled with real evidence:
   referenced in `fixtures.ts`. The standalone concept's "unverified"
   finding here is closed.
 
-## New finding from this port: `yaml` doesn't fully close the round-trip requirement
+## New finding from this port: `yaml` doesn't fully close comment preservation, and that's fine
+
+**Demoted from hard requirement to best-effort/incidental (Kirk,
+2026-08-02).** The original concept brief said to use the `yaml` npm
+package for comment-preserving round-trip, framed as a hard
+requirement. Kirk's settled call: the builder itself never authors
+comments — only a hand-editor typing directly into the YAML pane would
+ever introduce one, and hand-editors own the consequences of their own
+edits. Comment preservation stays exactly as good as it already is (the
+CST round-trip behavior below is UNCHANGED — it works, and ripping it
+out would be pure loss for zero gain), but it's no longer a gate on
+anything, and the group-comment-orphaning question the finding below
+raises is CLOSED AS MOOT, not solved — see its own closure note. No
+further investment in comment semantics is planned unless Kirk reopens
+this.
 
 The original concept brief says to use the `yaml` npm package for
 comment-preserving round-trip, implying it's a solved problem once you
 reach for the right library. Two things worth knowing before assuming
-that:
+that (kept for the record — see the demotion note just above for why
+neither is being chased further):
 
 1. **Byte-stability needs `{ lineWidth: 0 }`, and even then one residual
    diff remains.** Default stringify options reflow every flow-style
@@ -140,12 +155,24 @@ that:
    `deletePlacement on a comment-carrying item silently drops the
 comment too`) demonstrate both directions of the failure mode this
    causes: dragging that first pillar carries the heading away with it;
-   deleting it removes the heading even though 7 pillars remain. **This
-   is a real, load-bearing UX question for the approved delivery
-   slices, not solved by picking the recommended library** — a production implementation needs
-   an explicit decision (attach group comments to the room instead of the
-   first item? warn on delete/move of a comment-carrying item? accept the
-   loss?), not just "use `yaml`".
+   deleting it removes the heading even though 7 pillars remain. This
+   was originally framed as a real, load-bearing UX question for the
+   approved delivery slices, needing an explicit decision (attach group
+   comments to the room instead of the first item? warn on delete/move
+   of a comment-carrying item? accept the loss?), not just "use `yaml`".
+
+   **Closed as MOOT (Kirk, 2026-08-02), not solved.** The scenario this
+   describes only arises when a HAND-EDITOR has typed a group comment
+   into the YAML pane and then the BUILDER's own UI (drag/delete) acts
+   on the item it's attached to — the builder itself never authors a
+   comment in the first place, so it can orphan one but never has to
+   decide how to preserve one it wrote. Given comment preservation is
+   now explicitly best-effort/incidental (see this section's opening
+   note), that's an acceptable, honestly-recorded gap, not a defect
+   pending a decision. The analysis above (the two demonstrating tests,
+   the exact `commentBefore` attachment behavior) stays as accurate,
+   useful documentation of how the underlying library actually behaves —
+   only the "needs a decision" framing is retracted.
 
 ## Live verification
 
@@ -195,17 +222,27 @@ hex math (`hexTrueCellCenter`, reusing `hexMath.ts`/`wallRuns.ts` per
 the original concept brief) shears diagonally across a wide room
 chain: `hexRow(col,row) = row + floor(col/2)`, so at a fixed row,
 world-Z drifts roughly linearly with column. Verified analytically, not
-a porting bug. This port adds the `flattened` layout mode
-(`hexLayout.ts`'s `flatCellCenter` — plain Cartesian, no hex-parity
-correction) specifically so this can be compared in place, one FloorPlan,
-two renderings, via the board's own toggle — see the evidence
-screenshots. **The original concept brief's "reuse the odd-q/hex-position
-helpers... for hex-to-screen positioning" direction needs an explicit
-decision in the ordered slices**: embrace the sheared/authentic-hex look,
-or specify a different flattening for the 2D top-down authoring board.
-This should not be inherited silently from reusing production code written
-for a different rendering context (revealed 3D rooms, not a flat
-multi-room chain).
+a porting bug. **This finding is still real hex geometry** — only the
+"what should the 2D board do about it" question below has since been
+settled (see "Flattened layout mode: explored and rejected," next).
+
+### Flattened layout mode: explored and rejected (2026-08-02)
+
+This port originally added a `flattened` layout mode (`hexLayout.ts`'s
+now-removed `flatCellCenter` — plain Cartesian, no hex-parity
+correction) specifically so the shear finding above could be compared
+in place, one `FloorPlan`, two renderings, via a board toggle — see the
+(now historical) evidence screenshots this section used to point to.
+That was the right way to SURFACE the question; it was not itself the
+answer. Kirk, choosing between the two once the toggle made the
+comparison genuinely legible: **"I like hex. turning them into squares
+feels way off and not what it will actually look like."** Hex-true is
+now THE board — the toggle, `flatCellCenter`, and the `LayoutMode` type
+are removed entirely (`hexLayout.ts`/`Board.tsx`/`boardGeometry.ts`/
+`DungeonBuilderConcept.tsx`), not merely defaulted or hidden. The
+diagonal shear itself remains exactly as true and as documented as
+before — it's no longer being treated as a legibility problem a second
+rendering mode should work around.
 
 ## UX learnings
 
@@ -232,19 +269,27 @@ multi-room chain).
    Seeing the same door-row band go from a diagonal streak to a level bar
    side by side (well, toggle by toggle) makes the shear finding
    immediately legible to someone who hasn't read this file — a stronger
-   argument than the writeup alone.
+   argument than the writeup alone. **Superseded 2026-08-02**: the toggle
+   did its job (making the comparison legible enough for Kirk to decide),
+   then was removed — see "Flattened layout mode: explored and
+   rejected," above. Worth having built it temporarily; not worth
+   keeping once it had answered the question it existed to surface.
 
 ## What the approved design gate and ordered slices must retain
 
 1. **Make the flattened-vs-hex-true call explicit** given the shear
    finding, rather than inheriting it from the original concept brief.
+   **Done, 2026-08-02**: Kirk's call is hex-true, no flattened mode — see
+   "Flattened layout mode: explored and rejected," above.
 2. **Use a board contract fixture wider than 2 rooms.** The old 2-room
    smoke-test fixture cannot catch chain accumulation; the available
    3-room `showcase.yaml` fixture (see `fixtures.ts`) can.
-3. **Make a real comment-preservation decision, not just "use the yaml
-   package."** See this file's "yaml package doesn't fully close..."
-   finding above — group-comment orphaning on delete/move is real even
-   with the recommended library.
+3. ~~Make a real comment-preservation decision, not just "use the yaml
+   package."~~ **Closed as moot, 2026-08-02** — comment preservation is
+   best-effort/incidental (the builder never authors comments; only a
+   hand-editor's own edits can orphan one). See this file's "yaml
+   package doesn't fully close comment preservation, and that's fine"
+   section above for the full closure note. No decision needed.
 4. **Add real rolled-content fixture coverage.** `showcase.yaml` (and
    everything else checked) has zero `obstacles:` entries, so
    `RolledContentPanel`'s non-empty path is genuinely untested against

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -1,10 +1,10 @@
 /**
  * DungeonBuilderConcept — composition root for the /concepts port of the
  * standalone dungeon-builder HTML concept (rpg-project#170 design gate).
- * Owns the CST/doc state board clicks and YAML edits both mutate, the
- * live-vs-fixtures data source (`usePutDungeonPreview`), and the
- * hex-true/flattened layout toggle. See CONTRACT.md for the full findings
- * writeup.
+ * Owns the CST/doc state board clicks and YAML edits both mutate, and the
+ * live-vs-fixtures data source (`usePutDungeonPreview`). See CONTRACT.md
+ * for the full findings writeup — including the now-removed
+ * hex-true/flattened layout toggle, explored and rejected 2026-08-02.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Document } from 'yaml';
@@ -45,7 +45,6 @@ import {
   type WallKind,
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
-import type { LayoutMode } from './hexLayout';
 import { Inspector } from './Inspector';
 import { Palette } from './Palette';
 import { PALETTE_PROPS } from './paletteData';
@@ -251,7 +250,6 @@ export function DungeonBuilderConcept() {
   // Markers palette categories) — also mutually exclusive with everything
   // above, folded into the same clearOtherSelections below.
   const [selectedTool, setSelectedTool] = useState<BoardTool | null>(null);
-  const [layoutMode, setLayoutMode] = useState<LayoutMode>('hex-true');
   const [boardDim, setBoardDim] = useState<'2d' | '3d'>('2d');
   const [toast, setToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -721,34 +719,6 @@ export function DungeonBuilderConcept() {
               </button>
             ))}
           </div>
-          {boardDim === '2d' && (
-            <label
-              style={{
-                fontSize: 12,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
-              Layout:
-              <select
-                value={layoutMode}
-                onChange={(e) => setLayoutMode(e.target.value as LayoutMode)}
-                style={{
-                  background: 'var(--bg-secondary)',
-                  color: 'var(--text-primary)',
-                  border: '1px solid var(--border-primary)',
-                  borderRadius: 4,
-                  padding: '2px 6px',
-                }}
-              >
-                <option value="hex-true">
-                  hex-true (shears — real game math)
-                </option>
-                <option value="flattened">flattened (plain grid)</option>
-              </select>
-            </label>
-          )}
           <div
             style={{
               fontSize: 12.5,
@@ -804,16 +774,14 @@ export function DungeonBuilderConcept() {
                     color: '#8a7a5a',
                   }}
                 >
-                  Board renders the game's actual odd-q pointy-top hex math when
-                  "hex-true" is selected — the diagonal shear across the chain
-                  is a real property of that addressing, not a rendering bug.
-                  Toggle to "flattened" to compare. See CONTRACT.md.
+                  Board renders the game's actual odd-q pointy-top hex math —
+                  the diagonal shear across the chain is a real property of that
+                  addressing, not a rendering bug. See CONTRACT.md.
                 </div>
                 <div style={{ flex: 1, overflow: 'auto', padding: 18 }}>
                   <Board
                     floorPlan={preview.floorPlan}
                     doc={doc}
-                    layoutMode={layoutMode}
                     selectedPalette={edit.selectedPalette}
                     selectedPlacement={edit.selectedPlacement}
                     selectedConnectorIndex={selectedConnectorIndex}

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -341,13 +341,15 @@ not a new rectangular 4/8-way compass. Deliberate: the codebase already
 has exactly one facing convention (defined for the hex-true board,
 currently mechanically inert per that file's own doc comment) — inventing
 a second, incompatible one for board authoring would create a
-reconciliation problem the moment both became real at once. The genuine,
-unresolved tension this keeps: 6 directions spaced 60° apart is a
-hex-native division of the circle — it reads naturally on the hex-true
-board and slightly oddly on the flattened one (no direction points along
-either axis). Carried over unchanged from the creation flow's original
-finding — not re-litigated, just now living on real `place:`/`boss:`
-entries instead of a separate invented `Placement` type.
+reconciliation problem the moment both became real at once. 6 directions
+spaced 60° apart is a hex-native division of the circle, and reads
+naturally on the hex-true board — the tension this used to name against
+a flattened/rectangular comparison mode no longer applies: that mode was
+explored and rejected (Kirk, 2026-08-02: "I like hex. turning them into
+squares feels way off and not what it will actually look like" —
+CONTRACT.md's "Flattened layout mode: explored and rejected"), so
+hex-true is grounded as the only board this convention has to read
+naturally on.
 
 ## z-axis: `mount` + `height`
 
@@ -395,10 +397,10 @@ placement inspector's optional height field, when cheap to add for a
 known wall-mountable ref, is the only UI this round ships).
 
 **Open question, not decided here: is 6-direction hex facing too coarse
-for a wall-mounted prop?** The tension named just above ("6 directions
-spaced 60° apart... reads slightly oddly on the flattened board") gets
-sharper once `facing` is driving a mounted prop's actual on-wall
-rotation rather than a floor-standing model's general orientation — a
+for a wall-mounted prop?** 6 directions spaced 60° apart is a coarse
+division of the circle, and gets sharper as a limitation once `facing`
+is driving a mounted prop's actual on-wall rotation rather than a
+floor-standing model's general orientation — a
 banner or sconce genuinely needs to sit FLUSH and SQUARE against the
 wall face it's mounted on, and the wall itself sits at whatever angle
 the edge geometry gives it, not necessarily one of the 6 hex-facing

--- a/src/concepts/dungeon-builder/boardGeometry.ts
+++ b/src/concepts/dungeon-builder/boardGeometry.ts
@@ -9,7 +9,7 @@ import type {
   FloorPlanRoom,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type { DungeonDoc } from './dungeonYaml';
-import { cellCenter, type CellPos, type LayoutMode } from './hexLayout';
+import { cellCenter, type CellPos } from './hexLayout';
 
 export function roomAtColumn(
   floorPlan: FloorPlan,
@@ -109,15 +109,14 @@ export function isEntranceBlocked(
  * verify than a closed-form inverse of `cellCenter`. */
 export function nearestCell(
   point: CellPos,
-  floorPlan: FloorPlan,
-  mode: LayoutMode
+  floorPlan: FloorPlan
 ): { absCol: number; row: number; room: FloorPlanRoom | null } {
   let best = { absCol: 0, row: 0, room: null as FloorPlanRoom | null };
   let bestDist = Infinity;
   const cols = totalColumns(floorPlan);
   for (let col = 0; col < cols; col++) {
     for (let row = 0; row < floorPlan.height; row++) {
-      const c = cellCenter(mode, col, row);
+      const c = cellCenter(col, row);
       const d = (c.x - point.x) ** 2 + (c.y - point.y) ** 2;
       if (d < bestDist) {
         bestDist = d;

--- a/src/concepts/dungeon-builder/hexLayout.ts
+++ b/src/concepts/dungeon-builder/hexLayout.ts
@@ -1,31 +1,36 @@
 /**
  * hexLayout — board cell positioning for the dungeon-builder concept.
  *
- * `hexTrueCellCenter` reuses the game's REAL hex math (`hexMath.ts`'s
+ * `cellCenter` reuses the game's REAL hex math (`hexMath.ts`'s
  * `cubeToWorld`, `wallRuns.ts`'s `cubeAtColRow`) rather than re-deriving
  * it — the standalone HTML concept ported these functions by hand because
  * it had no module system; this one imports them, per the concepts
  * convention ("real components/logic, not a parallel implementation").
  *
- * `flatCellCenter` is this concept's own addition: a plain Cartesian grid
- * that ignores hex-column parity entirely. It exists because of a finding
- * from the standalone concept (see CONTRACT.md "the floor plan shears
- * diagonally"): rendering a wide multi-room FloorPlan through the game's
- * real odd-q pointy-top math produces a board that shears — "row 0"
- * drifts upward on screen by roughly half a hex per column, since
- * `hexRow(col, row) = row + floor(col/2)` at a fixed row. That's provably
- * correct hex geometry, not a bug, but it may hurt legibility for an
- * authoring tool where precise clicking matters more than exact hex
- * adjacency. The toggle lets Kirk compare both renderings of the SAME
- * FloorPlan in-app and decide — see `DungeonBuilderConcept.tsx`.
+ * Hex-true is the ONLY edit-mode board — Kirk, 2026-08-02, choosing
+ * between it and a since-removed flattened/rectangular comparison
+ * toggle: "I like hex. turning them into squares feels way off and not
+ * what it will actually look like." The toggle existed to let him
+ * compare both renderings of the same `FloorPlan` in-app and decide; he
+ * decided. See CONTRACT.md's "Flattened layout mode: explored and
+ * rejected" section for the full history — the diagonal-shear finding
+ * that motivated building the comparison in the first place is still
+ * real hex geometry, just no longer treated as a legibility problem
+ * worth a second mode to work around.
+ *
+ * `FLAT_COL_SPACING`/`FLAT_ROW_SPACING` below are UNRELATED to that
+ * removed toggle, despite the similar naming — they're creation mode's
+ * own rectangular-canvas spacing (`CreationBoard.tsx`/
+ * `creationGeometry.ts`), a deliberately separate, still-live renderer
+ * for a freeform drawing canvas that was never claiming hex adjacency in
+ * the first place (see CONTRACT.md: "CreationBoard.tsx is still its own
+ * renderer, not Board.tsx itself — two genuinely different geometries").
  */
 import {
   cubeToWorld,
   hexCorners as realHexCorners,
 } from '@/components/hex-grid/hexMath';
 import { cubeAtColRow, hexColumn, hexRow } from '@/hooks/wallRuns';
-
-export type LayoutMode = 'hex-true' | 'flattened';
 
 /** Board-space hex radius. Smaller than the 3D game's world-unit
  * `HEX_SIZE` (which is 1.0 world unit) — this is a 2D SVG pixel radius,
@@ -38,54 +43,27 @@ export interface CellPos {
   y: number;
 }
 
-/** Same odd-q pointy-top math the real 3D floor renders with. */
-export function hexTrueCellCenter(col: number, row: number): CellPos {
+/** Same odd-q pointy-top math the real 3D floor renders with — edit
+ * mode's only board mode. */
+export function cellCenter(col: number, row: number): CellPos {
   const cube = cubeAtColRow(col, row);
   const world = cubeToWorld(cube, BOARD_HEX_SIZE);
   return { x: world.x, y: world.z };
 }
 
-/** Plain rectangular grid — no hex-column parity correction. Spacing
- * chosen to roughly match hex-true's average column/row pitch so toggling
- * between modes doesn't wildly rescale the board. */
+export function cellCorners(center: CellPos, size: number): [number, number][] {
+  return realHexCorners({ x: center.x, z: center.y }, size).map(
+    (c) => [c.x, c.z] as [number, number]
+  );
+}
+
+/** Creation mode's rectangular-canvas spacing — see this file's header
+ * doc comment for why these live here despite the "FLAT" naming echo of
+ * the removed edit-mode toggle. Spacing values unchanged from before the
+ * removal (chosen to roughly match hex-true's average column/row pitch,
+ * a purely cosmetic choice with no bearing on this decision). */
 export const FLAT_COL_SPACING = BOARD_HEX_SIZE * Math.sqrt(3);
 export const FLAT_ROW_SPACING = BOARD_HEX_SIZE * 1.5;
-
-export function flatCellCenter(col: number, row: number): CellPos {
-  return { x: col * FLAT_COL_SPACING, y: row * FLAT_ROW_SPACING };
-}
-
-export function cellCenter(
-  mode: LayoutMode,
-  col: number,
-  row: number
-): CellPos {
-  return mode === 'hex-true'
-    ? hexTrueCellCenter(col, row)
-    : flatCellCenter(col, row);
-}
-
-/** Hex corner points for `hex-true` mode (reused from hexMath.ts).
- * `flattened` mode draws simple squares — it's explicitly not claiming
- * hex adjacency, so a hex outline there would be misleading. */
-export function cellCorners(
-  mode: LayoutMode,
-  center: CellPos,
-  size: number
-): [number, number][] {
-  if (mode === 'hex-true') {
-    return realHexCorners({ x: center.x, z: center.y }, size).map(
-      (c) => [c.x, c.z] as [number, number]
-    );
-  }
-  const half = size * 0.85;
-  return [
-    [center.x - half, center.y - half],
-    [center.x + half, center.y - half],
-    [center.x + half, center.y + half],
-    [center.x - half, center.y + half],
-  ];
-}
 
 // Re-exported so callers doing manual col/row bookkeeping (e.g. nearest-cell
 // hit testing during a drag) use the same real conversion, never a second


### PR DESCRIPTION
## What changed

Two settled Kirk decisions, relayed by the team lead.

**1. Remove the flattened layout mode entirely.** Kirk: "I like hex. turning them into squares feels way off and not what it will actually look like." The hex-true/flattened comparison toggle existed to make the diagonal-shear finding legible enough to decide -- it did its job, so it's removed: `LayoutMode` type, `flatCellCenter`, the toggle UI, and every `layoutMode` parameter/prop across `hexLayout.ts`/`Board.tsx`/`boardGeometry.ts`/`DungeonBuilderConcept.tsx`.

Creation mode's own `FLAT_COL_SPACING`/`FLAT_ROW_SPACING` constants are **unrelated** -- a separate, still-live rectangular-canvas renderer that was never part of this toggle -- and are untouched, kept in `hexLayout.ts` with a doc comment explaining the naming echo.

`CONTRACT.md` records the rejection with Kirk's quote next to the original shear finding (still real hex geometry, unaffected). `TARGET-YAML.md`'s facing section drops the "reads oddly on the flattened board" tension.

**2. Demote comment-preservation from hard requirement to best-effort/incidental.** Kirk: the builder never authors comments, only a hand-editor's own edits could ever orphan one. The CST round-trip behavior itself is completely unchanged -- this is a documentation-only demotion. `CONTRACT.md`'s group-comment-orphaning finding is closed as MOOT, not solved: the analysis stays as accurate documentation, only the "needs a decision" framing is retracted.

## Verification

- Live: `Layout:` toggle gone from the UI, board still renders (240 polygons, unchanged, same fixture).
- 43/43 concept tests pass, `ci-check` clean (format/lint/typecheck/build/tests).

Related: rpg-dnd5e-web#666, rpg-project#170/#169.

— asset-pipeline agent, on behalf of KirkDiggler
