### PR TITLE
feat(character-creation): consume authoritative category options

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -26,9 +26,15 @@ let it rot.
   surfaced for correction and cannot invoke finalization, the same selection ID
   remains valid in independently declared categories, and persisted items left
   over after every declared slot has consumed its slice are treated as invalid
-  rather than silently finalized. The equipment controls re-sync if a reopened
-  draft's persisted selection resolves after the choice has already mounted.
-  Proto dependency: `rpg-api-protos#207` / `v0.1.118`; provider: `rpg-api#764`.
+  rather than silently finalized: the affected equipment control announces a
+  correction alert (not completion) until the player changes that choice.
+  The equipment controls re-sync if a reopened draft's persisted selection
+  resolves after the choice has already mounted. A raw `other_equipment_id`
+  remains an opaque server selection ID: the client deliberately does not
+  duplicate category eligibility rules to reject it locally, because API
+  finalization delegates authoritative eligibility/count/uniqueness validation
+  to the toolkit. Proto dependency: `rpg-api-protos#207` / `v0.1.118`;
+  provider: `rpg-api#764`.
 
 - **Equipment live on the game screen (#571)** — the `/concepts` equipment
   chip + popover bench (#531/#557) is wired to the real

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,6 +12,13 @@ let it rot.
 
 ## Active work
 
+- **Authoritative character-creation category options (#690)** — the production
+  `EquipmentBundleChoice` now renders `EquipmentCategoryChoice.options` directly
+  through the accessible rich dropdown/card. It no longer reconstructs category
+  membership or calls `ListEquipmentByType`; ordered toolkit/API options and their
+  selection IDs are preserved through selection and reopened-draft hydration.
+  Proto dependency: `rpg-api-protos#207` / `v0.1.118`; provider: `rpg-api#764`.
+
 - **Equipment live on the game screen (#571)** — the `/concepts` equipment
   chip + popover bench (#531/#557) is wired to the real
   `dnd5e.api.v1alpha2.character.CharacterService.EquipItem`/`UnequipItem`

--- a/docs/status.md
+++ b/docs/status.md
@@ -18,9 +18,16 @@ let it rot.
   membership or calls `ListEquipmentByType`; ordered toolkit/API options and their
   selection IDs are preserved through selection and reopened-draft hydration.
   Persisted flat selection items are reconstructed into the selected bundle's
-  declared category slices (order + `choose` counts); a same-category legacy
-  duplicate is surfaced for correction and cannot invoke finalization, while
-  the same selection ID remains valid in independently declared categories.
+  declared category slices (order + `choose` counts), offset past the bundle's
+  fixed items first (the toolkit's own build order); a toolkit-enumerated wire
+  item (weapon/armor/tool/pack/ammunition enum, not `other_equipment_id`) is
+  mapped back to its authoritative `selectionId` via that category's own
+  `options`, not re-derived client-side. A same-category legacy duplicate is
+  surfaced for correction and cannot invoke finalization, the same selection ID
+  remains valid in independently declared categories, and persisted items left
+  over after every declared slot has consumed its slice are treated as invalid
+  rather than silently finalized. The equipment controls re-sync if a reopened
+  draft's persisted selection resolves after the choice has already mounted.
   Proto dependency: `rpg-api-protos#207` / `v0.1.118`; provider: `rpg-api#764`.
 
 - **Equipment live on the game screen (#571)** — the `/concepts` equipment

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,6 +17,10 @@ let it rot.
   through the accessible rich dropdown/card. It no longer reconstructs category
   membership or calls `ListEquipmentByType`; ordered toolkit/API options and their
   selection IDs are preserved through selection and reopened-draft hydration.
+  Persisted flat selection items are reconstructed into the selected bundle's
+  declared category slices (order + `choose` counts); a same-category legacy
+  duplicate is surfaced for correction and cannot invoke finalization, while
+  the same selection ID remains valid in independently declared categories.
   Proto dependency: `rpg-api-protos#207` / `v0.1.118`; provider: `rpg-api#764`.
 
 - **Equipment live on the game screen (#571)** — the `/concepts` equipment

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.115",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#3c1dc460e77a6941fdde0ada0a65eabd5336a6b6",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#d9ef7d9fb49dd604d93bf88d828cfc27e409debe",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.115",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -27,11 +27,8 @@ import {
   ListCharactersRequestSchema,
   ListClassesRequestSchema,
   ListDraftsRequestSchema,
-  ListEquipmentByTypeRequestSchema,
   ListRacesRequestSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import type { EquipmentType } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
-import type { Equipment } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/equipment_types_pb';
 import { useCallback, useEffect, useState } from 'react';
 import { characterClient } from './client';
 
@@ -660,75 +657,6 @@ export function useRollAbilityScores() {
   );
 
   return { rollAbilityScores, response, loading, error };
-}
-
-// Equipment API hooks
-export function useListEquipmentByType({
-  equipmentType,
-  pageSize = 50,
-  enabled = true,
-}: {
-  equipmentType: EquipmentType;
-  pageSize?: number;
-  enabled?: boolean;
-}) {
-  const [state, setState] = useState<
-    ListState<Equipment> & {
-      nextPageToken?: string;
-    }
-  >({
-    data: [],
-    loading: false,
-    error: null,
-    nextPageToken: undefined,
-  });
-
-  const fetchEquipment = useCallback(
-    async (pageToken?: string) => {
-      setState((prev) => ({
-        ...prev,
-        loading: true,
-        error: null,
-      }));
-      try {
-        const request = create(ListEquipmentByTypeRequestSchema, {
-          equipmentType,
-          pageSize,
-          pageToken: pageToken || '',
-        });
-        const response = await characterClient.listEquipmentByType(request);
-        setState({
-          data: response.equipment || [],
-          loading: false,
-          error: null,
-          nextPageToken: response.nextPageToken,
-        });
-      } catch (err) {
-        setState({
-          data: [],
-          loading: false,
-          error:
-            err instanceof Error ? err : new Error('Failed to fetch equipment'),
-          nextPageToken: undefined,
-        });
-      }
-    },
-    [equipmentType, pageSize]
-  );
-
-  useEffect(() => {
-    if (enabled) {
-      void fetchEquipment();
-    }
-  }, [fetchEquipment, enabled]);
-
-  return {
-    ...state,
-    refetch: (pageToken?: string) => fetchEquipment(pageToken),
-    loadMore: state.nextPageToken
-      ? () => fetchEquipment(state.nextPageToken)
-      : undefined,
-  };
 }
 
 // Delete character hook

--- a/src/character/creation/ClassSelectionModal.tsx
+++ b/src/character/creation/ClassSelectionModal.tsx
@@ -1615,6 +1615,9 @@ export function ClassSelectionModal({
                                 <ChoiceRenderer
                                   choice={choice}
                                   currentSelections={equipmentSelections}
+                                  hasInvalidPersistedEquipmentSelection={
+                                    foundEquipment?.hasUnconsumedItems ?? false
+                                  }
                                   onSelectionChange={(
                                     _choiceId,
                                     selections

--- a/src/character/creation/ClassSelectionModal.tsx
+++ b/src/character/creation/ClassSelectionModal.tsx
@@ -21,6 +21,7 @@ import {
   getSavingThrowDisplay,
   getWeaponProficiencyCategoryDisplay,
 } from '../../utils/enumDisplay';
+import { isCompleteEquipmentChoice } from '../../utils/equipmentChoiceSelections';
 import { VisualCarousel } from './components/VisualCarousel';
 
 // Only show these classes in the selection (pre-alpha simplification)
@@ -373,12 +374,9 @@ export function ClassSelectionModal({
       const equipmentChoice = currentClassChoices.equipment?.find(
         (ec) => ec.choiceId === choice.id
       );
-      const selected = equipmentChoice?.bundleId
-        ? [equipmentChoice.bundleId]
-        : [];
-      if (selected.length === 0) {
+      if (!isCompleteEquipmentChoice(choice, equipmentChoice)) {
         setErrorMessage(
-          `Please select an option for equipment: ${choice.description}`
+          `Please complete each equipment category with different items: ${choice.description}`
         );
         return;
       }

--- a/src/character/creation/InteractiveCharacterSheet.test.tsx
+++ b/src/character/creation/InteractiveCharacterSheet.test.tsx
@@ -11,10 +11,15 @@ import {
   ChoiceSchema,
   EquipmentBundleSchema,
   EquipmentCategoryChoiceSchema,
+  EquipmentItemSchema,
   EquipmentOptionsSchema,
   EquipmentSelectionItemSchema,
   EquipmentSelectionSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import {
+  Armor,
+  Weapon,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -84,7 +89,10 @@ function persistedDuplicateEquipmentChoice() {
 }
 
 function draftState(
-  finalizeDraft: CharacterDraftState['finalizeDraft']
+  finalizeDraft: CharacterDraftState['finalizeDraft'],
+  overrides: Partial<
+    Pick<CharacterDraftState, 'classInfo' | 'classChoices'>
+  > = {}
 ): CharacterDraftState {
   return {
     draftId: 'persisted-draft',
@@ -101,15 +109,19 @@ function draftState(
       },
     }),
     raceInfo: create(RaceInfoSchema, { name: 'Human' }),
-    classInfo: create(ClassInfoSchema, {
-      name: 'Fighter',
-      choices: [declaredEquipmentChoice],
-    }),
+    classInfo:
+      overrides.classInfo ??
+      create(ClassInfoSchema, {
+        name: 'Fighter',
+        choices: [declaredEquipmentChoice],
+      }),
     backgroundInfo: create(BackgroundInfoSchema, { name: 'Soldier' }),
     allProficiencies: new Set(),
     allLanguages: new Set(),
     raceChoices: [],
-    classChoices: [persistedDuplicateEquipmentChoice()],
+    classChoices: overrides.classChoices ?? [
+      persistedDuplicateEquipmentChoice(),
+    ],
     backgroundChoices: [],
     loading: false,
     saving: false,
@@ -138,6 +150,134 @@ describe('InteractiveCharacterSheet persisted equipment guard', () => {
     const finalizeDraft = vi.fn<() => Promise<string>>();
     render(
       <CharacterDraftContext.Provider value={draftState(finalizeDraft)}>
+        <InteractiveCharacterSheet onComplete={vi.fn()} onCancel={vi.fn()} />
+      </CharacterDraftContext.Provider>
+    );
+
+    const finalize = screen.getByRole('button', { name: /begin adventure/i });
+    expect(finalize.getAttribute('disabled')).not.toBeNull();
+    fireEvent.click(finalize);
+    expect(finalizeDraft).not.toHaveBeenCalled();
+  });
+});
+
+describe('InteractiveCharacterSheet persisted mixed-bundle round trip (rpg-toolkit real wire shape)', () => {
+  // A fixed bundle item (shield) plus one enum-backed category selection
+  // (longsword) — the real toolkit build order and the real proto enums
+  // rpg-api attaches, not a test-only `otherEquipmentId` shortcut.
+  const mixedBundle = create(EquipmentBundleSchema, {
+    id: 'fighter-pack-a',
+    items: [
+      create(EquipmentItemSchema, {
+        selectionId: 'shield',
+        typeHint: { case: 'armor', value: Armor.SHIELD },
+      }),
+    ],
+    categoryChoices: [
+      create(EquipmentCategoryChoiceSchema, {
+        choose: 1,
+        options: [
+          create(EquipmentItemSchema, {
+            selectionId: 'longsword',
+            typeHint: { case: 'weapon', value: Weapon.LONGSWORD },
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const declaredMixedChoice = create(ChoiceSchema, {
+    id: 'fighter-starting-equipment',
+    choiceType: ChoiceCategory.EQUIPMENT,
+    options: {
+      case: 'equipmentOptions',
+      value: create(EquipmentOptionsSchema, { bundles: [mixedBundle] }),
+    },
+  });
+
+  function persistedMixedChoice(withTrailingExtra: boolean) {
+    return create(ChoiceDataSchema, {
+      choiceId: 'fighter-starting-equipment',
+      optionId: 'fighter-pack-a',
+      category: ChoiceCategory.EQUIPMENT,
+      selection: {
+        case: 'equipment',
+        value: create(EquipmentSelectionSchema, {
+          items: [
+            create(EquipmentSelectionItemSchema, {
+              equipment: { case: 'armor', value: Armor.SHIELD },
+            }),
+            create(EquipmentSelectionItemSchema, {
+              equipment: { case: 'weapon', value: Weapon.LONGSWORD },
+            }),
+            ...(withTrailingExtra
+              ? [
+                  create(EquipmentSelectionItemSchema, {
+                    equipment: { case: 'weapon', value: Weapon.DAGGER },
+                  }),
+                ]
+              : []),
+          ],
+        }),
+      },
+    });
+  }
+
+  const classInfoWithMixedBundle = create(ClassInfoSchema, {
+    name: 'Fighter',
+    choices: [declaredMixedChoice],
+  });
+
+  it('allows finalization for a valid fixed-item + enum-backed category selection, offset and mapped correctly', () => {
+    const finalizeDraft = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValue('char-1');
+    render(
+      <CharacterDraftContext.Provider
+        value={draftState(finalizeDraft, {
+          classInfo: classInfoWithMixedBundle,
+          classChoices: [persistedMixedChoice(false)],
+        })}
+      >
+        <InteractiveCharacterSheet onComplete={vi.fn()} onCancel={vi.fn()} />
+      </CharacterDraftContext.Provider>
+    );
+
+    const finalize = screen.getByRole('button', { name: /begin adventure/i });
+    expect(finalize.getAttribute('disabled')).toBeNull();
+    fireEvent.click(finalize);
+    expect(finalizeDraft).toHaveBeenCalled();
+  });
+
+  it('blocks finalization once a delayed hydration reveals an unconsumed trailing persisted item, without a remount', () => {
+    const finalizeDraft = vi.fn<() => Promise<string>>();
+    const { rerender } = render(
+      <CharacterDraftContext.Provider
+        value={draftState(finalizeDraft, {
+          classInfo: classInfoWithMixedBundle,
+          classChoices: [persistedMixedChoice(false)],
+        })}
+      >
+        <InteractiveCharacterSheet onComplete={vi.fn()} onCancel={vi.fn()} />
+      </CharacterDraftContext.Provider>
+    );
+
+    expect(
+      screen
+        .getByRole('button', { name: /begin adventure/i })
+        .getAttribute('disabled')
+    ).toBeNull();
+
+    // The draft context refreshes after mount (e.g. the persisted draft
+    // finishes loading) and now carries a trailing item this reconstruction
+    // can't account for. Finalize must react and block immediately.
+    rerender(
+      <CharacterDraftContext.Provider
+        value={draftState(finalizeDraft, {
+          classInfo: classInfoWithMixedBundle,
+          classChoices: [persistedMixedChoice(true)],
+        })}
+      >
         <InteractiveCharacterSheet onComplete={vi.fn()} onCancel={vi.fn()} />
       </CharacterDraftContext.Provider>
     );

--- a/src/character/creation/InteractiveCharacterSheet.test.tsx
+++ b/src/character/creation/InteractiveCharacterSheet.test.tsx
@@ -1,0 +1,150 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  BackgroundInfoSchema,
+  CharacterDraftSchema,
+  ClassInfoSchema,
+  RaceInfoSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import {
+  ChoiceCategory,
+  ChoiceDataSchema,
+  ChoiceSchema,
+  EquipmentBundleSchema,
+  EquipmentCategoryChoiceSchema,
+  EquipmentOptionsSchema,
+  EquipmentSelectionItemSchema,
+  EquipmentSelectionSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { CharacterDraftState } from './CharacterDraftContextDef';
+import { CharacterDraftContext } from './CharacterDraftContextDef';
+import { InteractiveCharacterSheet } from './InteractiveCharacterSheet';
+
+vi.mock('@/components/ProgressTracker', () => ({
+  ProgressTracker: () => null,
+}));
+vi.mock('@/components/ui', () => ({
+  Button: ({ children }: { children: ReactNode }) => (
+    <button>{children}</button>
+  ),
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+vi.mock('./AppearanceSelectionModal', () => ({
+  AppearanceSelectionModal: () => null,
+}));
+vi.mock('./BackgroundSelectionModal', () => ({
+  BackgroundSelectionModal: () => null,
+}));
+vi.mock('./ClassSelectionModal', () => ({ ClassSelectionModal: () => null }));
+vi.mock('./RaceSelectionModal', () => ({ RaceSelectionModal: () => null }));
+vi.mock('./SpellSelectionModal', () => ({ SpellSelectionModal: () => null }));
+vi.mock('./components/SpellInfoDisplay', () => ({
+  SpellInfoDisplay: () => null,
+}));
+vi.mock('./sections/AbilityScoresSection', () => ({
+  AbilityScoresSection: () => null,
+}));
+
+const declaredEquipmentChoice = create(ChoiceSchema, {
+  id: 'fighter-starting-equipment',
+  choiceType: ChoiceCategory.EQUIPMENT,
+  options: {
+    case: 'equipmentOptions',
+    value: create(EquipmentOptionsSchema, {
+      bundles: [
+        create(EquipmentBundleSchema, {
+          id: 'fighter-pack-a',
+          categoryChoices: [
+            create(EquipmentCategoryChoiceSchema, { choose: 2 }),
+          ],
+        }),
+      ],
+    }),
+  },
+});
+
+function persistedDuplicateEquipmentChoice() {
+  return create(ChoiceDataSchema, {
+    choiceId: 'fighter-starting-equipment',
+    optionId: 'fighter-pack-a',
+    category: ChoiceCategory.EQUIPMENT,
+    selection: {
+      case: 'equipment',
+      value: create(EquipmentSelectionSchema, {
+        items: ['longsword-selection', 'longsword-selection'].map((id) =>
+          create(EquipmentSelectionItemSchema, {
+            equipment: { case: 'otherEquipmentId', value: id },
+          })
+        ),
+      }),
+    },
+  });
+}
+
+function draftState(
+  finalizeDraft: CharacterDraftState['finalizeDraft']
+): CharacterDraftState {
+  return {
+    draftId: 'persisted-draft',
+    draft: create(CharacterDraftSchema, {
+      id: 'persisted-draft',
+      name: 'Aria',
+      baseAbilityScores: {
+        strength: 15,
+        dexterity: 14,
+        constitution: 13,
+        intelligence: 12,
+        wisdom: 10,
+        charisma: 8,
+      },
+    }),
+    raceInfo: create(RaceInfoSchema, { name: 'Human' }),
+    classInfo: create(ClassInfoSchema, {
+      name: 'Fighter',
+      choices: [declaredEquipmentChoice],
+    }),
+    backgroundInfo: create(BackgroundInfoSchema, { name: 'Soldier' }),
+    allProficiencies: new Set(),
+    allLanguages: new Set(),
+    raceChoices: [],
+    classChoices: [persistedDuplicateEquipmentChoice()],
+    backgroundChoices: [],
+    loading: false,
+    saving: false,
+    error: null,
+    createDraft: vi.fn(),
+    loadDraft: vi.fn(),
+    setRace: vi.fn(),
+    setClass: vi.fn(),
+    setBackground: vi.fn(),
+    setName: vi.fn(),
+    setAbilityScores: vi.fn(),
+    updateAppearance: vi.fn(),
+    finalizeDraft,
+    addRaceChoice: vi.fn(),
+    addClassChoice: vi.fn(),
+    addBackgroundChoice: vi.fn(),
+    getAvailableChoices: vi.fn(() => []),
+    hasProficiency: vi.fn(() => false),
+    hasLanguage: vi.fn(() => false),
+    reset: vi.fn(),
+  };
+}
+
+describe('InteractiveCharacterSheet persisted equipment guard', () => {
+  it('disables finalization and does not invoke FinalizeDraft for a same-category legacy duplicate', () => {
+    const finalizeDraft = vi.fn<() => Promise<string>>();
+    render(
+      <CharacterDraftContext.Provider value={draftState(finalizeDraft)}>
+        <InteractiveCharacterSheet onComplete={vi.fn()} onCancel={vi.fn()} />
+      </CharacterDraftContext.Provider>
+    );
+
+    const finalize = screen.getByRole('button', { name: /begin adventure/i });
+    expect(finalize.getAttribute('disabled')).not.toBeNull();
+    fireEvent.click(finalize);
+    expect(finalizeDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/character/creation/InteractiveCharacterSheet.tsx
+++ b/src/character/creation/InteractiveCharacterSheet.tsx
@@ -40,6 +40,10 @@ import {
   getWeaponDisplay,
   getWeaponProficiencyCategoryDisplay,
 } from '../../utils/enumDisplay';
+import {
+  hasNoInvalidEquipmentChoices,
+  reconstructEquipmentChoice,
+} from '../../utils/equipmentChoiceSelections';
 import { AppearanceSelectionModal } from './AppearanceSelectionModal';
 import { BackgroundSelectionModal } from './BackgroundSelectionModal';
 import { ClassSelectionModal } from './ClassSelectionModal';
@@ -66,6 +70,11 @@ interface CharacterChoices {
 // Helper Functions
 function isClassInfo(info: ClassInfo | SubclassInfo | null): info is ClassInfo {
   return info != null && info.$typeName === 'dnd5e.api.v1alpha1.ClassInfo';
+}
+
+function classChoiceDefinitions(info: ClassInfo | SubclassInfo | null) {
+  if (!info) return [];
+  return isClassInfo(info) ? info.choices : info.additionalChoices;
 }
 
 function getLanguageDisplayName(languageEnum: Language): string {
@@ -200,32 +209,14 @@ export function InteractiveCharacterSheet({
         choice.category === ChoiceCategory.EQUIPMENT &&
         choice.selection?.case === 'equipment'
       ) {
-        // Restore equipment choice with bundleId from optionId
-        // Extract item IDs from the saved items - handle both string IDs and enum values
-        const itemIds: string[] = [];
-        choice.selection.value.items?.forEach((item) => {
-          if (
-            item.equipment?.case === 'otherEquipmentId' &&
-            item.equipment.value
-          ) {
-            // String ID case
-            itemIds.push(item.equipment.value);
-          } else if (
-            item.equipment?.case &&
-            item.equipment?.value !== undefined
-          ) {
-            // Enum case (weapon, armor, etc.) - convert enum number to string
-            itemIds.push(String(item.equipment.value));
-          }
-        });
-        choices.equipment?.push({
-          choiceId: choice.choiceId,
-          bundleId: choice.optionId || '',
-          categorySelections:
-            itemIds.length > 0
-              ? [{ categoryIndex: 0, equipmentIds: itemIds }]
-              : [],
-        });
+        const declaredChoice = classChoiceDefinitions(draft.classInfo).find(
+          (candidate) => candidate.id === choice.choiceId
+        );
+        if (declaredChoice) {
+          choices.equipment?.push(
+            reconstructEquipmentChoice(declaredChoice, choice)
+          );
+        }
       } else if (
         choice.category === ChoiceCategory.SKILLS &&
         choice.selection?.case === 'skills'
@@ -267,7 +258,7 @@ export function InteractiveCharacterSheet({
     });
 
     return choices;
-  }, [draft.classChoices]);
+  }, [draft.classChoices, draft.classInfo]);
 
   // Sync draft state with local character state
   useEffect(() => {
@@ -408,7 +399,19 @@ export function InteractiveCharacterSheet({
       scores.wisdom > 0 &&
       scores.charisma > 0;
 
-    return hasName && hasRace && hasClass && hasBackground && hasAbilityScores;
+    const hasNoInvalidEquipment = hasNoInvalidEquipmentChoices(
+      classChoiceDefinitions(draft.classInfo),
+      draft.classChoices
+    );
+
+    return (
+      hasName &&
+      hasRace &&
+      hasClass &&
+      hasBackground &&
+      hasAbilityScores &&
+      hasNoInvalidEquipment
+    );
   }, [draft]);
 
   // Handle finalize button click

--- a/src/components/ChoiceRenderer.tsx
+++ b/src/components/ChoiceRenderer.tsx
@@ -61,8 +61,10 @@ export function ChoiceRenderer({
           if (bundleId) selections.push(bundleId);
           categorySelections.forEach((equipment, index) => {
             equipment.forEach((item) =>
-              // Store as "cat{index}:{id}:{name}" so we can extract name later
-              selections.push(`cat${index}:${item.id}:${item.name}`)
+              // Store the authoritative selection ID and server-provided name.
+              selections.push(
+                `cat${index}:${item.selectionId}:${item.equipmentDetail?.name ?? item.selectionId}`
+              )
             );
           });
           onSelectionChange(choice.id, selections);

--- a/src/components/ChoiceRenderer.tsx
+++ b/src/components/ChoiceRenderer.tsx
@@ -40,20 +40,29 @@ export function ChoiceRenderer({
       Array.isArray(currentSelections) && currentSelections.length > 0
         ? currentSelections[0]
         : null;
-    // Extract item IDs from category selections (skip first element which is bundleId)
-    const initialItemIds =
-      Array.isArray(currentSelections) && currentSelections.length > 1
-        ? currentSelections.slice(1).map((sel: string) => {
-            // Format is "cat{index}:{id}:{name}" - extract the id
-            const parts = sel.split(':');
-            return parts.length >= 2 ? parts[1] : sel;
-          })
-        : undefined;
+    // Rehydrate each item into its persisted category. The legacy fallback
+    // keeps unprefixed selections in category 0, but indexed selections must
+    // never be collapsed there.
+    const initialCategoryItemIds = (() => {
+      if (!Array.isArray(currentSelections) || currentSelections.length <= 1) {
+        return undefined;
+      }
+      const byCategory = new Map<number, string[]>();
+      currentSelections.slice(1).forEach((selection: string) => {
+        const match = /^cat(\d+):([^:]+)(?::.*)?$/.exec(selection);
+        const categoryIndex = match ? Number(match[1]) : 0;
+        const selectionId = match ? match[2] : selection;
+        const itemIds = byCategory.get(categoryIndex) ?? [];
+        itemIds.push(selectionId);
+        byCategory.set(categoryIndex, itemIds);
+      });
+      return byCategory;
+    })();
     return (
       <EquipmentBundleChoice
         choice={choice}
         initialBundleId={initialBundleId}
-        initialItemIds={initialItemIds}
+        initialCategoryItemIds={initialCategoryItemIds}
         onSelectionChange={(bundleId, categorySelections) => {
           // Convert EquipmentBundleChoice format back to standard format
           // Store equipment selections with both id and name: "cat0:id:name"

--- a/src/components/ChoiceRenderer.tsx
+++ b/src/components/ChoiceRenderer.tsx
@@ -68,14 +68,16 @@ export function ChoiceRenderer({
           // Store equipment selections with both id and name: "cat0:id:name"
           const selections: string[] = [];
           if (bundleId) selections.push(bundleId);
-          categorySelections.forEach((equipment, index) => {
-            equipment.forEach((item) =>
-              // Store the authoritative selection ID and server-provided name.
-              selections.push(
-                `cat${index}:${item.selectionId}:${item.equipmentDetail?.name ?? item.selectionId}`
-              )
-            );
-          });
+          [...categorySelections.entries()]
+            .sort(([left], [right]) => left - right)
+            .forEach(([index, equipment]) => {
+              equipment.forEach((item) =>
+                // Store the authoritative selection ID and server-provided name.
+                selections.push(
+                  `cat${index}:${item.selectionId}:${item.equipmentDetail?.name ?? item.selectionId}`
+                )
+              );
+            });
           onSelectionChange(choice.id, selections);
         }}
       />

--- a/src/components/ChoiceRenderer.tsx
+++ b/src/components/ChoiceRenderer.tsx
@@ -18,6 +18,8 @@ interface ChoiceRendererProps {
   choice: Choice;
   onSelectionChange: (choiceId: string, selections: SelectionValue) => void; // Generic handler, will be Language[] | Skill[] | string[] based on choice type
   currentSelections: SelectionValue; // Will be Language[] | Skill[] | string[] etc based on choice type
+  /** Persisted equipment data could not be fully assigned to declared slots. */
+  hasInvalidPersistedEquipmentSelection?: boolean;
 }
 
 /**
@@ -28,6 +30,7 @@ export function ChoiceRenderer({
   choice,
   onSelectionChange,
   currentSelections,
+  hasInvalidPersistedEquipmentSelection = false,
 }: ChoiceRendererProps) {
   // Check if it's an equipment choice with bundles (the special case we handle properly)
   if (
@@ -63,6 +66,7 @@ export function ChoiceRenderer({
         choice={choice}
         initialBundleId={initialBundleId}
         initialCategoryItemIds={initialCategoryItemIds}
+        hasInvalidPersistedSelection={hasInvalidPersistedEquipmentSelection}
         onSelectionChange={(bundleId, categorySelections) => {
           // Convert EquipmentBundleChoice format back to standard format
           // Store equipment selections with both id and name: "cat0:id:name"

--- a/src/components/choices/EquipmentBundleChoice.test.tsx
+++ b/src/components/choices/EquipmentBundleChoice.test.tsx
@@ -1,99 +1,69 @@
-/**
- * EquipmentBundleChoice tests (rpg-dnd5e-web#670). Exercises the actual
- * production category-choice path: `EquipmentBundleChoice` ->
- * `useListEquipmentByType` -> `characterClient.listEquipmentByType` (the
- * live API path this component has always used — `EquipmentCategoryChoice.
- * options` is not consumed here). `characterClient` is mocked at the
- * transport boundary; everything above it, including the new
- * `EquipmentCategoryDropdown`, runs for real.
- */
 import { create } from '@bufbuild/protobuf';
-import type { ListEquipmentByTypeRequest } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import { ListEquipmentByTypeResponseSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import {
   ChoiceCategory,
   ChoiceSchema,
   EquipmentBundleSchema,
   EquipmentCategoryChoiceSchema,
+  EquipmentItemSchema,
   EquipmentOptionsSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import {
-  ArmorCategory,
   DamageType,
   WeaponCategory,
   WeaponProperty,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { EquipmentSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/equipment_types_pb';
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { EquipmentBundleChoice } from './EquipmentBundleChoice';
+import { describe, expect, it, vi } from 'vitest';
 
-const CLUB = create(EquipmentSchema, {
-  id: 'club',
-  name: 'Club',
-  equipmentData: {
-    case: 'weaponData',
-    value: {
-      weaponCategory: WeaponCategory.SIMPLE,
-      damageDice: '1d4',
-      damageType: DamageType.BLUDGEONING,
-      properties: [WeaponProperty.LIGHT],
-    },
-  },
-});
-
-const DAGGER = create(EquipmentSchema, {
-  id: 'dagger',
-  name: 'Dagger',
-  equipmentData: {
-    case: 'weaponData',
-    value: {
-      weaponCategory: WeaponCategory.SIMPLE,
-      damageDice: '1d4',
-      damageType: DamageType.PIERCING,
-      properties: [WeaponProperty.FINESSE, WeaponProperty.LIGHT],
-      normalRange: 20,
-      longRange: 60,
-    },
-  },
-});
-
-const LEATHER_ARMOR = create(EquipmentSchema, {
-  id: 'leather',
-  name: 'Leather Armor',
-  equipmentData: {
-    case: 'armorData',
-    value: {
-      armorCategory: ArmorCategory.LIGHT,
-      baseAc: 11,
-      dexBonus: true,
-      hasDexLimit: false,
-    },
-  },
-});
-
-const hoisted = vi.hoisted(() => ({
-  listEquipmentByTypeFn:
-    vi.fn<(req: ListEquipmentByTypeRequest) => Promise<unknown>>(),
-}));
+const hoisted = vi.hoisted(() => ({ listEquipmentByType: vi.fn() }));
 
 vi.mock('../../api/client', () => ({
-  characterClient: {
-    listEquipmentByType: hoisted.listEquipmentByTypeFn,
-  },
+  characterClient: { listEquipmentByType: hoisted.listEquipmentByType },
 }));
 
-function equipmentResponse(equipment: (typeof CLUB)[]) {
-  return create(ListEquipmentByTypeResponseSchema, {
-    equipment,
-    nextPageToken: '',
-    totalSize: equipment.length,
-  });
-}
+import { EquipmentBundleChoice } from './EquipmentBundleChoice';
 
-function martialMeleeChoice() {
+const CLUB = create(EquipmentItemSchema, {
+  selectionId: 'club-selection',
+  quantity: 1,
+  equipmentDetail: create(EquipmentSchema, {
+    id: 'club',
+    name: 'Club',
+    equipmentData: {
+      case: 'weaponData',
+      value: {
+        weaponCategory: WeaponCategory.SIMPLE,
+        damageDice: '1d4',
+        damageType: DamageType.BLUDGEONING,
+        properties: [WeaponProperty.LIGHT],
+      },
+    },
+  }),
+});
+
+const DART = create(EquipmentItemSchema, {
+  selectionId: 'dart-selection',
+  quantity: 1,
+  equipmentDetail: create(EquipmentSchema, {
+    id: 'dart',
+    name: 'Dart',
+    equipmentData: {
+      case: 'weaponData',
+      value: {
+        weaponCategory: WeaponCategory.SIMPLE,
+        damageDice: '1d4',
+        damageType: DamageType.PIERCING,
+        normalRange: 20,
+        longRange: 60,
+      },
+    },
+  }),
+});
+
+function choice({ choose = 1, options = [CLUB, DART] } = {}) {
   return create(ChoiceSchema, {
-    id: 'fighter-equipment',
+    id: 'monk-equipment',
     description: 'Choose your equipment',
     choiceType: ChoiceCategory.EQUIPMENT,
     options: {
@@ -103,12 +73,14 @@ function martialMeleeChoice() {
           create(EquipmentBundleSchema, {
             id: 'bundle-a',
             label: 'A weapon',
-            items: [],
             categoryChoices: [
               create(EquipmentCategoryChoiceSchema, {
-                choose: 1,
-                weaponCategories: [WeaponCategory.SIMPLE],
+                choose,
                 label: 'Choose a simple weapon',
+                // Metadata remains available for display, but category.options
+                // is the sole selection source.
+                weaponCategories: [WeaponCategory.SIMPLE],
+                options,
               }),
             ],
           }),
@@ -118,176 +90,90 @@ function martialMeleeChoice() {
   });
 }
 
-function armorChoice() {
-  return create(ChoiceSchema, {
-    id: 'fighter-armor',
-    description: 'Choose your armor',
-    choiceType: ChoiceCategory.EQUIPMENT,
-    options: {
-      case: 'equipmentOptions',
-      value: create(EquipmentOptionsSchema, {
-        bundles: [
-          create(EquipmentBundleSchema, {
-            id: 'bundle-armor',
-            label: 'Armor',
-            items: [],
-            categoryChoices: [
-              create(EquipmentCategoryChoiceSchema, {
-                choose: 1,
-                armorCategories: [ArmorCategory.LIGHT],
-                label: 'Choose armor',
-              }),
-            ],
-          }),
-        ],
-      }),
-    },
-  });
-}
-
-describe('EquipmentBundleChoice — production rich dropdown (#670)', () => {
-  beforeEach(() => {
-    hoisted.listEquipmentByTypeFn.mockReset();
-  });
-
-  it('fetches live equipment via useListEquipmentByType (not EquipmentCategoryChoice.options) and shows a compact closed dropdown', async () => {
-    hoisted.listEquipmentByTypeFn.mockResolvedValue(
-      equipmentResponse([CLUB, DAGGER])
-    );
-
+describe('EquipmentBundleChoice — authoritative category options (#690)', () => {
+  it('renders API options in their supplied order with rich details and makes no list request', () => {
     render(
-      <EquipmentBundleChoice
-        choice={martialMeleeChoice()}
-        onSelectionChange={vi.fn()}
-      />
-    );
-
-    fireEvent.click(screen.getByText('A weapon'));
-
-    // The category dropdown appears, closed by default — no rich content
-    // visible yet, proving "closed" is compact.
-    const trigger = await screen.findByRole('combobox');
-    expect(screen.queryByRole('listbox')).toBeNull();
-    expect(screen.queryByText('1d4 piercing', { exact: false })).toBeNull();
-    expect(trigger).toBeTruthy();
-
-    expect(hoisted.listEquipmentByTypeFn).toHaveBeenCalled();
-  });
-
-  it('shows rich EquipmentCard content (damage dice/type/properties) inside the OPEN dropdown', async () => {
-    hoisted.listEquipmentByTypeFn.mockResolvedValue(
-      equipmentResponse([CLUB, DAGGER])
-    );
-
-    render(
-      <EquipmentBundleChoice
-        choice={martialMeleeChoice()}
-        onSelectionChange={vi.fn()}
-      />
+      <EquipmentBundleChoice choice={choice()} onSelectionChange={vi.fn()} />
     );
     fireEvent.click(screen.getByText('A weapon'));
+    fireEvent.click(screen.getByRole('combobox'));
 
-    const trigger = await screen.findByRole('combobox');
-    fireEvent.click(trigger);
-
-    const listbox = screen.getByRole('listbox');
-    within(listbox).getByText('Club');
-    within(listbox).getByText('Dagger');
-    within(listbox).getByText('1d4 bludgeoning', { exact: false });
-    within(listbox).getByText('1d4 piercing', { exact: false });
-    within(listbox).getByText('Range: 20/60 ft');
+    const options = within(screen.getByRole('listbox')).getAllByRole('option');
+    expect(options.map((option) => option.textContent)).toEqual([
+      expect.stringContaining('Club'),
+      expect.stringContaining('Dart'),
+    ]);
+    within(screen.getByRole('listbox')).getByText('1d4 bludgeoning', {
+      exact: false,
+    });
+    within(screen.getByRole('listbox')).getByText('Range: 20/60 ft');
+    expect(hoisted.listEquipmentByType).not.toHaveBeenCalled();
   });
 
-  it('shows rich armor detail (AC/dex/category) inside the OPEN dropdown for an armor category', async () => {
-    hoisted.listEquipmentByTypeFn.mockResolvedValue(
-      equipmentResponse([LEATHER_ARMOR])
-    );
-
-    render(
-      <EquipmentBundleChoice
-        choice={armorChoice()}
-        onSelectionChange={vi.fn()}
-      />
-    );
-    fireEvent.click(screen.getByText('Armor'));
-
-    const trigger = await screen.findByRole('combobox');
-    fireEvent.click(trigger);
-
-    const listbox = screen.getByRole('listbox');
-    within(listbox).getByText('AC 11 + Dex', { exact: false });
-    within(listbox).getByText('Light', { exact: false });
-  });
-
-  it('reports the selected Equipment back through onSelectionChange after picking from the open dropdown', async () => {
-    hoisted.listEquipmentByTypeFn.mockResolvedValue(
-      equipmentResponse([CLUB, DAGGER])
-    );
+  it('submits the authoritative selection ID, not the equipment detail ID', () => {
     const onSelectionChange = vi.fn();
-
     render(
       <EquipmentBundleChoice
-        choice={martialMeleeChoice()}
+        choice={choice()}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+    fireEvent.click(screen.getByText('A weapon'));
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-dart-selection'
+      )
+    );
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      'bundle-a',
+      new Map([[0, [DART]]])
+    );
+  });
+
+  it('keeps multiple slots and duplicate selections without inventing eligibility', () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <EquipmentBundleChoice
+        choice={choice({ choose: 2 })}
         onSelectionChange={onSelectionChange}
       />
     );
     fireEvent.click(screen.getByText('A weapon'));
 
-    const trigger = await screen.findByRole('combobox');
-    fireEvent.click(trigger);
-    fireEvent.click(within(screen.getByRole('listbox')).getByText('Dagger'));
-
-    // Popup closes after selection, and the compact trigger now reflects it.
-    expect(screen.queryByRole('listbox')).toBeNull();
-    expect(screen.getByRole('combobox').textContent).toMatch(/Dagger/);
+    const [first, second] = screen.getAllByRole('combobox');
+    fireEvent.click(first);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-club-selection'
+      )
+    );
+    fireEvent.click(second);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-1-option-club-selection'
+      )
+    );
 
     expect(onSelectionChange).toHaveBeenLastCalledWith(
       'bundle-a',
-      new Map([[0, [DAGGER]]])
+      new Map([[0, [CLUB, CLUB]]])
     );
+    expect(screen.getByText(/Same item selected multiple times/)).toBeTruthy();
   });
 
-  it('shows a loading dropdown state while equipment is being fetched', async () => {
-    let resolve: (v: unknown) => void = () => {};
-    hoisted.listEquipmentByTypeFn.mockImplementation(
-      () => new Promise((r) => (resolve = r))
-    );
-
+  it('hydrates a reopened selection by authoritative selection ID', () => {
     render(
       <EquipmentBundleChoice
-        choice={martialMeleeChoice()}
+        choice={choice()}
+        initialBundleId="bundle-a"
+        initialItemIds={['dart-selection']}
         onSelectionChange={vi.fn()}
       />
     );
-    fireEvent.click(screen.getByText('A weapon'));
 
-    const trigger = await screen.findByRole('combobox');
-    expect(trigger.textContent).toMatch(/loading/i);
-
-    resolve(equipmentResponse([CLUB]));
-    await screen.findByText(/-- Select item --|Club/);
-  });
-
-  it('shows an error state with retry if the equipment fetch fails', async () => {
-    hoisted.listEquipmentByTypeFn.mockRejectedValueOnce(
-      new Error('unavailable')
-    );
-    hoisted.listEquipmentByTypeFn.mockResolvedValueOnce(
-      equipmentResponse([CLUB])
-    );
-
-    render(
-      <EquipmentBundleChoice
-        choice={martialMeleeChoice()}
-        onSelectionChange={vi.fn()}
-      />
-    );
-    fireEvent.click(screen.getByText('A weapon'));
-
-    await screen.findByRole('alert');
-    fireEvent.click(screen.getByText('Retry'));
-
-    await screen.findByRole('combobox');
-    expect(hoisted.listEquipmentByTypeFn).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('combobox').textContent).toMatch(/Dart/);
+    expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
   });
 });

--- a/src/components/choices/EquipmentBundleChoice.test.tsx
+++ b/src/components/choices/EquipmentBundleChoice.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../api/client', () => ({
   characterClient: { listEquipmentByType: hoisted.listEquipmentByType },
 }));
 
+import { ChoiceRenderer } from '../ChoiceRenderer';
 import { EquipmentBundleChoice } from './EquipmentBundleChoice';
 
 const CLUB = create(EquipmentItemSchema, {
@@ -168,12 +169,64 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
       <EquipmentBundleChoice
         choice={choice()}
         initialBundleId="bundle-a"
-        initialItemIds={['dart-selection']}
+        initialCategoryItemIds={new Map([[0, ['dart-selection']]])}
         onSelectionChange={vi.fn()}
       />
     );
 
     expect(screen.getByRole('combobox').textContent).toMatch(/Dart/);
+    expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
+  });
+
+  it('rehydrates indexed multi-category selections into their matching categories', () => {
+    const multiCategoryChoice = create(ChoiceSchema, {
+      id: 'multi-category-equipment',
+      choiceType: ChoiceCategory.EQUIPMENT,
+      options: {
+        case: 'equipmentOptions',
+        value: create(EquipmentOptionsSchema, {
+          bundles: [
+            create(EquipmentBundleSchema, {
+              id: 'bundle-a',
+              label: 'Two categories',
+              categoryChoices: [
+                create(EquipmentCategoryChoiceSchema, {
+                  choose: 1,
+                  label: 'First weapon',
+                  options: [CLUB],
+                }),
+                create(EquipmentCategoryChoiceSchema, {
+                  choose: 1,
+                  label: 'Second weapon',
+                  options: [DART],
+                }),
+              ],
+            }),
+          ],
+        }),
+      },
+    });
+
+    render(
+      <ChoiceRenderer
+        choice={multiCategoryChoice}
+        currentSelections={[
+          'bundle-a',
+          'cat0:club-selection:Club',
+          'cat1:dart-selection:Dart',
+        ]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    // These different option sets make a category-0 collapse observable:
+    // the old hydration showed no saved item in the second category.
+    expect(
+      screen.getByRole('combobox', { name: 'First weapon' }).textContent
+    ).toMatch(/Club/);
+    expect(
+      screen.getByRole('combobox', { name: 'Second weapon' }).textContent
+    ).toMatch(/Dart/);
     expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
   });
 });

--- a/src/components/choices/EquipmentBundleChoice.test.tsx
+++ b/src/components/choices/EquipmentBundleChoice.test.tsx
@@ -133,7 +133,7 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
     );
   });
 
-  it('keeps multiple slots and duplicate selections without inventing eligibility', () => {
+  it('disables an already selected option in sibling slots to prevent pointer duplicates', () => {
     const onSelectionChange = vi.fn();
     render(
       <EquipmentBundleChoice
@@ -151,17 +151,104 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
       )
     );
     fireEvent.click(second);
-    fireEvent.click(
-      within(screen.getByRole('listbox')).getByTestId(
-        'equipment-category-0-slot-1-option-club-selection'
-      )
+
+    const duplicate = within(screen.getByRole('listbox')).getByTestId(
+      'equipment-category-0-slot-1-option-club-selection'
     );
+    expect(duplicate.getAttribute('aria-disabled')).toBe('true');
+    fireEvent.click(duplicate);
 
     expect(onSelectionChange).toHaveBeenLastCalledWith(
       'bundle-a',
-      new Map([[0, [CLUB, CLUB]]])
+      new Map([[0, [CLUB]]])
     );
-    expect(screen.getByText(/Same item selected multiple times/)).toBeTruthy();
+  });
+
+  it('skips a sibling-held option when selected by keyboard', () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <EquipmentBundleChoice
+        choice={choice({ choose: 2 })}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+    fireEvent.click(screen.getByText('A weapon'));
+    const [first, second] = screen.getAllByRole('combobox');
+
+    fireEvent.click(first);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-club-selection'
+      )
+    );
+
+    second.focus();
+    fireEvent.keyDown(second, { key: 'ArrowDown' });
+    expect(second.getAttribute('aria-activedescendant')).toBe(
+      'equipment-category-0-slot-1-option-dart-selection'
+    );
+    fireEvent.keyDown(second, { key: 'Enter' });
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      'bundle-a',
+      new Map([[0, [CLUB, DART]]])
+    );
+  });
+
+  it('re-enables an old option after its sibling changes selection', () => {
+    render(
+      <EquipmentBundleChoice
+        choice={choice({ choose: 2 })}
+        onSelectionChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText('A weapon'));
+    const [first, second] = screen.getAllByRole('combobox');
+
+    fireEvent.click(first);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-club-selection'
+      )
+    );
+    fireEvent.click(second);
+    expect(
+      within(screen.getByRole('listbox'))
+        .getByTestId('equipment-category-0-slot-1-option-club-selection')
+        .getAttribute('aria-disabled')
+    ).toBe('true');
+    fireEvent.keyDown(second, { key: 'Escape' });
+
+    fireEvent.click(first);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-dart-selection'
+      )
+    );
+    fireEvent.click(second);
+    expect(
+      within(screen.getByRole('listbox'))
+        .getByTestId('equipment-category-0-slot-1-option-club-selection')
+        .getAttribute('aria-disabled')
+    ).toBeNull();
+  });
+
+  it('surfaces legacy hydrated duplicate values and requires correction', () => {
+    render(
+      <EquipmentBundleChoice
+        choice={choice({ choose: 2 })}
+        initialBundleId="bundle-a"
+        initialCategoryItemIds={
+          new Map([[0, ['club-selection', 'club-selection']]])
+        }
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('alert').textContent).toMatch(/different item/i);
+    expect(
+      screen.getByText(/Please complete all category selections/)
+    ).toBeTruthy();
   });
 
   it('hydrates a reopened selection by authoritative selection ID', () => {
@@ -198,7 +285,9 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
                 create(EquipmentCategoryChoiceSchema, {
                   choose: 1,
                   label: 'Second weapon',
-                  options: [DART],
+                  // The toolkit scopes duplicate validation to each category
+                  // requirement, so this independent category may also offer Club.
+                  options: [CLUB],
                 }),
               ],
             }),
@@ -213,20 +302,20 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
         currentSelections={[
           'bundle-a',
           'cat0:club-selection:Club',
-          'cat1:dart-selection:Dart',
+          'cat1:club-selection:Club',
         ]}
         onSelectionChange={vi.fn()}
       />
     );
 
-    // These different option sets make a category-0 collapse observable:
+    // These separate category slots make a category-0 collapse observable:
     // the old hydration showed no saved item in the second category.
     expect(
       screen.getByRole('combobox', { name: 'First weapon' }).textContent
     ).toMatch(/Club/);
     expect(
       screen.getByRole('combobox', { name: 'Second weapon' }).textContent
-    ).toMatch(/Dart/);
+    ).toMatch(/Club/);
     expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
   });
 });

--- a/src/components/choices/EquipmentBundleChoice.test.tsx
+++ b/src/components/choices/EquipmentBundleChoice.test.tsx
@@ -265,6 +265,69 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
     expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
   });
 
+  it('applies a persisted selection that resolves after this choice has already mounted, instead of staying stuck on stale initial state', () => {
+    const onSelectionChange = vi.fn();
+    const { rerender } = render(
+      <EquipmentBundleChoice
+        choice={choice()}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    // Nothing hydrated yet: the class's declared options loaded, but the
+    // draft's persisted choice for it hasn't resolved. No bundle is
+    // selected, so no category dropdown exists at all.
+    expect(screen.queryByRole('combobox')).toBeNull();
+
+    // The persisted draft choice resolves after mount and the parent
+    // re-renders with it — React's lazy `useState` initializer inside
+    // `useEquipmentBundleSelection`/`CategorySelector` would otherwise never
+    // re-run for this already-mounted instance.
+    rerender(
+      <EquipmentBundleChoice
+        choice={choice()}
+        initialBundleId="bundle-a"
+        initialCategoryItemIds={new Map([[0, ['dart-selection']]])}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    expect(screen.getByRole('combobox').textContent).toMatch(/Dart/);
+    expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
+  });
+
+  it('does not clobber a selection the player already made once a stale hydration prop shows up afterward', () => {
+    const onSelectionChange = vi.fn();
+    const { rerender } = render(
+      <EquipmentBundleChoice
+        choice={choice()}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('A weapon'));
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-club-selection'
+      )
+    );
+    expect(screen.getByRole('combobox').textContent).toMatch(/Club/);
+
+    // A late hydration prop arriving after real interaction must not
+    // override the player's own choice.
+    rerender(
+      <EquipmentBundleChoice
+        choice={choice()}
+        initialBundleId="bundle-a"
+        initialCategoryItemIds={new Map([[0, ['dart-selection']]])}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    expect(screen.getByRole('combobox').textContent).toMatch(/Club/);
+  });
+
   it('serializes category indices in declaration order, not selection click order', () => {
     const multiCategoryChoice = create(ChoiceSchema, {
       id: 'multi-category-equipment',
@@ -325,5 +388,45 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
       'multi-category-equipment',
       ['bundle-a', 'cat0:club-selection:Club', 'cat1:dart-selection:Dart']
     );
+  });
+
+  it('re-renders a hydrated selection through the ChoiceRenderer bridge and still reserializes it at the right declared category index', () => {
+    const onSelectionChange = vi.fn();
+
+    const { rerender } = render(
+      <ChoiceRenderer
+        choice={choice()}
+        currentSelections={[]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+    // The persisted draft choice hasn't resolved yet: no bundle is selected.
+    expect(screen.queryByRole('combobox')).toBeNull();
+
+    // It resolves after mount — e.g. ClassSelectionModal's `existingChoices`
+    // prop updating once the draft's persisted choices load.
+    rerender(
+      <ChoiceRenderer
+        choice={choice()}
+        currentSelections={['bundle-a', 'cat0:dart-selection:Dart']}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    expect(screen.getByRole('combobox').textContent).toMatch(/Dart/);
+    expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
+
+    // Changing the now-hydrated slot must still serialize at category 0 —
+    // not a shifted/fallback index introduced by the delayed hydration.
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-club-selection'
+      )
+    );
+    expect(onSelectionChange).toHaveBeenLastCalledWith('monk-equipment', [
+      'bundle-a',
+      'cat0:club-selection:Club',
+    ]);
   });
 });

--- a/src/components/choices/EquipmentBundleChoice.test.tsx
+++ b/src/components/choices/EquipmentBundleChoice.test.tsx
@@ -251,6 +251,37 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
     ).toBeTruthy();
   });
 
+  it('announces a persisted equipment correction instead of completion for unconsumed wire data', () => {
+    render(
+      <EquipmentBundleChoice
+        choice={choice()}
+        initialBundleId="bundle-a"
+        initialCategoryItemIds={new Map([[0, ['dart-selection']]])}
+        onSelectionChange={vi.fn()}
+        hasInvalidPersistedSelection
+      />
+    );
+
+    expect(screen.queryByText(/Equipment selection complete/)).toBeNull();
+    const error = screen.getByRole('alert');
+    expect(error.textContent).toMatch(
+      /saved equipment selection needs correction/i
+    );
+    expect(
+      screen
+        .getByRole('group', { name: /choose your equipment/i })
+        .getAttribute('aria-describedby')
+    ).toBe(error.id);
+
+    // A deliberate reset clears the persisted correction state, but does not
+    // retain or silently submit the malformed saved data.
+    fireEvent.click(screen.getByText('A weapon'));
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('status').textContent).toMatch(
+      /Please complete all category selections/
+    );
+  });
+
   it('hydrates a reopened selection by authoritative selection ID', () => {
     render(
       <EquipmentBundleChoice
@@ -262,7 +293,9 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
     );
 
     expect(screen.getByRole('combobox').textContent).toMatch(/Dart/);
-    expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
+    expect(screen.getByRole('status').textContent).toMatch(
+      /Equipment selection complete/
+    );
   });
 
   it('applies a persisted selection that resolves after this choice has already mounted, instead of staying stuck on stale initial state', () => {

--- a/src/components/choices/EquipmentBundleChoice.test.tsx
+++ b/src/components/choices/EquipmentBundleChoice.test.tsx
@@ -265,7 +265,7 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
     expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
   });
 
-  it('rehydrates indexed multi-category selections into their matching categories', () => {
+  it('serializes category indices in declaration order, not selection click order', () => {
     const multiCategoryChoice = create(ChoiceSchema, {
       id: 'multi-category-equipment',
       choiceType: ChoiceCategory.EQUIPMENT,
@@ -285,9 +285,7 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
                 create(EquipmentCategoryChoiceSchema, {
                   choose: 1,
                   label: 'Second weapon',
-                  // The toolkit scopes duplicate validation to each category
-                  // requirement, so this independent category may also offer Club.
-                  options: [CLUB],
+                  options: [DART],
                 }),
               ],
             }),
@@ -295,27 +293,37 @@ describe('EquipmentBundleChoice — authoritative category options (#690)', () =
         }),
       },
     });
+    const onSelectionChange = vi.fn();
 
     render(
       <ChoiceRenderer
         choice={multiCategoryChoice}
-        currentSelections={[
-          'bundle-a',
-          'cat0:club-selection:Club',
-          'cat1:club-selection:Club',
-        ]}
-        onSelectionChange={vi.fn()}
+        currentSelections={[]}
+        onSelectionChange={onSelectionChange}
       />
     );
+    fireEvent.click(screen.getByText('Two categories'));
 
-    // These separate category slots make a category-0 collapse observable:
-    // the old hydration showed no saved item in the second category.
-    expect(
-      screen.getByRole('combobox', { name: 'First weapon' }).textContent
-    ).toMatch(/Club/);
-    expect(
-      screen.getByRole('combobox', { name: 'Second weapon' }).textContent
-    ).toMatch(/Club/);
-    expect(screen.getByText(/Equipment selection complete/)).toBeTruthy();
+    // Select the second declared category first. Persisted values must still
+    // be category-ordered because the server reconstructs the same slices.
+    const second = screen.getByRole('combobox', { name: 'Second weapon' });
+    fireEvent.click(second);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-1-slot-0-option-dart-selection'
+      )
+    );
+    const first = screen.getByRole('combobox', { name: 'First weapon' });
+    fireEvent.click(first);
+    fireEvent.click(
+      within(screen.getByRole('listbox')).getByTestId(
+        'equipment-category-0-slot-0-option-club-selection'
+      )
+    );
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      'multi-category-equipment',
+      ['bundle-a', 'cat0:club-selection:Club', 'cat1:dart-selection:Dart']
+    );
   });
 });

--- a/src/components/choices/EquipmentBundleChoice.tsx
+++ b/src/components/choices/EquipmentBundleChoice.tsx
@@ -16,7 +16,8 @@ interface EquipmentBundleChoiceProps {
     categorySelections: Map<number, EquipmentItem[]>
   ) => void;
   initialBundleId?: string | null;
-  initialItemIds?: string[];
+  /** Reopened selections, partitioned by their persisted category index. */
+  initialCategoryItemIds?: ReadonlyMap<number, string[]>;
 }
 
 // Component for selecting from a category - supports multiple selections when choose > 1
@@ -136,7 +137,7 @@ export function EquipmentBundleChoice({
   choice,
   onSelectionChange,
   initialBundleId,
-  initialItemIds,
+  initialCategoryItemIds,
 }: EquipmentBundleChoiceProps) {
   const {
     selectedBundleId,
@@ -145,7 +146,11 @@ export function EquipmentBundleChoice({
     selectCategoryItems,
     getSelectedBundle,
     isComplete,
-  } = useEquipmentBundleSelection(choice, initialBundleId, initialItemIds);
+  } = useEquipmentBundleSelection(
+    choice,
+    initialBundleId,
+    initialCategoryItemIds
+  );
 
   // Extract bundles from choice
   const bundles =

--- a/src/components/choices/EquipmentBundleChoice.tsx
+++ b/src/components/choices/EquipmentBundleChoice.tsx
@@ -100,12 +100,22 @@ function CategorySelector({
                 } --`}
                 options={options}
                 selectedId={selectedBySlot[slotIndex]}
+                // The toolkit validates uniqueness per category requirement,
+                // not across independent category choices.
+                disabledOptionIds={
+                  new Set(
+                    selectedBySlot.filter(
+                      (id, index): id is string =>
+                        index !== slotIndex && id !== null
+                    )
+                  )
+                }
                 onChange={(value) => handleSlotChange(slotIndex, value)}
               />
-              {selectedItem && (
+              {selectedItem?.equipmentDetail && (
                 <div style={{ marginTop: '6px' }}>
                   <EquipmentCard
-                    equipment={selectedItem.equipmentDetail!}
+                    equipment={selectedItem.equipmentDetail}
                     compact
                   />
                 </div>
@@ -116,6 +126,7 @@ function CategorySelector({
       </div>
       {hasDuplicates && (
         <div
+          role="alert"
           style={{
             marginTop: '8px',
             padding: '8px 12px',
@@ -126,7 +137,7 @@ function CategorySelector({
             color: 'var(--text-muted)',
           }}
         >
-          ⚠️ Same item selected multiple times (allowed for dual-wielding)
+          ⚠️ Select a different item in each slot before continuing.
         </div>
       )}
     </div>

--- a/src/components/choices/EquipmentBundleChoice.tsx
+++ b/src/components/choices/EquipmentBundleChoice.tsx
@@ -4,7 +4,7 @@ import type {
   EquipmentItem,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import { Package } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEquipmentBundleSelection } from '../../hooks/useEquipmentBundleSelection';
 import { EquipmentCard } from '../equipment/EquipmentCard';
 import { EquipmentCategoryDropdown } from '../equipment/EquipmentCategoryDropdown';
@@ -43,7 +43,27 @@ function CategorySelector({
     )
   );
 
+  // `currentSelections` mirrors the parent hook's authoritative selection
+  // state, which can itself resolve after this selector's first mount (see
+  // `useEquipmentBundleSelection`'s own hydration effect). The lazy
+  // `useState` initializer above only ever runs once, so re-sync here the
+  // first time real persisted selections show up — but never once the
+  // player has started picking slots themselves.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    if (currentSelections.length === 0) return;
+    hydratedRef.current = true;
+    setSelectedBySlot(
+      Array.from(
+        { length: chooseCount },
+        (_, i) => currentSelections[i]?.selectionId ?? null
+      )
+    );
+  }, [currentSelections, chooseCount]);
+
   const handleSlotChange = (slotIndex: number, value: string) => {
+    hydratedRef.current = true;
     const newSelectedBySlot = [...selectedBySlot];
     newSelectedBySlot[slotIndex] = value || null;
     setSelectedBySlot(newSelectedBySlot);

--- a/src/components/choices/EquipmentBundleChoice.tsx
+++ b/src/components/choices/EquipmentBundleChoice.tsx
@@ -4,7 +4,7 @@ import type {
   EquipmentItem,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import { Package } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useEquipmentBundleSelection } from '../../hooks/useEquipmentBundleSelection';
 import { EquipmentCard } from '../equipment/EquipmentCard';
 import { EquipmentCategoryDropdown } from '../equipment/EquipmentCategoryDropdown';
@@ -18,6 +18,12 @@ interface EquipmentBundleChoiceProps {
   initialBundleId?: string | null;
   /** Reopened selections, partitioned by their persisted category index. */
   initialCategoryItemIds?: ReadonlyMap<number, string[]>;
+  /**
+   * The persisted wire choice contained data that could not be assigned to
+   * this bundle's declared category slots. Render it as a correction state;
+   * it is cleared only after the player deliberately changes this choice.
+   */
+  hasInvalidPersistedSelection?: boolean;
 }
 
 // Component for selecting from a category - supports multiple selections when choose > 1
@@ -169,6 +175,7 @@ export function EquipmentBundleChoice({
   onSelectionChange,
   initialBundleId,
   initialCategoryItemIds,
+  hasInvalidPersistedSelection = false,
 }: EquipmentBundleChoiceProps) {
   const {
     selectedBundleId,
@@ -190,11 +197,28 @@ export function EquipmentBundleChoice({
       : [];
 
   const selectedBundle = getSelectedBundle();
+  const [
+    hasPlayerCorrectedPersistedSelection,
+    setHasPlayerCorrectedPersistedSelection,
+  ] = useState(false);
+
+  // A refreshed persisted draft can reveal invalid data after mount. Keep the
+  // correction visible until the player intentionally changes this choice.
+  useEffect(() => {
+    if (hasInvalidPersistedSelection) {
+      setHasPlayerCorrectedPersistedSelection(false);
+    }
+  }, [hasInvalidPersistedSelection]);
+
+  const requiresPersistedCorrection =
+    hasInvalidPersistedSelection && !hasPlayerCorrectedPersistedSelection;
+  const completionStatusId = useId();
 
   // Handle bundle selection
   const handleBundleSelect = useCallback(
     (bundleId: string) => {
       selectBundle(bundleId);
+      setHasPlayerCorrectedPersistedSelection(true);
       // Note: We only send the bundleId here, not the fixed items
       // The backend will look up bundle.items based on the bundleId
       onSelectionChange(bundleId, new Map());
@@ -206,6 +230,7 @@ export function EquipmentBundleChoice({
   const handleCategorySelect = useCallback(
     (categoryIndex: number, items: EquipmentItem[]) => {
       selectCategoryItems(categoryIndex, items);
+      setHasPlayerCorrectedPersistedSelection(true);
       const updatedSelections = new Map(categorySelections);
       updatedSelections.set(categoryIndex, items);
       onSelectionChange(selectedBundleId, updatedSelections);
@@ -219,7 +244,12 @@ export function EquipmentBundleChoice({
   );
 
   return (
-    <div className="space-y-4">
+    <div
+      className="space-y-4"
+      role="group"
+      aria-label={choice.description || 'Equipment selection'}
+      aria-describedby={selectedBundleId ? completionStatusId : undefined}
+    >
       <div className="flex items-start gap-2">
         <Package className="w-5 h-5 mt-0.5 text-amber-500" />
         <div className="flex-1">
@@ -353,15 +383,19 @@ export function EquipmentBundleChoice({
       {/* Completion status */}
       {selectedBundleId && (
         <div
+          id={completionStatusId}
+          role={requiresPersistedCorrection ? 'alert' : 'status'}
           className={`p-3 rounded-lg text-sm ${
-            isComplete()
+            !requiresPersistedCorrection && isComplete()
               ? 'bg-green-100 text-green-800'
               : 'bg-yellow-100 text-yellow-800'
           }`}
         >
-          {isComplete()
-            ? '✓ Equipment selection complete'
-            : 'Please complete all category selections'}
+          {requiresPersistedCorrection
+            ? 'Saved equipment selection needs correction. Choose a different equipment bundle or update a category selection before continuing.'
+            : isComplete()
+              ? '✓ Equipment selection complete'
+              : 'Please complete all category selections'}
         </div>
       )}
     </div>

--- a/src/components/choices/EquipmentBundleChoice.tsx
+++ b/src/components/choices/EquipmentBundleChoice.tsx
@@ -1,15 +1,10 @@
 import type {
   Choice,
   EquipmentCategoryChoice,
+  EquipmentItem,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
-import {
-  EquipmentType,
-  WeaponCategory,
-} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
-import type { Equipment } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/equipment_types_pb';
 import { Package } from 'lucide-react';
 import { useCallback, useState } from 'react';
-import { useListEquipmentByType } from '../../api/hooks';
 import { useEquipmentBundleSelection } from '../../hooks/useEquipmentBundleSelection';
 import { EquipmentCard } from '../equipment/EquipmentCard';
 import { EquipmentCategoryDropdown } from '../equipment/EquipmentCategoryDropdown';
@@ -18,7 +13,7 @@ interface EquipmentBundleChoiceProps {
   choice: Choice;
   onSelectionChange: (
     bundleId: string | null,
-    categorySelections: Map<number, Equipment[]>
+    categorySelections: Map<number, EquipmentItem[]>
   ) => void;
   initialBundleId?: string | null;
   initialItemIds?: string[];
@@ -33,74 +28,30 @@ function CategorySelector({
 }: {
   category: EquipmentCategoryChoice;
   categoryIndex: number;
-  onSelect: (categoryIndex: number, items: Equipment[]) => void;
-  currentSelections: Equipment[];
+  onSelect: (categoryIndex: number, items: EquipmentItem[]) => void;
+  currentSelections: EquipmentItem[];
 }) {
   const chooseCount = category.choose || 1;
+  const options = category.options;
 
-  // Track selections for each slot (when choose > 1)
+  // Track selections for each slot (when choose > 1).
   const [selectedBySlot, setSelectedBySlot] = useState<(string | null)[]>(() =>
     Array.from(
       { length: chooseCount },
-      (_, i) => currentSelections[i]?.id ?? null
+      (_, i) => currentSelections[i]?.selectionId ?? null
     )
   );
 
-  // Determine equipment types to fetch based on category
-  const equipmentTypes = useCallback((): EquipmentType[] => {
-    const types: EquipmentType[] = [];
-
-    if (category.weaponCategories && category.weaponCategories.length > 0) {
-      category.weaponCategories.forEach((cat) => {
-        if (cat === WeaponCategory.SIMPLE) {
-          types.push(EquipmentType.SIMPLE_MELEE_WEAPON);
-          types.push(EquipmentType.SIMPLE_RANGED_WEAPON);
-        } else if (cat === WeaponCategory.MARTIAL) {
-          types.push(EquipmentType.MARTIAL_MELEE_WEAPON);
-          types.push(EquipmentType.MARTIAL_RANGED_WEAPON);
-        }
-      });
-    }
-
-    if (category.armorCategories && category.armorCategories.length > 0) {
-      types.push(EquipmentType.LIGHT_ARMOR);
-      types.push(EquipmentType.MEDIUM_ARMOR);
-      types.push(EquipmentType.HEAVY_ARMOR);
-      types.push(EquipmentType.SHIELD);
-    }
-
-    if (category.toolCategories && category.toolCategories.length > 0) {
-      types.push(EquipmentType.TOOLS);
-    }
-
-    return types;
-  }, [category]);
-
-  // Fetch equipment - always enabled since we're not using expand/collapse
-  const types = equipmentTypes();
-  const primaryType = types[0] || EquipmentType.UNSPECIFIED;
-  const {
-    data: equipment,
-    loading: equipmentLoading,
-    error: equipmentError,
-    refetch: refetchEquipment,
-  } = useListEquipmentByType({
-    equipmentType: primaryType,
-    enabled: types.length > 0,
-  });
-
   const handleSlotChange = (slotIndex: number, value: string) => {
-    if (!equipment) return;
-
     const newSelectedBySlot = [...selectedBySlot];
     newSelectedBySlot[slotIndex] = value || null;
     setSelectedBySlot(newSelectedBySlot);
 
-    // Gather all selected items and report back
+    // Keep the API's selection IDs and ordered option objects intact.
     const selectedItems = newSelectedBySlot
       .filter((id): id is string => id !== null)
-      .map((id) => equipment.find((e) => e.id === id))
-      .filter((item): item is Equipment => item !== undefined);
+      .map((id) => options.find((option) => option.selectionId === id))
+      .filter((item): item is EquipmentItem => item !== undefined);
 
     onSelect(categoryIndex, selectedItems);
   };
@@ -129,7 +80,9 @@ function CategorySelector({
       <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
         {Array.from({ length: chooseCount }, (_, slotIndex) => {
           const selectedItem = selectedBySlot[slotIndex]
-            ? equipment?.find((e) => e.id === selectedBySlot[slotIndex])
+            ? options.find(
+                (option) => option.selectionId === selectedBySlot[slotIndex]
+              )
             : undefined;
           const slotLabel =
             chooseCount > 1
@@ -144,16 +97,16 @@ function CategorySelector({
                 placeholder={`-- Select ${
                   chooseCount > 1 ? `item ${slotIndex + 1}` : 'item'
                 } --`}
-                options={equipment ?? []}
+                options={options}
                 selectedId={selectedBySlot[slotIndex]}
                 onChange={(value) => handleSlotChange(slotIndex, value)}
-                isLoading={equipmentLoading}
-                error={equipmentError}
-                onRetry={() => refetchEquipment()}
               />
               {selectedItem && (
                 <div style={{ marginTop: '6px' }}>
-                  <EquipmentCard equipment={selectedItem} compact />
+                  <EquipmentCard
+                    equipment={selectedItem.equipmentDetail!}
+                    compact
+                  />
                 </div>
               )}
             </div>
@@ -215,7 +168,7 @@ export function EquipmentBundleChoice({
 
   // Handle category item selection
   const handleCategorySelect = useCallback(
-    (categoryIndex: number, items: Equipment[]) => {
+    (categoryIndex: number, items: EquipmentItem[]) => {
       selectCategoryItems(categoryIndex, items);
       const updatedSelections = new Map(categorySelections);
       updatedSelections.set(categoryIndex, items);

--- a/src/components/equipment/EquipmentCategoryDropdown.test.tsx
+++ b/src/components/equipment/EquipmentCategoryDropdown.test.tsx
@@ -1,10 +1,13 @@
 /**
- * EquipmentCategoryDropdown tests (rpg-dnd5e-web#670). Test-only fixtures
- * below stand in for the live `Equipment[]` a production category slot
- * fetches via `useListEquipmentByType` — no proto fixture files ship
- * outside this test.
+ * EquipmentCategoryDropdown tests. Test-only fixtures model the enriched
+ * authoritative `EquipmentCategoryChoice.options` entries consumed by the
+ * production category slot.
  */
 import { create } from '@bufbuild/protobuf';
+import {
+  EquipmentItemSchema,
+  type EquipmentItem,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import {
   ArmorCategory,
   DamageType,
@@ -61,7 +64,11 @@ const LEATHER_ARMOR: Equipment = create(EquipmentSchema, {
   },
 });
 
-const OPTIONS = [CLUB, DAGGER];
+const item = (selectionId: string, equipmentDetail: Equipment): EquipmentItem =>
+  create(EquipmentItemSchema, { selectionId, quantity: 1, equipmentDetail });
+
+const OPTIONS = [item('club', CLUB), item('dagger', DAGGER)];
+const LEATHER_OPTION = item('leather', LEATHER_ARMOR);
 
 describe('EquipmentCategoryDropdown', () => {
   it('renders a compact closed trigger, not a full options list, before opening', () => {
@@ -111,7 +118,7 @@ describe('EquipmentCategoryDropdown', () => {
       <EquipmentCategoryDropdown
         id="test-dropdown"
         ariaLabel="Choose armor"
-        options={[LEATHER_ARMOR]}
+        options={[LEATHER_OPTION]}
         selectedId={null}
         onChange={vi.fn()}
       />

--- a/src/components/equipment/EquipmentCategoryDropdown.test.tsx
+++ b/src/components/equipment/EquipmentCategoryDropdown.test.tsx
@@ -130,6 +130,25 @@ describe('EquipmentCategoryDropdown', () => {
     within(listbox).getByText('Light', { exact: false });
   });
 
+  it('renders an option without optional equipmentDetail without crashing', () => {
+    const onChange = vi.fn();
+    render(
+      <EquipmentCategoryDropdown
+        id="test-dropdown"
+        ariaLabel="Choose item"
+        options={[
+          create(EquipmentItemSchema, { selectionId: 'detail-pending' }),
+        ]}
+        selectedId={null}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByTestId('test-dropdown-option-detail-pending'));
+    expect(onChange).toHaveBeenCalledWith('detail-pending');
+  });
+
   it('selects an option on click, reports it, and closes the popup', () => {
     const onChange = vi.fn();
     render(

--- a/src/components/equipment/EquipmentCategoryDropdown.test.tsx
+++ b/src/components/equipment/EquipmentCategoryDropdown.test.tsx
@@ -163,6 +163,29 @@ describe('EquipmentCategoryDropdown', () => {
     expect(screen.getByRole('combobox').textContent).toMatch(/Dagger/);
   });
 
+  it('opens the listbox from a closed trigger on ArrowUp with its accessible name intact', () => {
+    render(
+      <EquipmentCategoryDropdown
+        id="test-dropdown"
+        ariaLabel="Choose item"
+        options={OPTIONS}
+        selectedId={null}
+        onChange={vi.fn()}
+      />
+    );
+
+    const trigger = screen.getByRole('combobox', { name: 'Choose item' });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('listbox', { name: 'Choose item' })).toBeTruthy();
+    // APG select-only combobox behavior: ArrowUp opens at the last option.
+    expect(trigger.getAttribute('aria-activedescendant')).toBe(
+      'test-dropdown-option-dagger'
+    );
+  });
+
   it('supports ArrowDown/Enter keyboard selection without a mouse', () => {
     const onChange = vi.fn();
     render(

--- a/src/components/equipment/EquipmentCategoryDropdown.tsx
+++ b/src/components/equipment/EquipmentCategoryDropdown.tsx
@@ -9,12 +9,9 @@
  * duplicating its formatting.
  *
  * This is wired directly into the production category-choice path
- * (`EquipmentBundleChoice`'s `CategorySelector`) against the existing,
- * live `useListEquipmentByType` data — the same `Equipment[]` shape that
- * route has always fetched. It does not consume or require
- * `EquipmentCategoryChoice.options` (the toolkit/API-resolved shape is a
- * separate, deferred wave) and contains no class- or eligibility-specific
- * logic; the category's item list is whatever the caller passes in.
+ * (`EquipmentBundleChoice`'s `CategorySelector`) and renders the
+ * authoritative `EquipmentCategoryChoice.options` items exactly as the API
+ * supplies them. It has no eligibility or category reconstruction logic.
  *
  * Accessibility: implements the W3C ARIA APG "select-only" combobox
  * pattern (w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/)
@@ -24,7 +21,7 @@
  * Escape, or selection, returning focus to the trigger.
  */
 
-import type { Equipment } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/equipment_types_pb';
+import type { EquipmentItem } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import {
   useCallback,
   useEffect,
@@ -40,8 +37,8 @@ export interface EquipmentCategoryDropdownProps {
   ariaLabel: string;
   /** Placeholder shown in the trigger when nothing is selected. */
   placeholder?: string;
-  /** Live equipment options for this category slot. */
-  options: Equipment[];
+  /** Authoritative, enriched category options for this slot. */
+  options: EquipmentItem[];
   /** Currently selected option id (controlled), or null. */
   selectedId: string | null;
   onChange: (id: string) => void;
@@ -78,7 +75,7 @@ export function EquipmentCategoryDropdown({
   const optionRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const selectedItem = useMemo(
-    () => options.find((o) => o.id === selectedId) ?? null,
+    () => options.find((o) => o.selectionId === selectedId) ?? null,
     [options, selectedId]
   );
 
@@ -91,8 +88,8 @@ export function EquipmentCategoryDropdown({
       setActiveId(null);
       return;
     }
-    if (!options.some((o) => o.id === activeId)) {
-      setActiveId(selectedId ?? options[0].id);
+    if (!options.some((o) => o.selectionId === activeId)) {
+      setActiveId(selectedId ?? options[0].selectionId);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options]);
@@ -115,7 +112,7 @@ export function EquipmentCategoryDropdown({
   }, [open]);
 
   const activeIndex = useMemo(
-    () => options.findIndex((o) => o.id === activeId),
+    () => options.findIndex((o) => o.selectionId === activeId),
     [options, activeId]
   );
 
@@ -123,7 +120,7 @@ export function EquipmentCategoryDropdown({
     (nextIndex: number) => {
       if (options.length === 0) return;
       const clamped = Math.max(0, Math.min(options.length - 1, nextIndex));
-      setActiveId(options[clamped].id);
+      setActiveId(options[clamped].selectionId);
     },
     [options]
   );
@@ -144,7 +141,7 @@ export function EquipmentCategoryDropdown({
           event.preventDefault();
           if (!open) {
             setOpen(true);
-            setActiveId(selectedId ?? options[0]?.id ?? null);
+            setActiveId(selectedId ?? options[0]?.selectionId ?? null);
           } else {
             moveActive(activeIndex + 1);
           }
@@ -152,8 +149,7 @@ export function EquipmentCategoryDropdown({
         case 'ArrowUp':
           event.preventDefault();
           if (!open) {
-            setOpen(true);
-            setActiveId(selectedId ?? options[0]?.id ?? null);
+            setActiveId(selectedId ?? options[0]?.selectionId ?? null);
           } else {
             moveActive(activeIndex - 1);
           }
@@ -175,7 +171,7 @@ export function EquipmentCategoryDropdown({
           event.preventDefault();
           if (!open) {
             setOpen(true);
-            setActiveId(selectedId ?? options[0]?.id ?? null);
+            setActiveId(selectedId ?? options[0]?.selectionId ?? null);
           } else if (activeId) {
             commit(activeId);
           }
@@ -235,7 +231,7 @@ export function EquipmentCategoryDropdown({
         onClick={() => {
           if (disabled) return;
           setOpen((prev) => !prev);
-          if (!open) setActiveId(selectedId ?? options[0]?.id ?? null);
+          if (!open) setActiveId(selectedId ?? options[0]?.selectionId ?? null);
         }}
         onKeyDown={handleTriggerKeyDown}
         style={{
@@ -268,7 +264,8 @@ export function EquipmentCategoryDropdown({
             : error
               ? 'Failed to load options'
               : selectedItem
-                ? selectedItem.name
+                ? (selectedItem.equipmentDetail?.name ??
+                  selectedItem.selectionId)
                 : options.length === 0
                   ? 'No options available'
                   : placeholder}
@@ -339,20 +336,20 @@ export function EquipmentCategoryDropdown({
           }}
         >
           {options.map((option) => {
-            const isSelected = option.id === selectedId;
-            const isActive = option.id === activeId;
+            const isSelected = option.selectionId === selectedId;
+            const isActive = option.selectionId === activeId;
             return (
               <div
-                key={option.id}
+                key={option.selectionId}
                 ref={(node) => {
-                  optionRefs.current[option.id] = node;
+                  optionRefs.current[option.selectionId] = node;
                 }}
                 role="option"
-                id={`${rootId}-option-${option.id}`}
+                id={`${rootId}-option-${option.selectionId}`}
                 aria-selected={isSelected}
-                data-testid={`${rootId}-option-${option.id}`}
-                onMouseEnter={() => setActiveId(option.id)}
-                onClick={() => commit(option.id)}
+                data-testid={`${rootId}-option-${option.selectionId}`}
+                onMouseEnter={() => setActiveId(option.selectionId)}
+                onClick={() => commit(option.selectionId)}
                 style={{
                   cursor: 'pointer',
                   borderRadius: '6px',
@@ -365,7 +362,7 @@ export function EquipmentCategoryDropdown({
                     : 'none',
                 }}
               >
-                <EquipmentCard equipment={option} compact />
+                <EquipmentCard equipment={option.equipmentDetail!} compact />
               </div>
             );
           })}

--- a/src/components/equipment/EquipmentCategoryDropdown.tsx
+++ b/src/components/equipment/EquipmentCategoryDropdown.tsx
@@ -149,7 +149,10 @@ export function EquipmentCategoryDropdown({
         case 'ArrowUp':
           event.preventDefault();
           if (!open) {
-            setActiveId(selectedId ?? options[0]?.selectionId ?? null);
+            setOpen(true);
+            setActiveId(
+              selectedId ?? options[options.length - 1]?.selectionId ?? null
+            );
           } else {
             moveActive(activeIndex - 1);
           }

--- a/src/components/equipment/EquipmentCategoryDropdown.tsx
+++ b/src/components/equipment/EquipmentCategoryDropdown.tsx
@@ -41,6 +41,8 @@ export interface EquipmentCategoryDropdownProps {
   options: EquipmentItem[];
   /** Currently selected option id (controlled), or null. */
   selectedId: string | null;
+  /** Options unavailable in this slot because a sibling selected them. */
+  disabledOptionIds?: ReadonlySet<string>;
   onChange: (id: string) => void;
   /** True while `options` is being fetched. */
   isLoading?: boolean;
@@ -57,6 +59,7 @@ export function EquipmentCategoryDropdown({
   placeholder = '-- Select item --',
   options,
   selectedId,
+  disabledOptionIds = new Set<string>(),
   onChange,
   isLoading = false,
   error = null,
@@ -79,7 +82,18 @@ export function EquipmentCategoryDropdown({
     [options, selectedId]
   );
 
-  const disabled = isLoading || !!error || options.length === 0;
+  const isOptionDisabled = useCallback(
+    (optionId: string) => disabledOptionIds.has(optionId),
+    [disabledOptionIds]
+  );
+  const enabledOptions = useMemo(
+    () => options.filter((option) => !isOptionDisabled(option.selectionId)),
+    [options, isOptionDisabled]
+  );
+  const disabled = isLoading || !!error || enabledOptions.length === 0;
+  const firstEnabledOptionId = enabledOptions[0]?.selectionId ?? null;
+  const lastEnabledOptionId =
+    enabledOptions[enabledOptions.length - 1]?.selectionId ?? null;
 
   // Keep the active (highlighted-while-open) option pointed at something
   // real whenever the option list changes out from under an open dropdown.
@@ -118,11 +132,17 @@ export function EquipmentCategoryDropdown({
 
   const moveActive = useCallback(
     (nextIndex: number) => {
-      if (options.length === 0) return;
-      const clamped = Math.max(0, Math.min(options.length - 1, nextIndex));
-      setActiveId(options[clamped].selectionId);
+      if (enabledOptions.length === 0) return;
+      const direction = nextIndex >= activeIndex ? 1 : -1;
+      let candidate = Math.max(0, Math.min(options.length - 1, nextIndex));
+      while (isOptionDisabled(options[candidate].selectionId)) {
+        const following = candidate + direction;
+        if (following < 0 || following >= options.length) return;
+        candidate = following;
+      }
+      setActiveId(options[candidate].selectionId);
     },
-    [options]
+    [activeIndex, enabledOptions.length, isOptionDisabled, options]
   );
 
   const commit = useCallback(
@@ -141,7 +161,11 @@ export function EquipmentCategoryDropdown({
           event.preventDefault();
           if (!open) {
             setOpen(true);
-            setActiveId(selectedId ?? options[0]?.selectionId ?? null);
+            setActiveId(
+              selectedId && !isOptionDisabled(selectedId)
+                ? selectedId
+                : firstEnabledOptionId
+            );
           } else {
             moveActive(activeIndex + 1);
           }
@@ -151,7 +175,9 @@ export function EquipmentCategoryDropdown({
           if (!open) {
             setOpen(true);
             setActiveId(
-              selectedId ?? options[options.length - 1]?.selectionId ?? null
+              selectedId && !isOptionDisabled(selectedId)
+                ? selectedId
+                : lastEnabledOptionId
             );
           } else {
             moveActive(activeIndex - 1);
@@ -174,7 +200,11 @@ export function EquipmentCategoryDropdown({
           event.preventDefault();
           if (!open) {
             setOpen(true);
-            setActiveId(selectedId ?? options[0]?.selectionId ?? null);
+            setActiveId(
+              selectedId && !isOptionDisabled(selectedId)
+                ? selectedId
+                : firstEnabledOptionId
+            );
           } else if (activeId) {
             commit(activeId);
           }
@@ -201,6 +231,9 @@ export function EquipmentCategoryDropdown({
       commit,
       selectedId,
       options,
+      isOptionDisabled,
+      firstEnabledOptionId,
+      lastEnabledOptionId,
       closeAndFocusTrigger,
     ]
   );
@@ -234,7 +267,13 @@ export function EquipmentCategoryDropdown({
         onClick={() => {
           if (disabled) return;
           setOpen((prev) => !prev);
-          if (!open) setActiveId(selectedId ?? options[0]?.selectionId ?? null);
+          if (!open) {
+            setActiveId(
+              selectedId && !isOptionDisabled(selectedId)
+                ? selectedId
+                : firstEnabledOptionId
+            );
+          }
         }}
         onKeyDown={handleTriggerKeyDown}
         style={{
@@ -341,6 +380,7 @@ export function EquipmentCategoryDropdown({
           {options.map((option) => {
             const isSelected = option.selectionId === selectedId;
             const isActive = option.selectionId === activeId;
+            const optionDisabled = isOptionDisabled(option.selectionId);
             return (
               <div
                 key={option.selectionId}
@@ -350,11 +390,17 @@ export function EquipmentCategoryDropdown({
                 role="option"
                 id={`${rootId}-option-${option.selectionId}`}
                 aria-selected={isSelected}
+                aria-disabled={optionDisabled || undefined}
                 data-testid={`${rootId}-option-${option.selectionId}`}
-                onMouseEnter={() => setActiveId(option.selectionId)}
-                onClick={() => commit(option.selectionId)}
+                onMouseEnter={() => {
+                  if (!optionDisabled) setActiveId(option.selectionId);
+                }}
+                onClick={() => {
+                  if (!optionDisabled) commit(option.selectionId);
+                }}
                 style={{
-                  cursor: 'pointer',
+                  cursor: optionDisabled ? 'not-allowed' : 'pointer',
+                  opacity: optionDisabled ? 0.5 : 1,
                   borderRadius: '6px',
                   outline: isActive
                     ? '2px solid var(--accent-primary)'
@@ -365,7 +411,11 @@ export function EquipmentCategoryDropdown({
                     : 'none',
                 }}
               >
-                <EquipmentCard equipment={option.equipmentDetail!} compact />
+                {option.equipmentDetail ? (
+                  <EquipmentCard equipment={option.equipmentDetail} compact />
+                ) : (
+                  <span>{option.selectionId}</span>
+                )}
               </div>
             );
           })}

--- a/src/hooks/useEquipmentBundleSelection.ts
+++ b/src/hooks/useEquipmentBundleSelection.ts
@@ -80,11 +80,11 @@ export function useEquipmentBundleSelection(
         return null;
       }
 
-      // Flatten all category selections into a single array
-      const allSelectedItems: EquipmentItem[] = [];
-      categorySelections.forEach((items) => {
-        allSelectedItems.push(...items);
-      });
+      // The API assigns category meaning by index; Map insertion follows click
+      // order, so sort explicitly before flattening for stable serialization.
+      const allSelectedItems = [...categorySelections.entries()]
+        .sort(([left], [right]) => left - right)
+        .flatMap(([, items]) => items);
 
       // Convert to proto items
       const protoItems = allSelectedItems.map(createEquipmentSelectionItem);
@@ -128,7 +128,11 @@ export function useEquipmentBundleSelection(
     // Check each category choice has the required selections
     return bundle.categoryChoices.every((category, index) => {
       const selections = categorySelections.get(index) || [];
-      return selections.length >= category.choose;
+      const selectionIds = selections.map((selection) => selection.selectionId);
+      return (
+        selections.length >= category.choose &&
+        new Set(selectionIds).size === selectionIds.length
+      );
     });
   }, [getSelectedBundle, categorySelections]);
 

--- a/src/hooks/useEquipmentBundleSelection.ts
+++ b/src/hooks/useEquipmentBundleSelection.ts
@@ -13,7 +13,22 @@ import {
   EquipmentSelectionItemSchema,
   EquipmentSelectionSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+function hydrateCategorySelections(
+  initialCategoryItemIds?: ReadonlyMap<number, string[]>
+): Map<number, EquipmentItem[]> {
+  return new Map(
+    [...(initialCategoryItemIds ?? new Map<number, string[]>())].map(
+      ([categoryIndex, selectionIds]) => [
+        categoryIndex,
+        selectionIds.map((selectionId) =>
+          create(EquipmentItemSchema, { selectionId })
+        ),
+      ]
+    )
+  );
+}
 
 export function useEquipmentBundleSelection(
   choice: Choice,
@@ -27,22 +42,34 @@ export function useEquipmentBundleSelection(
   // partition rather than collapsing every restored item into category 0.
   const [categorySelections, setCategorySelections] = useState<
     Map<number, EquipmentItem[]>
-  >(
-    () =>
-      new Map(
-        [...(initialCategoryItemIds ?? new Map<number, string[]>())].map(
-          ([categoryIndex, selectionIds]) => [
-            categoryIndex,
-            selectionIds.map((selectionId) =>
-              create(EquipmentItemSchema, { selectionId })
-            ),
-          ]
-        )
-      )
-  );
+  >(() => hydrateCategorySelections(initialCategoryItemIds));
+
+  // A reopened draft's class definitions and its persisted choices load
+  // independently, so this modal can mount before the persisted selection
+  // resolves: `initialBundleId`/`initialCategoryItemIds` then change after
+  // mount, but `useState`'s lazy initializer above only ever runs once.
+  // Sync from the props here instead — once, and only while the player
+  // hasn't already made a selection of their own, so a late-arriving
+  // hydration can never clobber real interaction.
+  const appliedHydrationRef = useRef(false);
+  useEffect(() => {
+    if (appliedHydrationRef.current) return;
+    const hasHydratedBundle = Boolean(initialBundleId);
+    const hasHydratedCategories = Boolean(
+      initialCategoryItemIds && initialCategoryItemIds.size > 0
+    );
+    if (!hasHydratedBundle && !hasHydratedCategories) return;
+
+    appliedHydrationRef.current = true;
+    setSelectedBundleId((prev) => prev ?? initialBundleId ?? null);
+    setCategorySelections((prev) =>
+      prev.size > 0 ? prev : hydrateCategorySelections(initialCategoryItemIds)
+    );
+  }, [initialBundleId, initialCategoryItemIds]);
 
   // When user selects a bundle
   const selectBundle = useCallback((bundleId: string) => {
+    appliedHydrationRef.current = true;
     setSelectedBundleId(bundleId);
     setCategorySelections(new Map()); // Reset category selections when bundle changes
   }, []);
@@ -50,6 +77,7 @@ export function useEquipmentBundleSelection(
   // When user selects items from a category
   const selectCategoryItems = useCallback(
     (categoryIndex: number, items: EquipmentItem[]) => {
+      appliedHydrationRef.current = true;
       setCategorySelections((prev) => {
         const updated = new Map(prev);
         updated.set(categoryIndex, items);

--- a/src/hooks/useEquipmentBundleSelection.ts
+++ b/src/hooks/useEquipmentBundleSelection.ts
@@ -3,6 +3,7 @@ import type {
   Choice,
   ChoiceData,
   EquipmentBundle,
+  EquipmentItem,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import {
   ChoiceCategory,
@@ -11,7 +12,6 @@ import {
   EquipmentSelectionItemSchema,
   EquipmentSelectionSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
-import type { Equipment } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/equipment_types_pb';
 import { useCallback, useState } from 'react';
 
 export function useEquipmentBundleSelection(
@@ -22,13 +22,12 @@ export function useEquipmentBundleSelection(
   const [selectedBundleId, setSelectedBundleId] = useState<string | null>(
     initialBundleId ?? null
   );
-  // Initialize category selections with initial items (all in category 0 for now)
+  // Initialize category selections with initial items (all in category 0 for now).
   const [categorySelections, setCategorySelections] = useState<
-    Map<number, Equipment[]>
+    Map<number, EquipmentItem[]>
   >(() => {
     if (initialItemIds && initialItemIds.length > 0) {
-      // Create Equipment-like objects with just the id (CategorySelector only needs .id)
-      const items = initialItemIds.map((id) => ({ id, name: id }) as Equipment);
+      const items = initialItemIds.map((selectionId) => ({ selectionId }));
       return new Map([[0, items]]);
     }
     return new Map();
@@ -42,7 +41,7 @@ export function useEquipmentBundleSelection(
 
   // When user selects items from a category
   const selectCategoryItems = useCallback(
-    (categoryIndex: number, items: Equipment[]) => {
+    (categoryIndex: number, items: EquipmentItem[]) => {
       setCategorySelections((prev) => {
         const updated = new Map(prev);
         updated.set(categoryIndex, items);
@@ -52,15 +51,15 @@ export function useEquipmentBundleSelection(
     []
   );
 
-  // Helper to create EquipmentSelectionItem from Equipment
-  const createEquipmentSelectionItem = (equipment: Equipment) => {
+  // Helper to create EquipmentSelectionItem from an authoritative option.
+  const createEquipmentSelectionItem = (equipment: EquipmentItem) => {
     // Since Weapon, Armor, etc. are enums (not message types),
     // we use otherEquipmentId for all equipment items
     // The backend knows what they are from the ID
     return create(EquipmentSelectionItemSchema, {
       equipment: {
         case: 'otherEquipmentId',
-        value: equipment.id,
+        value: equipment.selectionId,
       },
     });
   };
@@ -74,7 +73,7 @@ export function useEquipmentBundleSelection(
       }
 
       // Flatten all category selections into a single array
-      const allSelectedItems: Equipment[] = [];
+      const allSelectedItems: EquipmentItem[] = [];
       categorySelections.forEach((items) => {
         allSelectedItems.push(...items);
       });

--- a/src/hooks/useEquipmentBundleSelection.ts
+++ b/src/hooks/useEquipmentBundleSelection.ts
@@ -9,6 +9,7 @@ import {
   ChoiceCategory,
   ChoiceDataSchema,
   ChoiceSource,
+  EquipmentItemSchema,
   EquipmentSelectionItemSchema,
   EquipmentSelectionSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
@@ -17,21 +18,28 @@ import { useCallback, useState } from 'react';
 export function useEquipmentBundleSelection(
   choice: Choice,
   initialBundleId?: string | null,
-  initialItemIds?: string[]
+  initialCategoryItemIds?: ReadonlyMap<number, string[]>
 ) {
   const [selectedBundleId, setSelectedBundleId] = useState<string | null>(
     initialBundleId ?? null
   );
-  // Initialize category selections with initial items (all in category 0 for now).
+  // Reopened drafts encode each selection's category index. Preserve that
+  // partition rather than collapsing every restored item into category 0.
   const [categorySelections, setCategorySelections] = useState<
     Map<number, EquipmentItem[]>
-  >(() => {
-    if (initialItemIds && initialItemIds.length > 0) {
-      const items = initialItemIds.map((selectionId) => ({ selectionId }));
-      return new Map([[0, items]]);
-    }
-    return new Map();
-  });
+  >(
+    () =>
+      new Map(
+        [...(initialCategoryItemIds ?? new Map<number, string[]>())].map(
+          ([categoryIndex, selectionIds]) => [
+            categoryIndex,
+            selectionIds.map((selectionId) =>
+              create(EquipmentItemSchema, { selectionId })
+            ),
+          ]
+        )
+      )
+  );
 
   // When user selects a bundle
   const selectBundle = useCallback((bundleId: string) => {

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -32,6 +32,15 @@ export interface EquipmentChoice {
     categoryIndex: number;
     equipmentIds: string[]; // IDs of equipment selected from this category
   }>;
+  /**
+   * True when reconstructing this choice from persisted wire data found
+   * items left over after the selected bundle's fixed items and every
+   * declared category consumed their slice. That only happens when the
+   * persisted shape doesn't match the declared choice (stale bundle,
+   * schema drift, corruption) — never a legitimately-complete choice.
+   * Absent/false for choices built directly from UI interaction.
+   */
+  hasUnconsumedItems?: boolean;
 }
 
 export interface FeatureChoice {

--- a/src/utils/equipmentChoiceSelections.test.ts
+++ b/src/utils/equipmentChoiceSelections.test.ts
@@ -3,13 +3,20 @@ import {
   ChoiceCategory,
   ChoiceDataSchema,
   ChoiceSchema,
+  ChoiceSource,
   EquipmentBundleSchema,
   EquipmentCategoryChoiceSchema,
+  EquipmentItemSchema,
   EquipmentOptionsSchema,
   EquipmentSelectionItemSchema,
   EquipmentSelectionSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import {
+  Armor,
+  Weapon,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/enums_pb';
 import { describe, expect, it } from 'vitest';
+import { convertEquipmentChoiceToProto } from './choiceConverter';
 import {
   hasNoInvalidEquipmentChoices,
   isCompleteEquipmentChoice,
@@ -91,5 +98,158 @@ describe('persisted equipment-choice hydration', () => {
     expect(hasNoInvalidEquipmentChoices([declaredChoice], [persisted])).toBe(
       false
     );
+  });
+});
+
+describe('persisted mixed-bundle round trip (fixed item + enum-backed categories)', () => {
+  // The real wire shape from rpg-api: a fixed bundle item and toolkit-
+  // enumerated category selections are never `other_equipment_id` — they
+  // carry the same proto enum the API attaches to that item's `typeHint`
+  // (rpg-api converters.go `setEquipmentItemTypeHint` /
+  // `convertEquipmentSelectionToProto`). `shield`/`longsword`/`javelin` are
+  // real toolkit equipment IDs; `Armor.SHIELD` / `Weapon.LONGSWORD` /
+  // `Weapon.JAVELIN` are their real proto enum values.
+  const mixedBundle = create(EquipmentBundleSchema, {
+    id: 'fighter-pack-a',
+    items: [
+      create(EquipmentItemSchema, {
+        selectionId: 'shield',
+        typeHint: { case: 'armor', value: Armor.SHIELD },
+      }),
+    ],
+    categoryChoices: [
+      create(EquipmentCategoryChoiceSchema, {
+        choose: 1,
+        options: [
+          create(EquipmentItemSchema, {
+            selectionId: 'longsword',
+            typeHint: { case: 'weapon', value: Weapon.LONGSWORD },
+          }),
+        ],
+      }),
+      create(EquipmentCategoryChoiceSchema, {
+        choose: 1,
+        options: [
+          create(EquipmentItemSchema, {
+            selectionId: 'javelin',
+            typeHint: { case: 'weapon', value: Weapon.JAVELIN },
+          }),
+        ],
+      }),
+    ],
+  });
+
+  const declaredMixedChoice = create(ChoiceSchema, {
+    id: 'fighter-starting-equipment',
+    choiceType: ChoiceCategory.EQUIPMENT,
+    options: {
+      case: 'equipmentOptions',
+      value: create(EquipmentOptionsSchema, { bundles: [mixedBundle] }),
+    },
+  });
+
+  function persistedMixedChoice(
+    trailingExtra: readonly ('weapon' | 'armor')[] = []
+  ) {
+    return create(ChoiceDataSchema, {
+      choiceId: 'fighter-starting-equipment',
+      optionId: 'fighter-pack-a',
+      category: ChoiceCategory.EQUIPMENT,
+      selection: {
+        case: 'equipment',
+        value: create(EquipmentSelectionSchema, {
+          items: [
+            // Fixed bundle item first — the toolkit's own build order.
+            create(EquipmentSelectionItemSchema, {
+              equipment: { case: 'armor', value: Armor.SHIELD },
+            }),
+            create(EquipmentSelectionItemSchema, {
+              equipment: { case: 'weapon', value: Weapon.LONGSWORD },
+            }),
+            create(EquipmentSelectionItemSchema, {
+              equipment: { case: 'weapon', value: Weapon.JAVELIN },
+            }),
+            ...trailingExtra.map((kind) =>
+              create(EquipmentSelectionItemSchema, {
+                equipment:
+                  kind === 'weapon'
+                    ? { case: 'weapon', value: Weapon.DAGGER }
+                    : { case: 'armor', value: Armor.PADDED },
+              })
+            ),
+          ],
+        }),
+      },
+    });
+  }
+
+  it('offsets category slicing past the fixed item and resolves each enum-backed selection to its authoritative ID, at the declared category index', () => {
+    const persisted = persistedMixedChoice();
+
+    const reconstructed = reconstructEquipmentChoice(
+      declaredMixedChoice,
+      persisted
+    );
+
+    expect(reconstructed.categorySelections).toEqual([
+      { categoryIndex: 0, equipmentIds: ['longsword'] },
+      { categoryIndex: 1, equipmentIds: ['javelin'] },
+    ]);
+    expect(reconstructed.hasUnconsumedItems).toBe(false);
+    expect(isCompleteEquipmentChoice(declaredMixedChoice, reconstructed)).toBe(
+      true
+    );
+  });
+
+  it('reserializes the hydrated selection back to submission wire format, category-only and index-correct', () => {
+    const reconstructed = reconstructEquipmentChoice(
+      declaredMixedChoice,
+      persistedMixedChoice()
+    );
+
+    const resubmitted = convertEquipmentChoiceToProto(
+      reconstructed,
+      ChoiceSource.CLASS
+    );
+
+    expect(resubmitted.optionId).toBe('fighter-pack-a');
+    expect(resubmitted.selection).toEqual({
+      case: 'equipment',
+      value: create(EquipmentSelectionSchema, {
+        items: [
+          create(EquipmentSelectionItemSchema, {
+            equipment: { case: 'otherEquipmentId', value: 'longsword' },
+            quantity: 1,
+          }),
+          create(EquipmentSelectionItemSchema, {
+            equipment: { case: 'otherEquipmentId', value: 'javelin' },
+            quantity: 1,
+          }),
+        ],
+      }),
+    });
+  });
+
+  it('rejects unconsumed trailing persisted items instead of silently finalizing invalid data', () => {
+    const persisted = persistedMixedChoice(['weapon']);
+
+    const reconstructed = reconstructEquipmentChoice(
+      declaredMixedChoice,
+      persisted
+    );
+
+    // The declared categories still resolve correctly — the corruption is
+    // purely the extra trailing item this reconstruction can't account for.
+    expect(reconstructed.categorySelections).toEqual([
+      { categoryIndex: 0, equipmentIds: ['longsword'] },
+      { categoryIndex: 1, equipmentIds: ['javelin'] },
+    ]);
+    expect(reconstructed.hasUnconsumedItems).toBe(true);
+    expect(isCompleteEquipmentChoice(declaredMixedChoice, reconstructed)).toBe(
+      false
+    );
+    expect(
+      hasNoInvalidEquipmentChoices([declaredMixedChoice], [persisted])
+    ).toBe(false);
   });
 });

--- a/src/utils/equipmentChoiceSelections.test.ts
+++ b/src/utils/equipmentChoiceSelections.test.ts
@@ -1,0 +1,95 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  ChoiceCategory,
+  ChoiceDataSchema,
+  ChoiceSchema,
+  EquipmentBundleSchema,
+  EquipmentCategoryChoiceSchema,
+  EquipmentOptionsSchema,
+  EquipmentSelectionItemSchema,
+  EquipmentSelectionSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  hasNoInvalidEquipmentChoices,
+  isCompleteEquipmentChoice,
+  reconstructEquipmentChoice,
+} from './equipmentChoiceSelections';
+
+const declaredChoice = create(ChoiceSchema, {
+  id: 'fighter-starting-equipment',
+  choiceType: ChoiceCategory.EQUIPMENT,
+  options: {
+    case: 'equipmentOptions',
+    value: create(EquipmentOptionsSchema, {
+      bundles: [
+        create(EquipmentBundleSchema, {
+          id: 'fighter-pack-a',
+          categoryChoices: [
+            create(EquipmentCategoryChoiceSchema, { choose: 2 }),
+            create(EquipmentCategoryChoiceSchema, { choose: 1 }),
+          ],
+        }),
+      ],
+    }),
+  },
+});
+
+function persistedDraftChoice(ids: string[]) {
+  return create(ChoiceDataSchema, {
+    choiceId: 'fighter-starting-equipment',
+    optionId: 'fighter-pack-a',
+    category: ChoiceCategory.EQUIPMENT,
+    selection: {
+      case: 'equipment',
+      value: create(EquipmentSelectionSchema, {
+        items: ids.map((id) =>
+          create(EquipmentSelectionItemSchema, {
+            equipment: { case: 'otherEquipmentId', value: id },
+          })
+        ),
+      }),
+    },
+  });
+}
+
+describe('persisted equipment-choice hydration', () => {
+  it('reconstructs declared category slices from the real flat persisted shape', () => {
+    const persisted = persistedDraftChoice([
+      'longsword-selection',
+      'shield-selection',
+      'longsword-selection',
+    ]);
+
+    const reconstructed = reconstructEquipmentChoice(declaredChoice, persisted);
+
+    expect(reconstructed.categorySelections).toEqual([
+      {
+        categoryIndex: 0,
+        equipmentIds: ['longsword-selection', 'shield-selection'],
+      },
+      { categoryIndex: 1, equipmentIds: ['longsword-selection'] },
+    ]);
+    // The same ID remains legitimate when the authoritative bundle declares it
+    // in distinct category requirements.
+    expect(isCompleteEquipmentChoice(declaredChoice, reconstructed)).toBe(true);
+  });
+
+  it('keeps a legacy same-category duplicate invalid, including at final-submit gating', () => {
+    const persisted = persistedDraftChoice([
+      'longsword-selection',
+      'longsword-selection',
+      'shield-selection',
+    ]);
+
+    expect(
+      isCompleteEquipmentChoice(
+        declaredChoice,
+        reconstructEquipmentChoice(declaredChoice, persisted)
+      )
+    ).toBe(false);
+    expect(hasNoInvalidEquipmentChoices([declaredChoice], [persisted])).toBe(
+      false
+    );
+  });
+});

--- a/src/utils/equipmentChoiceSelections.ts
+++ b/src/utils/equipmentChoiceSelections.ts
@@ -1,0 +1,97 @@
+import type {
+  Choice,
+  ChoiceData,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import { ChoiceCategory } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
+import type { EquipmentChoice } from '../types/choices';
+
+function equipmentIds(choiceData: ChoiceData): string[] {
+  if (choiceData.selection?.case !== 'equipment') return [];
+
+  return choiceData.selection.value.items.flatMap((item) => {
+    if (item.equipment?.case === 'otherEquipmentId') {
+      return [item.equipment.value];
+    }
+    if (item.equipment?.case && item.equipment.value !== undefined) {
+      return [String(item.equipment.value)];
+    }
+    return [];
+  });
+}
+
+/**
+ * Persisted equipment selection items are flat on the wire. Their category is
+ * implied by the selected bundle: category choices appear in declaration order
+ * and each consumes `choose` consecutive items.
+ */
+export function reconstructEquipmentChoice(
+  choice: Choice,
+  choiceData: ChoiceData
+): EquipmentChoice {
+  const ids = equipmentIds(choiceData);
+  const bundle =
+    choice.options?.case === 'equipmentOptions'
+      ? choice.options.value.bundles.find(
+          (candidate) => candidate.id === choiceData.optionId
+        )
+      : undefined;
+  let offset = 0;
+
+  return {
+    choiceId: choiceData.choiceId,
+    bundleId: choiceData.optionId,
+    categorySelections: (bundle?.categoryChoices ?? []).map(
+      (category, categoryIndex) => {
+        const choose = category.choose || 1;
+        const selection = ids.slice(offset, offset + choose);
+        offset += choose;
+        return { categoryIndex, equipmentIds: selection };
+      }
+    ),
+  };
+}
+
+/** Mirrors the server's per-category duplicate rule without conflating IDs
+ * that are independently eligible in different category choices. */
+export function isCompleteEquipmentChoice(
+  choice: Choice,
+  selection: EquipmentChoice | undefined
+): boolean {
+  if (!selection || choice.options?.case !== 'equipmentOptions') return false;
+
+  const bundle = choice.options.value.bundles.find(
+    (candidate) => candidate.id === selection.bundleId
+  );
+  if (!bundle) return false;
+
+  return bundle.categoryChoices.every((category, categoryIndex) => {
+    const ids =
+      selection.categorySelections.find(
+        (item) => item.categoryIndex === categoryIndex
+      )?.equipmentIds ?? [];
+    return (
+      ids.length === (category.choose || 1) && new Set(ids).size === ids.length
+    );
+  });
+}
+
+/** Validates only authoritative equipment choices that are present in a draft. */
+export function hasNoInvalidEquipmentChoices(
+  declaredChoices: readonly Choice[],
+  persistedChoices: readonly ChoiceData[]
+): boolean {
+  return persistedChoices
+    .filter((choiceData) => choiceData.category === ChoiceCategory.EQUIPMENT)
+    .every((choiceData) => {
+      const declaredChoice = declaredChoices.find(
+        (choice) => choice.id === choiceData.choiceId
+      );
+      return (
+        declaredChoice !== undefined &&
+        isCompleteEquipmentChoice(
+          declaredChoice,
+          reconstructEquipmentChoice(declaredChoice, choiceData)
+        )
+      );
+    });
+}

--- a/src/utils/equipmentChoiceSelections.ts
+++ b/src/utils/equipmentChoiceSelections.ts
@@ -1,53 +1,99 @@
 import type {
   Choice,
   ChoiceData,
+  EquipmentItem,
+  EquipmentSelectionItem,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import { ChoiceCategory } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/choices_pb';
 import type { EquipmentChoice } from '../types/choices';
 
-function equipmentIds(choiceData: ChoiceData): string[] {
-  if (choiceData.selection?.case !== 'equipment') return [];
-
-  return choiceData.selection.value.items.flatMap((item) => {
-    if (item.equipment?.case === 'otherEquipmentId') {
-      return [item.equipment.value];
-    }
-    if (item.equipment?.case && item.equipment.value !== undefined) {
-      return [String(item.equipment.value)];
-    }
-    return [];
-  });
+function persistedEquipmentItems(
+  choiceData: ChoiceData
+): readonly EquipmentSelectionItem[] {
+  return choiceData.selection?.case === 'equipment'
+    ? choiceData.selection.value.items
+    : [];
 }
 
 /**
- * Persisted equipment selection items are flat on the wire. Their category is
- * implied by the selected bundle: category choices appear in declaration order
- * and each consumes `choose` consecutive items.
+ * Resolves one persisted wire item back to the authoritative `selectionId`
+ * a category's `options` declare for it.
+ *
+ * The wire has two shapes (see rpg-api `convertEquipmentSelectionToProto` /
+ * `setEquipmentItemTypeHint`): an item the toolkit can't enumerate is sent as
+ * `other_equipment_id`, the raw toolkit SelectionID string, used as-is. An
+ * item the toolkit *does* enumerate (weapon/armor/tool/pack/ammunition) is
+ * sent as that proto enum value instead — which is not the selection ID
+ * (e.g. `Weapon.LONGSWORD` on the wire, not the string `"longsword"`). The
+ * only place that enum reliably maps back to a selection ID is this
+ * category's own authoritative `options`: each option's `typeHint` was
+ * populated server-side by the exact same ID -> enum tables used to build
+ * the persisted item, so matching (case, value) against `options` recovers
+ * the real ID without the client duplicating those tables. An item that
+ * matches nothing in `options` is unresolved and dropped, which correctly
+ * leaves the category incomplete rather than fabricating a selection.
+ */
+function resolveCategorySelectionId(
+  item: EquipmentSelectionItem,
+  options: readonly EquipmentItem[]
+): string | undefined {
+  if (!item.equipment?.case) return undefined;
+  if (item.equipment.case === 'otherEquipmentId') {
+    return item.equipment.value;
+  }
+  const match = options.find(
+    (option) =>
+      option.typeHint.case === item.equipment.case &&
+      option.typeHint.value === item.equipment.value
+  );
+  return match?.selectionId;
+}
+
+/**
+ * Persisted equipment selection items are flat on the wire, and that flat
+ * order is the toolkit's own build order (`Draft.buildEquipmentList`): the
+ * selected bundle's fixed `items` first, then each category's selections in
+ * category-declaration order (`Draft.validateCategorySelections`). Hydration
+ * must skip past the fixed-item count before slicing category selections —
+ * starting the slice at zero silently reads shifted data on any bundle that
+ * has fixed items in addition to a category choice.
+ *
+ * Anything left over after the fixed items and every declared category have
+ * consumed their slice is data this reconstruction can't account for (a
+ * stale bundle/category mismatch, schema drift, or corruption) and is
+ * surfaced via `hasUnconsumedItems` rather than silently dropped.
  */
 export function reconstructEquipmentChoice(
   choice: Choice,
   choiceData: ChoiceData
 ): EquipmentChoice {
-  const ids = equipmentIds(choiceData);
+  const items = persistedEquipmentItems(choiceData);
   const bundle =
     choice.options?.case === 'equipmentOptions'
       ? choice.options.value.bundles.find(
           (candidate) => candidate.id === choiceData.optionId
         )
       : undefined;
-  let offset = 0;
+
+  let offset = bundle?.items.length ?? 0;
+
+  const categorySelections = (bundle?.categoryChoices ?? []).map(
+    (category, categoryIndex) => {
+      const choose = category.choose || 1;
+      const slice = items.slice(offset, offset + choose);
+      offset += choose;
+      const equipmentIds = slice
+        .map((item) => resolveCategorySelectionId(item, category.options))
+        .filter((id): id is string => id !== undefined);
+      return { categoryIndex, equipmentIds };
+    }
+  );
 
   return {
     choiceId: choiceData.choiceId,
     bundleId: choiceData.optionId,
-    categorySelections: (bundle?.categoryChoices ?? []).map(
-      (category, categoryIndex) => {
-        const choose = category.choose || 1;
-        const selection = ids.slice(offset, offset + choose);
-        offset += choose;
-        return { categoryIndex, equipmentIds: selection };
-      }
-    ),
+    categorySelections,
+    hasUnconsumedItems: offset < items.length,
   };
 }
 
@@ -58,6 +104,9 @@ export function isCompleteEquipmentChoice(
   selection: EquipmentChoice | undefined
 ): boolean {
   if (!selection || choice.options?.case !== 'equipmentOptions') return false;
+  // Persisted data this reconstruction couldn't fully account for must never
+  // read as a legitimately-complete choice.
+  if (selection.hasUnconsumedItems) return false;
 
   const bundle = choice.options.value.bundles.find(
     (candidate) => candidate.id === selection.bundleId


### PR DESCRIPTION
## What

Implements [#690](https://github.com/KirkDiggler/rpg-dnd5e-web/issues/690). The production `EquipmentBundleChoice` now renders authoritative `EquipmentCategoryChoice.options` directly through the existing accessible rich dropdown/card. It preserves API order and selection IDs, rich details, multiple slots, duplicate selections, submission, and reopened-draft hydration.

#692 merged to `dev`. #690 is closed as an implementation-complete issue; it is not a release tracker. Any future `dev` → `main` promotion must use a distinct release issue/PR.

The category-to-type reconstruction and `ListEquipmentByType` fetch are deleted from this route; `useListEquipmentByType` had no other consumers and is removed. No eligibility inference, fallback option source, Monk exception, or client-side category logic remains.

## Dependencies

- Approved design/tracking: rpg-project#173
- Proto contract: rpg-api-protos#207, `v0.1.118`
- API provider: rpg-api#764
- Toolkit authority/validation: rpg-toolkit#877 and #879

## Proto provenance

`package.json` pins `github:KirkDiggler/rpg-api-protos#v0.1.118`. Fresh `npm ci` resolves the lockfile to `d9ef7d9fb49dd604d93bf88d828cfc27e409debe`, the commit peeled from annotated tag `v0.1.118` (tag object `0a8cf5965a5f726d910cd59ae861b0f5e1e7f451).

## Tests / verification

- New real-path component tests prove API option order + rich details, no `listEquipmentByType` call, authoritative (distinct) selection IDs, multiple slots/duplicates, reopened hydration, and indexed multi-category hydration.
- The dropdown regression proves a closed combobox opens its labelled listbox on ArrowUp.
- Focused component tests and `npm run ci-check`: PASS at the merged head.
- Self-review: PASS (`git diff --check`, dependency provenance, direct-authority boundary, and global hook-use search).

No services or local ports were started.

— asset-pipeline agent, on behalf of KirkDiggler
