### PR TITLE
unit: defaults map prototype (per-ref inherited fields)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -2709,3 +2709,121 @@ settles.
 `ci-check` clean. Full suite: 84 dungeon-builder tests passing (up from
 69 before this sweep — 15 new: 8 `nearestEdge` + 7 `useSaveDungeon`),
 1772 repo-wide.
+
+## `defaults:` — dungeon-wide, ref-keyed default fields (2026-08-03)
+
+Kirk's ask, verbatim: "maybe we can set a default for all skeletons." A
+ref-keyed `defaults:` map — target dialect, proposed, same status as
+every other construct this file tracks. Full design writeup, the
+defaultable-field rationale table, the `mount`-exclusion reasoning, and
+the recorded (not decided) open questions live in TARGET-YAML.md's own
+`` `defaults:` `` section — this is the shipping ledger entry, not a
+duplicate of that write-up.
+
+**What shipped**:
+
+- `dungeonYaml.ts`: `PlacementDoc` grows an `explicit` companion
+  (`{ blocksMovement, blocksLos, height, facing, targeting }`) recording
+  which fields were literally present on that instance's own YAML,
+  distinguishing "explicitly false/absent" from "inheriting." New
+  `DungeonDoc.defaults: Record<string, RefDefaultsDoc>` and
+  `resolvePlacement(doc, placement)` — the one accessor that applies
+  inheritance (a placement's own explicit field always wins), returning
+  effective values plus an `inheritedFrom` map. Never mutates the
+  document and never runs at parse time — the serialized YAML stays
+  sparse. New mutators `setRefDefault`/`clearRefDefault` (the ref key is
+  forced double-quoted via an explicit `Scalar` — `YAMLMap.set()` with a
+  bare JS string key stores a plain string and only wraps it at
+  stringify time, too late to mark it quoted; confirmed by hand before
+  landing, not assumed) and `clearPlacementFlag` (deletes
+  `blocks_movement`/`blocks_los` entirely — distinct from
+  `setPlacementFlags`, which always writes a literal boolean and has no
+  reason to delete either key; needed for a real "revert to default,"
+  which must un-set the key, not copy the default's current value into
+  it).
+- `stripToV1Subset` materializes-on-strip: every placement INHERITING a
+  `blocks_movement`/`blocks_los` value gets it baked on as a literal key
+  before `defaults:` itself is dropped, so the compilable subset
+  preserves the authored behavior a default was standing in for — a
+  `blocks_movement: true` default silently vanishing on save would
+  reintroduce the exact entrance-blocked gap this file's own UX learning
+  exists to catch. Monster placements are skipped (dungeonspec rejects
+  both flags on a monster ref). `targeting`/`height`/`facing` have no v1
+  form regardless of inheritance and just drop, counted the same way an
+  explicit one already was — not double-counted against the new
+  `defaults (...)` entry.
+- `boardGeometry.ts`'s `isEntranceBlocked` and
+  `DungeonPreview3D.tsx`'s `buildOnePlacement` now read placement
+  fields through `resolvePlacement` instead of the raw `PlacementDoc`
+  fields — a defaulted `blocks_movement` trips the entrance-blocked
+  warning exactly like an explicit one; a defaulted `height` floats a
+  candle in the 3D preview exactly like an explicit one. Reading the raw
+  field instead would have silently missed both the moment any dungeon
+  actually used `defaults:`.
+- `Inspector.tsx`: `facing`/`height`/`targeting`/`blocks_movement`/
+  `blocks_los` now render resolved (not raw) values. A field currently
+  following its ref's default renders muted with a small "inherited"
+  tag — visually distinct from the existing "dialect"/"experiment"
+  badges (those mark a CONSTRUCT as uncompiled; "inherited" marks a
+  VALUE as not-this-instance's-own; a field is routinely both).
+  Override-in-place needed no new affordance — every setter already
+  writes an explicit value the moment a control is touched. A "revert to
+  default" button appears only when a field is both explicit on this
+  placement and has a ref default to fall back to.
+
+**A named, honest limitation, not silently glossed over** (also
+recorded in TARGET-YAML.md): for `height`/`targeting`/`facing`,
+"clear" and "revert to default" are the same action, because absence of
+the key IS the inherit signal — there is no way today to author
+"explicitly no height, overriding a default that provides one."
+Unchecking an inherited `height` checkbox is a documented no-op, not a
+bug: nothing explicit exists yet to delete, so the value keeps following
+the default until either overridden with a real number or the default
+itself is cleared.
+
+**Verified live**, hand-editing the YAML pane directly (the same
+"only a hand-editor can produce this" path CONTRACT.md's comment-
+orphaning finding already established, since `placeItem` always stamps
+fresh prop placements with explicit `blocks_movement`/`blocks_los` —
+true inheritance for those two fields needs a hand-authored or
+`clearPlacementFlag`-cleared instance): added
+`` `defaults: { "dnd5e:props:pillar": { height: 1.2, facing: SE } }` ``
+to showcase.yaml's live document, then selected a placed pillar.
+Screenshot 1 (`docs/evidence/dungeon-builder-defaults-inherited.png`)
+shows both `facing` and `height` muted with the "inherited" tag, and the
+YAML pane's own compile badge reading `Uses: defaults (1 ref) — not yet
+compiled server-side`. Edited the height field to `2` in place; screenshot
+2 (`docs/evidence/dungeon-builder-defaults-overridden.png`) shows, in ONE
+frame, `height` now explicit (value `2`, a "revert to default" button,
+the "inherited" tag gone) sitting right above `facing`, still muted and
+still inherited — the contrast the whole feature is for. The compile
+badge updated live to `Uses: defaults (1 ref), height (1 placement)`.
+Clicked "revert to default"; screenshot 3
+(`docs/evidence/dungeon-builder-defaults-reverted.png`) shows `height`
+back to `1.2`, muted, "inherited" tag restored, compile badge back to
+`Uses: defaults (1 ref)` — the full inherit → override → revert cycle,
+live, not just unit-tested. Console showed only the expected FIXTURES-mode
+`AuthoringService` gate-off errors this concept's own live-preview probe
+always produces locally (CONTRACT.md's "Live verification" section) — no
+new errors from this change.
+
+**Not independently re-verified in the browser**: materialize-on-strip
+itself (covered thoroughly at the data layer — see `dungeonYaml.test.ts`
+below — but not re-clicked through "Save the compilable subset" live;
+the compile-badge wiring shown live above is the same code path that
+feeds that button's diff summary) and the 3D preview's resolved-height
+render (attempted; this ephemeral worktree's `public/models/synty` isn't
+populated the way a `rsync`'d checkout is, per this file's own "Save &
+Play" section note, so the 3D canvas rendered blank from missing
+textures/models — an environment gap, not a regression, and not
+conflated with a real finding here).
+
+`ci-check` clean. 99 dungeon-builder tests passing (up from 84 — 15
+new: parsing, `resolvePlacement` inheritance/override, `setRefDefault`/
+`clearRefDefault`/`clearPlacementFlag`, boss-exclusion, and
+materialize-on-strip both directions — a real v1-expressible field that
+bakes in, and a target-dialect-only one that doesn't), 1802 repo-wide.
+Specimen pack bumped to v0.2 (`specimens/README.md`'s own changelog) —
+`kitchen-sink.yaml` now shows a decoupled floor-standing `height` (#688)
+and the new `defaults:` map exercising both outcomes above;
+`kitchen-sink.v1-subset.yaml`/`.dropped.json` regenerated to match.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -701,6 +701,7 @@ export function DungeonBuilderConcept() {
           floorPlan={preview.floorPlan}
           selected={edit.selectedPlacement}
           onSetFlags={edit.handleSetFlags}
+          onClearFlag={edit.handleClearFlag}
           onDelete={edit.handleDelete}
           onSetMount={edit.handleSetMount}
           onSetHeight={edit.handleSetHeight}

--- a/src/concepts/dungeon-builder/Inspector.tsx
+++ b/src/concepts/dungeon-builder/Inspector.tsx
@@ -27,7 +27,7 @@ import {
   stepWallFacing,
   wallBearingFacings,
 } from './boardGeometry';
-import type { DungeonDoc, Mount } from './dungeonYaml';
+import { resolvePlacement, type DungeonDoc, type Mount } from './dungeonYaml';
 import type { PlacementSelection } from './types';
 
 /** Wall-mountable props this round wires the `mount:` checkbox UI up
@@ -91,6 +91,62 @@ function ExperimentBadge() {
   );
 }
 
+/** A field is showing its ref's `defaults:` entry (target dialect,
+ * proposed — `resolvePlacement`'s own doc comment), not a value set on
+ * this placement itself. Distinct, muted color from both badges above so
+ * "this construct isn't compiled yet" (dialect/experiment) and "this
+ * VALUE isn't this instance's own" (inherited) never get visually
+ * conflated — a field can be target-dialect AND inherited at once
+ * (height, facing, targeting all are), and a reader needs to tell the
+ * two facts apart. */
+function InheritedTag() {
+  return (
+    <span
+      title="following this ref's dungeon-wide default (defaults:, target dialect, proposed) — not set on this placement itself"
+      style={{
+        fontSize: 9,
+        fontStyle: 'italic',
+        color: '#8a7a5a',
+        background: '#2a2015',
+        border: '1px solid #4a3a1f',
+        borderRadius: 3,
+        padding: '1px 5px',
+        marginLeft: 6,
+      }}
+    >
+      inherited
+    </span>
+  );
+}
+
+/** Clears this placement's own explicit override for one field, falling
+ * back to its ref's `defaults:` entry — only ever rendered when an
+ * explicit value AND a ref default both exist (otherwise there is
+ * nothing to revert TO, or nothing to revert FROM). See
+ * `clearPlacementFlag`'s doc comment in dungeonYaml.ts for why
+ * blocks_movement/blocks_los route through a dedicated clear rather than
+ * `onSetFlags`. */
+function RevertToDefaultButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      title="clear this placement's own value and fall back to the ref's default"
+      style={{
+        marginLeft: 6,
+        fontSize: 9,
+        background: 'transparent',
+        color: '#8fe8e0',
+        border: '1px solid #2a5a54',
+        borderRadius: 3,
+        padding: '0 5px',
+        cursor: 'pointer',
+      }}
+    >
+      revert to default
+    </button>
+  );
+}
+
 interface InspectorProps {
   doc: DungeonDoc;
   /** Absent for the "New Dungeon" creation board — there is no compiled
@@ -103,6 +159,12 @@ interface InspectorProps {
   floorPlan?: FloorPlan;
   selected: PlacementSelection | null;
   onSetFlags: (blocksMovement: boolean, blocksLos: boolean) => void;
+  /** Revert-to-default for blocks_movement/blocks_los (`defaults:`,
+   * target dialect, proposed) — deletes the key so the placement goes
+   * back to inheriting its ref's default, rather than re-setting it to
+   * match that default's current value. See `clearPlacementFlag`'s own
+   * doc comment. */
+  onClearFlag: (flag: 'blocksMovement' | 'blocksLos') => void;
   onDelete: () => void;
   onSetMount: (mount: Mount) => void;
   /** DECOUPLED from `onSetMount` (Kirk-batch, 2026-08-02 — see
@@ -138,6 +200,7 @@ export function Inspector({
   floorPlan,
   selected,
   onSetFlags,
+  onClearFlag,
   onDelete,
   onSetMount,
   onSetHeight,
@@ -174,24 +237,72 @@ export function Inspector({
   const at = selected.boss ? boss?.at : placement?.at;
   if (!ref || !at) return null;
   const isMonster = selected.boss ? true : (placement?.isMonster ?? true);
+  // `defaults:` (target dialect, proposed — see `resolvePlacement`'s own
+  // doc comment) resolves a PLACEMENT's inherited fields; a boss entry is
+  // deliberately excluded (TARGET-YAML.md's "defaults:" section records
+  // "does defaults apply to boss?" as an open question, not decided
+  // here) — a boss's own facing/targeting below stay direct reads of
+  // `BossDoc`, exactly as before this feature existed.
+  const resolved =
+    !selected.boss && placement ? resolvePlacement(doc, placement) : undefined;
+  const refDefaults = !selected.boss ? doc.defaults[ref] : undefined;
   const blocksMovement = selected.boss
     ? false
-    : (placement?.blocksMovement ?? false);
-  const blocksLos = selected.boss ? false : (placement?.blocksLos ?? false);
+    : (resolved?.blocksMovement ?? false);
+  const blocksLos = selected.boss ? false : (resolved?.blocksLos ?? false);
   // target dialect — mount/height don't exist on a boss entry (bosses
-  // aren't wall furniture); targeting/facing exist on both.
+  // aren't wall furniture); targeting/facing exist on both. `mount` is
+  // NOT resolved — it is deliberately not a defaultable field at all
+  // (`DungeonDoc.defaults`'s own doc comment: which wall edge a mount
+  // uses is a property of the specific cell, not the ref).
   const mount = selected.boss ? 'floor' : (placement?.mount ?? 'floor');
-  const height = selected.boss ? null : (placement?.height ?? null);
+  const height = selected.boss ? null : (resolved?.height ?? null);
   const rotationDegrees = selected.boss
     ? null
     : (placement?.rotationDegrees ?? null);
   const targeting = selected.boss
     ? (boss?.targeting ?? null)
-    : (placement?.targeting ?? null);
+    : (resolved?.targeting ?? null);
   const facing = selected.boss
     ? (boss?.facing ?? null)
-    : (placement?.facing ?? null);
+    : (resolved?.facing ?? null);
   const isWallMountable = !selected.boss && WALL_MOUNTABLE_REFS.has(ref);
+
+  // Which fields are showing an INHERITED value right now (muted +
+  // "inherited" tag below), and which can be REVERTED to that default
+  // (an explicit value on this placement AND a default on its ref both
+  // exist — otherwise there's nothing to revert to, or nothing to revert
+  // from). Both stay all-false for a boss selection (see above).
+  const inherited = resolved?.inheritedFrom ?? {
+    blocksMovement: false,
+    blocksLos: false,
+    height: false,
+    facing: false,
+    targeting: false,
+  };
+  const canRevert = selected.boss
+    ? {
+        blocksMovement: false,
+        blocksLos: false,
+        height: false,
+        facing: false,
+        targeting: false,
+      }
+    : {
+        blocksMovement:
+          !!placement?.explicit.blocksMovement &&
+          refDefaults?.blocksMovement !== undefined,
+        blocksLos:
+          !!placement?.explicit.blocksLos &&
+          refDefaults?.blocksLos !== undefined,
+        height:
+          !!placement?.explicit.height && refDefaults?.height !== undefined,
+        facing:
+          !!placement?.explicit.facing && refDefaults?.facing !== undefined,
+        targeting:
+          !!placement?.explicit.targeting &&
+          refDefaults?.targeting !== undefined,
+      };
 
   const fpRoom = selected.roomId
     ? floorPlan?.rooms.find((r) => r.id === selected.roomId)
@@ -274,6 +385,7 @@ export function Inspector({
           gap: 6,
           margin: '6px 0',
           fontSize: 11,
+          opacity: inherited.facing ? 0.65 : 1,
         }}
       >
         <button
@@ -305,6 +417,10 @@ export function Inspector({
         </button>
         <span>facing</span>
         <TargetDialectBadge />
+        {inherited.facing && <InheritedTag />}
+        {canRevert.facing && (
+          <RevertToDefaultButton onClick={() => onSetFacing(null)} />
+        )}
       </div>
 
       {mount === 'wall' && (
@@ -352,7 +468,7 @@ export function Inspector({
           alignItems: 'center',
           gap: 8,
           margin: '6px 0',
-          opacity: isMonster ? 0.5 : 1,
+          opacity: isMonster ? 0.5 : inherited.blocksMovement ? 0.65 : 1,
         }}
       >
         <input
@@ -363,6 +479,12 @@ export function Inspector({
           onChange={(e) => onSetFlags(e.target.checked, blocksLos)}
         />
         <label htmlFor="db-chk-bm">blocks_movement</label>
+        {!isMonster && inherited.blocksMovement && <InheritedTag />}
+        {!isMonster && canRevert.blocksMovement && (
+          <RevertToDefaultButton
+            onClick={() => onClearFlag('blocksMovement')}
+          />
+        )}
       </div>
       <div
         style={{
@@ -370,7 +492,7 @@ export function Inspector({
           alignItems: 'center',
           gap: 8,
           margin: '6px 0',
-          opacity: isMonster ? 0.5 : 1,
+          opacity: isMonster ? 0.5 : inherited.blocksLos ? 0.65 : 1,
         }}
       >
         <input
@@ -381,15 +503,27 @@ export function Inspector({
           onChange={(e) => onSetFlags(blocksMovement, e.target.checked)}
         />
         <label htmlFor="db-chk-bl">blocks_los</label>
+        {!isMonster && inherited.blocksLos && <InheritedTag />}
+        {!isMonster && canRevert.blocksLos && (
+          <RevertToDefaultButton onClick={() => onClearFlag('blocksLos')} />
+        )}
       </div>
 
       {!isMonster && (
-        <div style={{ marginTop: 8 }}>
+        <div style={{ marginTop: 8, opacity: inherited.height ? 0.65 : 1 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <input
               type="checkbox"
               id="db-chk-height"
               checked={height !== null}
+              // Unchecking while INHERITED is a documented no-op (nothing
+              // explicit to delete yet — see TARGET-YAML.md's "defaults:"
+              // section, "reverting a field with no explicit-null
+              // sentinel"): the value keeps following the ref default
+              // until either overridden (type a new number below) or the
+              // default itself changes. This never corrupts state, it's
+              // just not a way to say "explicitly no height" while a
+              // default is active.
               onChange={(e) => onSetHeight(e.target.checked ? 0.5 : null)}
             />
             <label
@@ -398,6 +532,10 @@ export function Inspector({
             >
               height (m)
               <TargetDialectBadge />
+              {inherited.height && <InheritedTag />}
+              {canRevert.height && (
+                <RevertToDefaultButton onClick={() => onSetHeight(null)} />
+              )}
             </label>
           </div>
           {/* DECOUPLED from mount (Kirk-batch, 2026-08-02: "height:
@@ -465,13 +603,17 @@ export function Inspector({
       )}
 
       {isMonster && (
-        <div style={{ marginTop: 8 }}>
+        <div style={{ marginTop: 8, opacity: inherited.targeting ? 0.65 : 1 }}>
           <label
             htmlFor="db-targeting"
             style={{ display: 'flex', alignItems: 'center', fontSize: 11 }}
           >
             targeting
             <TargetDialectBadge />
+            {inherited.targeting && <InheritedTag />}
+            {canRevert.targeting && (
+              <RevertToDefaultButton onClick={() => onSetTargeting(null)} />
+            )}
           </label>
           <select
             id="db-targeting"

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -242,6 +242,15 @@ lighting:
   #     at: [1, 1]
   #     intensity: 1.0
   #     radius: 3
+
+# Dungeon-wide, ref-keyed default fields (Kirk's ask, verbatim: "maybe we
+# can set a default for all skeletons") — see "defaults:" below for the
+# full design. A placement's own explicit field always overrides its
+# ref's entry here; the serialized YAML stays SPARSE either way (a
+# placement never needs to repeat what its ref already defaults).
+defaults:
+  'dnd5e:monsters:skeleton': { targeting: lowest-health }
+  'dnd5e:props:candles': { blocks_movement: false, height: 1.2 }
 ```
 
 ## Top-level placement: rooms are semantic, not placement containers
@@ -540,6 +549,161 @@ field: authored, badged, not yet compiled.
 UI this round: a targeting dropdown in the monster/boss inspector,
 badged as target-dialect-only like every other Structural/Markers control.
 
+## `defaults:` — dungeon-wide, ref-keyed default fields
+
+Kirk's ask, verbatim: "maybe we can set a default for all skeletons." A
+dungeon-wide, ref-keyed map — target dialect, proposed, same status as
+every other construct in this file. A placement's own explicit field
+always overrides its ref's entry here; when it doesn't set the field at
+all, it inherits the ref's default.
+
+```yaml
+defaults:
+  'dnd5e:monsters:skeleton': { targeting: lowest-health }
+  'dnd5e:props:candles': { blocks_movement: false, height: 1.2 }
+```
+
+### Defaultable fields, and why each one qualifies
+
+| Field             | Why it's defaultable                                                                                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targeting`       | Purely a property of the REF (a skeleton's preferred AI strategy doesn't vary by which cell it's standing in) — the textbook case for a ref-level default.        |
+| `blocks_movement` | Usually a property of what the prop IS (a pillar always blocks; a candle never does) — an instance overriding it is the exception, not the rule.                  |
+| `blocks_los`      | Same reasoning as `blocks_movement` — most props of one ref agree on whether they block sight, and per-instance overrides stay rare and worth flagging as such.   |
+| `height`          | A ref usually has one natural resting height (a floating candle floats every time) — worth stating once per ref rather than repeating on every placement.         |
+| `facing`          | Some refs have a natural canonical orientation (a wall-banner ref that's always hung one way) even though most individual placements still want their own facing. |
+
+### `mount` is deliberately NOT defaultable
+
+Every other field above is a property of the REF. `mount` isn't: WHICH
+wall edge a `mount: wall` placement uses is a property of the specific
+CELL it sits in (see "wall-mount edge-selection rework" under "z-axis:
+`mount` + `height`," above) — two placements of the identical ref at two
+different cells can need two different edges, or one might not even be
+adjacent to a wall at all. A single ref-level default has no one honest
+value to carry, so `mount` stays a purely per-instance field with no
+inheritance path.
+
+### Inheritance lives in an accessor, not in the parse
+
+`resolvePlacement(doc, placement)` (`dungeonYaml.ts`) is the ONE place
+this inheritance is resolved: it returns the placement's effective
+`blocksMovement`/`blocksLos`/`height`/`facing`/`targeting`, using the
+placement's own field wherever it's explicitly set and falling back to
+its ref's `defaults:` entry otherwise, plus an `inheritedFrom` map saying
+which fields came from the default. Deliberately NOT resolved at parse
+time and NOT written back into the document — `PlacementDoc`'s own
+fields stay exactly what's literally on that instance (a placement
+without an explicit `height` still parses to `height: null`, `defaults:`
+or no `defaults:`), and telling "explicitly absent" apart from
+"literally false/null" is what `PlacementDoc.explicit` (a small
+`{ blocksMovement, blocksLos, height, facing, targeting }` boolean
+companion, populated straight from which raw YAML keys were actually
+present) exists for.
+
+This keeps the serialized YAML SPARSE: a placement only ever carries
+`defaults:` itself plus whatever explicit overrides genuinely differ
+from the default, never every inherited value stamped onto every
+instance. Any consumer that renders a placement's fields — the board,
+the 3D preview, the entrance-blocked check — must read them through
+`resolvePlacement`, not off `PlacementDoc` directly, once a document has
+any `defaults:` at all; reading the raw field would silently miss an
+inherited value (a defaulted `height` that should float a candle, a
+defaulted `blocks_movement` that should trip the entrance-blocked
+warning). `DungeonPreview3D.tsx`'s placement builder and
+`boardGeometry.ts`'s `isEntranceBlocked` both do this now.
+
+### Inspector: inherited vs. explicit, override-in-place, revert-to-default
+
+A field currently following its ref's default renders muted with a small
+"inherited" tag, distinct from the existing "dialect"/"experiment"
+badges (those mark a CONSTRUCT as not-yet-compiled; "inherited" marks a
+VALUE as not-this-instance's-own — a field can be both at once, and a
+reader needs to tell the two facts apart). Editing any control always
+writes an explicit value on THAT placement — override-in-place needs no
+separate affordance, since every setter (`setPlacementFacing`,
+`setPlacementHeight`, `setPlacementTargeting`, `setPlacementFlags`)
+already writes a literal value the moment an author touches it. A
+"revert to default" button appears only when a field is BOTH explicit
+on this placement AND has a ref-level default to fall back to (nothing
+to revert to, or from, otherwise) — it deletes the explicit key rather
+than re-setting it to match the default's current value, so the
+placement goes back to genuinely INHERITING (and keeps tracking the
+default if it changes later, rather than freezing a copy of today's
+value). `blocks_movement`/`blocks_los` route through a dedicated
+`clearPlacementFlag` mutator for this, since the board's own flag
+checkboxes (`setPlacementFlags`) always want to write both fields
+explicitly and have no reason to ever delete them.
+
+**A named, honest limitation, not silently glossed over**: for
+`height`/`targeting`/`facing`, "clear this field" and "revert to
+default" are the SAME action (calling the field's existing
+`setX(cst, ..., null)`, which deletes the key) — there is no way to
+author "explicitly no height, overriding a ref default that provides
+one" today, because absence of the key IS the inherit signal. Concretely:
+unchecking an inherited `height` checkbox is a documented no-op (nothing
+explicit exists yet to delete), so the value keeps floating until either
+overridden with a real number or the ref default itself is cleared. This
+never corrupts state — it's a UX rough edge, not a data bug — and is
+recorded here rather than worked around with a new explicit-null
+sentinel, which would be a real schema decision (`height: null` written
+literally IS already distinguishable from absence by
+`PlacementDoc.explicit`, so the plumbing exists — nothing currently
+writes that value on purpose) worth deciding deliberately, not as a
+side effect of this prototype.
+
+### Board/3D rendering uses RESOLVED values
+
+A defaulted `height` floats the candle in `DungeonPreview3D.tsx` exactly
+like an explicit one would; a defaulted `blocks_movement` trips
+`isEntranceBlocked`'s warning exactly like an explicit one would. Both
+consumers call `resolvePlacement` now rather than reading
+`PlacementDoc.height`/`blocksMovement` directly — see "Inheritance lives
+in an accessor," above.
+
+### `stripToV1Subset`: `defaults:` drops, but MATERIALIZES first
+
+`defaults:` itself is target-dialect-only and is dropped like any other
+construct in "The v1-subset strip," below — but not silently. Before it's
+removed, every placement that INHERITS a `blocks_movement`/`blocks_los`
+value from its ref gets that value baked onto it as a literal key first
+(`materializeRefDefaults` in `dungeonYaml.ts`), so the compilable subset
+preserves the authored behavior the default was standing in for — a
+`blocks_movement: true` default silently vanishing on save would
+reintroduce exactly the entrance-blocked gap this file's own UX learning
+exists to catch, just moved from the live board to the saved document.
+`targeting`/`height`/`facing` have no v1 wire representation at all,
+inherited or not, so they simply drop — counted the same way an explicit
+one would be, via the existing per-field facing/height/targeting tallies
+"The v1-subset strip" already describes; they are NOT double-counted
+against the `defaults (...)` entry. Monster placements are skipped
+entirely (dungeonspec rejects `blocks_movement`/`blocks_los` on a
+monster ref) — a monster ref's `defaults:` entry is only ever meaningful
+for `targeting`, which materialization doesn't touch anyway since it has
+no v1 form to preserve.
+
+### Open questions this prototype records, and deliberately does NOT decide
+
+- **Does `defaults:` apply to a room's `boss:` entry?** Not implemented
+  either way here — `resolvePlacement` only ever takes a `PlacementDoc`,
+  never a `BossDoc`, so a `defaults:` entry matching a boss's own ref is
+  simply inert today (confirmed by this unit's own test: a
+  `targeting` default for the exact ref a room's `boss:` uses does not
+  change `BossDoc.targeting`). `BossDoc` doesn't even carry
+  `blocksMovement`/`blocksLos`/`height` fields at all (a boss isn't wall
+  furniture) — only `facing`/`targeting` would be in scope if this were
+  ever decided yes.
+- **Wildcard/category keys** (e.g. "all monsters," "all props") — the
+  map today is keyed by an exact ref string only; nothing here proposes
+  or implements a broader match.
+- **Interaction with a future toolkit prop registry** — if a real
+  prop/monster registry ever grows its OWN server-side defaults (a
+  registry-level "skeletons block movement by default" fact, as opposed
+  to this dungeon-level authoring convenience), the two would need a
+  reconciliation rule (which wins? does a dungeon-level default only
+  override a registry default, or can it also unset one?) that this
+  prototype does not attempt to answer.
+
 ## Why connectors have no add/remove UI, and what that means for walls
 
 Verified against the real Go source
@@ -585,14 +749,15 @@ live `validate_only` preview call or a real `Save & Play`, the current
 document is stripped down to exactly what v1 compiles
 (`dungeonYaml.ts`'s `stripToV1Subset`):
 
-| Field                                              | v1 subset                                                                                                                                |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`                                          | forced to `1` (never `2` — see the annotated example's own note)                                                                         |
-| `key`, `name`, `theme`, `height`                   | kept as-is                                                                                                                               |
-| `rooms:`                                           | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                    |
-| `connectors:`                                      | kept as-is, including `locked:`                                                                                                          |
-| top-level `place:`                                 | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above |
-| `canvas:`, `walls:`, `start:`, `end:`, `lighting:` | dropped entirely                                                                                                                         |
+| Field                                              | v1 subset                                                                                                                                                          |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `version`                                          | forced to `1` (never `2` — see the annotated example's own note)                                                                                                   |
+| `key`, `name`, `theme`, `height`                   | kept as-is                                                                                                                                                         |
+| `rooms:`                                           | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                              |
+| `connectors:`                                      | kept as-is, including `locked:`                                                                                                                                    |
+| top-level `place:`                                 | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                           |
+| `canvas:`, `walls:`, `start:`, `end:`, `lighting:` | dropped entirely                                                                                                                                                   |
+| `defaults:`                                        | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above |
 
 If, after stripping, `rooms:` has fewer than 2 entries (dungeonspec's own
 `minRooms = 2`), there IS no compilable subset — a from-scratch canvas

--- a/src/concepts/dungeon-builder/boardGeometry.ts
+++ b/src/concepts/dungeon-builder/boardGeometry.ts
@@ -9,7 +9,7 @@ import type {
   FloorPlanConnector,
   FloorPlanRoom,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
-import type { DungeonDoc, WallDoc } from './dungeonYaml';
+import { resolvePlacement, type DungeonDoc, type WallDoc } from './dungeonYaml';
 import {
   cellCenter,
   cubeAtColRow,
@@ -126,7 +126,20 @@ export function isEntranceBlocked(
     if (!fpRoom) continue;
     for (const p of room.place) {
       const absCol = fpRoom.startColumn + p.at[0];
-      if (absCol === column && p.at[1] === row && p.blocksMovement) return true;
+      // Resolved, not raw `p.blocksMovement` — a `blocks_movement: true`
+      // ref-level default (`defaults:`, target dialect, proposed) must trip
+      // this warning exactly like an explicit one does. Reading the raw
+      // field here would silently miss an inherited block, reintroducing
+      // the exact gap CONTRACT.md's "entrance-blocked" UX learning exists
+      // to catch, just one layer removed (via a default instead of a
+      // direct per-instance flag).
+      if (
+        absCol === column &&
+        p.at[1] === row &&
+        resolvePlacement(doc, p).blocksMovement
+      ) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -324,6 +324,7 @@ export function CreationConcept({
         doc={doc}
         selected={edit.selectedPlacement}
         onSetFlags={edit.handleSetFlags}
+        onClearFlag={edit.handleClearFlag}
         onDelete={edit.handleDelete}
         onSetMount={edit.handleSetMount}
         onSetHeight={edit.handleSetHeight}

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -3,12 +3,15 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildWalkItYaml,
+  clearPlacementFlag,
+  clearRefDefault,
   deletePlacement,
   DungeonParseError,
   movePlacement,
   movePlacementAcrossLists,
   parseDungeon,
   placeItem,
+  resolvePlacement,
   serializeDungeon,
   setBossFacing,
   setBossTargeting,
@@ -20,6 +23,7 @@ import {
   setPlacementMount,
   setPlacementRotationDegrees,
   setPlacementTargeting,
+  setRefDefault,
   setStart,
   setWallEdge,
   stripMonsterPlacements,
@@ -715,6 +719,269 @@ connectors: []
       expect(doc.place[0].mount).toBe('wall');
       expect(doc.place[0].height).toBe(2.0);
       expect(doc.place[0].targeting).toBe('closest');
+    });
+  });
+});
+
+describe('defaults: ref-keyed inherited fields (rpg-project#175, Kirk\'s ask verbatim: "maybe we can set a default for all skeletons")', () => {
+  it('parses a defaults: map, snake_case wire keys converted to the same camelCase shape a placement itself uses', () => {
+    const withDefaults = SHOWCASE_YAML.replace(
+      'rooms:',
+      'defaults:\n  "dnd5e:monsters:skeleton-captain": { targeting: lowest-health }\n  "dnd5e:props:candles": { blocks_movement: false, height: 1.2, facing: SE }\nrooms:'
+    );
+    const { doc } = parseDungeon(withDefaults);
+    expect(doc.defaults['dnd5e:monsters:skeleton-captain']).toEqual({
+      targeting: 'lowest-health',
+    });
+    expect(doc.defaults['dnd5e:props:candles']).toEqual({
+      blocksMovement: false,
+      height: 1.2,
+      facing: 5, // SE — HEX_FACING_LABELS index, same convention as every other facing field
+    });
+  });
+
+  it('resolvePlacement falls back to the plain false/null default when the ref has no defaults: entry at all — the overwhelmingly common case today', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const room = doc.rooms.find((r) => r.id === 'shrine')!;
+    // showcase.yaml's own statue-reaper carries no blocks_movement/
+    // blocks_los/height/facing/targeting at all (fixtures.ts) — a real,
+    // pre-existing "nothing explicit" instance, not one hand-crafted for
+    // this test.
+    const statue = room.place.find(
+      (p) => p.ref === 'dnd5e:props:statue-reaper'
+    )!;
+    expect(resolvePlacement(doc, statue)).toEqual({
+      blocksMovement: false,
+      blocksLos: false,
+      height: null,
+      facing: null,
+      targeting: null,
+      inheritedFrom: {
+        blocksMovement: false,
+        blocksLos: false,
+        height: false,
+        facing: false,
+        targeting: false,
+      },
+    });
+  });
+
+  it('resolvePlacement inherits a ref default for every field the placement itself leaves unset', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setRefDefault(cst, 'dnd5e:props:statue-reaper', 'blocksMovement', true);
+    setRefDefault(cst, 'dnd5e:props:statue-reaper', 'height', 1.5);
+    const doc = toDungeonDoc(cst);
+    const room = doc.rooms.find((r) => r.id === 'shrine')!;
+    const statue = room.place.find(
+      (p) => p.ref === 'dnd5e:props:statue-reaper'
+    )!;
+    const resolved = resolvePlacement(doc, statue);
+    expect(resolved.blocksMovement).toBe(true);
+    expect(resolved.height).toBe(1.5);
+    expect(resolved.inheritedFrom.blocksMovement).toBe(true);
+    expect(resolved.inheritedFrom.height).toBe(true);
+    // A field with no matching default key stays at its plain fallback.
+    expect(resolved.blocksLos).toBe(false);
+    expect(resolved.inheritedFrom.blocksLos).toBe(false);
+  });
+
+  it("a placement's own EXPLICIT field always overrides its ref's default, never the other way around", () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    // showcase.yaml's own braziers are already explicit blocks_movement: true.
+    setRefDefault(cst, 'dnd5e:props:brazier', 'blocksMovement', false);
+    const doc = toDungeonDoc(cst);
+    const room = doc.rooms.find((r) => r.id === 'antechamber')!;
+    const brazier = room.place.find((p) => p.ref === 'dnd5e:props:brazier')!;
+    const resolved = resolvePlacement(doc, brazier);
+    expect(resolved.blocksMovement).toBe(true);
+    expect(resolved.inheritedFrom.blocksMovement).toBe(false);
+  });
+
+  it('setRefDefault creates defaults: and a flow-style ref entry, accumulating multiple fields on the same ref', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setRefDefault(
+      cst,
+      'dnd5e:monsters:skeleton-captain',
+      'targeting',
+      'lowest-health'
+    );
+    setRefDefault(cst, 'dnd5e:monsters:skeleton-captain', 'facing', 5); // SE
+    const yaml = serializeDungeon(cst);
+    expect(yaml).toContain('defaults:');
+    expect(yaml).toMatch(
+      /"dnd5e:monsters:skeleton-captain":\s*\{\s*targeting:\s*lowest-health,\s*facing:\s*SE\s*\}/
+    );
+  });
+
+  it('clearRefDefault removes one field, then the ref entry once empty, then defaults: itself once the last ref is cleared', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setRefDefault(cst, 'dnd5e:props:candles', 'blocksMovement', false);
+    setRefDefault(cst, 'dnd5e:props:candles', 'height', 0.5);
+
+    clearRefDefault(cst, 'dnd5e:props:candles', 'blocksMovement');
+    expect(toDungeonDoc(cst).defaults['dnd5e:props:candles']).toEqual({
+      height: 0.5,
+    });
+
+    clearRefDefault(cst, 'dnd5e:props:candles', 'height');
+    expect(toDungeonDoc(cst).defaults['dnd5e:props:candles']).toBeUndefined();
+    expect(serializeDungeon(cst)).not.toContain('defaults:');
+  });
+
+  it('clearRefDefault on a field/ref/defaults: that was never set is a no-op, not an error', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    expect(() =>
+      clearRefDefault(cst, 'dnd5e:props:candles', 'height')
+    ).not.toThrow();
+    expect(toDungeonDoc(cst).defaults).toEqual({});
+  });
+
+  it("clearPlacementFlag reverts an explicit blocks_movement back to inheriting the ref's default — the Inspector's revert-to-default affordance", () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setRefDefault(cst, 'dnd5e:props:brazier', 'blocksMovement', false);
+
+    let doc = toDungeonDoc(cst);
+    let brazier = doc.rooms.find((r) => r.id === 'antechamber')!.place[0];
+    expect(brazier.explicit.blocksMovement).toBe(true); // showcase's own explicit true
+    expect(resolvePlacement(doc, brazier).blocksMovement).toBe(true);
+
+    clearPlacementFlag(cst, 'antechamber', 0, 'blocksMovement');
+
+    doc = toDungeonDoc(cst);
+    brazier = doc.rooms.find((r) => r.id === 'antechamber')!.place[0];
+    expect(brazier.explicit.blocksMovement).toBe(false);
+    const resolved = resolvePlacement(doc, brazier);
+    expect(resolved.blocksMovement).toBe(false); // now following the ref default
+    expect(resolved.inheritedFrom.blocksMovement).toBe(true);
+  });
+
+  it('boss inheritance is an open question this prototype records, not decides — a defaults: entry never applies to a BossDoc', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setRefDefault(
+      cst,
+      'dnd5e:monsters:skeleton-captain',
+      'targeting',
+      'lowest-health'
+    );
+    const doc = toDungeonDoc(cst);
+    const vault = doc.rooms.find((r) => r.id === 'vault')!;
+    expect(vault.boss?.ref).toBe('dnd5e:monsters:skeleton-captain');
+    // A matching defaults: entry exists for this exact ref, and yet the
+    // boss's own targeting stays null — resolvePlacement only ever takes
+    // a PlacementDoc, never a BossDoc (see its own doc comment).
+    expect(vault.boss?.targeting).toBeNull();
+  });
+
+  describe('stripToV1Subset: materialize-on-strip', () => {
+    it('bakes an inherited blocks_movement: true onto EVERY placement of that ref that never set it explicitly', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      // showcase.yaml's own statue-reaper appears twice, in two different
+      // rooms (shrine [13,3] and vault [1,1]), neither with an explicit
+      // blocks_movement — a real fixture case, not one hand-crafted for
+      // this test, that happens to exercise "materializes across more
+      // than one instance of the same ref" for free.
+      setRefDefault(cst, 'dnd5e:props:statue-reaper', 'blocksMovement', true);
+      const stripped = stripToV1Subset(serializeDungeon(cst));
+
+      expect(stripped.compilable).toBe(true);
+      const entry = stripped.dropped.find((d) => d.startsWith('defaults ('));
+      expect(entry).toContain('materialized onto 2 placements');
+
+      const { doc: strippedDoc } = parseDungeon(stripped.yaml);
+      expect(strippedDoc.defaults).toEqual({}); // defaults: itself is gone
+      for (const roomId of ['shrine', 'vault']) {
+        const statue = strippedDoc.rooms
+          .find((r) => r.id === roomId)!
+          .place.find((p) => p.ref === 'dnd5e:props:statue-reaper')!;
+        expect(statue.blocksMovement).toBe(true);
+        expect(statue.explicit.blocksMovement).toBe(true); // now a real, literal key
+      }
+    });
+
+    it('bakes an inherited blocks_los: false too — materializing does not gate on the value being true', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setRefDefault(
+        cst,
+        'dnd5e:props:statue-knight-hooded',
+        'blocksLos',
+        false
+      );
+      const stripped = stripToV1Subset(serializeDungeon(cst));
+      const { doc: strippedDoc } = parseDungeon(stripped.yaml);
+      const statue = strippedDoc.rooms
+        .find((r) => r.id === 'shrine')!
+        .place.find((p) => p.ref === 'dnd5e:props:statue-knight-hooded')!;
+      expect(statue.explicit.blocksLos).toBe(true);
+      expect(statue.blocksLos).toBe(false);
+    });
+
+    it('does NOT touch an already-EXPLICIT placement — its own value wins and stays exactly as authored', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      // showcase's own braziers are already explicit blocks_movement: true.
+      setRefDefault(cst, 'dnd5e:props:brazier', 'blocksMovement', false);
+      const stripped = stripToV1Subset(serializeDungeon(cst));
+      const { doc: strippedDoc } = parseDungeon(stripped.yaml);
+      const brazier = strippedDoc.rooms
+        .find((r) => r.id === 'antechamber')!
+        .place.find((p) => p.ref === 'dnd5e:props:brazier')!;
+      expect(brazier.blocksMovement).toBe(true);
+    });
+
+    it('never materializes blocks_movement/blocks_los onto a MONSTER placement, even with a matching default — dungeonspec rejects both on monster refs', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      placeItem(cst, 'shrine', 'dnd5e:monsters:skeleton-captain', [3, 3]);
+      setRefDefault(
+        cst,
+        'dnd5e:monsters:skeleton-captain',
+        'targeting',
+        'lowest-health'
+      );
+      const stripped = stripToV1Subset(serializeDungeon(cst));
+      const { doc: strippedDoc } = parseDungeon(stripped.yaml);
+      const monster = strippedDoc.rooms
+        .find((r) => r.id === 'shrine')!
+        .place.find((p) => p.ref === 'dnd5e:monsters:skeleton-captain')!;
+      expect(monster.explicit.blocksMovement).toBe(false);
+      expect(monster.explicit.blocksLos).toBe(false);
+      // targeting has no v1 representation regardless of inheritance —
+      // dropped like every other target-dialect-only field, never baked in.
+      expect(monster.targeting).toBeNull();
+    });
+
+    it('materializes a top-level placement BEFORE it is mapped down into its containing room', () => {
+      // NOT via `placeItem` — it always stamps a fresh prop placement
+      // with EXPLICIT blocks_movement/blocks_los: false (see `placeItem`'s
+      // own doc comment), so a board-placed instance can never actually
+      // be inheriting either field; only a hand-authored YAML entry
+      // (typed directly into the pane, CONTRACT.md's own framing for
+      // what a hand-editor can produce that the board itself wouldn't)
+      // omits them. Column 2 falls inside antechamber's range
+      // (startColumn 0, width 6).
+      const withTopPlace = `${SHOWCASE_YAML}\nplace:\n  - { ref: "dnd5e:props:statue-reaper", at: [2, 2] }\n`;
+      const { cst } = parseDungeon(withTopPlace);
+      setRefDefault(cst, 'dnd5e:props:statue-reaper', 'blocksMovement', true);
+      const stripped = stripToV1Subset(serializeDungeon(cst));
+      const { doc: strippedDoc } = parseDungeon(stripped.yaml);
+      const mapped = strippedDoc.rooms
+        .find((r) => r.id === 'antechamber')!
+        .place.find(
+          (p) =>
+            p.ref === 'dnd5e:props:statue-reaper' &&
+            p.at[0] === 2 &&
+            p.at[1] === 2
+        );
+      expect(mapped).toBeDefined();
+      expect(mapped!.blocksMovement).toBe(true);
+      expect(mapped!.explicit.blocksMovement).toBe(true);
+    });
+
+    it('reports a plain "defaults (N refs)" — no materialize wording — when nothing actually inherits from the ref', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setRefDefault(cst, 'dnd5e:props:not-placed-anywhere', 'height', 1.0);
+      const stripped = stripToV1Subset(serializeDungeon(cst));
+      expect(stripped.dropped.find((d) => d.startsWith('defaults ('))).toBe(
+        'defaults (1 ref)'
+      );
     });
   });
 });

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -86,6 +86,13 @@ function parsePlacementList(raw: unknown, context: string): PlacementDoc[] {
       height: parseHeight(p.height),
       rotationDegrees: parseRotationDegrees(p.rotate_degrees),
       targeting: parseTargeting(p.targeting),
+      explicit: {
+        blocksMovement: p.blocks_movement !== undefined,
+        blocksLos: p.blocks_los !== undefined,
+        height: p.height !== undefined,
+        facing: p.facing !== undefined,
+        targeting: p.targeting !== undefined,
+      },
     };
   });
 }
@@ -144,6 +151,25 @@ export interface PlacementDoc {
    * never behavior (Boundary Rule). Only meaningful when `isMonster`;
    * `null` when unset. Not compiled server-side. */
   targeting: string | null;
+  /** Which of the fields above were actually present as a literal key on
+   * THIS placement, as parsed straight from the raw YAML — as opposed to
+   * absent and (as of the `defaults:` map, target dialect, proposed —
+   * see `DungeonDoc.defaults`'s own doc comment) potentially INHERITED
+   * from the placement's `ref`. `blocksMovement`/`blocksLos`/`height`/
+   * `facing`/`targeting` above are always populated with a concrete
+   * fallback (`false`/`null`) when absent, same as before `defaults:`
+   * existed — this field is what lets `resolvePlacement` (below) tell
+   * "explicitly false/absent" apart from "inheriting a default," which
+   * the fallback-carrying fields alone cannot. `mount` has no entry here
+   * — it is deliberately not defaultable, see `DungeonDoc.defaults`'s own
+   * doc comment for why. */
+  explicit: {
+    blocksMovement: boolean;
+    blocksLos: boolean;
+    height: boolean;
+    facing: boolean;
+    targeting: boolean;
+  };
 }
 
 export interface BossDoc {
@@ -218,6 +244,36 @@ export interface LightingDoc {
   ambient: number;
 }
 
+/** The fields a ref-keyed `defaults:` entry may carry — target dialect,
+ * proposed, Kirk's ask verbatim: "maybe we can set a default for all
+ * skeletons." See TARGET-YAML.md's "defaults:" section for the full
+ * design writeup and the rationale for each field's inclusion.
+ * Deliberately NOT included: `mount` — see `DungeonDoc.defaults`'s own
+ * doc comment. All optional; an entry with only some fields set is the
+ * normal case (`{ targeting: lowest-health }`, no blocks_movement,
+ * blocks_los, height, or facing at all). */
+export type DefaultableField =
+  | 'targeting'
+  | 'blocksMovement'
+  | 'blocksLos'
+  | 'height'
+  | 'facing';
+
+export interface RefDefaultsDoc {
+  targeting?: string;
+  blocksMovement?: boolean;
+  blocksLos?: boolean;
+  height?: number;
+  /** Same numeric HEX_FACING_LABELS index every other `facing` field
+   * uses — never a bare string on this side of the parse boundary. */
+  facing?: number;
+}
+
+/** Ref-keyed, e.g. `{ "dnd5e:monsters:skeleton": { targeting:
+ * "lowest-health" } }` — target dialect, proposed. See TARGET-YAML.md's
+ * "defaults:" section. */
+export type DefaultsDoc = Record<string, RefDefaultsDoc>;
+
 export interface DungeonDoc {
   version: number;
   key: string;
@@ -249,6 +305,31 @@ export interface DungeonDoc {
    * needs an owning room; see TARGET-YAML.md for how the target dialect
    * eventually frees it). */
   place: PlacementDoc[];
+  /** Dungeon-wide, ref-keyed default fields — target dialect, proposed
+   * (Kirk's ask, verbatim: "maybe we can set a default for all
+   * skeletons"). See TARGET-YAML.md's "defaults:" section for the full
+   * design. A placement's own explicit field (per-instance, tracked in
+   * `PlacementDoc.explicit`) always overrides its ref's entry here — see
+   * `resolvePlacement` below, the one accessor that applies this
+   * inheritance. This map itself changes NOTHING about how a placement
+   * parses (`PlacementDoc.blocksMovement`/`height`/etc. above stay exactly
+   * what's literally on that instance) — inheritance is resolved at READ
+   * time, not baked into the parse, so the serialized YAML stays sparse
+   * (defaults + only the overrides that actually differ, never every
+   * inherited value materialized onto every instance).
+   *
+   * `mount` is deliberately NOT a defaultable field: it's edge-dependent
+   * (TARGET-YAML.md's "wall-mount edge-selection rework" — WHICH wall
+   * edge a `mount: wall` placement uses is a property of the specific
+   * cell it sits in, not of its ref; two skeletons at two different
+   * cells could need two different edges even if both are "wall-mounted
+   * by default," so a single ref-level default has no one honest value
+   * to carry). Not compiled server-side, dropped entirely by
+   * `stripToV1Subset` — except that its v1-EXPRESSIBLE effects
+   * (`blocks_movement`/`blocks_los` on props) are first MATERIALIZED onto
+   * every inheriting placement so the compilable subset preserves
+   * authored behavior; see `stripToV1Subset`'s own doc comment. */
+  defaults: DefaultsDoc;
 }
 
 export interface ParsedDungeon {
@@ -389,6 +470,33 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
   // own doc comment.
   const place = parsePlacementList(raw.place, 'place');
 
+  // Ref-keyed default fields — target dialect, proposed. See
+  // DungeonDoc.defaults's own doc comment. Every field is independently
+  // optional on a given ref's entry; an entry present with none of the
+  // five recognized keys parses to `{}` rather than being skipped, same
+  // "authored but currently inert" honesty every other target-dialect
+  // parse in this function follows (e.g. an empty `lighting: {}`).
+  const defaults: DefaultsDoc = {};
+  if (raw.defaults && typeof raw.defaults === 'object') {
+    for (const [ref, v] of Object.entries(
+      raw.defaults as Record<string, unknown>
+    )) {
+      if (!v || typeof v !== 'object') continue;
+      const entry = v as Record<string, unknown>;
+      const parsed: RefDefaultsDoc = {};
+      if (typeof entry.targeting === 'string')
+        parsed.targeting = entry.targeting;
+      if (typeof entry.blocks_movement === 'boolean')
+        parsed.blocksMovement = entry.blocks_movement;
+      if (typeof entry.blocks_los === 'boolean')
+        parsed.blocksLos = entry.blocks_los;
+      if (typeof entry.height === 'number') parsed.height = entry.height;
+      const facing = parseFacing(entry.facing);
+      if (facing !== null) parsed.facing = facing;
+      defaults[ref] = parsed;
+    }
+  }
+
   return {
     version: (raw.version as number) ?? 1,
     key: raw.key as string,
@@ -404,6 +512,98 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
     end,
     lighting,
     place,
+    defaults,
+  };
+}
+
+export interface ResolvedPlacementFields {
+  blocksMovement: boolean;
+  blocksLos: boolean;
+  height: number | null;
+  facing: number | null;
+  targeting: string | null;
+  /** Which fields above are the placement's OWN default rather than an
+   * inherited one — `true` only when the field is absent on the
+   * placement itself (`!explicit.X`) AND its ref has a `defaults:` entry
+   * carrying that field. `false` whenever the ref has no defaults entry
+   * at all (the overwhelmingly common case today), so most callers can
+   * ignore this and only the Inspector's inherited/muted rendering needs
+   * it. */
+  inheritedFrom: {
+    blocksMovement: boolean;
+    blocksLos: boolean;
+    height: boolean;
+    facing: boolean;
+    targeting: boolean;
+  };
+}
+
+/** Resolve a placement's EFFECTIVE field values — its own explicit
+ * fields where present, else its ref's `defaults:` entry, else the
+ * pre-existing plain fallback (`false`/`null`) — target dialect,
+ * proposed, see `DungeonDoc.defaults`'s own doc comment.
+ *
+ * Pure function over already-parsed `DungeonDoc`/`PlacementDoc` state,
+ * no CST access — safe to call from render code on every frame, and
+ * this is exactly what board/3D rendering should do: `DungeonPreview3D`'s
+ * `buildOnePlacement` and `boardGeometry.ts`'s `isEntranceBlocked` both
+ * read placement fields through this now rather than a placement's own
+ * `PlacementDoc.height`/`blocksMovement` directly, so a `defaults:`-driven
+ * value (a defaulted `height` floating a candle, a defaulted
+ * `blocks_movement` correctly tripping the entrance-blocked warning) is
+ * never silently invisible to a consumer that only ever looked at the
+ * instance.
+ *
+ * Never mutates `placement` or writes an inherited value back into the
+ * document — the serialized YAML stays SPARSE (only defaults + the
+ * overrides that genuinely differ), which is the entire point of
+ * inheritance living here instead of being baked in at parse time. Only
+ * `stripToV1Subset` ever materializes a resolved value onto an instance,
+ * and only into the STRIPPED copy it returns, never the live document —
+ * see that function's own doc comment.
+ *
+ * Deliberately takes a `PlacementDoc`, not a `BossDoc` — whether
+ * `defaults:` should apply to a room's `boss:` entry at all is an open
+ * question this prototype records, not decides (TARGET-YAML.md's
+ * "defaults:" section); `BossDoc` doesn't even carry
+ * blocksMovement/blocksLos/height fields (a boss isn't wall furniture),
+ * and extending inheritance to its facing/targeting fields is exactly
+ * the kind of scope this file's `PlacementDoc`-only signature is
+ * deliberately NOT deciding yet. */
+export function resolvePlacement(
+  doc: DungeonDoc,
+  placement: PlacementDoc
+): ResolvedPlacementFields {
+  const d = doc.defaults[placement.ref];
+  const blocksMovement = placement.explicit.blocksMovement
+    ? placement.blocksMovement
+    : (d?.blocksMovement ?? false);
+  const blocksLos = placement.explicit.blocksLos
+    ? placement.blocksLos
+    : (d?.blocksLos ?? false);
+  const height = placement.explicit.height
+    ? placement.height
+    : (d?.height ?? null);
+  const facing = placement.explicit.facing
+    ? placement.facing
+    : (d?.facing ?? null);
+  const targeting = placement.explicit.targeting
+    ? placement.targeting
+    : (d?.targeting ?? null);
+  return {
+    blocksMovement,
+    blocksLos,
+    height,
+    facing,
+    targeting,
+    inheritedFrom: {
+      blocksMovement:
+        !placement.explicit.blocksMovement && d?.blocksMovement !== undefined,
+      blocksLos: !placement.explicit.blocksLos && d?.blocksLos !== undefined,
+      height: !placement.explicit.height && d?.height !== undefined,
+      facing: !placement.explicit.facing && d?.facing !== undefined,
+      targeting: !placement.explicit.targeting && d?.targeting !== undefined,
+    },
   };
 }
 
@@ -596,6 +796,30 @@ export function setPlacementFlags(
   if (!isMap(item)) return;
   item.set('blocks_movement', flags.blocksMovement);
   item.set('blocks_los', flags.blocksLos);
+}
+
+/** Clear a `place:` entry's `blocks_movement` or `blocks_los` key
+ * entirely — distinct from `setPlacementFlags` (which always writes a
+ * literal boolean; correct for the board's own flag checkboxes, which
+ * always want an explicit value the moment an author touches them).
+ * This exists for the Inspector's "revert to default" affordance
+ * (`defaults:`, target dialect, proposed — see `DungeonDoc.defaults`'s
+ * own doc comment): reverting must remove the key so the placement goes
+ * back to actually INHERITING its ref's default through
+ * `resolvePlacement`, not merely get re-set to match the default's
+ * CURRENT value — the latter would render identically today but would
+ * silently stop tracking the ref's default if it changes later, which
+ * defeats the entire point of inheriting rather than copying. */
+export function clearPlacementFlag(
+  cst: Document,
+  roomId: string | null,
+  index: number,
+  flag: 'blocksMovement' | 'blocksLos'
+): void {
+  const place = placeSeq(cst, roomId);
+  const item = place.items[index];
+  if (!isMap(item)) return;
+  item.delete(flag === 'blocksMovement' ? 'blocks_movement' : 'blocks_los');
 }
 
 /** Strip every monster `place:` entry (any `ref` starting
@@ -1055,6 +1279,198 @@ export function setLightingAmbient(
   cst.set('lighting', node);
 }
 
+/** `DefaultableField`'s camelCase name -> the wire's snake_case key —
+ * one lookup table so `setRefDefault`/`clearRefDefault` share a single
+ * mapping instead of hand-rolling it twice. */
+const DEFAULT_FIELD_KEYS: Record<DefaultableField, string> = {
+  targeting: 'targeting',
+  blocksMovement: 'blocks_movement',
+  blocksLos: 'blocks_los',
+  height: 'height',
+  facing: 'facing',
+};
+
+/** Get-or-create the top-level `defaults:` map — same "get or create,
+ * mutate the live node" discipline as `topSeq`, for a `YAMLMap` instead
+ * of a `YAMLSeq`. */
+function defaultsMap(cst: Document): YAMLMap {
+  const existing = cst.get('defaults', true);
+  if (isMap(existing)) return existing;
+  const node = new YAMLMap(cst.schema);
+  cst.set('defaults', node);
+  return node;
+}
+
+/** A ref's own entry inside `defaults:` — created flow-style
+ * (`{ targeting: ... }`, matching every other small inline map this file
+ * creates) when `create` is true and absent; `undefined` when `create` is
+ * false and either `defaults:` or the ref's own entry doesn't exist yet
+ * (the read-only path `clearRefDefault` uses — clearing a field that was
+ * never set is a no-op, not an error). */
+function refDefaultEntry(
+  cst: Document,
+  ref: string,
+  create: boolean
+): YAMLMap | undefined {
+  if (!create) {
+    const existing = cst.get('defaults', true);
+    if (!isMap(existing)) return undefined;
+    const entry = existing.get(ref, true);
+    return isMap(entry) ? entry : undefined;
+  }
+  const defaults = defaultsMap(cst);
+  const existing = defaults.get(ref, true);
+  if (isMap(existing)) return existing;
+  const node = new YAMLMap(cst.schema);
+  node.flow = true;
+  // The key must be an explicit `Scalar` (not a plain JS string handed to
+  // `.set()`, which `yaml` stores as a bare string and only wraps at
+  // stringify time, too late to mark it quoted) to force double-quoting —
+  // matching `createPlacementNode`'s own `ref` field and TARGET-YAML.md's
+  // annotated example (`"dnd5e:monsters:skeleton": { ... }`). A
+  // colon-bearing key parses fine unquoted in block style too, but
+  // quoting keeps every ref-shaped key in this file rendered identically,
+  // never ambiguous.
+  const keyNode = new Scalar(ref);
+  keyNode.type = Scalar.QUOTE_DOUBLE;
+  defaults.set(keyNode, node);
+  return node;
+}
+
+/** Set (or update) one field of a ref's dungeon-wide `defaults:` entry —
+ * target dialect, proposed, Kirk's ask verbatim: "maybe we can set a
+ * default for all skeletons." See `DungeonDoc.defaults`'s own doc
+ * comment for the full design. Creates `defaults:` and the ref's own
+ * flow-style entry if either is absent yet. `facing` is written as the
+ * same `HEX_FACING_LABELS` string every other facing field uses
+ * (`facingLabel`), matching `setPlacementFacing`'s own convention —
+ * never a bare numeric index on the wire.
+ *
+ * Deliberately does NOT reach into any existing placement of this ref
+ * and stamp the value on — the whole point of a ref-level default is
+ * that placements stay sparse and inherit through `resolvePlacement` at
+ * read time, not that authoring one rewrites every instance that already
+ * exists. */
+export function setRefDefault(
+  cst: Document,
+  ref: string,
+  field: DefaultableField,
+  value: string | number | boolean
+): void {
+  const entry = refDefaultEntry(cst, ref, true)!;
+  const key = DEFAULT_FIELD_KEYS[field];
+  entry.set(key, field === 'facing' ? facingLabel(value as number) : value);
+}
+
+/** Clear one field from a ref's `defaults:` entry — target dialect,
+ * proposed. Removes the ref's own entry entirely once its last field is
+ * cleared, and removes `defaults:` itself once its last ref is cleared —
+ * an empty `{}` / stray `defaults: {}` left behind after every field is
+ * reverted would be a no-op construct on the wire, the same
+ * "don't materialize nothing" discipline `setLightingAmbient`/
+ * `setConnectorLocked` already follow via `cst.delete(...)`. A no-op
+ * (not an error) when the field, the ref's entry, or `defaults:` itself
+ * doesn't exist yet — matching every other `clear`-shaped mutator in
+ * this file (e.g. `setPlacementFacing(cst, ..., null)` on a placement
+ * with no `facing:` key). */
+export function clearRefDefault(
+  cst: Document,
+  ref: string,
+  field: DefaultableField
+): void {
+  const entry = refDefaultEntry(cst, ref, false);
+  if (!entry) return;
+  entry.delete(DEFAULT_FIELD_KEYS[field]);
+  if (entry.items.length === 0) {
+    const defaults = cst.get('defaults', true);
+    if (isMap(defaults)) {
+      defaults.delete(ref);
+      if (defaults.items.length === 0) cst.delete('defaults');
+    }
+  }
+}
+
+/** Bake every INHERITED `blocks_movement`/`blocks_los` value onto the CST
+ * placement that inherits it — the materialize-on-strip half of
+ * `defaults:` (target dialect, proposed, see `DungeonDoc.defaults`'s own
+ * doc comment). Called by `stripToV1Subset` BEFORE `defaults:` itself is
+ * dropped and before any other stripping runs, so it can still see the
+ * original `defaults:` map and the original (pre-mapping) top-level
+ * `place:` list.
+ *
+ * Only `blocks_movement`/`blocks_los` are handled here — they're the
+ * only two defaultable fields with a real v1 wire representation on a
+ * prop placement at all. `targeting`/`height`/`facing` have NO v1
+ * representation regardless of whether they're inherited or explicit;
+ * they're simply dropped (and counted) by the existing
+ * `stripPlacementFields` pass further down, same as always — inheriting
+ * one doesn't make it any more compilable. Monster placements are
+ * skipped entirely: `dungeonspec.Validate` rejects `blocks_movement`/
+ * `blocks_los` on a monster ref (confirmed real, see `PlacementDoc.isMonster`'s
+ * own doc comment), so materializing either onto one would turn a
+ * currently-valid v1 subset into one the real server rejects — a
+ * monster ref's `defaults:` entry is only ever meaningful for
+ * `targeting`, which this function doesn't touch anyway.
+ *
+ * Walks the CST in lockstep with `doc` (`doc` was derived from this same
+ * `cst` via `toDungeonDoc`, so `doc.rooms[i].place[j]` and the `j`-th
+ * item of `cst`'s `rooms[i].place:` sequence are guaranteed to be the
+ * same node in the same order) rather than re-resolving placements by
+ * ref/at, which would be ambiguous the moment two placements share a
+ * ref and a defaults entry differs from what either one already has
+ * explicit. */
+function materializeRefDefaults(
+  cst: Document,
+  doc: DungeonDoc
+): { usedRefs: Set<string>; placementsMaterialized: number } {
+  const usedRefs = new Set<string>();
+  let placementsMaterialized = 0;
+
+  const materializeOne = (item: YAMLMap, placement: PlacementDoc) => {
+    if (placement.isMonster) return;
+    const resolved = resolvePlacement(doc, placement);
+    let touched = false;
+    if (resolved.inheritedFrom.blocksMovement) {
+      item.set('blocks_movement', resolved.blocksMovement);
+      touched = true;
+    }
+    if (resolved.inheritedFrom.blocksLos) {
+      item.set('blocks_los', resolved.blocksLos);
+      touched = true;
+    }
+    if (touched) {
+      usedRefs.add(placement.ref);
+      placementsMaterialized++;
+    }
+  };
+
+  const roomsSeq = cst.get('rooms');
+  if (isSeq(roomsSeq)) {
+    roomsSeq.items.forEach((room, ri) => {
+      if (!isMap(room)) return;
+      const place = room.get('place', true);
+      const docPlacements = doc.rooms[ri]?.place;
+      if (!isSeq(place) || !docPlacements) return;
+      place.items.forEach((item, pi) => {
+        if (isMap(item) && docPlacements[pi]) {
+          materializeOne(item, docPlacements[pi]);
+        }
+      });
+    });
+  }
+
+  const topPlace = cst.get('place');
+  if (isSeq(topPlace)) {
+    topPlace.items.forEach((item, pi) => {
+      if (isMap(item) && doc.place[pi]) {
+        materializeOne(item, doc.place[pi]);
+      }
+    });
+  }
+
+  return { usedRefs, placementsMaterialized };
+}
+
 export interface V1SubsetResult {
   /** The stripped, v1-only YAML text — always `version: 1`, never any
    * target-dialect-only field. */
@@ -1076,13 +1492,44 @@ export interface V1SubsetResult {
  * v1-subset strip" table, in code. Parses a FRESH CST from `yamlText`
  * (never mutates a caller's live board CST), so this is safe to call on
  * every live-preview debounce tick and every Save & Play click without
- * disturbing what the author is editing. */
+ * disturbing what the author is editing.
+ *
+ * `defaults:` (target dialect, proposed — see `DungeonDoc.defaults`'s own
+ * doc comment) is the one dropped construct that isn't simply discarded:
+ * `materializeRefDefaults` bakes every inherited `blocks_movement`/
+ * `blocks_los` onto its placement FIRST, so the returned subset preserves
+ * the authored behavior a default was standing in for. `targeting`/
+ * `height`/`facing` defaults have no v1 representation regardless and are
+ * lost the same way an explicit one would be — only counted via the
+ * `defaults (...)` entry below, not double-counted in the per-field
+ * facing/height/targeting tallies further down (those only ever count a
+ * literal key actually present on the instance). */
 export function stripToV1Subset(yamlText: string): V1SubsetResult {
   const { cst, doc } = parseDungeon(yamlText);
   const dropped: string[] = [];
 
   cst.set('version', 1);
   cst.delete('canvas');
+
+  // Materialize-on-strip (see `materializeRefDefaults`'s own doc
+  // comment): bake every INHERITED blocks_movement/blocks_los onto its
+  // placement BEFORE defaults: is dropped below, so the compilable
+  // subset preserves the authored behavior a ref-level default was
+  // standing in for — a `blocks_movement: true` default silently
+  // vanishing on strip would be exactly the kind of gap CONTRACT.md's
+  // "entrance-blocked" UX learning exists to catch, just moved from the
+  // live board to the saved subset.
+  const { usedRefs: defaultRefsUsed, placementsMaterialized } =
+    materializeRefDefaults(cst, doc);
+  const defaultRefCount = Object.keys(doc.defaults).length;
+  if (defaultRefCount > 0) {
+    dropped.push(
+      placementsMaterialized > 0
+        ? `defaults (${defaultRefCount} ref${defaultRefCount === 1 ? '' : 's'}; blocks_movement/blocks_los materialized onto ${placementsMaterialized} placement${placementsMaterialized === 1 ? '' : 's'} from ${defaultRefsUsed.size} of them)`
+        : `defaults (${defaultRefCount} ref${defaultRefCount === 1 ? '' : 's'})`
+    );
+  }
+  cst.delete('defaults');
 
   if (doc.walls.length > 0) {
     dropped.push(

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -64,11 +64,11 @@
  */
 import { facingDirection } from '@/components/hex-grid/authorGridHelpers';
 import {
-  type CubeCoord,
   cubeToWorld,
   HEX_SIZE,
   hexCorners,
   hexEdgeBetween,
+  type CubeCoord,
 } from '@/components/hex-grid/hexMath';
 import { resolvePropVariant } from '@/components/hex-grid/propManifest';
 import { PropModel } from '@/components/hex-grid/PropModel';
@@ -85,7 +85,12 @@ import {
   isEntranceBlocked,
   isSameSelection,
 } from '../boardGeometry';
-import type { DungeonDoc, PlacementDoc, WallDoc } from '../dungeonYaml';
+import {
+  resolvePlacement,
+  type DungeonDoc,
+  type PlacementDoc,
+  type WallDoc,
+} from '../dungeonYaml';
 import { cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
 import { END_COLOR, START_COLOR } from '../markerStyle';
 import type { PaletteSelection, PlacementSelection } from '../types';
@@ -286,12 +291,21 @@ function buildWalls(walls: readonly WallDoc[]): PlacedWall[] {
  * back (`roomId: null` for a top-level entry — `types.ts`'s own
  * `PlacementSelection` doc comment). */
 function buildOnePlacement(
+  doc: DungeonDoc,
   p: PlacementDoc,
   absCol: number,
   row: number,
   sel: PlacementSelection,
   key: string
 ): { prop?: PlacedProp; monster?: PlacedMonster } {
+  // Resolved, not raw `p.height`/`p.facing` — a ref-level `defaults:`
+  // entry (target dialect, proposed) must render identically to an
+  // explicit field: a defaulted `height` still floats the candle, a
+  // defaulted `facing` still orients the prop. `resolvePlacement` is a
+  // no-op read (falls through to the placement's own explicit value)
+  // whenever `doc.defaults` has nothing for this ref, so this costs
+  // nothing for the overwhelmingly common case of no defaults at all.
+  const resolved = resolvePlacement(doc, p);
   // Target dialect, proposed (TARGET-YAML.md's "z-axis: mount +
   // height" section) — `height` is DECOUPLED from `mount` (Kirk-batch,
   // 2026-08-02: "height: decouples from mount... any placement may
@@ -302,9 +316,9 @@ function buildOnePlacement(
   // the decoupling exists for). Rotation stays mount-gated below —
   // ROTATION is still a wall-vs-floor question (flush-against-the-edge
   // vs. general facing), height no longer is.
-  const position = worldPosition(absCol, row, p.height ?? 0);
+  const position = worldPosition(absCol, row, resolved.height ?? 0);
   const rotationY =
-    p.facing === null
+    resolved.facing === null
       ? 0
       : p.mount === 'wall'
         ? // EXPERIMENT (see PlacementDoc.rotationDegrees's own doc
@@ -316,9 +330,9 @@ function buildOnePlacement(
           // feel: does the coarse pick get close enough that a small
           // nudge covers the gap, or is a from-scratch free control
           // needed instead?
-          wallMountRotationY(absCol, row, p.facing) +
+          wallMountRotationY(absCol, row, resolved.facing) +
           ((p.rotationDegrees ?? 0) * Math.PI) / 180
-        : facingToRotationY(p.facing);
+        : facingToRotationY(resolved.facing);
   if (p.isMonster) {
     const monsterRefId = p.ref.split(':').pop();
     return monsterRefId
@@ -342,6 +356,7 @@ function buildPlacements(
     room.place.forEach((p, index) => {
       const absCol = fpRoom.startColumn + p.at[0];
       const { prop, monster } = buildOnePlacement(
+        doc,
         p,
         absCol,
         p.at[1],
@@ -376,6 +391,7 @@ function buildPlacements(
   // pass (rpg-dnd5e-web#679).
   doc.place.forEach((p, index) => {
     const { prop, monster } = buildOnePlacement(
+      doc,
       p,
       p.at[0],
       p.at[1],

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -1,6 +1,6 @@
 # Dungeon Builder — specimen pack
 
-**Specimen pack version: v0.1** (2026-08-02). Posted in full on
+**Specimen pack version: v0.2** (2026-08-03). Posted in full on
 [rpg-project#175](https://github.com/KirkDiggler/rpg-project/issues/175)
 for the backend session implementing YAML processing.
 
@@ -16,6 +16,22 @@ addition. Never conflate the two numbers.
 
 ## Changelog
 
+- **v0.2** (2026-08-03) — `+ height on any placement (#688)`: the
+  top-level `candles` placement now carries an explicit `height: 0.4`
+  with NO `mount:` key at all — the decoupled floor-standing/floating
+  case #688 shipped, not just the pre-existing wall-mounted height
+  examples. `+ defaults: map (this PR)`: a `defaults:` block with two
+  shapes side by side — `dnd5e:props:tomb-open`'s `blocks_movement: true`
+  (a real v1-expressible field: the `entry` room's `tomb-open` instance
+  carries NO explicit `blocks_movement`/`blocks_los` at all, so it's
+  genuinely inheriting, and `kitchen-sink.v1-subset.yaml` shows the value
+  MATERIALIZED onto that instance on strip) and
+  `dnd5e:props:statue-reaper`'s `height: 1` (target-dialect-only, no v1
+  form regardless of inheritance — dropped on strip like any other,
+  counted in `dropped.json`'s `"defaults (...)"` entry, never
+  materialized). `kitchen-sink.v1-subset.dropped.json`'s `"defaults (2
+refs; blocks_movement/blocks_los materialized onto 1 placement from 1
+of them)"` entry names both outcomes explicitly.
 - **v0.1** (2026-08-02) — initial pack, built from what the builder
   emits as of this date. Does not yet include the height-decouples-
   from-mount or `defaults:` map work (Kirk-batch, queued) — those land
@@ -62,6 +78,7 @@ import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it } from 'vitest';
 import {
+  clearPlacementFlag,
   moveBoss,
   parseDungeon,
   placeItem,
@@ -77,6 +94,7 @@ import {
   setPlacementMount,
   setPlacementRotationDegrees,
   setPlacementTargeting,
+  setRefDefault,
   setStart,
   setWallEdge,
   stripToV1Subset,
@@ -125,6 +143,14 @@ connectors:
     placeItem(cst, 'entry', 'dnd5e:props:statue-reaper', [3, 1]);
     setPlacementFacing(cst, 'entry', 1, 2); // NW
 
+    // v0.2: a placement lacking blocks_movement/blocks_los entirely
+    // (cleared right back off after placeItem's own auto-stamp) --
+    // exercises clearPlacementFlag AND gives `defaults:` below a REAL
+    // instance to inherit blocks_movement onto, materialized on strip.
+    placeItem(cst, 'entry', 'dnd5e:props:tomb-open', [5, 1]);
+    clearPlacementFlag(cst, 'entry', 2, 'blocksMovement');
+    clearPlacementFlag(cst, 'entry', 2, 'blocksLos');
+
     placeItem(cst, 'hall', 'dnd5e:monsters:skeleton-captain', [5, 2]);
     setPlacementTargeting(cst, 'hall', 0, 'dnd5e:targeting:nearest');
 
@@ -148,11 +174,16 @@ connectors:
     setPlacementMount(cst, null, 0, 'wall');
     setPlacementHeight(cst, null, 0, 1.5);
     setPlacementRotationDegrees(cst, null, 0, -8);
+
     placeItem(cst, null, 'dnd5e:props:candles', [16, 3]);
     setPlacementFlags(cst, null, 1, {
       blocksMovement: false,
       blocksLos: false,
     });
+    // v0.2 (#688): height decoupled from mount -- a FLOOR-standing
+    // placement (no mount: key at all) carrying its own height, the
+    // "floating candle" case the decoupling exists for.
+    setPlacementHeight(cst, null, 1, 0.4);
 
     setConnectorLocked(cst, 0, { dc: 14, ability: 'dex' });
     // second connector stays unlocked (locked: null) -- proves elision.
@@ -160,6 +191,12 @@ connectors:
     setStart(cst, [1, 3]);
     setEnd(cst, [4, 5]);
     setLightingAmbient(cst, 0.35);
+
+    // v0.2: defaults: map (this PR). Two different shapes on purpose --
+    // see this file's changelog entry above for the full explanation of
+    // what each one demonstrates (materialize-on-strip vs plain drop).
+    setRefDefault(cst, 'dnd5e:props:tomb-open', 'blocksMovement', true);
+    setRefDefault(cst, 'dnd5e:props:statue-reaper', 'height', 1.0);
 
     const yaml = serializeDungeon(cst);
     writeFileSync(resolve(OUT_DIR, 'kitchen-sink.yaml'), yaml);

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
@@ -1,5 +1,6 @@
 {
   "dropped": [
+    "defaults (2 refs; blocks_movement/blocks_los materialized onto 1 placement from 1 of them)",
     "2 walls",
     "1 hole",
     "start/end",
@@ -7,6 +8,7 @@
     "2 top-level placements (mapped into rooms)",
     "facing (4 placements)",
     "wall-mount (2 placements)",
+    "height (3 placements)",
     "targeting (2 placements)",
     "fine-rotation experiment (2 placements)"
   ],

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.yaml
@@ -10,6 +10,7 @@ rooms:
     place:
       - { ref: "dnd5e:props:brazier", at: [ 1, 1 ], blocks_movement: true, blocks_los: false }
       - { ref: "dnd5e:props:statue-reaper", at: [ 3, 1 ], blocks_movement: false, blocks_los: false }
+      - { ref: "dnd5e:props:tomb-open", at: [ 5, 1 ], blocks_movement: true }
   - id: hall
     archetype: chamber
     width: 12

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
@@ -10,6 +10,7 @@ rooms:
     place:
       - { ref: "dnd5e:props:brazier", at: [ 1, 1 ], blocks_movement: true, blocks_los: false }
       - { ref: "dnd5e:props:statue-reaper", at: [ 3, 1 ], blocks_movement: false, blocks_los: false, facing: NW }
+      - { ref: "dnd5e:props:tomb-open", at: [ 5, 1 ] }
   - id: hall
     archetype: chamber
     width: 12
@@ -32,8 +33,11 @@ holes:
   - [ 10, 4 ]
 place:
   - { ref: "dnd5e:props:wall-banner", at: [ 15, 3 ], blocks_movement: false, blocks_los: false, facing: E, mount: wall, height: 1.5, rotate_degrees: -8 }
-  - { ref: "dnd5e:props:candles", at: [ 16, 3 ], blocks_movement: false, blocks_los: false }
+  - { ref: "dnd5e:props:candles", at: [ 16, 3 ], blocks_movement: false, blocks_los: false, height: 0.4 }
 start: [ 1, 3 ]
 end: [ 4, 5 ]
 lighting:
   ambient: 0.35
+defaults:
+  "dnd5e:props:tomb-open": { blocks_movement: true }
+  "dnd5e:props:statue-reaper": { height: 1 }

--- a/src/concepts/dungeon-builder/useBoardEditing.ts
+++ b/src/concepts/dungeon-builder/useBoardEditing.ts
@@ -19,6 +19,7 @@
 import { useState } from 'react';
 import type { Document } from 'yaml';
 import {
+  clearPlacementFlag,
   deletePlacement,
   moveBoss,
   movePlacement,
@@ -176,6 +177,22 @@ export function useBoardEditing(
     syncFromCst(cst);
   };
 
+  // Inspector's "revert to default" affordance for blocks_movement/
+  // blocks_los (`defaults:`, target dialect, proposed — see
+  // `clearPlacementFlag`'s own doc comment for why this is a distinct
+  // handler from `handleSetFlags` rather than a call to it with the
+  // default's own value).
+  const handleClearFlag = (flag: 'blocksMovement' | 'blocksLos') => {
+    if (!selectedPlacement || selectedPlacement.boss) return;
+    clearPlacementFlag(
+      cst,
+      selectedPlacement.roomId,
+      selectedPlacement.index,
+      flag
+    );
+    syncFromCst(cst);
+  };
+
   const handleSetTargeting = (targeting: string | null) => {
     if (!selectedPlacement) return;
     if (selectedPlacement.boss) {
@@ -247,6 +264,7 @@ export function useBoardEditing(
     handleMove,
     handleDelete,
     handleSetFlags,
+    handleClearFlag,
     handleSetMount,
     handleSetHeight,
     handleSetRotationDegrees,


### PR DESCRIPTION
## Summary

Kirk's ask, verbatim: "maybe we can set a default for all skeletons." Prototypes a dungeon-wide, ref-keyed `defaults:` map in the Dungeon Builder concept (`src/concepts/dungeon-builder/`) — target dialect, proposed, same status as every other construct this concept has been building ahead of the real server.

- **Defaultable fields**: `targeting`, `blocks_movement`, `blocks_los`, `height`, `facing` — one-line rationale for each in `TARGET-YAML.md`'s new `defaults:` section. `mount` is deliberately **not** defaultable: which wall edge a `mount: wall` placement uses is a property of the specific cell, not the ref.
- **Inheritance lives in an accessor**: `resolvePlacement(doc, placement)` (`dungeonYaml.ts`) resolves a placement's effective fields — its own explicit value where set, else its ref's `defaults:` entry, else the plain fallback. Never mutates the document and never runs at parse time, so the serialized YAML stays sparse (no inherited value gets materialized into a `place:` entry just by existing). `PlacementDoc` grows a small `explicit` companion so "explicitly absent" can be told apart from "literally false/null."
- **Mutators**: `setRefDefault`/`clearRefDefault` (CST, comment-safe — the ref key is forced double-quoted, matching `TARGET-YAML.md`'s own annotated example), plus a new `clearPlacementFlag` for reverting `blocks_movement`/`blocks_los` back to inherited (distinct from `setPlacementFlags`, which always writes a literal boolean).
- **Materialize-on-strip**: `stripToV1Subset` bakes every inherited `blocks_movement`/`blocks_los` (the two v1-expressible defaultable fields) onto their placements *before* dropping `defaults:` itself, so the compilable subset preserves the authored behavior a default was standing in for. `targeting`/`height`/`facing` have no v1 form regardless of inheritance and just drop, same as any other target-dialect field.
- **Board/3D correctness**: `boardGeometry.ts`'s `isEntranceBlocked` and `DungeonPreview3D.tsx`'s placement builder now read through `resolvePlacement` instead of raw `PlacementDoc` fields — a defaulted `blocks_movement` correctly trips the entrance-blocked warning; a defaulted `height` correctly floats a candle in the 3D preview.
- **Inspector**: inherited values render muted with a small "inherited" tag (visually distinct from the existing dialect/experiment badges — a field can be both target-dialect *and* inherited at once). Editing a control always writes an explicit override in place; a "revert to default" button appears once a field is both explicit and has a ref default to fall back to.
- **Open questions recorded, not decided** (per `TARGET-YAML.md`): does `defaults:` apply to a room's `boss:` entry? wildcard/category keys ("all monsters")? interaction with a future toolkit prop registry?
- **Specimen pack bumped to v0.2** (`specimens/README.md`) — also picks up `#688`'s height-decoupling, which the v0.1 pack predates. `kitchen-sink.yaml` now shows a decoupled floor-standing `height` and the new `defaults:` map exercising both the materialize-on-strip case and the plain-drop case side by side.

## Test plan

- [x] `dungeonYaml.test.ts`: 15 new tests — parsing, `resolvePlacement` inheritance/override, `setRefDefault`/`clearRefDefault`/`clearPlacementFlag`, boss-exclusion (open question, confirmed inert), and materialize-on-strip in both directions (a real v1-expressible field that bakes in vs. a target-dialect-only one that doesn't). 99 dungeon-builder tests passing (up from 84), 1802 repo-wide.
- [x] `ci-check` clean (format, lint, typecheck, build, tests).
- [x] Live-verified in the browser (vite dev server on a free local port): hand-edited a `defaults:` block into the live YAML pane, selected a placement, and captured the full inherit → override → revert cycle — one screenshot shows an inherited `height`/`facing` side by side with a just-overridden `height` (explicit, with its own revert button) in the same Inspector panel, and the compile badge tracking `Uses: defaults (...)` live. See `CONTRACT.md`'s new `defaults:` ledger section for the full writeup (evidence screenshots referenced by path, per repo convention — `docs/evidence/` is gitignored).

— asset-pipeline agent, on behalf of KirkDiggler

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4