### PR TITLE
unit: builder cleanup & graduation prep

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { CharacterCarousel, SelectedCharacterPanel } from './components/home';
 import { PlaytestHarness } from './components/playtest/PlaytestHarness';
 import { ThemeSelector } from './components/ThemeSelector';
 import { ConceptsView } from './concepts/ConceptsView';
-import { ThumbHarness } from './concepts/dungeon-builder/thumbs/ThumbHarness';
+import { ThumbHarness } from './dev/ThumbHarness';
 import { DiscordDebugPanel, useDiscord } from './discord';
 
 /**

--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -554,12 +554,6 @@ export function Board({
   const vw = maxX - minX + pad * 2;
   const vh = maxY - minY + pad * 2 + 14;
 
-  const handlePointerMove: React.PointerEventHandler<SVGSVGElement> = () => {
-    // Visual-only during drag today; commit happens on pointer up. Kept as
-    // a named handler (rather than omitted) so a future hover-preview of
-    // the drop target has an obvious place to live.
-  };
-
   const handlePointerUp: React.PointerEventHandler<SVGSVGElement> = (e) => {
     if (!dragging || !svgRef.current) return;
     const svg = svgRef.current;
@@ -619,7 +613,6 @@ export function Board({
       viewBox={`${vx} ${vy} ${vw} ${vh}`}
       width={Math.max(vw, 600)}
       height={Math.max(vh, 420)}
-      onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onClick={(e) => {
         if (e.target === svgRef.current) onSelect(null);

--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -20,12 +20,7 @@ import {
 } from './boardGeometry';
 import type { DungeonDoc } from './dungeonYaml';
 import { BOARD_HEX_SIZE, cellCenter, cellCorners } from './hexLayout';
-import {
-  BOSS_COLOR,
-  MONSTER_COLOR,
-  PALETTE_PROPS,
-  ROLE_COLOR,
-} from './paletteData';
+import { resolveMarkerStyle } from './markerStyle';
 import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 
 interface BoardProps {
@@ -70,20 +65,6 @@ interface BoardProps {
   onToggleWallKind: (col: number, row: number) => void;
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
-}
-
-function markerColor(ref: string, isBoss: boolean): string {
-  if (isBoss) return BOSS_COLOR;
-  if (ref.startsWith('dnd5e:monsters:')) return MONSTER_COLOR;
-  const prop = PALETTE_PROPS.find((p) => p.ref === ref);
-  return prop ? ROLE_COLOR[prop.role] : '#888';
-}
-
-function shortLabel(ref: string, isBoss: boolean): string {
-  if (isBoss) return 'BOSS';
-  const prop = PALETTE_PROPS.find((p) => p.ref === ref);
-  if (prop) return prop.short;
-  return ref.startsWith('dnd5e:monsters:') ? 'M' : '?';
 }
 
 export function Board({
@@ -398,7 +379,7 @@ export function Board({
             cx={center.x}
             cy={center.y}
             r={BOARD_HEX_SIZE * 0.5}
-            fill={markerColor(p.ref, false)}
+            fill={resolveMarkerStyle(p.ref).color}
             stroke={isSelected ? '#ffd76a' : '#000'}
             strokeWidth={isSelected ? 2.5 : 1}
           />
@@ -409,7 +390,7 @@ export function Board({
             fill="#fff"
             fontSize={9}
           >
-            {shortLabel(p.ref, false)}
+            {resolveMarkerStyle(p.ref).short}
           </text>
         </g>
       );
@@ -433,7 +414,7 @@ export function Board({
             cx={center.x}
             cy={center.y}
             r={BOARD_HEX_SIZE * 0.62}
-            fill={markerColor(room.boss.ref, true)}
+            fill={resolveMarkerStyle(room.boss.ref, { isBoss: true }).color}
             stroke={isSelected ? '#ffd76a' : '#ffd76a'}
             strokeWidth={2}
           />
@@ -479,7 +460,7 @@ export function Board({
           cx={center.x}
           cy={center.y}
           r={BOARD_HEX_SIZE * 0.5}
-          fill={markerColor(p.ref, false)}
+          fill={resolveMarkerStyle(p.ref).color}
           stroke={isSelected ? '#ffd76a' : '#000'}
           strokeWidth={isSelected ? 2.5 : 1}
         />
@@ -490,7 +471,7 @@ export function Board({
           fill="#fff"
           fontSize={9}
         >
-          {shortLabel(p.ref, false)}
+          {resolveMarkerStyle(p.ref).short}
         </text>
       </g>
     );

--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -19,7 +19,12 @@ import {
   totalColumns,
 } from './boardGeometry';
 import type { DungeonDoc } from './dungeonYaml';
-import { BOARD_HEX_SIZE, cellCenter, cellCorners } from './hexLayout';
+import {
+  BOARD_HEX_SIZE,
+  cellCenter,
+  cellCorners,
+  edgeBetweenCells,
+} from './hexLayout';
 import { resolveMarkerStyle } from './markerStyle';
 import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 
@@ -237,7 +242,21 @@ export function Board({
   for (const wall of doc.walls) {
     trackCellExtent(wall.from[0], wall.from[1]);
     trackCellExtent(wall.to[0], wall.to[1]);
-    const center = cellCenter(wall.from[0], wall.from[1]);
+    // Real edge geometry (the actual shared hex edge between `from`/`to`),
+    // not a full-cell rect centered at `from` — the previous rendering
+    // drew a box covering the WHOLE `from` cell regardless of which of
+    // its 6 edges the wall was actually on, indistinguishable from a
+    // wall on any other edge of that same cell. Same `edgeBetweenCells`
+    // geometry the creation board (`CreationBoard.tsx`'s `wallGeometry`)
+    // and the 3D preview (`DungeonPreview3D.tsx`'s `edgeBetweenCells`)
+    // already draw walls with — one geometry convention across all three
+    // renderers now, not two correct ones and edit mode's own outlier.
+    const edge = edgeBetweenCells(
+      wall.from[0],
+      wall.from[1],
+      wall.to[0],
+      wall.to[1]
+    );
     const isDoor = wall.kind === 'door';
     // Same orange/cream distinction the creation board's own wall
     // rendering and the 3D preview's wall boxes already use for solid
@@ -245,31 +264,31 @@ export function Board({
     // difference here was hard to read at a glance (Kirk's own "make
     // sure drawn doors read as doors" ask), one visual language for
     // this construct across every view now, not three independently
-    // tuned ones. A door also gets a filled tint (a solid wall stays
-    // outline-only) and a small "D" label, matching this file's own
-    // start/end marker convention just below.
+    // tuned ones. Dashed/muted stays edit mode's own deliberate
+    // "PROPOSED, not compiled" language (this file's own header comment
+    // on this section) — creation mode draws walls solid, but its
+    // target-dialect status is signaled elsewhere (TARGET-YAML.md), not
+    // by line style, so the two aren't in conflict.
     structuralOverlay.push(
-      <rect
-        key={`wall-${wall.from[0]}-${wall.from[1]}`}
-        x={center.x - BOARD_HEX_SIZE * 0.55}
-        y={center.y - BOARD_HEX_SIZE * 0.55}
-        width={BOARD_HEX_SIZE * 1.1}
-        height={BOARD_HEX_SIZE * 1.1}
-        fill={isDoor ? '#ffb347' : 'none'}
-        fillOpacity={isDoor ? 0.2 : 1}
+      <line
+        key={`wall-${wall.from[0]}-${wall.from[1]}-${wall.to[0]}-${wall.to[1]}`}
+        x1={edge.a.x}
+        y1={edge.a.y}
+        x2={edge.b.x}
+        y2={edge.b.y}
         stroke={isDoor ? '#ffb347' : '#e8e2d8'}
-        strokeWidth={2}
+        strokeWidth={3}
         strokeDasharray={isDoor ? '2 2' : '5 3'}
-        rx={3}
+        strokeLinecap="round"
         pointerEvents="none"
       />
     );
     if (isDoor) {
       structuralOverlay.push(
         <text
-          key={`wall-${wall.from[0]}-${wall.from[1]}-label`}
-          x={center.x}
-          y={center.y + 3}
+          key={`wall-${wall.from[0]}-${wall.from[1]}-${wall.to[0]}-${wall.to[1]}-label`}
+          x={edge.mid.x}
+          y={edge.mid.y + 3}
           textAnchor="middle"
           fill="#ffb347"
           fontSize={8}

--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -25,7 +25,8 @@ import {
   cellCorners,
   edgeBetweenCells,
 } from './hexLayout';
-import { resolveMarkerStyle } from './markerStyle';
+import { END_COLOR, resolveMarkerStyle, START_COLOR } from './markerStyle';
+import { PlacementMarker } from './PlacementMarker';
 import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 
 interface BoardProps {
@@ -327,9 +328,9 @@ export function Board({
           cx={center.x}
           cy={center.y}
           r={BOARD_HEX_SIZE * 0.4}
-          fill="#5fd1c9"
+          fill={START_COLOR}
           fillOpacity={0.25}
-          stroke="#5fd1c9"
+          stroke={START_COLOR}
           strokeWidth={2}
           strokeDasharray="3 2"
         />
@@ -337,7 +338,7 @@ export function Board({
           x={center.x}
           y={center.y + 3}
           textAnchor="middle"
-          fill="#5fd1c9"
+          fill={START_COLOR}
           fontSize={8}
           fontWeight={700}
         >
@@ -355,9 +356,9 @@ export function Board({
           cx={center.x}
           cy={center.y}
           r={BOARD_HEX_SIZE * 0.4}
-          fill="#c9a227"
+          fill={END_COLOR}
           fillOpacity={0.25}
-          stroke="#c9a227"
+          stroke={END_COLOR}
           strokeWidth={2}
           strokeDasharray="3 2"
         />
@@ -365,7 +366,7 @@ export function Board({
           x={center.x}
           y={center.y + 3}
           textAnchor="middle"
-          fill="#c9a227"
+          fill={END_COLOR}
           fontSize={8}
           fontWeight={700}
         >
@@ -385,6 +386,7 @@ export function Board({
       const center = cellCenter(absCol, row);
       const sel: PlacementSelection = { roomId: room.id, index };
       const isSelected = isSameSelection(selectedPlacement, sel);
+      const style = resolveMarkerStyle(p.ref);
       markers.push(
         <g
           key={`place-${room.id}-${index}`}
@@ -394,23 +396,12 @@ export function Board({
             setDragging(sel);
           }}
         >
-          <circle
-            cx={center.x}
-            cy={center.y}
-            r={BOARD_HEX_SIZE * 0.5}
-            fill={resolveMarkerStyle(p.ref).color}
-            stroke={isSelected ? '#ffd76a' : '#000'}
-            strokeWidth={isSelected ? 2.5 : 1}
+          <PlacementMarker
+            center={center}
+            color={style.color}
+            short={style.short}
+            selected={isSelected}
           />
-          <text
-            x={center.x}
-            y={center.y + 3.5}
-            textAnchor="middle"
-            fill="#fff"
-            fontSize={9}
-          >
-            {resolveMarkerStyle(p.ref).short}
-          </text>
         </g>
       );
     });
@@ -466,6 +457,7 @@ export function Board({
     const center = cellCenter(p.at[0], p.at[1]);
     const sel: PlacementSelection = { roomId: null, index };
     const isSelected = isSameSelection(selectedPlacement, sel);
+    const style = resolveMarkerStyle(p.ref);
     markers.push(
       <g
         key={`place-top-${index}`}
@@ -475,23 +467,12 @@ export function Board({
           setDragging(sel);
         }}
       >
-        <circle
-          cx={center.x}
-          cy={center.y}
-          r={BOARD_HEX_SIZE * 0.5}
-          fill={resolveMarkerStyle(p.ref).color}
-          stroke={isSelected ? '#ffd76a' : '#000'}
-          strokeWidth={isSelected ? 2.5 : 1}
+        <PlacementMarker
+          center={center}
+          color={style.color}
+          short={style.short}
+          selected={isSelected}
         />
-        <text
-          x={center.x}
-          y={center.y + 3.5}
-          textAnchor="middle"
-          fill="#fff"
-          fontSize={9}
-        >
-          {resolveMarkerStyle(p.ref).short}
-        </text>
       </g>
     );
   });

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -2568,3 +2568,144 @@ compiled server-side`. Evidence:
 
 `ci-check` clean, full suite passing (58 tests: the `setPlacementMount`
 test split into a decoupling-focused pair, net +1 over the prior count).
+
+## Cleanup sweep (graduation audit items), 2026-08-03
+
+One unit, one branch, one PR — a ranked list from a graduation audit run
+against an earlier tree. Every item was re-verified against `dev` at
+the time this sweep started (several PRs had landed since the audit
+ran) before being fixed; anything already resolved is named as such
+below rather than redone.
+
+**1. Round-trip test path** — `dungeonYaml.test.ts`'s real-fixture
+round-trip resolved `join(__dirname, '../../../../../dungeon-content/
+showcase.yaml')`, one `../` too many; the catch silently fell back to
+the embedded fixture, making the test a self-comparison. Fixed to 4
+levels up. **Real verdict, not papered over**: verified independently
+(this sweep's worktree isn't nested under `~/game-dev/` the way a
+normal checkout is, so the corrected relative path itself still falls
+back to the embedded fixture here — a second, standalone check read
+the real file directly by absolute path) that the round-trip against
+the actual `dungeon-content/showcase.yaml` on disk is byte-stable
+(modulo the already-documented flow-sequence-padding normalization) —
+**no drift**, the fixture and the source file agree. On a normal
+checkout (canonical location `~/game-dev/rpg-dnd5e-web/`), the fixed
+relative path resolves directly and this same real comparison runs as
+part of the suite.
+
+**2. Dead-scaffolding sweep** — removed: `creationTypes.ts`/
+`creationGeometry.ts`'s `EdgeKey`/`hEdgeKey`/`vEdgeKey` and the
+`EdgeGeometry.key` field (nothing read `.key`); `creationGeometry.ts`'s
+`allInternalEdges` (never called); `Palette.tsx`'s `showBoardTools`
+prop (both call sites relied on the default `true`, so its doc comment
+claiming creation mode passes `false` no longer matched reality —
+Structural/Markers already rendered in both modes; this just dropped
+the dead plumbing); `useSaveDungeon.ts`'s `reset` (never called);
+`paletteData.ts`'s `PaletteProp.footprintHexes`/`blocksLoS` (set, never
+read); `fixtures.ts`'s `MONSTER_PLACE_CHECK_VERIFIED` export dropped,
+its evidence comment kept; `dungeonYaml.ts`'s doc comment pointing at a
+nonexistent `useWalkItVariant.ts` retargeted to `YamlPane.tsx`'s real
+`honestyNote`; `Board.tsx`'s empty `handlePointerMove` placeholder.
+**Skipped, already fixed**: `hexLayout.ts`'s `hexColumn`/`hexRow`
+re-exports are NOT dead — `boardGeometry.ts` and `DungeonPreview3D.tsx`
+both genuinely import and use them through this module, real usage
+added by the wall-mount edge-selection rework after the audit ran.
+
+**3. `specimens/README.md`** — its regeneration script's two
+`setPlacementMount(cst, roomId, index, 'wall', height)` examples were
+the pre-decouple 5-arg signature. Updated to the current independent
+`setPlacementMount(...,'wall')` + `setPlacementHeight(...,height)`
+pair. Verified by actually running the corrected script as a
+throwaway test: it compiles against the real `dungeonYaml.ts`, and the
+regenerated `kitchen-sink.yaml` is byte-identical to the checked-in
+v0.1 specimen.
+
+**4. Shared prop-visual module** — `Board.tsx`'s `markerColor`/
+`shortLabel` and `CreationBoard.tsx`'s near-verbatim `markerColor`/
+`markerShort` (both doing the same `PALETTE_PROPS`/`ROLE_COLOR`/
+`MONSTER_COLOR`/`BOSS_COLOR` lookup) consolidated into
+`markerStyle.ts`'s `resolveMarkerStyle(ref, opts?)`. The 3D preview
+does not participate — it renders real GLB models
+(`PropModel`/`PreviewMonsterModel`), not colored SVG swatches, so there
+was no actual duplication there to remove.
+
+**5. Unify wall geometry** — edit-mode `Board.tsx` drew each wall as a
+dashed rect covering the WHOLE `from` cell regardless of which of its 6
+edges the wall was actually on; creation mode and the 3D preview both
+already drew the real shared edge. Added `hexLayout.ts`'s
+`edgeBetweenCells` (wrapping `hexMath.ts`'s `hexEdgeBetween`, the same
+primitive the 3D preview's `wallBoxTransform` uses) and switched
+`Board.tsx` to a real edge-aligned `<line>`. Separately, reconciled
+`dungeonYaml.ts`'s two wall lookups: `wallIndexAt` (edit mode, matched
+by `from` cell ONLY) vs `wallIndexAtEdge` (creation mode, exact
+`from`/`to` pair) — the from-only lookup meant edit mode's Wall tool
+could find and delete a creation-drawn wall on a _different_ edge that
+merely shared the same `from` cell. Removed `wallIndexAt`;
+`toggleWall`/`toggleWallKind` now both call `wallIndexAtEdge`. New
+regression test in `dungeonYaml.test.ts` pins this — confirmed it
+actually catches the bug by temporarily reverting to the old
+from-cell-only lookup and watching it fail (the other wall vanished
+instead of surviving untouched) before restoring the fix. Visually
+verified live: walls now render as short edge segments at the correct
+hex boundary, solid/door color distinction intact.
+
+**6. Extract `useBoardEditing`** — moved verbatim from
+`DungeonBuilderConcept.tsx` to its own `useBoardEditing.ts` (it was
+already a cleanly self-contained hook, just in the wrong file);
+`CreationBoard.tsx`/`CreationConcept.tsx` now import the `BoardEditing`
+type from there directly. Also fixed the two per-render
+`parseDungeon(...)` calls the same audit flagged (`initial`/
+`creationInitial`) — neither was wrapped in a `useState` lazy
+initializer, so the parse (and the adjacent `serializeDungeon` calls
+feeding the initial `yamlText` state, same shape of the same bug) ran
+on every render even though only the first render's result was ever
+used. Wrapped both in `useState(() => ...)`. Verified live: both edit
+and creation mode still load and placing a prop through the extracted
+hook still updates the board/YAML correctly.
+
+**7. Shared marker module** — `PlacementMarker.tsx` extracted the
+circle+label a placed prop/monster gets, byte-identical between
+`Board.tsx` and `CreationBoard.tsx` before this (confirmed by diffing
+the two JSX blocks directly — same radius, same selection-stroke
+logic, same text styling). Does not own the `<g>`/pointer-handler
+wrapper, which differs meaningfully per board. Also deduped the
+`doc.start`/`doc.end` marker COLOR constants
+(`markerStyle.ts`'s `START_COLOR`/`END_COLOR`, `#5fd1c9`/`#c9a227`),
+independently hardcoded identically in `Board.tsx`, `CreationBoard.tsx`,
+and the 3D preview's `PointMarker`. Deliberately did NOT unify the
+actual start/end circle+label JSX — `Board.tsx` (filled swatch,
+"ST"/"EN") and `CreationBoard.tsx` (outline ring, full "START"/"END"
+above it, different label colors) render them with genuinely different
+visual treatments today, and picking one is a design call for Kirk,
+not a mechanical dedup. The boss pin (`Board.tsx`-only, different
+size/font, no creation-mode analog) and the 3D preview's own marker (a
+Three.js `<ringGeometry>` mesh, different rendering technology) were
+left out of `PlacementMarker` for the same "nothing to actually
+consolidate" reason item 4 already established.
+
+**8. Move `ThumbHarness`** — moved `ThumbHarness.tsx` from
+`src/concepts/dungeon-builder/thumbs/` to `src/dev/` (alongside
+`DevPerfProbe.tsx`, the existing convention) so `App.tsx`'s dev-only
+gate no longer imports from a concept folder. The `thumbs/*.png`
+assets stayed put — `paletteData.ts`'s `import.meta.glob('./thumbs/
+*.png', ...)` is relative to `paletteData.ts`'s own location, which
+didn't move. Verified with a full production build: the glob still
+resolves all 13 baked thumbnails correctly post-move.
+
+**9. Missing tests** — `creationGeometry.test.ts` (new file):
+`nearestEdge` had zero coverage; added baseline cases plus the
+orientation-lock regression guard — a hand-derived straight horizontal
+drag where, WITHOUT `lockOrientation`, the resolved edge flips from
+horizontal to vertical partway across a single cell (the "crenellated
+comb" bug this file's own wall-interaction finding describes), and
+WITH the lock stays on the same edge throughout. `useSaveDungeon.test.ts`
+(new file): zero coverage on the Save & Play hook; mirrors
+`usePutDungeonPreview.test.ts`'s `vi.hoisted`/`vi.mock('@/api/client')`
+pattern, covering idle/saving/saved/invalid/error transitions,
+`savedKey` echoing the request key (not the response, which has none),
+and a fresh `save()` clearing a prior error before the new request
+settles.
+
+`ci-check` clean. Full suite: 84 dungeon-builder tests passing (up from
+69 before this sweep — 15 new: 8 `nearestEdge` + 7 `useSaveDungeon`),
+1772 repo-wide.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -7,7 +7,6 @@
  * hex-true/flattened layout toggle, explored and rejected 2026-08-02.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Document } from 'yaml';
 import { Board } from './Board';
 import { CollapsibleSidePanel } from './CollapsibleSidePanel';
 import { ConnectorInspector } from './ConnectorInspector';
@@ -17,24 +16,13 @@ import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import './DungeonBuilderConcept.css';
 import {
   buildWalkItYaml,
-  deletePlacement,
   DungeonParseError,
-  moveBoss,
-  movePlacement,
-  movePlacementAcrossLists,
   parseDungeon,
   placeItem,
   serializeDungeon,
-  setBossFacing,
-  setBossTargeting,
   setConnectorLocked,
   setEnd,
   setPlacementFacing,
-  setPlacementFlags,
-  setPlacementHeight,
-  setPlacementMount,
-  setPlacementRotationDegrees,
-  setPlacementTargeting,
   setStart,
   setWallEdge,
   stripToV1Subset,
@@ -44,7 +32,6 @@ import {
   toggleWallKind,
   type DungeonDoc,
   type LockedDoc,
-  type Mount,
   type WallKind,
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
@@ -53,7 +40,8 @@ import { Palette } from './Palette';
 import { PALETTE_PROPS } from './paletteData';
 import { DungeonPreview3D } from './preview3d/DungeonPreview3D';
 import { RolledContentPanel } from './RolledContentPanel';
-import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
+import type { BoardTool } from './types';
+import { useBoardEditing } from './useBoardEditing';
 import { usePutDungeonPreview } from './usePutDungeonPreview';
 import { useSaveDungeon } from './useSaveDungeon';
 import { WallGashExplainer } from './WallGashExplainer';
@@ -63,249 +51,16 @@ const APPLY_DEBOUNCE_MS = 700;
 
 type BuilderMode = 'edit' | 'create';
 
-/** The palette/placement editing core — the part of edit mode's board
- * interaction that "New Dungeon" needs verbatim once it authors onto its
- * OWN cst/DungeonDoc instead of the bespoke CreationState (CONTRACT.md's
- * "unifying New Dungeon onto the shared CST" section). Pulled into one
- * hook, called once per mode with that mode's own `cst`/`doc`/
- * `syncFromCst`, rather than duplicated: placement selection is a `ref`
- * at a `[col,row]`, room-scoped (`roomId` a real id) or top-level
- * (`roomId: null`, TARGET-YAML.md's "top-level placement" section) —
- * `handlePlace`/`handleMove`/etc. below already generalize over both via
- * dungeonYaml.ts's own `roomId: string | null` mutators, so this hook
- * needs no special-casing per mode; only the SURROUNDING board/palette/
- * wall handling differs per mode, and stays defined separately where
- * it's called. */
-function useBoardEditing(
-  cst: Document,
-  doc: DungeonDoc,
-  syncFromCst: (cst: Document) => void,
-  flashToast?: (message: string) => void
-) {
-  const [selectedPalette, setSelectedPalette] =
-    useState<PaletteSelection | null>(null);
-  const [selectedPlacement, setSelectedPlacement] =
-    useState<PlacementSelection | null>(null);
-
-  const handlePlace = (roomId: string | null, at: [number, number]) => {
-    if (!selectedPalette) return;
-    const isMonster = selectedPalette.kind === 'monster';
-    if (selectedPalette.kind === 'boss') {
-      // Boss stays room-scoped even in the target dialect (moveBoss
-      // requires a real roomId) — callers arming the boss tool over a
-      // roomless canvas are expected to reject before ever reaching
-      // here (CreationBoard.tsx does), so this is a defensive backstop,
-      // not the primary guard.
-      if (roomId === null) return;
-      moveBoss(cst, roomId, at);
-      flashToast?.('Boss pin placed.');
-    } else {
-      placeItem(cst, roomId, selectedPalette.ref, at);
-      if (isMonster) {
-        flashToast?.(
-          'Monster placed — blocks_movement/blocks_los are forced off and disabled (dungeonspec.Validate rejects both flags on monster placements).'
-        );
-      }
-    }
-    syncFromCst(cst);
-  };
-
-  const handleMove = (
-    sel: PlacementSelection,
-    roomId: string | null,
-    at: [number, number]
-  ) => {
-    if (sel.boss) {
-      // A boss never leaves its own room (Board.tsx's own pointer-up
-      // handler already rejects a cross-room boss drop before onMove is
-      // ever called) — sel.roomId is the real, non-null id to use here,
-      // not the destination `roomId` parameter (which stays nullable to
-      // cover the non-boss, top-level case).
-      moveBoss(cst, sel.roomId, at);
-      syncFromCst(cst);
-      return;
-    }
-    if (roomId === sel.roomId) {
-      movePlacement(cst, sel.roomId, sel.index, at);
-      syncFromCst(cst);
-      setSelectedPlacement({ roomId, index: sel.index });
-      return;
-    }
-    // Cross-list move (room-scoped <-> top-level, or between two rooms):
-    // `movePlacementAcrossLists` preserves every field (facing/mount/
-    // height/rotate_degrees/targeting/blocks_*), not just ref+at — the
-    // naive delete+placeItem shape this used to be silently dropped all
-    // of those (2026-08-02 graduation audit finding). It also returns
-    // the item's real new index directly, rather than this caller
-    // re-deriving it from possibly-stale `doc` state via a
-    // `.find(...)!.place.length` that used to throw outright for a
-    // roomId: null destination (no room has id null to find).
-    const item = sel.roomId
-      ? doc.rooms.find((r) => r.id === sel.roomId)?.place[sel.index]
-      : doc.place[sel.index];
-    if (!item) return;
-    const newIndex = movePlacementAcrossLists(
-      cst,
-      sel.roomId,
-      sel.index,
-      roomId,
-      at,
-      item
-    );
-    syncFromCst(cst);
-    setSelectedPlacement({ roomId, index: newIndex });
-  };
-
-  const handleDelete = () => {
-    if (!selectedPlacement || selectedPlacement.boss) return;
-    deletePlacement(cst, selectedPlacement.roomId, selectedPlacement.index);
-    setSelectedPlacement(null);
-    syncFromCst(cst);
-  };
-
-  const handleSetFlags = (blocksMovement: boolean, blocksLos: boolean) => {
-    if (!selectedPlacement || selectedPlacement.boss) return;
-    setPlacementFlags(cst, selectedPlacement.roomId, selectedPlacement.index, {
-      blocksMovement,
-      blocksLos,
-    });
-    syncFromCst(cst);
-  };
-
-  // Boss entries have no mount/height (bosses aren't wall furniture) —
-  // only place: entries do, matching Inspector.tsx's own gate. Two
-  // separate handlers, not one — mount/height are DECOUPLED (Kirk-batch,
-  // 2026-08-02: "height: decouples from mount... any placement may carry
-  // height"), matching `setPlacementMount`'s/`setPlacementHeight`'s own
-  // now-independent shape.
-  const handleSetMount = (mount: Mount) => {
-    if (!selectedPlacement || selectedPlacement.boss) return;
-    setPlacementMount(
-      cst,
-      selectedPlacement.roomId,
-      selectedPlacement.index,
-      mount
-    );
-    syncFromCst(cst);
-  };
-
-  const handleSetHeight = (height: number | null) => {
-    if (!selectedPlacement || selectedPlacement.boss) return;
-    setPlacementHeight(
-      cst,
-      selectedPlacement.roomId,
-      selectedPlacement.index,
-      height
-    );
-    syncFromCst(cst);
-  };
-
-  // EXPERIMENT, not a target-dialect field (Inspector.tsx's own
-  // ExperimentBadge doc comment) — same boss-excluded gate as
-  // handleSetMount, since the control only ever shows for a
-  // mount: 'wall' place: entry, which a boss can never be.
-  const handleSetRotationDegrees = (rotationDegrees: number | null) => {
-    if (!selectedPlacement || selectedPlacement.boss) return;
-    setPlacementRotationDegrees(
-      cst,
-      selectedPlacement.roomId,
-      selectedPlacement.index,
-      rotationDegrees
-    );
-    syncFromCst(cst);
-  };
-
-  const handleSetTargeting = (targeting: string | null) => {
-    if (!selectedPlacement) return;
-    if (selectedPlacement.boss) {
-      setBossTargeting(cst, selectedPlacement.roomId, targeting);
-    } else {
-      setPlacementTargeting(
-        cst,
-        selectedPlacement.roomId,
-        selectedPlacement.index,
-        targeting
-      );
-    }
-    syncFromCst(cst);
-  };
-
-  const handleSetFacing = (facing: number | null) => {
-    if (!selectedPlacement) return;
-    if (selectedPlacement.boss) {
-      setBossFacing(cst, selectedPlacement.roomId, facing);
-    } else {
-      setPlacementFacing(
-        cst,
-        selectedPlacement.roomId,
-        selectedPlacement.index,
-        facing
-      );
-    }
-    syncFromCst(cst);
-  };
-
-  // Wall-mount edge-selection rework, part 2 (Inspector.tsx's own
-  // `onFlipMountSide` doc comment) — the Inspector already validated
-  // `target` against a real floor cell before ever calling this, so this
-  // handler's job is purely the mutation: a cross-list move (via
-  // `movePlacementAcrossLists`, which preserves every field) carrying
-  // the NEW mirrored facing instead of the old one. Boss-excluded, same
-  // gate every other placement-only handler here uses — a boss is never
-  // wall-mounted.
-  const handleFlipMountSide = (target: {
-    roomId: string;
-    at: [number, number];
-    newFacing: number;
-  }) => {
-    if (!selectedPlacement || selectedPlacement.boss) return;
-    const item = selectedPlacement.roomId
-      ? doc.rooms.find((r) => r.id === selectedPlacement.roomId)?.place[
-          selectedPlacement.index
-        ]
-      : doc.place[selectedPlacement.index];
-    if (!item) return;
-    const newIndex = movePlacementAcrossLists(
-      cst,
-      selectedPlacement.roomId,
-      selectedPlacement.index,
-      target.roomId,
-      target.at,
-      { ...item, facing: target.newFacing }
-    );
-    syncFromCst(cst);
-    setSelectedPlacement({ roomId: target.roomId, index: newIndex });
-  };
-
-  return {
-    selectedPalette,
-    setSelectedPalette,
-    selectedPlacement,
-    setSelectedPlacement,
-    handlePlace,
-    handleMove,
-    handleDelete,
-    handleSetFlags,
-    handleSetMount,
-    handleSetHeight,
-    handleSetRotationDegrees,
-    handleSetTargeting,
-    handleSetFacing,
-    handleFlipMountSide,
-  };
-}
-
-/** The `useBoardEditing` handle — exported so `CreationBoard.tsx`/
- * `CreationConcept.tsx` can type the `edit` prop they receive without
- * re-deriving the same shape. */
-export type BoardEditing = ReturnType<typeof useBoardEditing>;
-
 export function DungeonBuilderConcept() {
   const [mode, setMode] = useState<BuilderMode>('edit');
-  const initial = parseDungeon(SHOWCASE_YAML);
+  // Lazy initializers (graduation audit item) — parseDungeon/
+  // serializeDungeon both do real parsing/stringification work, and a
+  // bare `useState(parseDungeon(...))` evaluates that argument on EVERY
+  // render (React only USES it on the first), not just once on mount.
+  const [initial] = useState(() => parseDungeon(SHOWCASE_YAML));
   const [cst, setCst] = useState(initial.cst);
   const [doc, setDoc] = useState<DungeonDoc>(initial.doc);
-  const [yamlText, setYamlText] = useState(serializeDungeon(initial.cst));
+  const [yamlText, setYamlText] = useState(() => serializeDungeon(initial.cst));
   const [parseError, setParseError] = useState<string | null>(null);
   // Door/wall editing (Kirk's 2026-08-02 ask). Mutually exclusive with
   // selectedPalette/selectedPlacement (now owned by the `edit` =
@@ -484,14 +239,15 @@ export function DungeonBuilderConcept() {
   // placement selection is independent of edit mode's (same "remembered
   // per mode" precedent the collapse-state pairs above already set). See
   // CONTRACT.md's "unifying New Dungeon onto the shared CST" section.
-  const creationInitial = parseDungeon(
-    emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
+  // Same lazy-initializer fix as `initial` above.
+  const [creationInitial] = useState(() =>
+    parseDungeon(emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height))
   );
   const [creationCst, setCreationCst] = useState(creationInitial.cst);
   const [creationDoc, setCreationDoc] = useState<DungeonDoc>(
     creationInitial.doc
   );
-  const [creationYamlText, setCreationYamlText] = useState(
+  const [creationYamlText, setCreationYamlText] = useState(() =>
     serializeDungeon(creationInitial.cst)
   );
   const [creationSelectedTool, setCreationSelectedTool] =

--- a/src/concepts/dungeon-builder/Palette.tsx
+++ b/src/concepts/dungeon-builder/Palette.tsx
@@ -39,12 +39,6 @@ interface PaletteProps {
   onSelectTool: (tool: BoardTool | null) => void;
   wallCount: number;
   holeCount: number;
-  /** Default true. The creation flow (`CreationConcept.tsx`) has its OWN
-   * dedicated Tools strip already covering Wall/Door/Hole/Start/End
-   * against its own data model — false there so this shared Palette
-   * doesn't ALSO show Structural/Markers as a second, dead-clicking set
-   * of tool rows for the same actions. */
-  showBoardTools?: boolean;
 }
 
 const CATEGORY_LABELS: Record<PaletteCategory, string> = {
@@ -261,7 +255,6 @@ export function Palette({
   onSelectTool,
   wallCount,
   holeCount,
-  showBoardTools = true,
 }: PaletteProps) {
   const [openCategories, setOpenCategories] = useState<Set<PaletteCategory>>(
     new Set<PaletteCategory>(['obstacles-props'])
@@ -385,93 +378,89 @@ export function Palette({
         ))}
       </CategorySection>
 
-      {showBoardTools && (
-        <CategorySection
-          category="structural"
-          count={3}
-          open={openCategories.has('structural')}
-          onToggle={() => toggle('structural')}
+      <CategorySection
+        category="structural"
+        count={3}
+        open={openCategories.has('structural')}
+        onToggle={() => toggle('structural')}
+      >
+        <Row
+          color="#6a6255"
+          short="W"
+          label="Wall"
+          sub={`${wallCount}× drawn — click a wall cell to add/remove`}
+          isSelected={selectedTool === 'wall'}
+          onClick={() => toggleTool('wall')}
+          notCompiled
+        />
+        <Row
+          color="#9b7fd6"
+          short="D"
+          label="Door (on a drawn wall)"
+          sub="click an existing wall to flip solid ↔ door"
+          isSelected={selectedTool === 'door'}
+          onClick={() => toggleTool('door')}
+          notCompiled
+        />
+        <Row
+          color="#14110f"
+          short="H"
+          label="Hole"
+          sub={`${holeCount}× marked — impassable void, no floor`}
+          isSelected={selectedTool === 'hole'}
+          onClick={() => toggleTool('hole')}
+          deferred
+        />
+        <p
+          style={{
+            fontSize: 11,
+            color: '#8a7a5a',
+            padding: '4px 8px 2px',
+            lineHeight: 1.4,
+          }}
         >
-          <Row
-            color="#6a6255"
-            short="W"
-            label="Wall"
-            sub={`${wallCount}× drawn — click a wall cell to add/remove`}
-            isSelected={selectedTool === 'wall'}
-            onClick={() => toggleTool('wall')}
-            notCompiled
-          />
-          <Row
-            color="#9b7fd6"
-            short="D"
-            label="Door (on a drawn wall)"
-            sub="click an existing wall to flip solid ↔ door"
-            isSelected={selectedTool === 'door'}
-            onClick={() => toggleTool('door')}
-            notCompiled
-          />
-          <Row
-            color="#14110f"
-            short="H"
-            label="Hole"
-            sub={`${holeCount}× marked — impassable void, no floor`}
-            isSelected={selectedTool === 'hole'}
-            onClick={() => toggleTool('hole')}
-            deferred
-          />
-          <p
-            style={{
-              fontSize: 11,
-              color: '#8a7a5a',
-              padding: '4px 8px 2px',
-              lineHeight: 1.4,
-            }}
-          >
-            Structural is target dialect, proposed — TARGET-YAML.md. The real
-            connector door (locked/DC) lives on the board's own door cell, not
-            here — this "Door" is a door on a drawn wall, a different thing.
-          </p>
-        </CategorySection>
-      )}
+          Structural is target dialect, proposed — TARGET-YAML.md. The real
+          connector door (locked/DC) lives on the board's own door cell, not
+          here — this "Door" is a door on a drawn wall, a different thing.
+        </p>
+      </CategorySection>
 
-      {showBoardTools && (
-        <CategorySection
-          category="markers"
-          count={2}
-          open={openCategories.has('markers')}
-          onToggle={() => toggle('markers')}
+      <CategorySection
+        category="markers"
+        count={2}
+        open={openCategories.has('markers')}
+        onToggle={() => toggle('markers')}
+      >
+        <Row
+          color="#5fd1c9"
+          short="ST"
+          label="Start / spawn"
+          sub="author-placed — in tension with FloorPlan.entrance, see TARGET-YAML.md"
+          isSelected={selectedTool === 'start'}
+          onClick={() => toggleTool('start')}
+          notCompiled
+        />
+        <Row
+          color="#c9a227"
+          short="EN"
+          label="End / goal"
+          sub="no analog anywhere in the compiled FloorPlan today"
+          isSelected={selectedTool === 'end'}
+          onClick={() => toggleTool('end')}
+          notCompiled
+        />
+        <p
+          style={{
+            fontSize: 11,
+            color: '#8a7a5a',
+            padding: '4px 8px 2px',
+            lineHeight: 1.4,
+          }}
         >
-          <Row
-            color="#5fd1c9"
-            short="ST"
-            label="Start / spawn"
-            sub="author-placed — in tension with FloorPlan.entrance, see TARGET-YAML.md"
-            isSelected={selectedTool === 'start'}
-            onClick={() => toggleTool('start')}
-            notCompiled
-          />
-          <Row
-            color="#c9a227"
-            short="EN"
-            label="End / goal"
-            sub="no analog anywhere in the compiled FloorPlan today"
-            isSelected={selectedTool === 'end'}
-            onClick={() => toggleTool('end')}
-            notCompiled
-          />
-          <p
-            style={{
-              fontSize: 11,
-              color: '#8a7a5a',
-              padding: '4px 8px 2px',
-              lineHeight: 1.4,
-            }}
-          >
-            Select a tool, then click a cell to place/clear it. Click again on
-            the same cell to clear.
-          </p>
-        </CategorySection>
-      )}
+          Select a tool, then click a cell to place/clear it. Click again on the
+          same cell to clear.
+        </p>
+      </CategorySection>
     </aside>
   );
 }

--- a/src/concepts/dungeon-builder/PlacementMarker.tsx
+++ b/src/concepts/dungeon-builder/PlacementMarker.tsx
@@ -1,0 +1,57 @@
+/**
+ * PlacementMarker — the circle+label a placed prop/monster gets on the
+ * 2D board, extracted from Board.tsx (edit mode) and
+ * `creation/CreationBoard.tsx` (creation mode) where it was written
+ * byte-identically twice (graduation audit item). Does NOT own the
+ * `<g>` interaction wrapper (pointer handlers, cursor style, per-mode
+ * extras like CreationBoard's facing-direction arrow) — those differ
+ * meaningfully per board and stay owned by each caller; this component
+ * is purely the visual (fill, selection stroke, short label).
+ *
+ * Not used for the boss pin (Board.tsx-only, no creation-mode analog —
+ * creation mode's freeform canvas has no boss/room concept, see
+ * TARGET-YAML.md) or the 3D preview's marker (a Three.js
+ * `<ringGeometry>` mesh, not an SVG element — genuinely different
+ * rendering technology, not mechanically shareable with this).
+ */
+import type { CellPos } from './hexLayout';
+
+export interface PlacementMarkerProps {
+  center: CellPos;
+  color: string;
+  short: string;
+  selected: boolean;
+  radius?: number;
+  fontSize?: number;
+}
+
+export function PlacementMarker({
+  center,
+  color,
+  short,
+  selected,
+  radius = 12,
+  fontSize = 9,
+}: PlacementMarkerProps) {
+  return (
+    <>
+      <circle
+        cx={center.x}
+        cy={center.y}
+        r={radius}
+        fill={color}
+        stroke={selected ? '#ffd76a' : '#000'}
+        strokeWidth={selected ? 2.5 : 1}
+      />
+      <text
+        x={center.x}
+        y={center.y + 3.5}
+        textAnchor="middle"
+        fill="#fff"
+        fontSize={fontSize}
+      >
+        {short}
+      </text>
+    </>
+  );
+}

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -41,7 +41,7 @@ import { useRef, useState, type ReactElement } from 'react';
 import type { BoardEditing } from '../DungeonBuilderConcept';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
 import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
-import { MONSTER_COLOR, PALETTE_PROPS, ROLE_COLOR } from '../paletteData';
+import { resolveMarkerStyle } from '../markerStyle';
 import type { BoardTool, PlacementSelection } from '../types';
 import {
   creationCellCenter,
@@ -88,17 +88,6 @@ const FACING_ANGLES_DEG = HEX_FACING_LABELS.map((_, i) => {
   const world = cubeToWorld(dir, 1);
   return (Math.atan2(world.z, world.x) * 180) / Math.PI;
 });
-
-function markerColor(kind: 'prop' | 'monster', ref: string): string {
-  if (kind === 'monster') return MONSTER_COLOR;
-  const prop = PALETTE_PROPS.find((p) => p.ref === ref);
-  return prop ? ROLE_COLOR[prop.role] : '#888';
-}
-function markerShort(ref: string): string {
-  const prop = PALETTE_PROPS.find((p) => p.ref === ref);
-  if (prop) return prop.short;
-  return ref.startsWith('dnd5e:monsters:') ? 'M' : '?';
-}
 
 /** This edge's wall, or `undefined` if none is drawn there — a direct
  * `doc.walls` scan (creation-mode canvases are small enough that this is
@@ -356,7 +345,7 @@ export function CreationBoard({
       x: at[0] * FLAT_COL_SPACING,
       y: at[1] * FLAT_ROW_SPACING,
     };
-    const isMonster = ref.startsWith('dnd5e:monsters:');
+    const style = resolveMarkerStyle(ref);
     // roomId comparison matters here even though every creation-mode
     // placement shares roomId: null today — matches Board.tsx's own
     // isSelected check (roomId + index, not index alone), the correct
@@ -384,7 +373,7 @@ export function CreationBoard({
           cx={center.x}
           cy={center.y}
           r={12}
-          fill={markerColor(isMonster ? 'monster' : 'prop', ref)}
+          fill={style.color}
           stroke={selected ? '#ffd76a' : '#000'}
           strokeWidth={selected ? 2.5 : 1}
         />
@@ -395,7 +384,7 @@ export function CreationBoard({
           fill="#fff"
           fontSize={9}
         >
-          {markerShort(ref)}
+          {style.short}
         </text>
         {angle !== null && (
           <g transform={`translate(${center.x},${center.y}) rotate(${angle})`}>

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -40,7 +40,8 @@ import { cubeToWorld } from '@/components/hex-grid/hexMath';
 import { useRef, useState, type ReactElement } from 'react';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
 import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
-import { resolveMarkerStyle } from '../markerStyle';
+import { END_COLOR, resolveMarkerStyle, START_COLOR } from '../markerStyle';
+import { PlacementMarker } from '../PlacementMarker';
 import type { BoardTool, PlacementSelection } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import {
@@ -369,23 +370,12 @@ export function CreationBoard({
         }}
         style={{ cursor: tool === null ? 'grab' : 'default' }}
       >
-        <circle
-          cx={center.x}
-          cy={center.y}
-          r={12}
-          fill={style.color}
-          stroke={selected ? '#ffd76a' : '#000'}
-          strokeWidth={selected ? 2.5 : 1}
+        <PlacementMarker
+          center={center}
+          color={style.color}
+          short={style.short}
+          selected={selected}
         />
-        <text
-          x={center.x}
-          y={center.y + 3.5}
-          textAnchor="middle"
-          fill="#fff"
-          fontSize={9}
-        >
-          {style.short}
-        </text>
         {angle !== null && (
           <g transform={`translate(${center.x},${center.y}) rotate(${angle})`}>
             <polygon
@@ -480,7 +470,7 @@ export function CreationBoard({
             cy={doc.start[1] * FLAT_ROW_SPACING}
             r={13}
             fill="none"
-            stroke="#5fd1c9"
+            stroke={START_COLOR}
             strokeWidth={2.5}
             strokeDasharray="4 3"
           />
@@ -503,7 +493,7 @@ export function CreationBoard({
             cy={doc.end[1] * FLAT_ROW_SPACING}
             r={13}
             fill="none"
-            stroke="#c9a227"
+            stroke={END_COLOR}
             strokeWidth={2.5}
             strokeDasharray="4 3"
           />

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -38,11 +38,11 @@ import {
 } from '@/components/hex-grid/authorGridHelpers';
 import { cubeToWorld } from '@/components/hex-grid/hexMath';
 import { useRef, useState, type ReactElement } from 'react';
-import type { BoardEditing } from '../DungeonBuilderConcept';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
 import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
 import { resolveMarkerStyle } from '../markerStyle';
 import type { BoardTool, PlacementSelection } from '../types';
+import type { BoardEditing } from '../useBoardEditing';
 import {
   creationCellCenter,
   hEdgeGeometry,

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -9,11 +9,11 @@
  */
 import { useEffect, useState } from 'react';
 import { CollapsibleSidePanel } from '../CollapsibleSidePanel';
-import type { BoardEditing } from '../DungeonBuilderConcept';
 import type { DungeonDoc, WallKind } from '../dungeonYaml';
 import { Inspector } from '../Inspector';
 import { Palette } from '../Palette';
 import type { BoardTool } from '../types';
+import type { BoardEditing } from '../useBoardEditing';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';

--- a/src/concepts/dungeon-builder/creation/creationGeometry.test.ts
+++ b/src/concepts/dungeon-builder/creation/creationGeometry.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
+import { nearestCreationCell, nearestEdge } from './creationGeometry';
+import type { CreationGrid } from './creationTypes';
+
+const grid: CreationGrid = { width: 20, height: 20 };
+
+// A point built from fractional (col, row) coordinates, the same way
+// nearestEdge internally divides point.x/point.y by FLAT_COL_SPACING/
+// FLAT_ROW_SPACING to recover them -- keeps these tests independent of
+// the actual spacing constant values.
+function pointAt(colF: number, rowF: number) {
+  return { x: colF * FLAT_COL_SPACING, y: rowF * FLAT_ROW_SPACING };
+}
+
+describe('nearestEdge', () => {
+  it('resolves the horizontal edge for a point centered in a cell, closer to the row boundary below', () => {
+    const edge = nearestEdge(pointAt(5, 5.5), grid);
+    expect(edge?.orientation).toBe('h');
+    expect(edge?.cellA).toEqual([5, 5]);
+    expect(edge?.cellB).toEqual([5, 6]);
+  });
+
+  it('resolves the vertical edge for a point centered in a cell, closer to the column boundary to the right', () => {
+    const edge = nearestEdge(pointAt(5.5, 5), grid);
+    expect(edge?.orientation).toBe('v');
+    expect(edge?.cellA).toEqual([5, 5]);
+    expect(edge?.cellB).toEqual([6, 5]);
+  });
+
+  it('returns null off the canvas perimeter (no togglable internal edge there)', () => {
+    expect(nearestEdge(pointAt(-0.5, 5), grid)).toBeNull();
+    expect(nearestEdge(pointAt(5, grid.height - 0.5 + 0.6), grid)).toBeNull();
+  });
+
+  describe("orientation lock (CONTRACT.md's wall-interaction finding: a straight drag must hold one orientation)", () => {
+    // row=5, y fixed 0.4 of a row-height off the row-5/row-6 boundary
+    // (deliberately NOT exactly on it -- see this test's own assertion
+    // below for why the exact-boundary case doesn't actually surface the
+    // bug). Sweeping colF across a single cell's width (3.0 -> 3.49)
+    // means dx grows from 0 toward 0.5 while dy stays fixed at 0.4, so dx
+    // overtakes dy partway across the cell -- exactly the "the pointer
+    // crosses a cell boundary" moment CONTRACT.md describes.
+    const row = 5;
+    const rowF = row + 0.4;
+    const colFsAcrossOneCell = [3.0, 3.1, 3.2, 3.3, 3.45, 3.49];
+
+    it('WITHOUT a lock, a straight horizontal drag flips to a vertical edge as the pointer nears each column boundary -- the bug the lock exists to fix', () => {
+      const orientations = colFsAcrossOneCell.map(
+        (colF) => nearestEdge(pointAt(colF, rowF), grid)?.orientation
+      );
+      // Starts horizontal (pointer away from the column boundary)...
+      expect(orientations[0]).toBe('h');
+      // ...and flips to vertical once dx (growing toward 0.5) overtakes
+      // the fixed dy=0.4, well before the drag has actually left the row.
+      expect(orientations[orientations.length - 1]).toBe('v');
+      expect(new Set(orientations).size).toBeGreaterThan(1);
+    });
+
+    it('WITH lockOrientation: "h", the SAME straight horizontal drag stays on the SAME (row 5) horizontal edge the whole way -- never alternates', () => {
+      const edges = colFsAcrossOneCell.map((colF) =>
+        nearestEdge(pointAt(colF, rowF), grid, 'h')
+      );
+      expect(edges.every((e) => e?.orientation === 'h')).toBe(true);
+      expect(
+        edges.every((e) => e?.cellA[1] === row && e?.cellB[1] === row + 1)
+      ).toBe(true);
+    });
+
+    it('WITH lockOrientation: "v", a straight vertical drag stays vertical even where the unlocked comparison would pick horizontal', () => {
+      const col = 5;
+      const colFAcrossOneCell = col + 0.4;
+      const rowFsAcrossOneCell = [3.0, 3.1, 3.2, 3.3, 3.45, 3.49];
+      const edges = rowFsAcrossOneCell.map((rf) =>
+        nearestEdge(pointAt(colFAcrossOneCell, rf), grid, 'v')
+      );
+      expect(edges.every((e) => e?.orientation === 'v')).toBe(true);
+      expect(
+        edges.every((e) => e?.cellA[0] === col && e?.cellB[0] === col + 1)
+      ).toBe(true);
+    });
+  });
+});
+
+describe('nearestCreationCell', () => {
+  it('rounds to the nearest cell', () => {
+    expect(nearestCreationCell(pointAt(5.4, 5.4), grid)).toEqual([5, 5]);
+    expect(nearestCreationCell(pointAt(5.6, 5.6), grid)).toEqual([6, 6]);
+  });
+
+  it('clamps to the grid bounds', () => {
+    expect(nearestCreationCell(pointAt(-3, -3), grid)).toEqual([0, 0]);
+    expect(nearestCreationCell(pointAt(99, 99), grid)).toEqual([
+      grid.width - 1,
+      grid.height - 1,
+    ]);
+  });
+});

--- a/src/concepts/dungeon-builder/creation/creationGeometry.ts
+++ b/src/concepts/dungeon-builder/creation/creationGeometry.ts
@@ -4,19 +4,13 @@
  * `boardGeometry.ts`/`Board.tsx`.
  */
 import { FLAT_COL_SPACING, FLAT_ROW_SPACING, type CellPos } from '../hexLayout';
-import {
-  hEdgeKey,
-  vEdgeKey,
-  type CreationGrid,
-  type EdgeKey,
-} from './creationTypes';
+import { type CreationGrid } from './creationTypes';
 
 export function creationCellCenter(col: number, row: number): CellPos {
   return { x: col * FLAT_COL_SPACING, y: row * FLAT_ROW_SPACING };
 }
 
 export interface EdgeGeometry {
-  key: EdgeKey;
   orientation: 'h' | 'v';
   /** The two cells the edge sits between. */
   cellA: [number, number];
@@ -32,7 +26,6 @@ export function hEdgeGeometry(col: number, row: number): EdgeGeometry {
   const x0 = (col - 0.5) * FLAT_COL_SPACING;
   const x1 = (col + 0.5) * FLAT_COL_SPACING;
   return {
-    key: hEdgeKey(col, row),
     orientation: 'h',
     cellA: [col, row],
     cellB: [col, row + 1],
@@ -47,7 +40,6 @@ export function vEdgeGeometry(col: number, row: number): EdgeGeometry {
   const y0 = (row - 0.5) * FLAT_ROW_SPACING;
   const y1 = (row + 0.5) * FLAT_ROW_SPACING;
   return {
-    key: vEdgeKey(col, row),
     orientation: 'v',
     cellA: [col, row],
     cellB: [col + 1, row],
@@ -55,17 +47,6 @@ export function vEdgeGeometry(col: number, row: number): EdgeGeometry {
     b: { x, y: y1 },
     mid: { x, y: (y0 + y1) / 2 },
   };
-}
-
-export function allInternalEdges(grid: CreationGrid): EdgeGeometry[] {
-  const edges: EdgeGeometry[] = [];
-  for (let c = 0; c < grid.width; c++) {
-    for (let r = 0; r < grid.height - 1; r++) edges.push(hEdgeGeometry(c, r));
-  }
-  for (let c = 0; c < grid.width - 1; c++) {
-    for (let r = 0; r < grid.height; r++) edges.push(vEdgeGeometry(c, r));
-  }
-  return edges;
 }
 
 /** Nearest internal edge to a board-space point — computed analytically

--- a/src/concepts/dungeon-builder/creation/creationTypes.ts
+++ b/src/concepts/dungeon-builder/creation/creationTypes.ts
@@ -20,20 +20,11 @@ export interface CreationGrid {
   height: number;
 }
 
-/** Internal edge between two orthogonally adjacent cells. `h:c,r` is the
- * edge BELOW cell (c,r) (shared with (c,r+1)); `v:c,r` is the edge RIGHT
- * of cell (c,r) (shared with (c+1,r)). The canvas perimeter is an
+/** Internal edge between two orthogonally adjacent cells: the edge BELOW
+ * cell (c,r) (shared with (c,r+1)) is horizontal; the edge RIGHT of cell
+ * (c,r) (shared with (c+1,r)) is vertical. The canvas perimeter is an
  * always-on boundary, not a member of this set — only internal edges are
  * toggleable, matching "carve the space into rooms" (you start inside a
  * bounded room and cut it up, you don't have to draw the outer walls).
- * Geometry-only now — the actual authored wall lives in `doc.walls`
- * (`WallDoc[]`, dungeonYaml.ts), addressed by `from`/`to` cells directly;
- * this key exists purely for `creationGeometry.ts`'s hit-testing. */
-export type EdgeKey = string;
-
-export function hEdgeKey(col: number, row: number): EdgeKey {
-  return `h:${col},${row}`;
-}
-export function vEdgeKey(col: number, row: number): EdgeKey {
-  return `v:${col},${row}`;
-}
+ * Geometry-only — the actual authored wall lives in `doc.walls`
+ * (`WallDoc[]`, dungeonYaml.ts), addressed by `from`/`to` cells directly. */

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -21,12 +21,14 @@ import {
   setPlacementRotationDegrees,
   setPlacementTargeting,
   setStart,
+  setWallEdge,
   stripMonsterPlacements,
   stripToV1Subset,
   toDungeonDoc,
   toggleHole,
   toggleWall,
   toggleWallKind,
+  wallKindAtEdge,
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
 
@@ -389,6 +391,37 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
     expect(toDungeonDoc(cst).walls[0].kind).toBe('door');
     toggleWallKind(cst, 3, 3);
     expect(toDungeonDoc(cst).walls[0].kind).toBe('solid');
+  });
+
+  it('toggleWall/toggleWallKind never touch a wall on a DIFFERENT edge that merely shares the same `from` cell (wallIndexAt/wallIndexAtEdge reconciliation)', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    // A creation-mode-style wall on cell (7,0)'s OTHER edge — same `from`
+    // cell edit mode's Wall tool would use at (7,0), but a different `to`
+    // ([8,0] instead of [7,1]). Before the reconciliation this was
+    // reachable and deletable by clicking cell (7,0) with edit mode's
+    // Wall tool, since the old from-cell-only lookup didn't check `to`.
+    setWallEdge(cst, [7, 0], [8, 0], 'solid', true);
+    expect(wallKindAtEdge(cst, [7, 0], [8, 0])).toBe('solid');
+
+    // toggleWall on the SAME (7,0) cell must ADD a new wall on edit
+    // mode's own (7,0)->(7,1) edge, not touch the [7,0]->[8,0] one.
+    toggleWall(cst, 7, 0);
+    expect(toDungeonDoc(cst).walls).toEqual([
+      { from: [7, 0], to: [8, 0], kind: 'solid' },
+      { from: [7, 0], to: [7, 1], kind: 'solid' },
+    ]);
+
+    // toggleWallKind on (7,0) must flip ONLY the (7,0)->(7,1) wall.
+    expect(toggleWallKind(cst, 7, 0)).toBe(true);
+    expect(wallKindAtEdge(cst, [7, 0], [7, 1])).toBe('door');
+    expect(wallKindAtEdge(cst, [7, 0], [8, 0])).toBe('solid'); // untouched
+
+    // A second toggleWall on (7,0) must remove ONLY the (7,0)->(7,1)
+    // wall, leaving the [7,0]->[8,0] wall standing.
+    toggleWall(cst, 7, 0);
+    expect(toDungeonDoc(cst).walls).toEqual([
+      { from: [7, 0], to: [8, 0], kind: 'solid' },
+    ]);
   });
 
   it('toggleHole adds then removes a hole', () => {

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -187,7 +187,7 @@ describe('serializeDungeon round-trip', () => {
     // fixtures.ts drifting from the source of truth too.
     const realPath = join(
       __dirname,
-      '../../../../../dungeon-content/showcase.yaml'
+      '../../../../dungeon-content/showcase.yaml'
     );
     let real: string;
     try {

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -853,34 +853,23 @@ function createWallNode(cst: Document, wall: WallDoc): YAMLMap {
   return node;
 }
 
-/** A wall's index in `walls:`, matched by its `from` cell — this concept
- * represents one authored wall as ONE unit anchored at a specific
- * absolute [col,row] cell (its bottom edge, `to: [col, row+1]`) rather
- * than requiring a drag gesture to specify an arbitrary edge; see
- * TARGET-YAML.md's "Structural palette category" section for why a
- * single click-to-toggle affordance was chosen over full free-hand edge
- * drawing for this pass. */
-function wallIndexAt(cst: Document, col: number, row: number): number {
-  const walls = cst.get('walls');
-  if (!isSeq(walls)) return -1;
-  return walls.items.findIndex((w) => {
-    if (!isMap(w)) return false;
-    const from = w.get('from');
-    // `.get(0)`/`.get(1)`, not `.items[0]`/`.items[1]` — a sequence built
-    // via `cst.createNode(...)` (createWallNode below) wraps its number
-    // children in `Scalar` nodes; indexing `.items` directly returns
-    // those wrapper objects, which never `===` a raw number. `.get()`
-    // auto-resolves to the JS value, same contract `YAMLMap.get` already
-    // uses everywhere else in this file (see `findRoomSeqIndex`).
-    return isSeq(from) && from.get(0) === col && from.get(1) === row;
-  });
-}
-
 /** Wall tool: toggle a wall's PRESENCE at a cell (add as `kind: solid` /
  * remove) — target dialect, proposed. Adding always starts solid; use
- * `toggleWallKind` to flip an existing one to a door. */
+ * `toggleWallKind` to flip an existing one to a door. Anchored at a
+ * specific absolute [col,row] cell's bottom edge (`to: [col, row+1]`)
+ * rather than requiring a drag gesture to specify an arbitrary edge; see
+ * TARGET-YAML.md's "Structural palette category" section for why a
+ * single click-to-toggle affordance was chosen over full free-hand edge
+ * drawing for this pass. Looks the wall up by `wallIndexAtEdge`'s EXACT
+ * `from`/`to` match, not a from-cell-only match — a from-only match used
+ * to let this tool find and delete a wall drawn on a DIFFERENT edge that
+ * merely shared this cell as its `from` (e.g. a creation-mode-drawn
+ * `[c,r]->[c+1,r]` wall, reachable by clicking cell (c,r) with edit
+ * mode's Wall tool, which only ever intends the (c,r)->(c,r+1) edge) —
+ * graduation audit item, reconciling this with `wallIndexAtEdge` so
+ * there's one lookup convention, not two. */
 export function toggleWall(cst: Document, col: number, row: number): void {
-  const idx = wallIndexAt(cst, col, row);
+  const idx = wallIndexAtEdge(cst, [col, row], [col, row + 1]);
   if (idx !== -1) {
     (cst.get('walls') as YAMLSeq).items.splice(idx, 1);
     return;
@@ -895,13 +884,14 @@ export function toggleWall(cst: Document, col: number, row: number): void {
  * no-op if there's no wall at this cell yet (caller should reject/toast
  * "place a wall here first", matching the Structural category's own
  * two-tool split in TARGET-YAML.md). Returns whether a wall existed to
- * toggle, so the caller can distinguish "toggled" from "nothing there". */
+ * toggle, so the caller can distinguish "toggled" from "nothing there".
+ * Same exact-edge lookup as `toggleWall` above, for the same reason. */
 export function toggleWallKind(
   cst: Document,
   col: number,
   row: number
 ): boolean {
-  const idx = wallIndexAt(cst, col, row);
+  const idx = wallIndexAtEdge(cst, [col, row], [col, row + 1]);
   if (idx === -1) return false;
   const item = (cst.get('walls') as YAMLSeq).items[idx];
   if (!isMap(item)) return false;
@@ -910,15 +900,17 @@ export function toggleWallKind(
 }
 
 /** A wall's index in `walls:`, matched by an EXACT `from`/`to` pair (both
- * ends, not just `from` — see `wallIndexAt`'s doc comment for why edit
- * mode's own lookup only needs `from`). General edge lookup for the
+ * ends, not just `from`) — the one wall-lookup convention this concept
+ * uses now (`toggleWall`/`toggleWallKind` above route through this too,
+ * not a separate from-cell-only lookup). General edge lookup for the
  * "New Dungeon" creation board's freeform edge-painting, where a wall
  * can be either orientation (a `from`→`to` step of `[0,1]` or `[1,0]`)
- * at any cell, not just the one fixed edit-mode shape. Callers are
- * responsible for passing `from`/`to` in ONE canonical order (creation
- * mode's `hEdgeGeometry`/`vEdgeGeometry` already produce one) — this
- * does not check the reverse pairing, matching how the CST itself never
- * stores a wall's endpoints swapped. */
+ * at any cell, not just edit mode's own fixed (col,row)->(col,row+1)
+ * shape. Callers are responsible for passing `from`/`to` in ONE
+ * canonical order (creation mode's `hEdgeGeometry`/`vEdgeGeometry`
+ * already produce one, edit mode's `toggleWall`/`toggleWallKind` always
+ * pass `to: [col, row+1]`) — this does not check the reverse pairing,
+ * matching how the CST itself never stores a wall's endpoints swapped. */
 function wallIndexAtEdge(
   cst: Document,
   from: [number, number],

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -604,9 +604,10 @@ export function setPlacementFlags(
  * ask). Deliberately does NOT touch `boss:`: dungeonspec requires exactly
  * one boss per boss-archetype room (`moveBoss`'s own doc comment above),
  * so a boss-room YAML with `boss:` removed fails that validation rather
- * than producing a genuinely boss-free dungeon — see
- * `useWalkItVariant.ts`'s doc comment for how the UI stays honest about
- * this rather than silently rewriting the room's archetype to dodge it. */
+ * than producing a genuinely boss-free dungeon — see `YamlPane.tsx`'s
+ * `honestyNote` ("Boss remains — real free-roam mode needs server
+ * support") for how the UI stays honest about this rather than silently
+ * rewriting the room's archetype to dodge it. */
 export function stripMonsterPlacements(cst: Document): void {
   const rooms = cst.get('rooms');
   if (!isSeq(rooms)) return;

--- a/src/concepts/dungeon-builder/fixtures.ts
+++ b/src/concepts/dungeon-builder/fixtures.ts
@@ -213,4 +213,3 @@ export const S2_LOOP_FLOORPLAN: FloorPlan = create(FloorPlanSchema, {
  * This is why the palette below offers a general monster placement, not
  * just the boss pin.
  */
-export const MONSTER_PLACE_CHECK_VERIFIED = true;

--- a/src/concepts/dungeon-builder/hexLayout.ts
+++ b/src/concepts/dungeon-builder/hexLayout.ts
@@ -28,6 +28,7 @@
  */
 import {
   cubeToWorld,
+  hexEdgeBetween,
   hexCorners as realHexCorners,
 } from '@/components/hex-grid/hexMath';
 import { cubeAtColRow, hexColumn, hexRow } from '@/hooks/wallRuns';
@@ -55,6 +56,39 @@ export function cellCorners(center: CellPos, size: number): [number, number][] {
   return realHexCorners({ x: center.x, z: center.y }, size).map(
     (c) => [c.x, c.z] as [number, number]
   );
+}
+
+export interface CellEdge {
+  a: CellPos;
+  b: CellPos;
+  mid: CellPos;
+}
+
+/** The shared edge between two adjacent hex cells, in this file's board
+ * space — the SAME `hexEdgeBetween` geometry the 3D preview's wall boxes
+ * and wall-mount rotation use (`preview3d/DungeonPreview3D.tsx`'s
+ * `edgeBetweenCells`/`wallBoxTransform`/`wallMountRotationY`), just
+ * projected onto `CellPos`'s 2D plane instead of a Three.js Y rotation.
+ * Lets the 2D edit board draw walls as real edge segments (graduation
+ * audit item: it used to draw a dashed full-cell rect at the wall's
+ * `from` cell instead of the actual shared edge, the one place in this
+ * concept still drawing wall geometry wrong). */
+export function edgeBetweenCells(
+  colA: number,
+  rowA: number,
+  colB: number,
+  rowB: number
+): CellEdge {
+  const edge = hexEdgeBetween(
+    cubeAtColRow(colA, rowA),
+    cubeAtColRow(colB, rowB),
+    BOARD_HEX_SIZE
+  );
+  return {
+    a: { x: edge.a.x, y: edge.a.z },
+    b: { x: edge.b.x, y: edge.b.z },
+    mid: { x: edge.mid.x, y: edge.mid.z },
+  };
 }
 
 /** Creation mode's rectangular-canvas spacing — see this file's header

--- a/src/concepts/dungeon-builder/markerStyle.ts
+++ b/src/concepts/dungeon-builder/markerStyle.ts
@@ -23,6 +23,19 @@ export interface MarkerStyle {
   short: string;
 }
 
+/** `doc.start`/`doc.end` marker colors — independently hardcoded to the
+ * identical `#5fd1c9`/`#c9a227` values in Board.tsx, CreationBoard.tsx,
+ * and the 3D preview (graduation audit item) before this consolidation.
+ * Only the color constants are shared here: the three renderers' actual
+ * start/end circle+label JSX still differs by design intent (Board.tsx's
+ * filled swatch + "ST"/"EN" abbreviation vs CreationBoard.tsx's outline
+ * ring + full "START"/"END" label above it) — unifying THAT is a visual
+ * decision for Kirk to make, not a mechanical dedup, so it's left alone
+ * here; only the genuinely-identical-with-zero-semantic-difference color
+ * values are consolidated. */
+export const START_COLOR = '#5fd1c9';
+export const END_COLOR = '#c9a227';
+
 export function resolveMarkerStyle(
   ref: string,
   opts: { isBoss?: boolean } = {}

--- a/src/concepts/dungeon-builder/markerStyle.ts
+++ b/src/concepts/dungeon-builder/markerStyle.ts
@@ -1,0 +1,40 @@
+/**
+ * markerStyle — a placement ref's marker color + short label, resolved
+ * once instead of near-verbatim duplicated in `Board.tsx` and
+ * `creation/CreationBoard.tsx` (graduation audit item). `isBoss` stays a
+ * caller-supplied flag rather than something derivable from `ref` alone
+ * — only edit mode's compiled `FloorPlan` has a boss-pin concept at all;
+ * creation mode's freeform canvas has none (TARGET-YAML.md), so it never
+ * passes it. Monster-vs-prop is derived from the ref prefix, the same
+ * check both original implementations used. `PALETTE_PROPS` never
+ * contains a monster ref (its `SHOWCASE_PROP_KEYS` are all
+ * `dnd5e:props:*`), so checking it before falling back to the monster
+ * check is safe and matches both originals' real-world behavior exactly.
+ */
+import {
+  BOSS_COLOR,
+  MONSTER_COLOR,
+  PALETTE_PROPS,
+  ROLE_COLOR,
+} from './paletteData';
+
+export interface MarkerStyle {
+  color: string;
+  short: string;
+}
+
+export function resolveMarkerStyle(
+  ref: string,
+  opts: { isBoss?: boolean } = {}
+): MarkerStyle {
+  if (opts.isBoss) return { color: BOSS_COLOR, short: 'BOSS' };
+
+  const prop = PALETTE_PROPS.find((p) => p.ref === ref);
+  if (prop) return { color: ROLE_COLOR[prop.role], short: prop.short };
+
+  const isMonster = ref.startsWith('dnd5e:monsters:');
+  return {
+    color: isMonster ? MONSTER_COLOR : '#888',
+    short: isMonster ? 'M' : '?',
+  };
+}

--- a/src/concepts/dungeon-builder/paletteData.ts
+++ b/src/concepts/dungeon-builder/paletteData.ts
@@ -54,7 +54,7 @@ export function categoryForProp(
 /**
  * Pre-baked palette thumbnails (rpg-dnd5e-web#667, Kirk's "rich entries
  * that SHOW the assets" ask). Baked via the throwaway `?thumbGlb=` R3F
- * harness (`src/concepts/dungeon-builder/thumbs/ThumbHarness.tsx`) +
+ * harness (`src/dev/ThumbHarness.tsx`) +
  * `game-dev/tools/browser/screenshot.mjs` — see that harness file's own
  * doc comment and CONTRACT.md's "Thumbnail provenance" section for the
  * exact bake process. Filename convention: `<ref's last segment>.png`

--- a/src/concepts/dungeon-builder/paletteData.ts
+++ b/src/concepts/dungeon-builder/paletteData.ts
@@ -3,9 +3,8 @@
  * `propManifest.ts` (`PROP_KEYS`), not a hand-rolled color/icon table.
  * The standalone HTML concept had to invent per-key colors because it had
  * no module system to import the real manifest; this port fixes that —
- * `role`/`footprintHexes`/`blocksLoS` below all come straight from the
- * shared source of truth `src/components/hex-grid/PropModel.tsx` also
- * reads.
+ * `role` below comes straight from the shared source of truth
+ * `src/components/hex-grid/PropModel.tsx` also reads.
  *
  * Filtered to exactly the keys showcase.yaml's own `place:`/`boss:`
  * entries reference (task requirement: no invented refs) — see
@@ -17,8 +16,6 @@ export interface PaletteProp {
   ref: string;
   short: string;
   role: PropRole;
-  footprintHexes: number;
-  blocksLoS: boolean;
 }
 
 /**
@@ -111,25 +108,16 @@ function shortLabel(key: string): string {
 }
 
 /** The palette's prop list — one entry per key showcase.yaml references,
- * pulling role/footprint/blocksLoS from the first variant `propManifest`
- * lists for that key (same "first available" convention
- * `resolvePropVariant` itself uses). A key that's somehow missing from
- * `PROP_KEYS` is dropped rather than crashing the board — the concept
- * should degrade, not blank-page, if the manifest and showcase.yaml ever
- * drift. */
+ * pulling `role` from the first variant `propManifest` lists for that key
+ * (same "first available" convention `resolvePropVariant` itself uses). A
+ * key that's somehow missing from `PROP_KEYS` is dropped rather than
+ * crashing the board — the concept should degrade, not blank-page, if the
+ * manifest and showcase.yaml ever drift. */
 export const PALETTE_PROPS: PaletteProp[] = SHOWCASE_PROP_KEYS.flatMap(
   (ref) => {
     const variant = PROP_KEYS[ref]?.[0];
     if (!variant) return [];
-    return [
-      {
-        ref,
-        short: shortLabel(ref),
-        role: variant.role,
-        footprintHexes: variant.footprintHexes,
-        blocksLoS: variant.blocksLoS,
-      },
-    ];
+    return [{ ref, short: shortLabel(ref), role: variant.role }];
   }
 );
 

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -87,6 +87,7 @@ import {
 } from '../boardGeometry';
 import type { DungeonDoc, PlacementDoc, WallDoc } from '../dungeonYaml';
 import { cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
+import { END_COLOR, START_COLOR } from '../markerStyle';
 import type { PaletteSelection, PlacementSelection } from '../types';
 import { PreviewMonsterModel } from './PreviewMonsterModel';
 
@@ -537,8 +538,6 @@ function WallBox({ wall }: { wall: PlacedWall }) {
  * re-derived) — a flat ring lying on the floor plane, since this static
  * preview has no camera-facing billboard text to spend on a label the
  * way the 2D SVG board does. */
-const START_COLOR = '#5fd1c9';
-const END_COLOR = '#c9a227';
 const ENTRANCE_CLEAR_COLOR = '#5fd1c9';
 const ENTRANCE_BLOCKED_COLOR = '#ff5a3a';
 const MARKER_RING_INNER = HEX_SIZE * 0.32;

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -73,6 +73,7 @@ import {
   setLightingAmbient,
   setPlacementFacing,
   setPlacementFlags,
+  setPlacementHeight,
   setPlacementMount,
   setPlacementRotationDegrees,
   setPlacementTargeting,
@@ -129,7 +130,8 @@ connectors:
 
     placeItem(cst, 'hall', 'dnd5e:props:wall-banner', [7, 1]);
     setPlacementFacing(cst, 'hall', 1, 1); // NE
-    setPlacementMount(cst, 'hall', 1, 'wall', 2.0);
+    setPlacementMount(cst, 'hall', 1, 'wall');
+    setPlacementHeight(cst, 'hall', 1, 2.0);
     setPlacementRotationDegrees(cst, 'hall', 1, 12);
     setWallEdge(cst, [7, 1], [8, 0], 'solid', true);
     setWallEdge(cst, [7, 3], [8, 2], 'door', true);
@@ -143,7 +145,8 @@ connectors:
 
     placeItem(cst, null, 'dnd5e:props:wall-banner', [15, 3]);
     setPlacementFacing(cst, null, 0, 0); // E
-    setPlacementMount(cst, null, 0, 'wall', 1.5);
+    setPlacementMount(cst, null, 0, 'wall');
+    setPlacementHeight(cst, null, 0, 1.5);
     setPlacementRotationDegrees(cst, null, 0, -8);
     placeItem(cst, null, 'dnd5e:props:candles', [16, 3]);
     setPlacementFlags(cst, null, 1, {

--- a/src/concepts/dungeon-builder/useBoardEditing.ts
+++ b/src/concepts/dungeon-builder/useBoardEditing.ts
@@ -1,0 +1,262 @@
+/**
+ * useBoardEditing — the palette/placement editing core, extracted from
+ * `DungeonBuilderConcept.tsx` into its own module (graduation audit item:
+ * it was already cleanly factored as a standalone hook, just living in
+ * the wrong file). It's the part of edit mode's board interaction that
+ * "New Dungeon" needs verbatim once it authors onto its OWN cst/
+ * DungeonDoc instead of the bespoke CreationState (CONTRACT.md's
+ * "unifying New Dungeon onto the shared CST" section). Called once per
+ * mode with that mode's own `cst`/`doc`/`syncFromCst`, rather than
+ * duplicated: placement selection is a `ref` at a `[col,row]`,
+ * room-scoped (`roomId` a real id) or top-level (`roomId: null`,
+ * TARGET-YAML.md's "top-level placement" section) —
+ * `handlePlace`/`handleMove`/etc. below already generalize over both via
+ * dungeonYaml.ts's own `roomId: string | null` mutators, so this hook
+ * needs no special-casing per mode; only the SURROUNDING board/palette/
+ * wall handling differs per mode, and stays defined in
+ * `DungeonBuilderConcept.tsx` where it's called.
+ */
+import { useState } from 'react';
+import type { Document } from 'yaml';
+import {
+  deletePlacement,
+  moveBoss,
+  movePlacement,
+  movePlacementAcrossLists,
+  placeItem,
+  setBossFacing,
+  setBossTargeting,
+  setPlacementFacing,
+  setPlacementFlags,
+  setPlacementHeight,
+  setPlacementMount,
+  setPlacementRotationDegrees,
+  setPlacementTargeting,
+  type DungeonDoc,
+  type Mount,
+} from './dungeonYaml';
+import type { PaletteSelection, PlacementSelection } from './types';
+
+export function useBoardEditing(
+  cst: Document,
+  doc: DungeonDoc,
+  syncFromCst: (cst: Document) => void,
+  flashToast?: (message: string) => void
+) {
+  const [selectedPalette, setSelectedPalette] =
+    useState<PaletteSelection | null>(null);
+  const [selectedPlacement, setSelectedPlacement] =
+    useState<PlacementSelection | null>(null);
+
+  const handlePlace = (roomId: string | null, at: [number, number]) => {
+    if (!selectedPalette) return;
+    const isMonster = selectedPalette.kind === 'monster';
+    if (selectedPalette.kind === 'boss') {
+      // Boss stays room-scoped even in the target dialect (moveBoss
+      // requires a real roomId) — callers arming the boss tool over a
+      // roomless canvas are expected to reject before ever reaching
+      // here (CreationBoard.tsx does), so this is a defensive backstop,
+      // not the primary guard.
+      if (roomId === null) return;
+      moveBoss(cst, roomId, at);
+      flashToast?.('Boss pin placed.');
+    } else {
+      placeItem(cst, roomId, selectedPalette.ref, at);
+      if (isMonster) {
+        flashToast?.(
+          'Monster placed — blocks_movement/blocks_los are forced off and disabled (dungeonspec.Validate rejects both flags on monster placements).'
+        );
+      }
+    }
+    syncFromCst(cst);
+  };
+
+  const handleMove = (
+    sel: PlacementSelection,
+    roomId: string | null,
+    at: [number, number]
+  ) => {
+    if (sel.boss) {
+      // A boss never leaves its own room (Board.tsx's own pointer-up
+      // handler already rejects a cross-room boss drop before onMove is
+      // ever called) — sel.roomId is the real, non-null id to use here,
+      // not the destination `roomId` parameter (which stays nullable to
+      // cover the non-boss, top-level case).
+      moveBoss(cst, sel.roomId, at);
+      syncFromCst(cst);
+      return;
+    }
+    if (roomId === sel.roomId) {
+      movePlacement(cst, sel.roomId, sel.index, at);
+      syncFromCst(cst);
+      setSelectedPlacement({ roomId, index: sel.index });
+      return;
+    }
+    // Cross-list move (room-scoped <-> top-level, or between two rooms):
+    // `movePlacementAcrossLists` preserves every field (facing/mount/
+    // height/rotate_degrees/targeting/blocks_*), not just ref+at — the
+    // naive delete+placeItem shape this used to be silently dropped all
+    // of those (2026-08-02 graduation audit finding). It also returns
+    // the item's real new index directly, rather than this caller
+    // re-deriving it from possibly-stale `doc` state via a
+    // `.find(...)!.place.length` that used to throw outright for a
+    // roomId: null destination (no room has id null to find).
+    const item = sel.roomId
+      ? doc.rooms.find((r) => r.id === sel.roomId)?.place[sel.index]
+      : doc.place[sel.index];
+    if (!item) return;
+    const newIndex = movePlacementAcrossLists(
+      cst,
+      sel.roomId,
+      sel.index,
+      roomId,
+      at,
+      item
+    );
+    syncFromCst(cst);
+    setSelectedPlacement({ roomId, index: newIndex });
+  };
+
+  const handleDelete = () => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    deletePlacement(cst, selectedPlacement.roomId, selectedPlacement.index);
+    setSelectedPlacement(null);
+    syncFromCst(cst);
+  };
+
+  const handleSetFlags = (blocksMovement: boolean, blocksLos: boolean) => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    setPlacementFlags(cst, selectedPlacement.roomId, selectedPlacement.index, {
+      blocksMovement,
+      blocksLos,
+    });
+    syncFromCst(cst);
+  };
+
+  // Boss entries have no mount/height (bosses aren't wall furniture) —
+  // only place: entries do, matching Inspector.tsx's own gate. Two
+  // separate handlers, not one — mount/height are DECOUPLED (Kirk-batch,
+  // 2026-08-02: "height: decouples from mount... any placement may carry
+  // height"), matching `setPlacementMount`'s/`setPlacementHeight`'s own
+  // now-independent shape.
+  const handleSetMount = (mount: Mount) => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    setPlacementMount(
+      cst,
+      selectedPlacement.roomId,
+      selectedPlacement.index,
+      mount
+    );
+    syncFromCst(cst);
+  };
+
+  const handleSetHeight = (height: number | null) => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    setPlacementHeight(
+      cst,
+      selectedPlacement.roomId,
+      selectedPlacement.index,
+      height
+    );
+    syncFromCst(cst);
+  };
+
+  // EXPERIMENT, not a target-dialect field (Inspector.tsx's own
+  // ExperimentBadge doc comment) — same boss-excluded gate as
+  // handleSetMount, since the control only ever shows for a
+  // mount: 'wall' place: entry, which a boss can never be.
+  const handleSetRotationDegrees = (rotationDegrees: number | null) => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    setPlacementRotationDegrees(
+      cst,
+      selectedPlacement.roomId,
+      selectedPlacement.index,
+      rotationDegrees
+    );
+    syncFromCst(cst);
+  };
+
+  const handleSetTargeting = (targeting: string | null) => {
+    if (!selectedPlacement) return;
+    if (selectedPlacement.boss) {
+      setBossTargeting(cst, selectedPlacement.roomId, targeting);
+    } else {
+      setPlacementTargeting(
+        cst,
+        selectedPlacement.roomId,
+        selectedPlacement.index,
+        targeting
+      );
+    }
+    syncFromCst(cst);
+  };
+
+  const handleSetFacing = (facing: number | null) => {
+    if (!selectedPlacement) return;
+    if (selectedPlacement.boss) {
+      setBossFacing(cst, selectedPlacement.roomId, facing);
+    } else {
+      setPlacementFacing(
+        cst,
+        selectedPlacement.roomId,
+        selectedPlacement.index,
+        facing
+      );
+    }
+    syncFromCst(cst);
+  };
+
+  // Wall-mount edge-selection rework, part 2 (Inspector.tsx's own
+  // `onFlipMountSide` doc comment) — the Inspector already validated
+  // `target` against a real floor cell before ever calling this, so this
+  // handler's job is purely the mutation: a cross-list move (via
+  // `movePlacementAcrossLists`, which preserves every field) carrying
+  // the NEW mirrored facing instead of the old one. Boss-excluded, same
+  // gate every other placement-only handler here uses — a boss is never
+  // wall-mounted.
+  const handleFlipMountSide = (target: {
+    roomId: string;
+    at: [number, number];
+    newFacing: number;
+  }) => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    const item = selectedPlacement.roomId
+      ? doc.rooms.find((r) => r.id === selectedPlacement.roomId)?.place[
+          selectedPlacement.index
+        ]
+      : doc.place[selectedPlacement.index];
+    if (!item) return;
+    const newIndex = movePlacementAcrossLists(
+      cst,
+      selectedPlacement.roomId,
+      selectedPlacement.index,
+      target.roomId,
+      target.at,
+      { ...item, facing: target.newFacing }
+    );
+    syncFromCst(cst);
+    setSelectedPlacement({ roomId: target.roomId, index: newIndex });
+  };
+
+  return {
+    selectedPalette,
+    setSelectedPalette,
+    selectedPlacement,
+    setSelectedPlacement,
+    handlePlace,
+    handleMove,
+    handleDelete,
+    handleSetFlags,
+    handleSetMount,
+    handleSetHeight,
+    handleSetRotationDegrees,
+    handleSetTargeting,
+    handleSetFacing,
+    handleFlipMountSide,
+  };
+}
+
+/** The `useBoardEditing` handle — exported so `CreationBoard.tsx`/
+ * `CreationConcept.tsx` can type the `edit` prop they receive without
+ * re-deriving the same shape. */
+export type BoardEditing = ReturnType<typeof useBoardEditing>;

--- a/src/concepts/dungeon-builder/useSaveDungeon.test.ts
+++ b/src/concepts/dungeon-builder/useSaveDungeon.test.ts
@@ -1,0 +1,141 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+import type { PutDungeonResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  putDungeonFn:
+    vi.fn<
+      (req: {
+        key: string;
+        yaml: string;
+        validateOnly: boolean;
+      }) => Promise<PutDungeonResponse>
+    >(),
+}));
+
+vi.mock('@/api/client', () => ({
+  authoringClient: { putDungeon: hoisted.putDungeonFn },
+}));
+
+// Import AFTER vi.mock so the mock is applied (same pattern
+// usePutDungeonPreview.test.ts uses).
+import { useSaveDungeon } from './useSaveDungeon';
+
+beforeEach(() => {
+  hoisted.putDungeonFn.mockReset();
+});
+
+describe('useSaveDungeon', () => {
+  it('starts idle with no saved key/errors', () => {
+    const { result } = renderHook(() => useSaveDungeon());
+    expect(result.current.state).toBe('idle');
+    expect(result.current.savedKey).toBeNull();
+    expect(result.current.fieldErrors).toEqual([]);
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('goes to "saving" synchronously the moment save() is called, before the request resolves', () => {
+    hoisted.putDungeonFn.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useSaveDungeon());
+
+    act(() => {
+      result.current.save('my-dungeon', 'version: 1\nkey: my-dungeon\n');
+    });
+
+    expect(result.current.state).toBe('saving');
+  });
+
+  it('success:true -> "saved", savedKey echoes the REQUEST key, not anything off the response (PutDungeonResponse has no key field)', async () => {
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+    const { result } = renderHook(() => useSaveDungeon());
+
+    act(() => {
+      result.current.save('shrine-hall', 'version: 1\nkey: shrine-hall\n');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('saved'));
+    expect(result.current.savedKey).toBe('shrine-hall');
+    expect(result.current.errorMessage).toBeNull();
+
+    // The request itself: a real, explicit write (validate_only: false),
+    // not the live preview's debounced validate_only: true read.
+    expect(hoisted.putDungeonFn).toHaveBeenCalledOnce();
+    const req = hoisted.putDungeonFn.mock.calls[0][0];
+    expect(req.key).toBe('shrine-hall');
+    expect(req.validateOnly).toBe(false);
+  });
+
+  it('success:false -> "invalid", surfaces the real server-side field errors', async () => {
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: false,
+      fieldErrors: [{ field: '', message: 'boss room must declare a boss' }],
+    } as unknown as PutDungeonResponse);
+    const { result } = renderHook(() => useSaveDungeon());
+
+    act(() => {
+      result.current.save('bad-key', 'version: 1\nkey: bad-key\n');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('invalid'));
+    expect(result.current.fieldErrors).toEqual([
+      { field: '', message: 'boss room must declare a boss' },
+    ]);
+    expect(result.current.savedKey).toBeNull(); // never set on a rejected save
+  });
+
+  it('a thrown ConnectError -> "error", errorMessage is the connect error message (transport/gate-off, not author feedback)', async () => {
+    hoisted.putDungeonFn.mockRejectedValue(
+      new ConnectError(
+        'unknown service dnd5e.api.authoring.v1alpha1.AuthoringService',
+        Code.Unimplemented
+      )
+    );
+    const { result } = renderHook(() => useSaveDungeon());
+
+    act(() => {
+      result.current.save('any-key', 'version: 1\nkey: any-key\n');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('error'));
+    expect(result.current.errorMessage).toContain('unknown service');
+    expect(result.current.fieldErrors).toEqual([]);
+  });
+
+  it('a non-ConnectError throw (raw network failure) -> "error" with the generic fallback message', async () => {
+    hoisted.putDungeonFn.mockRejectedValue(new TypeError('Failed to fetch'));
+    const { result } = renderHook(() => useSaveDungeon());
+
+    act(() => {
+      result.current.save('any-key', 'version: 1\nkey: any-key\n');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('error'));
+    expect(result.current.errorMessage).toBe('PutDungeon request failed');
+  });
+
+  it('a fresh save() clears a prior error/invalid result before the new request resolves', async () => {
+    hoisted.putDungeonFn.mockRejectedValueOnce(
+      new TypeError('Failed to fetch')
+    );
+    const { result } = renderHook(() => useSaveDungeon());
+
+    act(() => {
+      result.current.save('key-a', 'version: 1\nkey: key-a\n');
+    });
+    await waitFor(() => expect(result.current.state).toBe('error'));
+    expect(result.current.errorMessage).not.toBeNull();
+
+    hoisted.putDungeonFn.mockReturnValueOnce(new Promise(() => {})); // never resolves
+    act(() => {
+      result.current.save('key-b', 'version: 1\nkey: key-b\n');
+    });
+
+    expect(result.current.state).toBe('saving');
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.fieldErrors).toEqual([]);
+  });
+});

--- a/src/concepts/dungeon-builder/useSaveDungeon.ts
+++ b/src/concepts/dungeon-builder/useSaveDungeon.ts
@@ -41,7 +41,6 @@ export interface UseSaveDungeonResult {
    * draws between field_errors and requestError. */
   errorMessage: string | null;
   save: (key: string, yamlText: string) => void;
-  reset: () => void;
 }
 
 export function useSaveDungeon(): UseSaveDungeonResult {
@@ -81,12 +80,5 @@ export function useSaveDungeon(): UseSaveDungeonResult {
     })();
   };
 
-  const reset = () => {
-    setState('idle');
-    setSavedKey(null);
-    setFieldErrors([]);
-    setErrorMessage(null);
-  };
-
-  return { state, savedKey, fieldErrors, errorMessage, save, reset };
+  return { state, savedKey, fieldErrors, errorMessage, save };
 }

--- a/src/dev/ThumbHarness.tsx
+++ b/src/dev/ThumbHarness.tsx
@@ -6,11 +6,16 @@
  * .glb`), auto-frames it with drei's `Bounds`, and fills the viewport with
  * zero app chrome — same dev-deep-link shape as PlaytestHarness's
  * `?encounterId=` gate in App.tsx, gated the same way (development mode
- * only).
+ * only). Lives in `src/dev/` (not `src/concepts/dungeon-builder/`, where
+ * it started) so `App.tsx`'s dev-only gate doesn't import from a concept
+ * folder — graduation audit item; this component has no dependency on
+ * anything dungeon-builder-specific, it just happens to be the tool that
+ * baked that concept's palette thumbnails.
  *
  * Baking process: point `game-dev/tools/browser/screenshot.mjs` at
  * `http://localhost:PORT/?thumbGlb=<path>` with a small square viewport
- * (128x128) and save straight into `./  *.png` — no cropping/resizing
+ * (128x128) and save straight into
+ * `src/concepts/dungeon-builder/thumbs/*.png` — no cropping/resizing
  * needed since the canvas already fills the viewport. See paletteData.ts's
  * `thumbForRef` doc comment for the filename convention
  * (`<ref's last segment>.png`) and CONTRACT.md's "Thumbnail provenance"


### PR DESCRIPTION
## Summary

Ranked cleanup sweep from a graduation audit against the Dungeon Builder concept (`src/concepts/dungeon-builder/`), landed as one unit per the audit's own item list. Each item was re-verified on current `dev` before being fixed — several PRs had landed since the audit ran, so one item (below) turned out to already be resolved and was skipped rather than redone.

## What shipped, per item

1. **Round-trip test path** — `dungeonYaml.test.ts`'s real-fixture comparison had one `../` too many, silently falling back to a self-comparison. Fixed. **Real verdict: no drift** — the embedded fixture and the real `dungeon-content/showcase.yaml` on disk are byte-stable against each other, verified independently since this sweep's worktree isn't nested under `~/game-dev/` the way a normal checkout is.
2. **Dead-scaffolding sweep** — removed ~120 lines of confirmed-unused code (EdgeKey chain, `allInternalEdges`, `Palette.tsx`'s `showBoardTools` prop + stale doc comment, `useSaveDungeon`'s `reset`, unused `PaletteProp` fields, a dangling doc-comment pointer, an empty no-op handler). **Skipped, already fixed**: `hexLayout.ts`'s `hexColumn`/`hexRow` re-exports — genuinely used by `boardGeometry.ts`/`DungeonPreview3D.tsx` today, real usage landed after the audit ran.
3. **`specimens/README.md`** — updated two stale `setPlacementMount(...,'wall',height)` examples to the current decoupled `setPlacementMount` + `setPlacementHeight` pair; verified by actually running the corrected script.
4. **Shared prop-visual module** — `markerStyle.ts`'s `resolveMarkerStyle` replaces near-duplicate color/label lookups in `Board.tsx`/`CreationBoard.tsx`.
5. **Unify wall geometry** — edit-mode walls now render as real edge segments (not full-cell rects), matching creation mode and the 3D preview. Reconciled `dungeonYaml.ts`'s two wall lookups (a from-cell-only match could delete a wall on the wrong edge) into one exact-pair convention, with a regression test verified to actually catch the bug.
6. **Extracted `useBoardEditing`** into its own module; fixed two per-render `parseDungeon`/`serializeDungeon` calls with lazy `useState` initializers.
7. **Shared `PlacementMarker`** component + deduped `START_COLOR`/`END_COLOR` constants across all three renderers. Start/end markers' differing *visual treatment* (filled vs. outline, abbreviated vs. full label) deliberately left alone — a design call, not a mechanical dedup.
8. **Moved `ThumbHarness`** from `src/concepts/dungeon-builder/thumbs/` to `src/dev/` so `App.tsx` no longer imports from a concept folder.
9. **New tests**: `creationGeometry.test.ts` (nearestEdge orientation-lock regression guard) and `useSaveDungeon.test.ts` (mirrors `usePutDungeonPreview.test.ts`'s mocking pattern) — both previously zero-coverage.
10. **CONTRACT.md ledger** — one new section recording this sweep.

## Test plan

- [x] `npm run ci-check` clean (format, lint, typecheck, build, tests)
- [x] Full suite: 1772/1772 passing repo-wide, 84 dungeon-builder tests (up from 69)
- [x] Visually verified live (Playwright + dev server): wall edge-segment rendering, marker selection/Inspector interaction, both edit and creation mode load correctly
- [x] Production build verified — thumbnail glob resolves correctly post-move
- [x] Regression test for the wall-lookup fix independently confirmed to fail against the old code before being restored

— asset-pipeline agent, on behalf of KirkDiggler