### PR TITLE
docs(dungeon-builder): specimen pack v0.1 (rpg-project#175 P0)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Dungeon Builder specimen pack (rpg-project#175) — real output from
+# dungeonYaml.ts's own serializeDungeon/stripToV1Subset, committed
+# byte-accurate on purpose. Prettier's YAML formatter reformats flow-style
+# maps onto multiple lines and swaps double quotes for single, which would
+# silently diverge these files from both what the real serializer emits
+# and what's posted verbatim on rpg-project#175 — see
+# src/concepts/dungeon-builder/specimens/README.md for the full context.
+src/concepts/dungeon-builder/specimens/*.yaml
+src/concepts/dungeon-builder/specimens/*.json

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -1,0 +1,205 @@
+# Dungeon Builder — specimen pack
+
+**Specimen pack version: v0.1** (2026-08-02). Posted in full on
+[rpg-project#175](https://github.com/KirkDiggler/rpg-project/issues/175)
+for the backend session implementing YAML processing.
+
+**Versioning note — read this before touching anything here.** The
+number above is the _specimen pack's own_ version. It is NOT the
+document schema version: every YAML file in this folder correctly stays
+`version: 1` per Kirk's settled additive model (rpg-project#175) — a new
+optional field the builder learns to emit does not bump the document
+version, only a real breaking/incompatible change would. Each time the
+builder gains a new emittable construct, this pack regenerates and bumps
+(v0.2, v0.3, ...) with a one-line changelog entry below naming the
+addition. Never conflate the two numbers.
+
+## Changelog
+
+- **v0.1** (2026-08-02) — initial pack, built from what the builder
+  emits as of this date. Does not yet include the height-decouples-
+  from-mount or `defaults:` map work (Kirk-batch, queued) — those land
+  as v0.2 with their own line here.
+
+## Files
+
+| File                                  | What it is                                                                                                                                                                                                                                     |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kitchen-sink.yaml`                   | One document exercising every construct + field variation the builder can emit today (3-room chain, locked connector, every `place:` field combo, boss facing+targeting, both wall kinds, a hole, start/end, lighting, count-based obstacles). |
+| `kitchen-sink.v1-subset.yaml`         | The same document run through `stripToV1Subset` — exactly what Save & Play would persist right now.                                                                                                                                            |
+| `kitchen-sink.v1-subset.dropped.json` | What `stripToV1Subset` dropped from the kitchen-sink doc, and whether the result is `compilable` (≥2 rooms).                                                                                                                                   |
+| `canvas.yaml`                         | What creation mode ("New Dungeon," a blank canvas) emits after a few walls/doors/placements/start/end — the second real document shape (`rooms: []` + `canvas: {width,height}`, so every placement is top-level).                              |
+
+**Live-verified, not just claimed**: `kitchen-sink.v1-subset.yaml` was
+run through a real `PutDungeon(validate_only: true)` against an isolated
+`rpg-api:local` instance (authoring gate on) and returned
+`success: true` with a real compiled `FloorPlan` — see the full
+transcript in the rpg-project#175 comment linked above (including a
+genuine validation rejection hit and fixed along the way: the first
+attempt placed the boss on the reserved door row, and the real server
+caught it).
+
+Status tags in the pack match `CONTRACT.md`/`TARGET-YAML.md` exactly:
+**[compiles-today]** = real, `dungeonspec`-validated; **[target-dialect]**
+= proposed, authored by this concept, not yet compiled server-side;
+**[experiment: not proposed]** = a concept-local probe, not even a
+dialect candidate; **[deferred: exploration]** = deliberately not part
+of the near-term dialect.
+
+## Regenerating for the next version bump
+
+There is no permanently-committed generator script in this repo (a
+`.test.ts` file here would auto-run on every `vitest run`/`ci-check`,
+writing to disk as a side effect on every CI pass — not what a
+version-bumped-only-when-the-builder-changes pack wants). Instead: copy
+the script below into a throwaway `src/concepts/dungeon-builder/_regen.test.ts`,
+run `npx vitest run src/concepts/dungeon-builder/_regen.test.ts`, delete
+the throwaway file, and diff the regenerated output against what's here
+— update the changelog above with what changed.
+
+```ts
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'vitest';
+import {
+  moveBoss,
+  parseDungeon,
+  placeItem,
+  serializeDungeon,
+  setBossFacing,
+  setBossTargeting,
+  setConnectorLocked,
+  setEnd,
+  setLightingAmbient,
+  setPlacementFacing,
+  setPlacementFlags,
+  setPlacementMount,
+  setPlacementRotationDegrees,
+  setPlacementTargeting,
+  setStart,
+  setWallEdge,
+  stripToV1Subset,
+  toggleHole,
+} from './dungeonYaml';
+import { emptyCanvasYaml, DEFAULT_CANVAS } from './creation/emptyCanvasDoc';
+
+const OUT_DIR = resolve(__dirname, 'specimens');
+
+describe('specimen generator', () => {
+  it('kitchen-sink', () => {
+    // Skeleton: room chain + connectors + obstacles + boss's own initial
+    // declaration -- constructs with no interactive mutator yet (no
+    // "add room"/"add connector"/"add boss" UI). Every field-level
+    // variation on top is driven by the real mutators below.
+    const skeleton = `version: 1
+key: specimen-kitchen-sink
+name: Specimen — Kitchen Sink
+theme: crypt
+height: 8
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 6
+  - id: hall
+    archetype: chamber
+    width: 12
+    obstacles:
+      - { ref: "dnd5e:props:bone-pile", count: 3 }
+  - id: sanctum
+    archetype: boss
+    width: 8
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [0, 0] }
+connectors:
+  - { from: entry, to: hall }
+  - { from: hall, to: sanctum }
+`;
+    const { cst } = parseDungeon(skeleton);
+
+    placeItem(cst, 'entry', 'dnd5e:props:brazier', [1, 1]);
+    setPlacementFlags(cst, 'entry', 0, {
+      blocksMovement: true,
+      blocksLos: false,
+    });
+
+    placeItem(cst, 'entry', 'dnd5e:props:statue-reaper', [3, 1]);
+    setPlacementFacing(cst, 'entry', 1, 2); // NW
+
+    placeItem(cst, 'hall', 'dnd5e:monsters:skeleton-captain', [5, 2]);
+    setPlacementTargeting(cst, 'hall', 0, 'dnd5e:targeting:nearest');
+
+    placeItem(cst, 'hall', 'dnd5e:props:wall-banner', [7, 1]);
+    setPlacementFacing(cst, 'hall', 1, 1); // NE
+    setPlacementMount(cst, 'hall', 1, 'wall', 2.0);
+    setPlacementRotationDegrees(cst, 'hall', 1, 12);
+    setWallEdge(cst, [7, 1], [8, 0], 'solid', true);
+    setWallEdge(cst, [7, 3], [8, 2], 'door', true);
+
+    toggleHole(cst, 10, 4);
+
+    // row 4 is the reserved door row (height/2) -- avoid it.
+    moveBoss(cst, 'sanctum', [4, 3]);
+    setBossFacing(cst, 'sanctum', 4); // SW
+    setBossTargeting(cst, 'sanctum', 'dnd5e:targeting:boss-priority');
+
+    placeItem(cst, null, 'dnd5e:props:wall-banner', [15, 3]);
+    setPlacementFacing(cst, null, 0, 0); // E
+    setPlacementMount(cst, null, 0, 'wall', 1.5);
+    setPlacementRotationDegrees(cst, null, 0, -8);
+    placeItem(cst, null, 'dnd5e:props:candles', [16, 3]);
+    setPlacementFlags(cst, null, 1, {
+      blocksMovement: false,
+      blocksLos: false,
+    });
+
+    setConnectorLocked(cst, 0, { dc: 14, ability: 'dex' });
+    // second connector stays unlocked (locked: null) -- proves elision.
+
+    setStart(cst, [1, 3]);
+    setEnd(cst, [4, 5]);
+    setLightingAmbient(cst, 0.35);
+
+    const yaml = serializeDungeon(cst);
+    writeFileSync(resolve(OUT_DIR, 'kitchen-sink.yaml'), yaml);
+
+    const stripped = stripToV1Subset(yaml);
+    writeFileSync(
+      resolve(OUT_DIR, 'kitchen-sink.v1-subset.yaml'),
+      stripped.yaml
+    );
+    writeFileSync(
+      resolve(OUT_DIR, 'kitchen-sink.v1-subset.dropped.json'),
+      JSON.stringify(
+        { dropped: stripped.dropped, compilable: stripped.compilable },
+        null,
+        2
+      )
+    );
+  });
+
+  it('canvas', () => {
+    const { cst } = parseDungeon(
+      emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
+    );
+
+    setWallEdge(cst, [4, 4], [5, 3], 'solid', true);
+    setWallEdge(cst, [4, 4], [4, 5], 'solid', true);
+    setWallEdge(cst, [5, 3], [6, 4], 'door', true);
+
+    placeItem(cst, null, 'dnd5e:props:pillar', [5, 5]);
+    placeItem(cst, null, 'dnd5e:props:altar', [8, 8]);
+    setPlacementFacing(cst, null, 1, 3); // W
+
+    setStart(cst, [2, 2]);
+    setEnd(cst, [12, 12]);
+
+    const yaml = serializeDungeon(cst);
+    writeFileSync(resolve(OUT_DIR, 'canvas.yaml'), yaml);
+  });
+});
+```
+
+When the next version adds new fields (e.g. v0.2's height-decouples-
+from-mount, or a `defaults:` map prototype), extend the script above
+with new mutator calls exercising them, add a "Regions section" example
+if #180 ever gains a real mutator (today it's proposed-shape-only, not
+emitted — see the rpg-project#175 comment), and re-run.

--- a/src/concepts/dungeon-builder/specimens/canvas.yaml
+++ b/src/concepts/dungeon-builder/specimens/canvas.yaml
@@ -1,0 +1,14 @@
+version: 1
+key: untitled-creation
+name: "Untitled Dungeon"
+height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads
+canvas:
+  width: 20
+  height: 30
+rooms: []
+connectors: []
+walls: [ { from: [ 4, 4 ], to: [ 5, 3 ], kind: solid }, { from: [ 4, 4 ], to: [ 4, 5 ], kind: solid }, { from: [ 5, 3 ], to: [ 6, 4 ], kind: door } ]
+holes: []
+start: [ 2, 2 ]
+end: [ 12, 12 ]
+place: [ { ref: "dnd5e:props:pillar", at: [ 5, 5 ], blocks_movement: false, blocks_los: false }, { ref: "dnd5e:props:altar", at: [ 8, 8 ], blocks_movement: false, blocks_los: false, facing: W } ]

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
@@ -1,0 +1,14 @@
+{
+  "dropped": [
+    "2 walls",
+    "1 hole",
+    "start/end",
+    "lighting",
+    "2 top-level placements (mapped into rooms)",
+    "facing (4 placements)",
+    "wall-mount (2 placements)",
+    "targeting (2 placements)",
+    "fine-rotation experiment (2 placements)"
+  ],
+  "compilable": true
+}

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.yaml
@@ -1,0 +1,29 @@
+version: 1
+key: specimen-kitchen-sink
+name: Specimen — Kitchen Sink
+theme: crypt
+height: 8
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 6
+    place:
+      - { ref: "dnd5e:props:brazier", at: [ 1, 1 ], blocks_movement: true, blocks_los: false }
+      - { ref: "dnd5e:props:statue-reaper", at: [ 3, 1 ], blocks_movement: false, blocks_los: false }
+  - id: hall
+    archetype: chamber
+    width: 12
+    obstacles:
+      - { ref: "dnd5e:props:bone-pile", count: 3 }
+    place:
+      - { ref: "dnd5e:monsters:skeleton-captain", at: [ 5, 2 ] }
+      - { ref: "dnd5e:props:wall-banner", at: [ 7, 1 ], blocks_movement: false, blocks_los: false }
+      - { ref: "dnd5e:props:wall-banner", at: [ 8, 3 ], blocks_movement: false, blocks_los: false }
+      - { ref: "dnd5e:props:candles", at: [ 9, 3 ], blocks_movement: false, blocks_los: false }
+  - id: sanctum
+    archetype: boss
+    width: 8
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [ 4, 3 ] }
+connectors:
+  - { from: entry, to: hall, locked: { dc: 14, ability: dex } }
+  - { from: hall, to: sanctum }

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
@@ -1,0 +1,39 @@
+version: 1
+key: specimen-kitchen-sink
+name: Specimen — Kitchen Sink
+theme: crypt
+height: 8
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 6
+    place:
+      - { ref: "dnd5e:props:brazier", at: [ 1, 1 ], blocks_movement: true, blocks_los: false }
+      - { ref: "dnd5e:props:statue-reaper", at: [ 3, 1 ], blocks_movement: false, blocks_los: false, facing: NW }
+  - id: hall
+    archetype: chamber
+    width: 12
+    obstacles:
+      - { ref: "dnd5e:props:bone-pile", count: 3 }
+    place:
+      - { ref: "dnd5e:monsters:skeleton-captain", at: [ 5, 2 ], targeting: dnd5e:targeting:nearest }
+      - { ref: "dnd5e:props:wall-banner", at: [ 7, 1 ], blocks_movement: false, blocks_los: false, facing: NE, mount: wall, height: 2, rotate_degrees: 12 }
+  - id: sanctum
+    archetype: boss
+    width: 8
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [ 4, 3 ], facing: SW, targeting: dnd5e:targeting:boss-priority }
+connectors:
+  - { from: entry, to: hall, locked: { dc: 14, ability: dex } }
+  - { from: hall, to: sanctum }
+walls:
+  - { from: [ 7, 1 ], to: [ 8, 0 ], kind: solid }
+  - { from: [ 7, 3 ], to: [ 8, 2 ], kind: door }
+holes:
+  - [ 10, 4 ]
+place:
+  - { ref: "dnd5e:props:wall-banner", at: [ 15, 3 ], blocks_movement: false, blocks_los: false, facing: E, mount: wall, height: 1.5, rotate_degrees: -8 }
+  - { ref: "dnd5e:props:candles", at: [ 16, 3 ], blocks_movement: false, blocks_los: false }
+start: [ 1, 3 ]
+end: [ 4, 5 ]
+lighting:
+  ambient: 0.35


### PR DESCRIPTION
Commits the specimen pack already posted in full on [rpg-project#175](https://github.com/KirkDiggler/rpg-project/issues/175) for the backend session implementing YAML processing.

- `specimens/kitchen-sink.yaml` -- one document exercising every construct + field variation the builder can emit today.
- `specimens/kitchen-sink.v1-subset.yaml` + `.dropped.json` -- the real compiles-today subset, live-verified against an isolated `rpg-api:local` instance (`PutDungeon(validate_only)` returned `success: true` with a real `FloorPlan` -- transcript in the #175 comment).
- `specimens/canvas.yaml` -- what creation mode emits from a blank canvas.
- `specimens/README.md` -- the versioning convention (specimen-pack version vs. the document's own `version: 1`, never conflated) + changelog + a copy-pasteable regenerator for future version bumps.

Built entirely by driving the real mutators/serializer, never hand-typed.

Adds `.prettierignore` for the specimen data files specifically: prettier's YAML formatter reformats the real serializer's single-line double-quoted flow-style maps into multi-line single-quoted ones, which would silently diverge the committed files from both the real serializer output and what's posted verbatim on #175 (same reason `fixtures.ts` embeds YAML as TS string literals -- solved here with an ignore entry instead since a real `.yaml` file is what was asked for directly).

`ci-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4