### PR TITLE
unit: region authoring prototype (create + attach)

### DIFF
--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -25,8 +25,14 @@ import {
   cellCorners,
   edgeBetweenCells,
 } from './hexLayout';
-import { END_COLOR, resolveMarkerStyle, START_COLOR } from './markerStyle';
+import {
+  END_COLOR,
+  regionArchetypeColor,
+  resolveMarkerStyle,
+  START_COLOR,
+} from './markerStyle';
 import { PlacementMarker } from './PlacementMarker';
+import { regionCentroid } from './regionGeometry';
 import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 
 interface BoardProps {
@@ -317,6 +323,54 @@ export function Board({
         strokeDasharray="3 2"
         pointerEvents="none"
       />
+    );
+  }
+  // Cell-authored semantic regions (rpg-project#180) — READ-ONLY here.
+  // Creation mode is the author surface for regions this round
+  // (TARGET-YAML.md's "regions:" section); edit mode only renders
+  // whatever a document already carries (typically hand-authored in the
+  // YAML pane, or round-tripped from a creation-mode document opened in
+  // edit mode), with no create/select/edit affordance — no pointer
+  // handlers, `pointerEvents="none"` throughout, same as the wall/hole
+  // overlay above. Same `regionArchetypeColor` the interactive creation
+  // board uses, so a region reads as the same archetype in both boards.
+  for (const region of doc.regions) {
+    const color = regionArchetypeColor(region.archetype);
+    for (const [col, row] of region.cells) {
+      trackCellExtent(col, row);
+      const center = cellCenter(col, row);
+      const corners = cellCorners(center, BOARD_HEX_SIZE - 1.5).map(
+        ([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`
+      );
+      structuralOverlay.push(
+        <polygon
+          key={`region-${region.id}-${col}-${row}`}
+          points={corners.join(' ')}
+          fill={color}
+          fillOpacity={0.18}
+          stroke={color}
+          strokeWidth={1}
+          strokeDasharray="3 2"
+          pointerEvents="none"
+        />
+      );
+    }
+    const centroid = regionCentroid(region.cells);
+    const labelPos = cellCenter(centroid.col, centroid.row);
+    structuralOverlay.push(
+      <text
+        key={`region-${region.id}-label`}
+        x={labelPos.x}
+        y={labelPos.y + 3}
+        textAnchor="middle"
+        fill={color}
+        fontSize={9}
+        fontWeight={700}
+        pointerEvents="none"
+        style={{ paintOrder: 'stroke', stroke: '#100d0b', strokeWidth: 3 }}
+      >
+        {region.name ?? region.id}
+      </text>
     );
   }
   if (doc.start) {

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3034,3 +3034,158 @@ tests passing (up from 112 — the 84-test shared base plus #693's 13 plus
 #691's 15, confirming no coverage was lost composing the two — plus 5
 new composition cases), `ci-check` clean (format/lint/typecheck/build/
 test).
+
+## Region-authoring unit: creation, attachment, and the folded backend-sync items (2026-08-03)
+
+Kirk's ask, verbatim: "creating a region and ideally attaching it to the
+next region" — the first real prototype of rpg-project#180 (cell-authored
+semantic room regions), proposed shape only until this round (this file's
+own "Regions section" the rpg-project#175 comment sketched, no mutator
+behind it). Real CST mutators, a creation-mode authoring UI, and an
+edit-mode read-only overlay now exist. Three small backend-sync items
+(facing badge split, holes reconciliation, a status-tracking note) folded
+into the same PR per this unit's brief — see their own subsections below.
+
+### `regions:` — shape, invariants, and where it lives
+
+`RegionDoc { id, name?, archetype, cells: [col,row][] }`
+(`dungeonYaml.ts`), matching the shape Kirk's own rpg-project#175 comment
+already sketched. Full design writeup — including three alternative cell
+encodings considered and rejected (run-length, bounding-box bitmap,
+per-row span list — all premature for the small regions this concept
+authors today) and the open questions this prototype deliberately does
+NOT decide (rooms/regions precedence in one document, whether regions
+must fully tile the space, minimum region size) — lives in
+`TARGET-YAML.md`'s new "regions:" section, not duplicated here.
+
+Client-side validation (`validateRegionCells`, `regionGeometry.ts`'s
+`cellsAreContiguous`/BFS) enforces exactly rpg-project#180's own
+acceptance criteria — non-empty, orthogonally contiguous, non-overlapping
+— on every mutator that changes a region's cell set
+(`createRegion`/`addCellToRegion`/`removeCellFromRegion`), not just at
+creation. `removeCellFromRegion` additionally refuses to empty a region
+(delete it instead) or split it into two disconnected pieces.
+
+### Attachment: a door edge on the shared boundary, distinct from chain `connectors:`
+
+`connectRegions` (`dungeonYaml.ts`) computes every shared orthogonal
+boundary edge between two regions (`regionGeometry.ts`'s
+`sharedBoundaryEdges`) and places a door on the MIDPOINT one
+(`pickAttachmentEdge`) via the existing `setWallEdge` mutator — mechanically
+just another `walls:` entry. Verified against the real
+`dungeonspec.Validate` source (rpg-project#175's own spot-check finding,
+re-confirmed here): an authored door edge does NOT replace, satisfy, or
+count as a chain connector — `connectors:` stays independently
+chain-constrained. `TARGET-YAML.md`'s new "Region attachment vs. chain
+connectors" section has the full side-by-side comparison.
+
+### UI: creation-mode paint-then-name, edit-mode read-only
+
+`creation/useRegionEditing.ts` (state: pending cells for a not-yet-created
+region, the selected existing region) + `creation/RegionPanel.tsx` (the
+floating create/connect/edit panel, `Inspector.tsx`'s visual language) +
+`CreationBoard.tsx`'s region-tool pointer handling and tinted-overlay
+rendering. Palette gets a 4th Structural row, **creation-mode only**
+(`Palette.tsx`'s new `showRegionTool` prop, `false` by default — edit
+mode's own `Palette` usage never passes it). Immediately after creating a
+SECOND-or-later region, the panel offers a one-click "Connect to
+'&lt;previous region&gt;'?" prompt if the two share a boundary — the
+"ideally attaching it to the next region" flow named directly.
+
+**A real bug caught by live verification, not just unit tests**: the
+panel's own early-return guard (`if (pendingCells.length === 0 &&
+!editingRegion) return null`) didn't account for the just-created-region
+state (`justCreatedId`), so the "connect to previous" callout never
+rendered — the panel just vanished the instant a region was created, no
+matter how many other regions already existed. Unit tests never caught
+this because they call the mutators directly, never render the component;
+only driving the actual browser (see "Live verification" below) surfaced
+it. Fixed by adding `justCreatedId` to the guard's own condition.
+
+Edit mode (`Board.tsx`, hex-true) renders any `regions:` a document
+carries — hand-typed in the YAML pane, or round-tripped from a document
+first built in creation mode — as a read-only tinted-hex overlay +
+centroid label (`regionGeometry.ts`'s `regionCentroid`), same archetype
+coloring (`markerStyle.ts`'s new `regionArchetypeColor`) as the creation
+board's own overlay, `pointerEvents="none"` throughout — no create/edit
+affordance there this round, matching this unit's own brief.
+
+### Folded sync item (a): facing badge now splits by entry type
+
+A real backend probe (rpg-project#175's "Backend feedback: exercising the
+new authoring API" comment, 2026-08-03) found floor-prop `facing` now
+genuinely compiles on Kirk's authoring branch — but ONLY for a
+room-scoped, non-monster, non-`mount:wall` placement; every other entry
+type (monster, boss, wall-mount) decodes and is then explicitly rejected
+(`"facing only supported on room-scoped floor props"`). The Inspector's
+single `TargetDialectBadge` on `facing` was therefore overstating "not yet
+compiled" uniformly the moment part of the field became real for one
+shape. Fixed: a new `FacingConservativeBadge` (`Inspector.tsx`) renders
+instead of the ordinary dialect badge whenever the selected placement is a
+monster, a boss, or `mount: wall` — its tooltip carries the real
+validator's own rejection message. `TARGET-YAML.md`'s "compile status now
+varies by entry type" section has the full per-entry-type table.
+
+### Folded sync item (b): holes reconciled out of the main specimen
+
+The v0.1/v0.2 kitchen-sink specimen inconsistently carried a `holes:`
+entry despite holes being deliberately deferred from the near-term dialect
+— fixed by dropping `holes:` from `kitchen-sink.yaml` (v0.3) and adding a
+small standalone `specimens/exploration/holes.yaml`, generated the same
+way (the real serializer, not hand-typed), so demonstrating the retained
+prototype never implies it carries the main pack's status. See
+`specimens/README.md`'s v0.3 changelog.
+
+### Folded sync item (c): status-tracking note, not a badge flip
+
+`start:` and floor-prop `facing` both now compile on Kirk's authoring
+branch (same 2026-08-03 probe) — but that branch is UNRELEASED, so every
+badge in this concept stays exactly as it was (target-dialect / the new
+conservative variant) until the branch actually merges. `TARGET-YAML.md`'s
+new "Status tracking note" section records this so the next session
+doesn't have to re-discover it, while being explicit that this note alone
+is not authorization to flip any badge.
+
+### Specimen pack v0.3
+
+`kitchen-sink.yaml` regenerated via the real serializer (the README's
+documented throwaway-`_regen.test.ts` process, not hand-typed): two
+regions (`hall-inner`, `hall-annex`) inside `hall`'s absolute column
+range, connected via `connectRegions` — the resulting door edge is a
+THIRD `walls:` entry, counted under the existing `"3 walls"` drop tally;
+`regions:` itself drops as a new, independent `"2 regions"` entry.
+`specimens/README.md`'s changelog has the full diff.
+
+### Live verification
+
+Real browser, real dev server (`npm run dev -- --port 5173`, this
+concept's own `/concepts?concept=dungeon-builder` route), driven via a
+throwaway Playwright script (`game-dev/tools/browser/_job_regions_*.mjs`,
+gitignored scratch pattern, not this repo). Three screenshots:
+
+1. A 2×2 region ("North Alcove") painted, created, and rendered with its
+   tinted overlay + label on the creation board, the Palette's Region row
+   showing a live count, and the proposed-YAML pane showing the real
+   `regions:` block this session's own click sequence produced.
+2. A second adjacent region ("East Annex") created, the "Connect to
+   'North Alcove'?" prompt accepted, and the resulting door
+   (`{ from: [5,4], to: [4,4], kind: door }`) visible in both the board
+   overlay and the YAML pane — the exact edge `pickAttachmentEdge`'s
+   midpoint rule predicts for this two-edge boundary.
+3. Edit mode (hex-true board) rendering a hand-typed `regions:` block
+   read-only — the "Inner Sanctum" region's tinted hex overlay + label,
+   and the compile-badge strip correctly showing "Uses: 1 region — not
+   yet compiled server-side" (the existing generic `dropped`-array badge
+   mechanism, unchanged, picking up the new construct automatically).
+
+The two expected `PutDungeon`/authoring-service console errors
+(`[unimplemented] unknown service ...AuthoringService`) are this concept's
+normal FIXTURES-MODE behavior against a dev server with no local `rpg-api`
+running — not a regression, and unrelated to regions.
+
+162 dungeon-builder tests passing (up from 117 — 45 new: 28 in
+`dungeonYaml.test.ts`'s new `regions:` describe block covering parse,
+every mutator, `connectRegions`, comment-safety, and `stripToV1Subset`;
+17 in the new `regionGeometry.test.ts` covering the pure adjacency/
+contiguity/boundary-edge/centroid math directly). `ci-check` clean
+(format/lint/typecheck/build/test).

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -13,6 +13,7 @@ import { ConnectorInspector } from './ConnectorInspector';
 import { CreationConcept } from './creation/CreationConcept';
 import type { DemoActions } from './creation/demoScript';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
+import { useRegionEditing } from './creation/useRegionEditing';
 import './DungeonBuilderConcept.css';
 import {
   buildWalkItYaml,
@@ -272,6 +273,17 @@ export function DungeonBuilderConcept() {
     syncFromCreationCst,
     flashToast
   );
+  // Cell-authored semantic region editing (rpg-project#180) —
+  // creation-mode-only this round (TARGET-YAML.md's "regions:" section).
+  // Same cst/doc/syncFromCst wiring as `creationEdit` above, since regions
+  // live on the SAME creation-mode CST every other creation-mode mutator
+  // does.
+  const regionEdit = useRegionEditing(
+    creationCst,
+    creationDoc,
+    syncFromCreationCst,
+    flashToast
+  );
 
   const handleCreationToggleWallEdge = (
     from: [number, number],
@@ -462,6 +474,7 @@ export function DungeonBuilderConcept() {
           onNewCanvas={handleNewCanvas}
           demoActions={creationDemoActions}
           toast={flashToast}
+          regionEdit={regionEdit}
           paletteCollapsed={createPaletteCollapsed}
           onTogglePalette={() => setCreatePaletteCollapsed((c) => !c)}
           yamlCollapsed={createYamlCollapsed}

--- a/src/concepts/dungeon-builder/Inspector.tsx
+++ b/src/concepts/dungeon-builder/Inspector.tsx
@@ -109,6 +109,47 @@ function ExperimentBadge() {
   );
 }
 
+/** More conservative than `TargetDialectBadge` for exactly one field:
+ * `facing` on a monster, a boss, or a `mount: wall` placement. Per the
+ * 2026-08-03 backend probe (rpg-project#175's "Backend feedback:
+ * exercising the new authoring API" comment — real `PutDungeon` calls
+ * against an isolated authoring server, not a guess): floor-prop `facing`
+ * on a room-scoped, non-monster, non-wall-mounted placement now genuinely
+ * COMPILES on Kirk's branch, but a monster's, a boss's, or a wall-mount's
+ * `facing` decodes and is then explicitly rejected — the real validator's
+ * own error names the constraint verbatim: `"facing only supported on
+ * room-scoped floor props"`. `TargetDialectBadge` alone ("not yet
+ * compiled server-side") reads as one uniform claim about the WHOLE
+ * `facing` field; it stops being honest the moment part of that field is
+ * real for one entry type and still rejected for three others. This badge
+ * says so explicitly rather than lumping every entry type under the same
+ * blanket "not yet compiled" language. */
+function FacingConservativeBadge() {
+  return (
+    <span
+      title={
+        'not yet server-supported for this entry type — the real validator ' +
+        'compiles facing ONLY for room-scoped, non-monster, non-wall-mounted ' +
+        '(floor-standing) props (rpg-project#175 backend probe, 2026-08-03: ' +
+        '"facing only supported on room-scoped floor props"). A plain ' +
+        "room-scoped floor prop's facing is real on Kirk's branch — see " +
+        'the other facing badge for that case.'
+      }
+      style={{
+        fontSize: 9,
+        color: '#ffb347',
+        background: '#2a2015',
+        border: '1px solid #5a4a1f',
+        borderRadius: 3,
+        padding: '1px 5px',
+        marginLeft: 6,
+      }}
+    >
+      not yet supported (this entry type)
+    </span>
+  );
+}
+
 /** A field is showing its ref's `defaults:` entry (target dialect,
  * proposed — `resolvePlacement`'s own doc comment), not a value set on
  * this placement itself. Distinct, muted color from both badges above so
@@ -455,7 +496,11 @@ export function Inspector({
           ↻
         </button>
         <span>facing</span>
-        <TargetDialectBadge />
+        {isMonster || selected.boss || mount === 'wall' ? (
+          <FacingConservativeBadge />
+        ) : (
+          <TargetDialectBadge />
+        )}
         {inherited.facing && <InheritedTag />}
         {canRevert.facing && (
           <RevertToDefaultButton onClick={() => onSetFacing(null)} />

--- a/src/concepts/dungeon-builder/Palette.tsx
+++ b/src/concepts/dungeon-builder/Palette.tsx
@@ -39,6 +39,14 @@ interface PaletteProps {
   onSelectTool: (tool: BoardTool | null) => void;
   wallCount: number;
   holeCount: number;
+  /** Region tool (rpg-project#180) — creation-mode-only this round
+   * (TARGET-YAML.md's "regions:" section: "creation-mode is the author
+   * surface this round"). `false`/omitted hides the row entirely rather
+   * than showing an inert tool — edit mode still RENDERS any authored
+   * regions read-only (`Board.tsx`), it just doesn't offer a way to
+   * create/edit them yet. */
+  showRegionTool?: boolean;
+  regionCount?: number;
 }
 
 const CATEGORY_LABELS: Record<PaletteCategory, string> = {
@@ -255,6 +263,8 @@ export function Palette({
   onSelectTool,
   wallCount,
   holeCount,
+  showRegionTool = false,
+  regionCount = 0,
 }: PaletteProps) {
   const [openCategories, setOpenCategories] = useState<Set<PaletteCategory>>(
     new Set<PaletteCategory>(['obstacles-props'])
@@ -380,7 +390,7 @@ export function Palette({
 
       <CategorySection
         category="structural"
-        count={3}
+        count={showRegionTool ? 4 : 3}
         open={openCategories.has('structural')}
         onToggle={() => toggle('structural')}
       >
@@ -411,6 +421,17 @@ export function Palette({
           onClick={() => toggleTool('hole')}
           deferred
         />
+        {showRegionTool && (
+          <Row
+            color="#3a9b6a"
+            short="R"
+            label="Region"
+            sub={`${regionCount}× drawn — paint cells, then name + connect (rpg-project#180)`}
+            isSelected={selectedTool === 'region'}
+            onClick={() => toggleTool('region')}
+            notCompiled
+          />
+        )}
         <p
           style={{
             fontSize: 11,

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -821,6 +821,259 @@ semantic region only when gameplay identity—not geometry alone—requires it.
 Branching topology then follows from the same canonical-edge/semantic-region
 model, rather than from giving every wall its own room boundary.
 
+## `regions:` — cell-authored semantic room regions (rpg-project#180)
+
+Target dialect, proposed — not compiled server-side, and not emitted by
+this concept before this round (the "Regions section" this file used to
+carry, and the matching sketch posted to rpg-project#175, were both
+proposed-shape-only with no mutator behind them; a real create/edit/
+attach UI and CST mutators now exist — see `dungeonYaml.ts`'s
+`createRegion`/`addCellToRegion`/`removeCellFromRegion`/`renameRegion`/
+`setRegionArchetype`/`deleteRegion`/`connectRegions` and
+`creation/RegionPanel.tsx`).
+
+Per the settled early-authoring model above (rpg-project#175): dungeon
+space owns canonical wall/door edges; rooms are stable semantic regions
+carrying reveal/placement/spawning/scripting/archetype meaning; an inner
+wall never splits a semantic room. `regions:` is the CELL-NATIVE
+alternative to the declared `rooms:` chain for expressing that same
+"stable semantic region" concept — instead of an `id`/`archetype`/`width`
+against a server-computed `start_column`, a region is an explicit list of
+absolute `[col,row]` cells, so it can be non-rectangular and takes no part
+in the linear connector chain at all.
+
+```yaml
+regions:
+  - id: shrine-inner
+    name: 'Shrine — Inner Sanctum' # optional; id doubles as the label otherwise, same as a room (RoomDoc has no separate name field either)
+    archetype: chamber # same vocabulary RoomDoc.archetype uses: entrance | chamber | corridor | boss
+    cells: [[9, 2], [9, 3], [9, 4], [10, 2], [10, 3], [10, 4]] # absolute [col,row], same space every other cell-native field uses
+```
+
+### Shape
+
+`RegionDoc { id: string; name?: string; archetype: string; cells:
+[number, number][] }` — see `dungeonYaml.ts`'s own doc comment for the
+full rationale. `name` is the one field a declared room doesn't have
+(CONTRACT.md's "room display names" finding: `id` doubles as the label for
+a room); it's offered here only because a hand-authored region id is more
+likely to be an opaque slug (`region-3`) than a room chain's own
+meaningful ids (`entry`, `vault`).
+
+**Alternatives considered for the cell encoding**, before settling on the
+plain `[[c,r],...]` array Kirk's own rpg-project#175 sketch already used:
+
+- **A compact run-length encoding** (e.g. row ranges per column) — rejected
+  as premature: every region this concept has authored or is likely to in
+  the near term is small (a handful to a few dozen cells), so the byte
+  savings don't yet justify a harder-to-hand-edit, harder-to-diff shape. A
+  plain cell list is also what a future real validator's own error
+  messages (à la the connector/boss messages already seen in the backend
+  probe) can point at directly, cell by cell.
+- **A bitmap/grid mask scoped to the region's own bounding box** (`origin:
+[c,r], mask: [[0,1,1],[1,1,0]]`) — rejected for the same reason
+  cell-painting lost to edge-painting for `walls:` (CONTRACT.md's
+  "wall-drawing interaction" finding): a mask needs a second decode step
+  before any consumer (this board, a future server) can answer "is cell
+  X in this region," where a flat cell list answers it by direct
+  membership. It would also complicate a sparse/scattered region (unusual,
+  but not disallowed — see "Open questions" below) far more than it helps
+  a compact rectangular one.
+- **Reusing `rooms:`'s `width`-against-`start_column` shape, generalized
+  to non-rectangular via a per-row `[startCol, endCol]` pair list** —
+  rejected: this is really the run-length encoding above wearing a
+  room-flavored name, and inherits the same "premature" objection; it also
+  couldn't express a region with more than one contiguous span in a single
+  row (an author drawing an L-shape or a room with a wall-hugging alcove)
+  without escalating to a list-of-lists anyway, at which point it's no
+  simpler than the flat cell list.
+
+### Invariants — validated client-side, matching rpg-project#180's own acceptance criteria
+
+`dungeonYaml.ts`'s `validateRegionCells` enforces exactly what #180's
+issue body already states as acceptance criteria ("Overlapping,
+disconnected, empty, and invalid cell sets fail with author-facing
+validation errors"), so this concept's authoring surface can never
+produce a region shape the eventual real #180 validator is already known
+to reject:
+
+- **Non-empty** — a region needs at least one cell.
+- **Orthogonally contiguous** — every cell must be reachable from every
+  other cell in the same region via 4-neighbor (not diagonal) adjacency
+  (`regionGeometry.ts`'s `cellsAreContiguous`, a plain BFS/flood-fill).
+  Diagonal-only adjacency doesn't count, matching `walls:`'s own
+  "orthogonally adjacent cells" requirement — there is no diagonal edge to
+  ever author a wall/door on between two cells that only touch at a
+  corner.
+- **Non-overlapping** — no cell may belong to more than one region at
+  once (`cellsOverlapAnotherRegion`). Enforced on create AND on every
+  membership edit (`addCellToRegion`), not just at creation time.
+- **No duplicate cell within one region's own list.**
+
+These four are enforced on every mutator that changes a region's cell
+set — `createRegion`, `addCellToRegion`, and (its own mirror-image
+version: removing a cell must not leave the region empty or split it in
+two) `removeCellFromRegion`.
+
+### Open questions this prototype records, and deliberately does NOT decide
+
+Per rpg-project#180's own acceptance criteria and non-goals, plus what
+this round's implementation had to assume to ship something usable —
+recorded here rather than silently decided, same discipline
+`defaults:`'s own "Open questions" section above follows:
+
+- **Precedence between a declared `rooms:` chain and `regions:` in the
+  SAME document.** #180's acceptance criteria call for "existing
+  rectangular specs retain a documented compatibility path," but don't say
+  what that path IS. This prototype does not attempt reconciliation: a
+  document can carry both `rooms:` and `regions:` today with no
+  cross-validation between them (a region's cells are never checked
+  against a declared room's own column range, or vice versa) — the two
+  are simply independent lists as far as this concept's own parser/board
+  are concerned. Recommendation, not a decision: the cleanest eventual
+  answer is probably that `regions:` supersedes `rooms:` once a document
+  declares any — i.e. a document picks ONE of the two topology models,
+  not both at once — but that's a real server-side compiler decision
+  #180's own implementer should make, not something a client-side
+  prototype should quietly assume by, say, hiding `rooms:` the moment
+  `regions:` appears.
+- **Must regions fully tile the dungeon's space?** No — not enforced, and
+  recommended not to be. Per the settled model, dungeon space owns
+  edges independent of semantic rooms/regions; a region is a claim about
+  gameplay identity for the cells it lists, not a partition of the whole
+  canvas. Sparse, disjoint regions (with "unclaimed" cells between or
+  around them) are allowed by this prototype's own validation.
+- **Minimum region size.** A single-cell region is allowed (trivially
+  contiguous, trivially non-overlapping) — not explicitly ruled in or out
+  by #180's issue body, but nothing about the acceptance criteria implies
+  a floor above 1.
+- **Does an inner wall inside a region ever split it?** No — this follows
+  directly from the settled model (rpg-project#175/#179), not a new
+  decision this file is making: "an inner wall never splits a semantic
+  room" applies to a `regions:`-declared region exactly as it does to a
+  `rooms:`-declared one. Drawing a `walls:` edge entirely inside one
+  region's cells changes movement/line-of-sight only; the region's own
+  `cells:` membership is untouched by any wall mutator.
+
+### Region attachment vs. chain `connectors:` — deliberately distinct constructs
+
+"Attach to the next region" (Kirk's ask) is implemented as placing a DOOR
+edge on the shared boundary between two regions — mechanically nothing
+more than an ordinary `walls:` entry with `kind: door`
+(`dungeonYaml.ts`'s `connectRegions`, `regionGeometry.ts`'s
+`sharedBoundaryEdges`/`pickAttachmentEdge`). This is DELIBERATELY NOT the
+same construct as a chain `connectors:` entry, and the distinction matters
+enough to spell out, not just imply:
+
+|                         | chain `connectors:`                                                                                                                                                       | region-attachment door                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `from`/`to`             | fixed by declared-room ARRAY ORDER — never independently authorable (`validateChain`, verified against the real Go source: "Why connectors have no add/remove UI," above) | freely chosen — any shared boundary edge between any two regions |
+| Cardinality             | exactly `len(rooms)-1`, always                                                                                                                                            | zero, one, or many between any pair of regions                   |
+| Server validation today | real, v1, `dungeonspec.Validate`                                                                                                                                          | none — this is a `walls:` entry, itself target-dialect-only      |
+| What it IS              | a required link in the linear room chain                                                                                                                                  | wall/door geometry only                                          |
+
+Per rpg-project#175's own spot-check finding (confirmed against the real
+`validateChain` source): **an authored door edge does NOT replace,
+satisfy, or count as a chain connector.** A document with two regions
+connected by a region-attachment door still needs its OWN, independently
+satisfied `connectors:` list if it also declares a `rooms:` chain — the
+two constructs coexist without one implying the other. Connecting two
+regions this way, on a `regions:`-only (no `rooms:`) document, produces a
+dungeon with real wall/door geometry between two semantic areas but NO
+chain topology at all — consistent with "the linear chain is a current
+encoding, not the permanent geometry model" (see "Why connectors have no
+add/remove UI," above): a `regions:`-only document was never trying to
+express a linear chain in the first place.
+
+**Which edge, when a boundary has more than one**: the MIDPOINT edge
+along the shared boundary run, chosen automatically
+(`pickAttachmentEdge`) rather than letting the author click a specific
+edge — the simplest first-pass choice, at the cost of not handling an
+L-shaped or multi-segment boundary as gracefully as an interactive picker
+would. See `regionGeometry.ts`'s own doc comment for the exact
+(deterministic, but not physically-distance-ordered) tie-breaking rule.
+An author who wants a DIFFERENT edge than the one auto-picked can still
+draw one directly with the Wall/Door tools — `connectRegions` is a
+convenience for the common case, not the only way to place a door between
+two regions.
+
+### UI: creation-mode-only this round
+
+The Region tool (Palette's Structural category, a 4th row alongside
+Wall/Door/Hole) exists only in creation mode
+(`creation/CreationBoard.tsx`, `creation/RegionPanel.tsx`,
+`creation/useRegionEditing.ts`) — matching this file's own "Settled early
+model" framing that a from-scratch canvas is the natural home for
+freeform, cell-native authoring. Painting cells with no region selected
+builds a PENDING (not-yet-created) region; a floating panel
+(`RegionPanel.tsx`, same visual language as `Inspector.tsx`) lets the
+author set an auto-suggested id, an optional name, and an archetype, then
+Create. Clicking an already-existing region selects it for editing:
+rename, change archetype, add/remove member cells by clicking board
+cells, connect to any other existing region, or delete. Immediately after
+a create, if a PREVIOUS region exists and shares a boundary, the panel
+offers a one-click "Connect to '<previous region>'?" prompt — the
+"ideally attaching it to the next region" flow Kirk's ask named directly.
+
+Edit mode (`Board.tsx`, the hex-true board) renders any `regions:` a
+document carries — hand-authored in the YAML pane, or round-tripped from
+a document first built in creation mode — as a read-only tinted-hex
+overlay + centroid label, same archetype coloring
+(`markerStyle.ts`'s `regionArchetypeColor`) as the creation board's own
+overlay, but with zero interaction: no tool exists there to create, edit,
+or delete a region this round.
+
+## `place:`/`boss:` facing — compile status now varies by entry type (2026-08-03)
+
+**Update, 2026-08-03, from a real backend probe (rpg-project#175's
+"Backend feedback: exercising the new authoring API" comment) — this
+supersedes the blanket "not yet compiled" framing this section's own
+badge used to give `facing` uniformly.** Reflection + `validate_only`
+calls against Kirk's authoring branch show floor-prop `facing` genuinely
+COMPILES now — but only for one specific shape: a room-scoped, non-monster,
+non-`mount:wall` placement. Every other entry type still decodes (the
+field is now schema-known) and is then explicitly rejected, with an
+author-actionable message naming the constraint: `"facing only supported
+on room-scoped floor props"`.
+
+| Entry type                                                        | Compile status                                                                                                                                                                                                                  |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| room-scoped floor prop (`mount` unset/`floor`, not a monster ref) | **compiles** — real, on Kirk's branch                                                                                                                                                                                           |
+| monster `place:` entry                                            | decodes, rejected ("floor props" only)                                                                                                                                                                                          |
+| `boss:` entry                                                     | decodes, rejected (same message)                                                                                                                                                                                                |
+| `mount: wall` placement (any ref)                                 | decodes, rejected (same message)                                                                                                                                                                                                |
+| top-level `place:` (any ref, any mount)                           | rejected for an INDEPENDENT reason first — top-level placement itself isn't supported yet ("place[0]: unsupported capability: top-level placement is not supported") — facing's own support never gets evaluated for this shape |
+
+The Inspector now renders TWO different badges on the same `facing`
+control depending on which of these applies to the currently-selected
+placement (`Inspector.tsx`'s `FacingConservativeBadge` vs.
+`TargetDialectBadge`) — a monster, a boss, or a `mount: wall` selection
+shows the more conservative "not yet supported (this entry type)" badge
+with the real validator's own rejection message in its tooltip; a plain
+room-scoped floor prop keeps the ordinary "target dialect, proposed"
+badge, which is now honestly stale in the OPPOSITE direction (see the
+tracking note immediately below) rather than overstated.
+
+## Status tracking note (2026-08-03): two fields now compile on Kirk's branch, unreleased
+
+Per the same rpg-project#175 backend-probe comment: **`start:`** (a bare
+`start: [c,r]`) and **floor-prop `facing`** (the one entry-type shape
+named above) now genuinely compile against Kirk's authoring branch — `start:`
+directly overrides the generator-chosen `FloorPlan.entrance`, exactly the
+"feed straight through, no generator step" resolution this file's own
+"Start/end" section left as an open question. **This branch is
+unreleased** — the shared, gate-off `rpg-api` instance this concept's own
+live-verification arc otherwise talks to does not have it yet. Every
+badge in this concept (`TargetDialectBadge` on `start:`, the facing split
+above) stays exactly as it is — "target dialect, proposed" / the new
+conservative variant — until the branch actually merges/releases; this
+note exists purely so the NEXT session that touches either field knows
+real server support already exists upstream, rather than re-discovering
+it from scratch. Do not flip either badge to "compiles" based on this
+note alone — badge state should track what the shared server this
+concept's own live-preview probe actually reaches, not what exists on an
+unmerged branch.
+
 ## The v1-subset strip — what actually reaches `PutDungeon`
 
 This concept NEVER sends a target-dialect document to the real server. Before any
@@ -828,15 +1081,16 @@ live `validate_only` preview call or a real `Save & Play`, the current
 document is stripped down to exactly what v1 compiles
 (`dungeonYaml.ts`'s `stripToV1Subset`):
 
-| Field                                              | v1 subset                                                                                                                                                          |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `version`                                          | forced to `1` (never `2` — see the annotated example's own note)                                                                                                   |
-| `key`, `name`, `theme`, `height`                   | kept as-is                                                                                                                                                         |
-| `rooms:`                                           | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                              |
-| `connectors:`                                      | kept as-is, including `locked:`                                                                                                                                    |
-| top-level `place:`                                 | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                           |
-| `canvas:`, `walls:`, `start:`, `end:`, `lighting:` | dropped entirely                                                                                                                                                   |
-| `defaults:`                                        | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above |
+| Field                                              | v1 subset                                                                                                                                                                                          |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`                                          | forced to `1` (never `2` — see the annotated example's own note)                                                                                                                                   |
+| `key`, `name`, `theme`, `height`                   | kept as-is                                                                                                                                                                                         |
+| `rooms:`                                           | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                                                              |
+| `connectors:`                                      | kept as-is, including `locked:`                                                                                                                                                                    |
+| top-level `place:`                                 | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                                                           |
+| `canvas:`, `walls:`, `start:`, `end:`, `lighting:` | dropped entirely                                                                                                                                                                                   |
+| `regions:`                                         | dropped entirely — no v1 representation of any kind (dungeonspec only knows the declared `rooms:` chain); a region-attachment door edge (`walls:`) is stripped independently, see "regions:" above |
+| `defaults:`                                        | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above                                 |
 
 If, after stripping, `rooms:` has fewer than 2 entries (dungeonspec's own
 `minRooms = 2`), there IS no compilable subset — a from-scratch canvas
@@ -869,24 +1123,40 @@ false)` of the whole document.
   catches up to the concept, instead of Save & Play just going dark the
   moment an author touches a target field.
 
-## Structural palette category (Kirk's 2026-08-02 addition)
+## Structural palette category (Kirk's 2026-08-02 addition, Region added 2026-08-03)
 
-The early Structural palette is **Wall, Door**. Unlike the other categories
-(draggable/placeable refs), these are TOOLS: selecting one arms a board click
-behavior (paint a wall or toggle a wall's kind) rather than placing a single
-ref at a cell. The existing Hole control is a retained prototype, not early-
-dialect UI; use Obstacles & Props for collapse visuals. Door here means "toggle
-an authored wall segment's `kind` between `solid` and `door`" — a target-dialect-only
-concept, distinct from `ConnectorInspector`'s real, v1 `locked:` editing
-on the chain's own doors (both are real, both are "doors," they answer
-different questions: a connector's door is WHERE the chain already
-crosses between two declared rooms; a wall's door is a door on a
-segment the author drew, wherever they drew it).
+The early Structural palette is **Wall, Door, Hole**, plus **Region**
+(creation mode only — see "regions:" above) since this round. Unlike the
+other categories (draggable/placeable refs), these are TOOLS: selecting
+one arms a board click behavior (paint a wall, toggle a wall's kind, paint
+region membership) rather than placing a single ref at a cell. Door here
+means "toggle an authored wall segment's `kind` between `solid` and
+`door`" — a target-dialect-only concept, distinct from
+`ConnectorInspector`'s real, v1 `locked:` editing on the chain's own doors
+(both are real, both are "doors," they answer different questions: a
+connector's door is WHERE the chain already crosses between two declared
+rooms; a wall's door is a door on a segment the author drew, wherever they
+drew it) — and ALSO distinct from a region-attachment door (see "Region
+attachment vs. chain connectors," above): three different "door" concepts
+in this one dialect, each answering a different question.
 
-The retained Hole prototype is not part of this early target dialect.
-For now, use an obstacle/prop for a collapse visual; do not infer no-floor,
-movement, line-of-sight, falling, bridging, or vertical-traversal semantics
-from that prototype.
+**Holes reconciled (2026-08-03) — moved out of the main kitchen-sink
+specimen, into an exploration appendix.** The retained Hole prototype is
+NOT part of this early target dialect (unchanged from before this round —
+see "Holes are deliberately deferred," above) — but the v0.1/v0.2
+kitchen-sink specimen (`specimens/kitchen-sink.yaml`) inconsistently
+included a `holes:` entry anyway, which read as a stronger commitment than
+"deferred exploration" actually is: a reader skimming the specimen would
+reasonably conclude holes are as real as walls/start/end, since they sat
+in the same main document. Fixed by regenerating the kitchen-sink specimen
+WITHOUT `holes:` (v0.3, see `specimens/README.md`'s changelog) and moving a
+minimal holes sample into a clearly-labeled
+`specimens/exploration/holes.yaml` appendix instead — the main pack now
+only contains constructs this file treats as real dialect proposals,
+whether compiled today or not; holes stay demonstrable without implying
+that same status. Use an obstacle/prop for a collapse visual in any
+real document; do not infer no-floor, movement, line-of-sight, falling,
+bridging, or vertical-traversal semantics from the retained prototype.
 
 **A `walls:`/`start:`/`end:` cell can sit outside the compiled
 `FloorPlan`'s own bounding box** — a from-scratch canvas draft, or a

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -40,8 +40,14 @@ import { cubeToWorld } from '@/components/hex-grid/hexMath';
 import { useRef, useState, type ReactElement } from 'react';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
 import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
-import { END_COLOR, resolveMarkerStyle, START_COLOR } from '../markerStyle';
+import {
+  END_COLOR,
+  regionArchetypeColor,
+  resolveMarkerStyle,
+  START_COLOR,
+} from '../markerStyle';
 import { PlacementMarker } from '../PlacementMarker';
+import { regionCentroid } from '../regionGeometry';
 import type { BoardTool, PlacementSelection } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import {
@@ -53,6 +59,7 @@ import {
   type EdgeGeometry,
 } from './creationGeometry';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+import type { RegionEditing } from './useRegionEditing';
 
 interface CreationBoardProps {
   doc: DungeonDoc;
@@ -72,6 +79,11 @@ interface CreationBoardProps {
   ) => void;
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
+  /** Cell-authored semantic region editing (rpg-project#180) — only
+   * meaningful when `tool === 'region'`; the board reads `regionEdit`'s
+   * own `pendingCells`/`selectedRegionId` to decide what a click does.
+   * See `useRegionEditing.ts`'s own doc comment. */
+  regionEdit: RegionEditing;
 }
 
 // Same 6-direction convention authorGridHelpers.ts already defines for
@@ -128,6 +140,7 @@ export function CreationBoard({
   onToggleWallEdge,
   onToggleHole,
   onSetPoint,
+  regionEdit,
 }: CreationBoardProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hoverEdge, setHoverEdge] = useState<EdgeGeometry | null>(null);
@@ -221,6 +234,37 @@ export function CreationBoard({
     if (tool === 'hole') {
       const cell = nearestCreationCell(p, grid);
       onToggleHole(cell[0], cell[1]);
+      return;
+    }
+    if (tool === 'region') {
+      const cell = nearestCreationCell(p, grid);
+      if (regionEdit.selectedRegionId) {
+        // Editing an existing region's membership — every click toggles
+        // this cell in/out of THAT region, regardless of whether it
+        // belongs to some other region already (addCellToRegion's own
+        // overlap validation catches that case and surfaces a toast).
+        regionEdit.handleToggleCellOnSelected(cell);
+        return;
+      }
+      // No region selected yet: a click on an EXISTING region's cell
+      // selects it for editing (only when there's no in-progress new-
+      // region paint session — a mid-paint click always means "toggle
+      // this cell into the region I'm painting," even if it happens to
+      // land on another region's territory, since createRegion's own
+      // overlap check is what should catch that, not a silent
+      // reinterpretation of the click). Otherwise, toggle the cell into
+      // the pending (not-yet-created) region.
+      const hit =
+        regionEdit.pendingCells.length === 0
+          ? doc.regions.find((r) =>
+              r.cells.some((c) => c[0] === cell[0] && c[1] === cell[1])
+            )
+          : undefined;
+      if (hit) {
+        regionEdit.selectRegion(hit.id);
+      } else {
+        regionEdit.togglePendingCell(cell);
+      }
       return;
     }
     const edge = nearestEdge(p, grid);
@@ -336,6 +380,82 @@ export function CreationBoard({
     );
   });
 
+  // Cell-authored semantic regions (rpg-project#180) — a tinted rect per
+  // member cell (archetype-colored via `regionArchetypeColor`, the SAME
+  // color the edit-mode hex board's read-only overlay uses) plus one
+  // label at the region's centroid. `pointerEvents="none"` throughout:
+  // the board's own `handlePointerDown` already resolves "was an existing
+  // region clicked" via `nearestCreationCell` + a `doc.regions` scan, so
+  // these elements are purely visual, not a second independent hit-test
+  // surface.
+  const regionEls: ReactElement[] = [];
+  for (const region of doc.regions) {
+    const color = regionArchetypeColor(region.archetype);
+    const selected = regionEdit.selectedRegionId === region.id;
+    for (const [col, row] of region.cells) {
+      const center = creationCellCenter(col, row);
+      const half = { x: FLAT_COL_SPACING * 0.46, y: FLAT_ROW_SPACING * 0.46 };
+      regionEls.push(
+        <rect
+          key={`region-${region.id}-${col}-${row}`}
+          x={center.x - half.x}
+          y={center.y - half.y}
+          width={half.x * 2}
+          height={half.y * 2}
+          fill={color}
+          fillOpacity={selected ? 0.32 : 0.18}
+          stroke={color}
+          strokeWidth={selected ? 2 : 1}
+          strokeDasharray={selected ? undefined : '3 2'}
+          pointerEvents="none"
+        />
+      );
+    }
+    const centroid = regionCentroid(region.cells);
+    const labelPos = creationCellCenter(centroid.col, centroid.row);
+    regionEls.push(
+      <text
+        key={`region-${region.id}-label`}
+        x={labelPos.x}
+        y={labelPos.y + 3}
+        textAnchor="middle"
+        fill={color}
+        fontSize={10}
+        fontWeight={700}
+        pointerEvents="none"
+        style={{ paintOrder: 'stroke', stroke: '#100d0b', strokeWidth: 3 }}
+      >
+        {region.name ?? region.id}
+      </text>
+    );
+  }
+
+  // The in-progress, not-yet-created region's own pending cells — same
+  // rect treatment, dashed amber to read as "not committed yet" (matching
+  // this file's own hover-edge/wall-drawing amber-for-provisional
+  // convention elsewhere in this component).
+  const pendingRegionEls: ReactElement[] = regionEdit.pendingCells.map(
+    ([col, row]) => {
+      const center = creationCellCenter(col, row);
+      const half = { x: FLAT_COL_SPACING * 0.46, y: FLAT_ROW_SPACING * 0.46 };
+      return (
+        <rect
+          key={`region-pending-${col}-${row}`}
+          x={center.x - half.x}
+          y={center.y - half.y}
+          width={half.x * 2}
+          height={half.y * 2}
+          fill="#ffb347"
+          fillOpacity={0.28}
+          stroke="#ffb347"
+          strokeWidth={2}
+          strokeDasharray="3 2"
+          pointerEvents="none"
+        />
+      );
+    }
+  );
+
   const renderPlacement = (
     ref: string,
     at: [number, number],
@@ -405,7 +525,10 @@ export function CreationBoard({
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
       style={{
-        cursor: tool === 'wall' || tool === 'door' ? 'crosshair' : 'default',
+        cursor:
+          tool === 'wall' || tool === 'door' || tool === 'region'
+            ? 'crosshair'
+            : 'default',
       }}
     >
       <defs>
@@ -446,6 +569,8 @@ export function CreationBoard({
         strokeWidth={3}
       />
 
+      {regionEls}
+      {pendingRegionEls}
       {wallEls}
       {holeEls}
 

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -18,7 +18,9 @@ import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
 import { ProposedYamlPane } from './ProposedYamlPane';
+import { RegionPanel } from './RegionPanel';
 import { useDemoScript } from './useDemoScript';
+import type { RegionEditing } from './useRegionEditing';
 
 interface CreationConceptProps {
   doc: DungeonDoc;
@@ -39,6 +41,9 @@ interface CreationConceptProps {
   onNewCanvas: (width: number, height: number) => void;
   demoActions: DemoActions;
   toast: (message: string) => void;
+  /** Cell-authored semantic region editing (rpg-project#180) —
+   * creation-mode-only this round. See `useRegionEditing.ts`. */
+  regionEdit: RegionEditing;
   /** Collapse state for the left Palette and the right proposed-schema
    * pane — owned by the parent (`DungeonBuilderConcept`) so it's
    * remembered across an edit<->create tab switch instead of resetting
@@ -64,6 +69,7 @@ export function CreationConcept({
   onNewCanvas,
   demoActions,
   toast,
+  regionEdit,
   paletteCollapsed,
   onTogglePalette,
   yamlCollapsed,
@@ -286,6 +292,8 @@ export function CreationConcept({
             }}
             wallCount={doc.walls.length}
             holeCount={doc.holes.length}
+            showRegionTool
+            regionCount={doc.regions.length}
           />
         </CollapsibleSidePanel>
 
@@ -302,6 +310,7 @@ export function CreationConcept({
             onToggleWallEdge={onToggleWallEdge}
             onToggleHole={onToggleHole}
             onSetPoint={onSetPoint}
+            regionEdit={regionEdit}
           />
         </main>
 
@@ -334,6 +343,14 @@ export function CreationConcept({
         onSetFacing={edit.handleSetFacing}
         onFlipMountSide={edit.handleFlipMountSide}
       />
+      {/* Gated on the Region tool being active — `regionEdit`'s own
+          pending/selected state is preserved when the author switches to
+          a different tool and back, but the panel itself only shows while
+          Region is the live tool, matching every other tool-scoped panel
+          in this concept. */}
+      {selectedTool === 'region' && (
+        <RegionPanel doc={doc} regionEdit={regionEdit} />
+      )}
     </div>
   );
 }

--- a/src/concepts/dungeon-builder/creation/RegionPanel.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.tsx
@@ -1,0 +1,369 @@
+/**
+ * RegionPanel — the region-authoring floating panel (rpg-project#180,
+ * "cell-authored semantic room regions"). Same visual language/position
+ * discipline as `Inspector.tsx`/`ConnectorInspector.tsx` (a small fixed
+ * panel near the board), shown whenever the Region tool has something to
+ * say: cells pending for a not-yet-created region, or an existing region
+ * selected for editing. Creation-mode only this round (TARGET-YAML.md's
+ * "regions:" section) — edit mode renders any authored regions read-only
+ * (`Board.tsx`), with no panel of its own yet.
+ */
+import { useEffect, useRef, useState } from 'react';
+import type { DungeonDoc } from '../dungeonYaml';
+import { sharedBoundaryEdges } from '../regionGeometry';
+import type { RegionEditing } from './useRegionEditing';
+
+const ARCHETYPE_OPTIONS = ['entrance', 'chamber', 'corridor', 'boss'];
+
+function TargetDialectBadge() {
+  return (
+    <span
+      title="target dialect, proposed — not yet compiled server-side (TARGET-YAML.md)"
+      style={{
+        fontSize: 9,
+        color: '#c9aeff',
+        background: '#241a33',
+        border: '1px solid #4a3a63',
+        borderRadius: 3,
+        padding: '1px 5px',
+        marginLeft: 6,
+      }}
+    >
+      dialect
+    </span>
+  );
+}
+
+/** `region-N`, skipping any id already in use (a deleted-then-recreated
+ * region, or a hand-authored id in the YAML pane, shouldn't collide). */
+function suggestRegionId(doc: DungeonDoc): string {
+  const existing = new Set(doc.regions.map((r) => r.id));
+  let n = doc.regions.length + 1;
+  while (existing.has(`region-${n}`)) n++;
+  return `region-${n}`;
+}
+
+const panelStyle: React.CSSProperties = {
+  position: 'fixed',
+  right: 434,
+  bottom: 18,
+  width: 260,
+  background: '#221d19',
+  border: '1px solid #3a9b6a',
+  borderRadius: 8,
+  padding: 12,
+  boxShadow: '0 6px 24px rgba(0,0,0,.5)',
+  zIndex: 20,
+  fontSize: 12,
+  color: '#e8e2d8',
+};
+
+const fieldRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  margin: '6px 0',
+};
+
+const inputStyle: React.CSSProperties = {
+  flex: 1,
+  background: 'var(--bg-secondary)',
+  color: 'var(--text-primary)',
+  border: '1px solid var(--border-primary)',
+  borderRadius: 4,
+  padding: '3px 6px',
+  fontSize: 12,
+};
+
+const buttonStyle: React.CSSProperties = {
+  border: 'none',
+  borderRadius: 4,
+  padding: '4px 10px',
+  fontSize: 11,
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+interface RegionPanelProps {
+  doc: DungeonDoc;
+  regionEdit: RegionEditing;
+}
+
+export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
+  const {
+    pendingCells,
+    clearPending,
+    selectedRegionId,
+    selectRegion,
+    justCreatedId,
+    handleCreate,
+    handleRename,
+    handleSetArchetype,
+    handleDelete,
+    handleConnect,
+  } = regionEdit;
+
+  const editingRegion = selectedRegionId
+    ? (doc.regions.find((r) => r.id === selectedRegionId) ?? null)
+    : null;
+
+  const [draftId, setDraftId] = useState(() => suggestRegionId(doc));
+  const [draftName, setDraftName] = useState('');
+  const [draftArchetype, setDraftArchetype] = useState('chamber');
+  const [renameDraft, setRenameDraft] = useState('');
+  const [connectTarget, setConnectTarget] = useState('');
+
+  // Re-suggest a fresh id/reset the draft fields the moment a NEW paint
+  // session starts (0 -> N pending cells) — keyed on that transition, not
+  // on every keystroke, so a manually-edited id survives while the author
+  // keeps clicking more cells onto the same in-progress region.
+  const wasEmpty = useRef(true);
+  useEffect(() => {
+    const isEmpty = pendingCells.length === 0;
+    if (wasEmpty.current && !isEmpty) {
+      setDraftId(suggestRegionId(doc));
+      setDraftName('');
+      setDraftArchetype('chamber');
+    }
+    wasEmpty.current = isEmpty;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingCells.length]);
+
+  useEffect(() => {
+    setRenameDraft(editingRegion?.name ?? '');
+  }, [editingRegion?.id, editingRegion?.name]);
+
+  if (pendingCells.length === 0 && !editingRegion && !justCreatedId)
+    return null;
+
+  // --- Create mode: painting a brand-new region ---
+  if (pendingCells.length > 0) {
+    const idTaken = doc.regions.some((r) => r.id === draftId);
+    const idValid = /^[a-z0-9-]+$/.test(draftId);
+    const canCreate = !idTaken && idValid && pendingCells.length > 0;
+
+    // The "connect to previous" callout appears right after a successful
+    // create (justCreatedId set) — but that clears pendingCells, so this
+    // branch and the callout branch below never render at the same time;
+    // shown here as a section instead for locality with the create form
+    // it follows from.
+    return (
+      <div role="dialog" aria-label="Create region" style={panelStyle}>
+        <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
+          New region <TargetDialectBadge />
+        </h4>
+        <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
+          {pendingCells.length} cell{pendingCells.length === 1 ? '' : 's'}{' '}
+          selected — click more cells to add, click a selected cell to remove.
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={{ width: 56 }}>id</span>
+          <input
+            style={inputStyle}
+            value={draftId}
+            onChange={(e) => setDraftId(e.target.value)}
+          />
+        </div>
+        {!idValid && (
+          <div style={{ fontSize: 10, color: '#ff9a8a', margin: '-2px 0 6px' }}>
+            id must match ^[a-z0-9-]+$
+          </div>
+        )}
+        {idValid && idTaken && (
+          <div style={{ fontSize: 10, color: '#ff9a8a', margin: '-2px 0 6px' }}>
+            a region with this id already exists
+          </div>
+        )}
+        <div style={fieldRowStyle}>
+          <span style={{ width: 56 }}>name</span>
+          <input
+            style={inputStyle}
+            placeholder="(optional)"
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+          />
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={{ width: 56 }}>archetype</span>
+          <select
+            style={inputStyle}
+            value={draftArchetype}
+            onChange={(e) => setDraftArchetype(e.target.value)}
+          >
+            {ARCHETYPE_OPTIONS.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+          <button
+            style={{
+              ...buttonStyle,
+              background: canCreate ? '#3a9b6a' : 'var(--bg-secondary)',
+              color: canCreate ? '#0d160f' : '#6a6255',
+              cursor: canCreate ? 'pointer' : 'not-allowed',
+            }}
+            disabled={!canCreate}
+            onClick={() =>
+              handleCreate(draftId, draftArchetype, draftName || undefined)
+            }
+          >
+            Create
+          </button>
+          <button
+            style={{
+              ...buttonStyle,
+              background: 'transparent',
+              color: '#8a7a5a',
+              border: '1px solid var(--border-primary)',
+            }}
+            onClick={clearPending}
+          >
+            Clear selection
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Just created: offer to connect to the previously-created region ---
+  if (justCreatedId) {
+    const idx = doc.regions.findIndex((r) => r.id === justCreatedId);
+    const created = doc.regions[idx];
+    const prev = idx > 0 ? doc.regions[idx - 1] : null;
+    if (created && prev) {
+      const edges = sharedBoundaryEdges(created.cells, prev.cells);
+      const adjacent = edges.length > 0;
+      return (
+        <div role="dialog" aria-label="Connect region" style={panelStyle}>
+          <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
+            Created "{created.name ?? created.id}"
+          </h4>
+          <p style={{ fontSize: 11, color: '#a89e90', lineHeight: 1.4 }}>
+            {adjacent
+              ? `Attach to "${prev.name ?? prev.id}"? Places a door edge on the shared boundary (${edges.length} candidate edge${edges.length === 1 ? '' : 's'}, midpoint chosen).`
+              : `"${prev.name ?? prev.id}" doesn't share a boundary with this region — nothing to connect automatically. Use the region list to connect any two regions manually once more exist.`}
+          </p>
+          <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+            {adjacent && (
+              <button
+                style={{
+                  ...buttonStyle,
+                  background: '#3a9b6a',
+                  color: '#0d160f',
+                }}
+                onClick={() => handleConnect(created.id, prev.id)}
+              >
+                Connect
+              </button>
+            )}
+            <button
+              style={{
+                ...buttonStyle,
+                background: 'transparent',
+                color: '#8a7a5a',
+                border: '1px solid var(--border-primary)',
+              }}
+              onClick={() => selectRegion(null)}
+            >
+              Skip
+            </button>
+          </div>
+        </div>
+      );
+    }
+  }
+
+  // --- Edit mode: an existing region is selected ---
+  if (editingRegion) {
+    const others = doc.regions.filter((r) => r.id !== editingRegion.id);
+    return (
+      <div role="dialog" aria-label="Edit region" style={panelStyle}>
+        <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
+          Region: {editingRegion.id} <TargetDialectBadge />
+        </h4>
+        <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
+          {editingRegion.cells.length} cell
+          {editingRegion.cells.length === 1 ? '' : 's'} — click a board cell to
+          add/remove it from this region.
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={{ width: 56 }}>name</span>
+          <input
+            style={inputStyle}
+            placeholder="(optional)"
+            value={renameDraft}
+            onChange={(e) => setRenameDraft(e.target.value)}
+            onBlur={() => handleRename(renameDraft)}
+          />
+        </div>
+        <div style={fieldRowStyle}>
+          <span style={{ width: 56 }}>archetype</span>
+          <select
+            style={inputStyle}
+            value={editingRegion.archetype}
+            onChange={(e) => handleSetArchetype(e.target.value)}
+          >
+            {ARCHETYPE_OPTIONS.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+        </div>
+        {others.length > 0 && (
+          <div style={fieldRowStyle}>
+            <span style={{ width: 56 }}>connect</span>
+            <select
+              style={inputStyle}
+              value={connectTarget}
+              onChange={(e) => setConnectTarget(e.target.value)}
+            >
+              <option value="">(pick a region)</option>
+              {others.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.name ?? r.id}
+                </option>
+              ))}
+            </select>
+            <button
+              style={{
+                ...buttonStyle,
+                background: connectTarget ? '#3a9b6a' : 'var(--bg-secondary)',
+                color: connectTarget ? '#0d160f' : '#6a6255',
+                cursor: connectTarget ? 'pointer' : 'not-allowed',
+              }}
+              disabled={!connectTarget}
+              onClick={() => handleConnect(editingRegion.id, connectTarget)}
+            >
+              Connect
+            </button>
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+          <button
+            style={{
+              ...buttonStyle,
+              background: 'transparent',
+              color: '#8a7a5a',
+              border: '1px solid var(--border-primary)',
+            }}
+            onClick={() => selectRegion(null)}
+          >
+            Done
+          </button>
+          <button
+            style={{ ...buttonStyle, background: '#5a2a20', color: '#ff9a8a' }}
+            onClick={() => handleDelete(editingRegion.id)}
+          >
+            Delete region
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/concepts/dungeon-builder/creation/useRegionEditing.ts
+++ b/src/concepts/dungeon-builder/creation/useRegionEditing.ts
@@ -1,0 +1,172 @@
+/**
+ * useRegionEditing — cell-authored semantic region editing state
+ * (rpg-project#180, "cell-authored semantic room regions"). Same shape as
+ * `useBoardEditing.ts`: owns the UI-only state a board's Region tool needs
+ * (which cells are pending for a not-yet-created region; which existing
+ * region, if any, is selected for membership editing) and wraps
+ * `dungeonYaml.ts`'s region mutators with `RegionValidationError`-to-toast
+ * handling, so `CreationBoard.tsx`'s pointer handlers and `RegionPanel.tsx`'s
+ * buttons stay thin — neither has to know dungeonspec#180's own
+ * contiguity/overlap rules, only that a rejected edit surfaces as a toast.
+ *
+ * Creation-mode-only this round (TARGET-YAML.md's "regions:" section) —
+ * there is no edit-mode equivalent of this hook yet; edit mode renders any
+ * authored `regions:` read-only (`Board.tsx`), it just doesn't offer a way
+ * to create/edit them.
+ */
+import { useState } from 'react';
+import type { Document } from 'yaml';
+import {
+  addCellToRegion,
+  connectRegions,
+  createRegion,
+  deleteRegion,
+  RegionValidationError,
+  removeCellFromRegion,
+  renameRegion,
+  setRegionArchetype,
+  type DungeonDoc,
+} from '../dungeonYaml';
+import type { Cell } from '../regionGeometry';
+
+function cellIn(cells: readonly Cell[], cell: Cell): boolean {
+  return cells.some((c) => c[0] === cell[0] && c[1] === cell[1]);
+}
+
+export function useRegionEditing(
+  cst: Document,
+  doc: DungeonDoc,
+  syncFromCst: (cst: Document) => void,
+  flashToast: (message: string) => void
+) {
+  const [pendingCells, setPendingCells] = useState<Cell[]>([]);
+  const [selectedRegionId, setSelectedRegionId] = useState<string | null>(null);
+  /** The id `createRegion` just successfully created — drives
+   * `RegionPanel.tsx`'s "Connect to '<previous region>'?" callout. Cleared
+   * by selecting/deleting/connecting, so it never lingers past the moment
+   * it's relevant. */
+  const [justCreatedId, setJustCreatedId] = useState<string | null>(null);
+
+  const reportError = (err: unknown) => {
+    flashToast(
+      err instanceof RegionValidationError ? err.message : String(err)
+    );
+  };
+
+  /** Toggle a cell in the NOT-YET-CREATED region's pending set — the
+   * Region tool's paint interaction before a region exists at all.
+   * Deliberately does not validate contiguity/overlap on every click
+   * (that would make painting a shape one cell at a time impossible the
+   * moment two disconnected starting clicks land) — validation runs once,
+   * at `handleCreate`, via `dungeonYaml.ts`'s own `createRegion`. */
+  const togglePendingCell = (cell: Cell) => {
+    setPendingCells((prev) =>
+      cellIn(prev, cell)
+        ? prev.filter((c) => !(c[0] === cell[0] && c[1] === cell[1]))
+        : [...prev, cell]
+    );
+  };
+
+  const clearPending = () => setPendingCells([]);
+
+  /** Select an existing region for membership/metadata editing, or `null`
+   * to deselect. Always clears any in-progress NEW-region paint session —
+   * the two are mutually exclusive board states (painting a fresh region
+   * vs. editing an existing one), same as every other selection-pair in
+   * this concept. */
+  const selectRegion = (regionId: string | null) => {
+    setSelectedRegionId(regionId);
+    setPendingCells([]);
+    setJustCreatedId(null);
+  };
+
+  const handleCreate = (id: string, archetype: string, name?: string) => {
+    try {
+      createRegion(cst, doc, id, archetype, pendingCells, name);
+      syncFromCst(cst);
+      setPendingCells([]);
+      setJustCreatedId(id);
+    } catch (err) {
+      reportError(err);
+    }
+  };
+
+  /** Toggle board-cell membership on the currently SELECTED region (edit
+   * mode of the panel, not the create-new-region paint mode above) —
+   * add if not a member, remove if it is. */
+  const handleToggleCellOnSelected = (cell: Cell) => {
+    if (!selectedRegionId) return;
+    const region = doc.regions.find((r) => r.id === selectedRegionId);
+    if (!region) return;
+    try {
+      if (cellIn(region.cells, cell)) {
+        removeCellFromRegion(cst, doc, selectedRegionId, cell);
+      } else {
+        addCellToRegion(cst, doc, selectedRegionId, cell);
+      }
+      syncFromCst(cst);
+    } catch (err) {
+      reportError(err);
+    }
+  };
+
+  const handleRename = (name: string) => {
+    if (!selectedRegionId) return;
+    renameRegion(cst, selectedRegionId, name.trim() === '' ? null : name);
+    syncFromCst(cst);
+  };
+
+  const handleSetArchetype = (archetype: string) => {
+    if (!selectedRegionId) return;
+    setRegionArchetype(cst, selectedRegionId, archetype);
+    syncFromCst(cst);
+  };
+
+  const handleDelete = (regionId: string) => {
+    deleteRegion(cst, regionId);
+    syncFromCst(cst);
+    if (selectedRegionId === regionId) setSelectedRegionId(null);
+    if (justCreatedId === regionId) setJustCreatedId(null);
+  };
+
+  /** "Attach to next region" (Kirk's ask) — places a door edge on the
+   * shared boundary via `dungeonYaml.ts`'s `connectRegions`. Surfaces "no
+   * shared boundary" as a toast rather than a silent no-op, same
+   * discipline every other board rejection in this concept follows
+   * (`CreationBoard.tsx`'s own `onReject`). */
+  const handleConnect = (regionAId: string, regionBId: string) => {
+    let result;
+    try {
+      result = connectRegions(cst, doc, regionAId, regionBId);
+    } catch (err) {
+      reportError(err);
+      return;
+    }
+    if (!result.edge) {
+      flashToast("These regions don't share a boundary — nothing to connect.");
+      return;
+    }
+    syncFromCst(cst);
+    flashToast(
+      `Connected — door placed at [${result.edge.from.join(',')}] ↔ [${result.edge.to.join(',')}].`
+    );
+    setJustCreatedId(null);
+  };
+
+  return {
+    pendingCells,
+    togglePendingCell,
+    clearPending,
+    selectedRegionId,
+    selectRegion,
+    justCreatedId,
+    handleCreate,
+    handleToggleCellOnSelected,
+    handleRename,
+    handleSetArchetype,
+    handleDelete,
+    handleConnect,
+  };
+}
+
+export type RegionEditing = ReturnType<typeof useRegionEditing>;

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -2,15 +2,22 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+  addCellToRegion,
   buildWalkItYaml,
   clearPlacementFlag,
   clearRefDefault,
+  connectRegions,
+  createRegion,
   deletePlacement,
+  deleteRegion,
   DungeonParseError,
   movePlacement,
   movePlacementAcrossLists,
   parseDungeon,
   placeItem,
+  RegionValidationError,
+  removeCellFromRegion,
+  renameRegion,
   resolvePlacement,
   serializeDungeon,
   setBossFacing,
@@ -24,6 +31,7 @@ import {
   setPlacementRotationDegrees,
   setPlacementTargeting,
   setRefDefault,
+  setRegionArchetype,
   setStart,
   setWallEdge,
   stripMonsterPlacements,
@@ -32,6 +40,7 @@ import {
   toggleHole,
   toggleWall,
   toggleWallKind,
+  validateRegionCells,
   wallKindAtEdge,
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
@@ -1018,6 +1027,382 @@ describe('defaults: ref-keyed inherited fields (rpg-project#175, Kirk\'s ask ver
       expect(stripped.dropped.find((d) => d.startsWith('defaults ('))).toBe(
         'defaults (1 ref)'
       );
+    });
+  });
+});
+
+describe('regions: cell-authored semantic room regions (rpg-project#180)', () => {
+  it('parses a regions: list into RegionDoc[], id/name/archetype/cells', () => {
+    const yaml = `${SHOWCASE_YAML}
+regions:
+  - id: shrine-inner
+    name: "Shrine — Inner Sanctum"
+    archetype: chamber
+    cells: [[9, 2], [9, 3], [10, 2], [10, 3]]
+`;
+    const { doc } = parseDungeon(yaml);
+    expect(doc.regions).toHaveLength(1);
+    expect(doc.regions[0]).toEqual({
+      id: 'shrine-inner',
+      name: 'Shrine — Inner Sanctum',
+      archetype: 'chamber',
+      cells: [
+        [9, 2],
+        [9, 3],
+        [10, 2],
+        [10, 3],
+      ],
+    });
+  });
+
+  it('defaults to an empty regions: list when absent — every pure v1 document', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    expect(doc.regions).toEqual([]);
+  });
+
+  it('a region with no name parses name: undefined, not a fabricated string', () => {
+    const yaml = `${SHOWCASE_YAML}
+regions:
+  - id: vault-annex
+    archetype: chamber
+    cells: [[1, 1]]
+`;
+    const { doc } = parseDungeon(yaml);
+    expect(doc.regions[0].name).toBeUndefined();
+  });
+
+  describe('validateRegionCells', () => {
+    it('rejects an empty cell set', () => {
+      const { doc } = parseDungeon(SHOWCASE_YAML);
+      expect(validateRegionCells(doc, [])).toMatch(/at least one cell/);
+    });
+
+    it('rejects a duplicate cell within the same set', () => {
+      const { doc } = parseDungeon(SHOWCASE_YAML);
+      expect(
+        validateRegionCells(doc, [
+          [1, 1],
+          [1, 1],
+        ])
+      ).toMatch(/selected twice/);
+    });
+
+    it('rejects a disconnected (non-contiguous) cell set', () => {
+      const { doc } = parseDungeon(SHOWCASE_YAML);
+      expect(
+        validateRegionCells(doc, [
+          [1, 1],
+          [9, 9],
+        ])
+      ).toMatch(/contiguous/);
+    });
+
+    it('accepts a single cell and a contiguous run', () => {
+      const { doc } = parseDungeon(SHOWCASE_YAML);
+      expect(validateRegionCells(doc, [[1, 1]])).toBeNull();
+      expect(
+        validateRegionCells(doc, [
+          [1, 1],
+          [2, 1],
+          [2, 2],
+        ])
+      ).toBeNull();
+    });
+
+    it('rejects a cell set overlapping an existing region, but allows it when self-excluded', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [
+        [1, 1],
+        [2, 1],
+      ]);
+      const doc2 = toDungeonDoc(cst);
+      expect(
+        validateRegionCells(doc2, [
+          [2, 1],
+          [3, 1],
+        ])
+      ).toMatch(/already belong to another region/);
+      // Excluding r1's own id lets r1's proposed new cell set (which still
+      // legitimately reuses its own current cells) validate cleanly.
+      expect(
+        validateRegionCells(
+          doc2,
+          [
+            [1, 1],
+            [2, 1],
+            [3, 1],
+          ],
+          'r1'
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe('createRegion', () => {
+    it("adds a region with a block-style entry and flow-style cells, matching this file's cell-native convention", () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'shrine-inner', 'chamber', [
+        [9, 2],
+        [9, 3],
+      ]);
+      const yaml = serializeDungeon(cst);
+      expect(yaml).toContain('regions:');
+      expect(yaml).toContain('id: shrine-inner');
+      // `yaml`'s own flow-sequence padding (this file's header doc
+      // comment names the same residual diff for `at: [1, 1]` etc.) —
+      // exact byte content isn't the point here, round-trip fidelity is
+      // (asserted via the reparse below).
+      expect(yaml).toMatch(
+        /cells: \[\s*\[\s*9,\s*2\s*\],\s*\[\s*9,\s*3\s*\]\s*\]/
+      );
+
+      const { doc: reparsed } = parseDungeon(yaml);
+      expect(reparsed.regions).toHaveLength(1);
+      expect(reparsed.regions[0].cells).toEqual([
+        [9, 2],
+        [9, 3],
+      ]);
+    });
+
+    it('writes an optional name: only when provided', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]], 'The Annex');
+      const { doc: reparsed } = parseDungeon(serializeDungeon(cst));
+      expect(reparsed.regions[0].name).toBe('The Annex');
+
+      const { cst: cst2, doc: doc2 } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst2, doc2, 'r2', 'chamber', [[1, 1]]);
+      const { doc: reparsed2 } = parseDungeon(serializeDungeon(cst2));
+      expect(reparsed2.regions[0].name).toBeUndefined();
+    });
+
+    it('throws RegionValidationError on a duplicate id', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      expect(() => createRegion(cst, doc2, 'r1', 'chamber', [[2, 1]])).toThrow(
+        RegionValidationError
+      );
+    });
+
+    it('throws RegionValidationError on an invalid cell set instead of writing anything', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      expect(() => createRegion(cst, doc, 'bad', 'chamber', [])).toThrow(
+        RegionValidationError
+      );
+      expect(toDungeonDoc(cst).regions).toEqual([]);
+    });
+  });
+
+  describe('addCellToRegion / removeCellFromRegion', () => {
+    it('adds an adjacent cell to an existing region', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      addCellToRegion(cst, doc2, 'r1', [2, 1]);
+      const doc3 = toDungeonDoc(cst);
+      expect(doc3.regions[0].cells).toEqual([
+        [1, 1],
+        [2, 1],
+      ]);
+    });
+
+    it('is a no-op when the cell is already a member', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      addCellToRegion(cst, doc2, 'r1', [1, 1]);
+      expect(toDungeonDoc(cst).regions[0].cells).toEqual([[1, 1]]);
+    });
+
+    it('refuses a cell that would make the region non-contiguous', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      expect(() => addCellToRegion(cst, doc2, 'r1', [9, 9])).toThrow(
+        RegionValidationError
+      );
+      expect(toDungeonDoc(cst).regions[0].cells).toEqual([[1, 1]]);
+    });
+
+    it('refuses a cell already claimed by another region', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      createRegion(cst, doc2, 'r2', 'chamber', [[5, 1]]);
+      const doc3 = toDungeonDoc(cst);
+      expect(() => addCellToRegion(cst, doc3, 'r2', [1, 1])).toThrow(
+        RegionValidationError
+      );
+    });
+
+    it('removes a member cell, leaving the rest intact', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [
+        [1, 1],
+        [2, 1],
+      ]);
+      const doc2 = toDungeonDoc(cst);
+      removeCellFromRegion(cst, doc2, 'r1', [2, 1]);
+      expect(toDungeonDoc(cst).regions[0].cells).toEqual([[1, 1]]);
+    });
+
+    it('refuses to remove the last cell — delete the region instead', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      expect(() => removeCellFromRegion(cst, doc2, 'r1', [1, 1])).toThrow(
+        RegionValidationError
+      );
+      expect(toDungeonDoc(cst).regions[0].cells).toEqual([[1, 1]]);
+    });
+
+    it('refuses a removal that would split the region into two pieces', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      // A 1x3 strip — removing the middle cell splits it into two islands.
+      createRegion(cst, doc, 'r1', 'chamber', [
+        [1, 1],
+        [2, 1],
+        [3, 1],
+      ]);
+      const doc2 = toDungeonDoc(cst);
+      expect(() => removeCellFromRegion(cst, doc2, 'r1', [2, 1])).toThrow(
+        RegionValidationError
+      );
+      expect(toDungeonDoc(cst).regions[0].cells).toHaveLength(3);
+    });
+  });
+
+  it('renameRegion sets/clears name:, setRegionArchetype updates archetype:', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+    renameRegion(cst, 'r1', 'The Annex');
+    setRegionArchetype(cst, 'r1', 'boss');
+    let reparsed = toDungeonDoc(cst);
+    expect(reparsed.regions[0].name).toBe('The Annex');
+    expect(reparsed.regions[0].archetype).toBe('boss');
+
+    renameRegion(cst, 'r1', null);
+    reparsed = toDungeonDoc(cst);
+    expect(reparsed.regions[0].name).toBeUndefined();
+  });
+
+  it('deleteRegion removes the region entirely; a no-op for an unknown id', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+    deleteRegion(cst, 'r1');
+    expect(toDungeonDoc(cst).regions).toEqual([]);
+    // No throw:
+    deleteRegion(cst, 'does-not-exist');
+  });
+
+  describe('connectRegions — attach via a door edge, distinct from chain connectors:', () => {
+    it('places a door edge on the shared boundary and returns it', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'north', 'chamber', [
+        [1, 1],
+        [2, 1],
+      ]);
+      const doc2 = toDungeonDoc(cst);
+      createRegion(cst, doc2, 'south', 'chamber', [
+        [1, 2],
+        [2, 2],
+      ]);
+      const doc3 = toDungeonDoc(cst);
+
+      const result = connectRegions(cst, doc3, 'north', 'south');
+      expect(result.edge).not.toBeNull();
+      // Two candidate edges ([1,1]-[1,2] and [2,1]-[2,2]) sorted by
+      // (row, col) of `to` — the midpoint of 2 picks the SECOND
+      // (index 1) per pickAttachmentEdge's own floor(n/2) rule.
+      expect(result.edge).toEqual({ from: [2, 1], to: [2, 2] });
+
+      const finalDoc = toDungeonDoc(cst);
+      expect(finalDoc.walls).toHaveLength(1);
+      expect(finalDoc.walls[0]).toEqual({
+        from: [2, 1],
+        to: [2, 2],
+        kind: 'door',
+      });
+      // The connectors: chain is completely untouched — a region-
+      // attachment door is not a chain connector (rpg-project#175 spot-
+      // check finding).
+      expect(finalDoc.connectors).toEqual(doc.connectors);
+    });
+
+    it('returns { edge: null } and writes nothing when the two regions share no boundary', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'north', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      createRegion(cst, doc2, 'far', 'chamber', [[9, 9]]);
+      const doc3 = toDungeonDoc(cst);
+
+      const result = connectRegions(cst, doc3, 'north', 'far');
+      expect(result.edge).toBeNull();
+      expect(toDungeonDoc(cst).walls).toEqual([]);
+    });
+
+    it('throws DungeonParseError for an unknown region id', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'north', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      expect(() => connectRegions(cst, doc2, 'north', 'nope')).toThrow(
+        DungeonParseError
+      );
+    });
+  });
+
+  it('comment-safety: a comment elsewhere in the document survives creating/editing a region', () => {
+    const yaml = `${SHOWCASE_YAML.trimEnd()}
+# a durable comment, unrelated to regions
+`;
+    const { cst, doc } = parseDungeon(yaml);
+    createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+    const doc2 = toDungeonDoc(cst);
+    addCellToRegion(cst, doc2, 'r1', [2, 1]);
+    expect(serializeDungeon(cst)).toContain(
+      '# a durable comment, unrelated to regions'
+    );
+  });
+
+  describe('stripToV1Subset', () => {
+    it('drops regions: entirely, with an honest count, and reports "1 region" (singular)', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const result = stripToV1Subset(serializeDungeon(cst));
+      expect(result.dropped).toContain('1 region');
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.regions).toEqual([]);
+    });
+
+    it('reports "N regions" (plural) and leaves the real room chain untouched', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      createRegion(cst, doc2, 'r2', 'chamber', [[5, 1]]);
+      const result = stripToV1Subset(serializeDungeon(cst));
+      expect(result.dropped).toContain('2 regions');
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.rooms.map((r) => r.id)).toEqual(
+        doc.rooms.map((r) => r.id)
+      );
+    });
+
+    it('a connectRegions door edge is dropped independently, via the existing walls: count, not the regions: count', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'north', 'chamber', [[1, 1]]);
+      const doc2 = toDungeonDoc(cst);
+      createRegion(cst, doc2, 'south', 'chamber', [[1, 2]]);
+      const doc3 = toDungeonDoc(cst);
+      connectRegions(cst, doc3, 'north', 'south');
+
+      const result = stripToV1Subset(serializeDungeon(cst));
+      expect(result.dropped).toEqual(
+        expect.arrayContaining(['1 wall', '2 regions'])
+      );
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.walls).toEqual([]);
+      expect(stripped.regions).toEqual([]);
     });
   });
 });

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -36,6 +36,13 @@ import {
   YAMLMap,
   YAMLSeq,
 } from 'yaml';
+import {
+  cellsAreContiguous,
+  cellsEqual,
+  pickAttachmentEdge,
+  sharedBoundaryEdges,
+  type Cell,
+} from './regionGeometry';
 
 function parseFacing(raw: unknown): number | null {
   if (typeof raw !== 'string') return null;
@@ -233,6 +240,40 @@ export interface CanvasDoc {
   height: number;
 }
 
+/** Cell-authored semantic room region — target dialect, proposed
+ * (rpg-project#180, "cell-authored semantic room regions"). See
+ * TARGET-YAML.md's "regions:" section for the full design writeup and the
+ * open questions this prototype records rather than decides. Distinct
+ * from the declared `rooms:` chain (`RoomDoc`): a region is drawn as an
+ * explicit set of absolute [col,row] cells rather than a width against a
+ * server-computed `start_column`, so it can be non-rectangular and takes
+ * no part in the linear connector chain at all — it exists purely as an
+ * additional semantic layer over the same edge-owning dungeon space (the
+ * settled model, rpg-project#175: dungeon space owns wall/door edges;
+ * rooms/regions are stable semantic regions carrying reveal/placement/
+ * spawning/archetype meaning). Same archetype vocabulary `RoomDoc.archetype`
+ * already uses (entrance|chamber|corridor|boss) so a future compiler could
+ * treat a region exactly like a room for reveal/placement/spawning/
+ * scripting purposes once #180 lands server-side. Not compiled
+ * server-side today; stripped by `stripToV1Subset`. */
+export interface RegionDoc {
+  id: string;
+  /** Optional display name — `RoomDoc` has no separate name field either
+   * (its `id` doubles as the label, confirmed against the real dungeonspec
+   * schema — CONTRACT.md's "room display names" finding); `name` is
+   * offered here only because a hand-authored region id is more likely to
+   * be an opaque slug (`region-3`) than a room chain's own meaningful ids
+   * (`entry`, `vault`). Purely cosmetic — no v1 analog either way. */
+  name?: string;
+  archetype: string;
+  /** Absolute [col,row] pairs, the SAME coordinate space every other
+   * cell-native field in this file uses (`walls:`, `holes:`, `start`,
+   * `end`, top-level `place:`). Order is authoring order, not spatially
+   * meaningful — see `regionGeometry.ts`'s `cellsAreContiguous` for how
+   * membership's own adjacency is actually determined. */
+  cells: [number, number][];
+}
+
 export type WallKind = 'solid' | 'door';
 
 /** Edge-native: `from`/`to` are orthogonally-adjacent absolute [col,row]
@@ -312,6 +353,12 @@ export interface DungeonDoc {
    * needs an owning room; see TARGET-YAML.md for how the target dialect
    * eventually frees it). */
   place: PlacementDoc[];
+  /** Cell-authored semantic regions — target dialect, proposed
+   * (rpg-project#180). See `RegionDoc`'s own doc comment and
+   * TARGET-YAML.md's "regions:" section. Empty in every document authored
+   * before this field existed and in any pure v1 document; not compiled
+   * server-side, dropped entirely by `stripToV1Subset`. */
+  regions: RegionDoc[];
   /** Dungeon-wide, ref-keyed default fields — target dialect, proposed
    * (Kirk's ask, verbatim: "maybe we can set a default for all
    * skeletons"). See TARGET-YAML.md's "defaults:" section for the full
@@ -477,6 +524,34 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
   // own doc comment.
   const place = parsePlacementList(raw.place, 'place');
 
+  // Cell-authored semantic regions — target dialect, proposed
+  // (rpg-project#180). See RegionDoc's own doc comment. A region with a
+  // missing/non-string id or archetype is a shape error, same discipline
+  // parseDungeon already applies to rooms/connectors above — this
+  // concept's own "can the board render it" check, not dungeonspec's real
+  // semantic validator (which doesn't know this field at all yet).
+  const regions: RegionDoc[] = Array.isArray(raw.regions)
+    ? (raw.regions as Record<string, unknown>[]).map((r, ri) => {
+        if (typeof r.id !== 'string') {
+          throw new DungeonParseError(`regions[${ri}] is missing id`);
+        }
+        if (typeof r.archetype !== 'string') {
+          throw new DungeonParseError(`region "${r.id}" has no archetype`);
+        }
+        const cells: [number, number][] = Array.isArray(r.cells)
+          ? (r.cells as [number, number][]).map(
+              (c) => [c[0], c[1]] as [number, number]
+            )
+          : [];
+        return {
+          id: r.id,
+          name: typeof r.name === 'string' ? r.name : undefined,
+          archetype: r.archetype,
+          cells,
+        };
+      })
+    : [];
+
   // Ref-keyed default fields — target dialect, proposed. See
   // DungeonDoc.defaults's own doc comment. Every field is independently
   // optional on a given ref's entry; an entry present with none of the
@@ -519,6 +594,7 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
     end,
     lighting,
     place,
+    regions,
     defaults,
   };
 }
@@ -1287,6 +1363,288 @@ export function setLightingAmbient(
   cst.set('lighting', node);
 }
 
+// ============================================================
+// regions: — cell-authored semantic room regions, target dialect,
+// proposed (rpg-project#180). See RegionDoc's own doc comment and
+// TARGET-YAML.md's "regions:" section for the full design writeup.
+// ============================================================
+
+export class RegionValidationError extends Error {}
+
+/** Whether `cells` shares any member with an EXISTING region OTHER than
+ * `excludeRegionId` (the region currently being edited, if any) —
+ * rpg-project#180's own "Overlapping... cell sets fail" acceptance
+ * criterion. */
+export function cellsOverlapAnotherRegion(
+  doc: DungeonDoc,
+  cells: readonly Cell[],
+  excludeRegionId?: string
+): boolean {
+  const claimed = new Set<string>();
+  for (const region of doc.regions) {
+    if (region.id === excludeRegionId) continue;
+    for (const c of region.cells) claimed.add(`${c[0]},${c[1]}`);
+  }
+  return cells.some((c) => claimed.has(`${c[0]},${c[1]}`));
+}
+
+/** Validate a candidate cell set for `createRegion`/membership edits —
+ * rpg-project#180's own acceptance criteria ("Overlapping, disconnected,
+ * empty, and invalid cell sets fail with author-facing validation
+ * errors"), enforced client-side here so this concept's authoring surface
+ * can never produce a document the eventual real #180 validator is
+ * already known to reject. Returns a human-readable rejection reason, or
+ * `null` when the cell set is valid. `excludeRegionId` lets a membership
+ * edit on region X check its own PROPOSED new cell set against every
+ * OTHER region without X's own existing cells counting as a
+ * self-overlap. */
+export function validateRegionCells(
+  doc: DungeonDoc,
+  cells: readonly Cell[],
+  excludeRegionId?: string
+): string | null {
+  if (cells.length === 0) return 'a region needs at least one cell';
+  const seen = new Set<string>();
+  for (const c of cells) {
+    const key = `${c[0]},${c[1]}`;
+    if (seen.has(key)) return `cell [${c[0]},${c[1]}] is selected twice`;
+    seen.add(key);
+  }
+  if (!cellsAreContiguous(cells)) {
+    return 'cells must be orthogonally contiguous (rpg-project#180)';
+  }
+  if (cellsOverlapAnotherRegion(doc, cells, excludeRegionId)) {
+    return 'one or more cells already belong to another region';
+  }
+  return null;
+}
+
+function regionsSeqReadonly(cst: Document): YAMLSeq | undefined {
+  const existing = cst.get('regions', true);
+  return isSeq(existing) ? existing : undefined;
+}
+
+function findRegionIndex(cst: Document, regionId: string): number {
+  const regions = regionsSeqReadonly(cst);
+  if (!regions) return -1;
+  return regions.items.findIndex((r) => isMap(r) && r.get('id') === regionId);
+}
+
+function regionMap(cst: Document, regionId: string): YAMLMap {
+  const idx = findRegionIndex(cst, regionId);
+  if (idx === -1) throw new DungeonParseError(`Unknown region "${regionId}"`);
+  const region = (cst.get('regions') as YAMLSeq).items[idx];
+  if (!isMap(region))
+    throw new DungeonParseError(`region "${regionId}" is not a map`);
+  return region;
+}
+
+/** Build a block-style `{ id, name?, archetype, cells: [[c,r],...] }` node
+ * — block (not flow) at the region's own top level so a region with many
+ * cells doesn't produce one unreadably long line, but the `cells:`
+ * sequence itself and each `[c,r]` pair inside it ARE flow-style, matching
+ * every other cell-native list in this file (`walls:`, `holes:`, `at:`). */
+function createRegionNode(
+  cst: Document,
+  region: { id: string; name?: string; archetype: string; cells: Cell[] }
+): YAMLMap {
+  const obj: Record<string, unknown> = { id: region.id };
+  if (region.name) obj.name = region.name;
+  obj.archetype = region.archetype;
+  obj.cells = region.cells;
+  const node = cst.createNode(obj) as YAMLMap;
+  const cellsNode = node.get('cells', true);
+  if (isSeq(cellsNode)) {
+    cellsNode.flow = true;
+    for (const item of cellsNode.items) {
+      if (isSeq(item)) item.flow = true;
+    }
+  }
+  return node;
+}
+
+/** Create a new cell-authored semantic region — target dialect, proposed
+ * (rpg-project#180). Throws `RegionValidationError` (a duplicate id, or a
+ * cell set `validateRegionCells` rejects) rather than silently no-op-ing
+ * or producing an invalid document — the region-authoring panel should
+ * catch this and surface the message, not let it propagate as an
+ * unhandled error. */
+export function createRegion(
+  cst: Document,
+  doc: DungeonDoc,
+  id: string,
+  archetype: string,
+  cells: Cell[],
+  name?: string
+): void {
+  if (findRegionIndex(cst, id) !== -1) {
+    throw new RegionValidationError(`region "${id}" already exists`);
+  }
+  const reason = validateRegionCells(doc, cells);
+  if (reason) throw new RegionValidationError(reason);
+  const regions = topSeq(cst, 'regions');
+  regions.items.push(createRegionNode(cst, { id, name, archetype, cells }));
+}
+
+/** Remove a region entirely — target dialect, proposed. A no-op if the id
+ * doesn't exist, matching this file's general "clearing something absent
+ * is fine" discipline. Never touches `walls:` — an attachment door edge a
+ * `connectRegions` call placed on this region's former boundary is
+ * independent authored content (see `connectRegions`'s own doc comment)
+ * and survives the region's own deletion, same as a hand-drawn wall
+ * survives whatever rooms it happened to sit near. */
+export function deleteRegion(cst: Document, regionId: string): void {
+  const idx = findRegionIndex(cst, regionId);
+  if (idx === -1) return;
+  (cst.get('regions') as YAMLSeq).items.splice(idx, 1);
+}
+
+/** Set or clear a region's optional `name:` — target dialect, proposed.
+ * `null` or an empty/whitespace-only string clears the key entirely
+ * (falls back to `id` as the label, same as a room). */
+export function renameRegion(
+  cst: Document,
+  regionId: string,
+  name: string | null
+): void {
+  const region = regionMap(cst, regionId);
+  if (name === null || name.trim() === '') region.delete('name');
+  else region.set('name', name);
+}
+
+/** Set a region's `archetype:` — target dialect, proposed. Same
+ * vocabulary `RoomDoc.archetype` uses (entrance|chamber|corridor|boss);
+ * not enforced as an enum here (rooms aren't validated against one
+ * client-side either — dungeonspec's own real validator would own that
+ * the day #180 lands). */
+export function setRegionArchetype(
+  cst: Document,
+  regionId: string,
+  archetype: string
+): void {
+  const region = regionMap(cst, regionId);
+  region.set('archetype', archetype);
+}
+
+function regionCellsSeq(cst: Document, regionId: string): YAMLSeq {
+  const region = regionMap(cst, regionId);
+  const existing = region.get('cells', true);
+  if (isSeq(existing)) return existing;
+  const seq = new YAMLSeq(cst.schema);
+  seq.flow = true;
+  region.set('cells', seq);
+  return seq;
+}
+
+/** Add one cell to an existing region's membership — validated against
+ * rpg-project#180's own contiguity/overlap rules (`validateRegionCells`),
+ * same as `createRegion`, so an interactive "click to add a cell" board
+ * affordance can never grow a region into an invalid shape. A no-op (not
+ * an error) when `cell` is already a member — matching this file's
+ * general toggle-shaped mutators. Throws `RegionValidationError` when
+ * adding would make the region non-contiguous (a cell not touching any
+ * existing member) or would claim a cell another region already owns. */
+export function addCellToRegion(
+  cst: Document,
+  doc: DungeonDoc,
+  regionId: string,
+  cell: Cell
+): void {
+  const region = doc.regions.find((r) => r.id === regionId);
+  if (!region) throw new DungeonParseError(`Unknown region "${regionId}"`);
+  if (region.cells.some((c) => cellsEqual(c, cell))) return;
+  const nextCells = [...region.cells, cell];
+  const reason = validateRegionCells(doc, nextCells, regionId);
+  if (reason) throw new RegionValidationError(reason);
+  const cellsSeq = regionCellsSeq(cst, regionId);
+  const cellNode = new YAMLSeq(cst.schema);
+  cellNode.flow = true;
+  cellNode.items = [...cell];
+  cellsSeq.items.push(cellNode);
+}
+
+/** Remove one cell from an existing region's membership — target
+ * dialect, proposed. A no-op when `cell` isn't currently a member.
+ * Refuses (throws `RegionValidationError`) a removal that would leave the
+ * region either EMPTY (delete the region instead — `deleteRegion`) or
+ * DISCONNECTED into two pieces — rpg-project#180's acceptance criteria
+ * apply to every post-edit state, not just creation, so this mutator
+ * enforces them on the way out the same way `addCellToRegion` enforces
+ * them on the way in. */
+export function removeCellFromRegion(
+  cst: Document,
+  doc: DungeonDoc,
+  regionId: string,
+  cell: Cell
+): void {
+  const region = doc.regions.find((r) => r.id === regionId);
+  if (!region) throw new DungeonParseError(`Unknown region "${regionId}"`);
+  const nextCells = region.cells.filter((c) => !cellsEqual(c, cell));
+  if (nextCells.length === region.cells.length) return;
+  if (nextCells.length === 0) {
+    throw new RegionValidationError(
+      'cannot remove the last cell — delete the region instead'
+    );
+  }
+  if (!cellsAreContiguous(nextCells)) {
+    throw new RegionValidationError(
+      'removing this cell would split the region into two disconnected pieces'
+    );
+  }
+  const cellsSeq = regionCellsSeq(cst, regionId);
+  const idx = cellsSeq.items.findIndex(
+    (c) => isSeq(c) && c.get(0) === cell[0] && c.get(1) === cell[1]
+  );
+  if (idx !== -1) cellsSeq.items.splice(idx, 1);
+}
+
+export interface ConnectRegionsResult {
+  /** The edge a door was placed on, or `null` when the two regions share
+   * no orthogonal boundary at all (nothing was written). */
+  edge: { from: Cell; to: Cell } | null;
+}
+
+/** "Attach to next region" (Kirk's ask) — places a DOOR edge on the
+ * shared boundary between two regions, chosen via `regionGeometry.ts`'s
+ * `pickAttachmentEdge` (the midpoint of the shared boundary run; see that
+ * function's own doc comment for why an automatic midpoint, not an
+ * author-clicked edge, was this round's choice).
+ *
+ * Mechanically this is nothing more than an ordinary `setWallEdge(cst,
+ * edge.from, edge.to, 'door', true)` call — a region-attachment door is
+ * DISTINCT from a chain `connectors:` entry (TARGET-YAML.md's "region
+ * attachment vs. chain connectors" section has the full writeup): a
+ * connector's `from`/`to` are fixed by declared-room order and validated
+ * server-side (`validateChain`, `rpg-toolkit/encounter/dungeonspec/
+ * validate.go`) — an authored door edge does NOT replace, satisfy, or
+ * count as one (confirmed against the real Go source, rpg-project#175's
+ * spot-check finding). A region-attachment door is just another `walls:`
+ * entry: freely authorable, no chain participation, no cardinality
+ * constraint. Two regions can be "attached" by any number of doors, or by
+ * none at all — this function is a convenience for placing one, not a
+ * requirement the document enforces.
+ *
+ * Returns `{ edge: null }` (writes nothing) when the two regions share no
+ * orthogonal boundary — the caller should surface this as a rejection
+ * ("these regions aren't adjacent"), not treat it as silent success. */
+export function connectRegions(
+  cst: Document,
+  doc: DungeonDoc,
+  regionAId: string,
+  regionBId: string
+): ConnectRegionsResult {
+  const a = doc.regions.find((r) => r.id === regionAId);
+  const b = doc.regions.find((r) => r.id === regionBId);
+  if (!a || !b) {
+    throw new DungeonParseError('connectRegions: unknown region');
+  }
+  const edges = sharedBoundaryEdges(a.cells, b.cells);
+  const edge = pickAttachmentEdge(edges);
+  if (!edge) return { edge: null };
+  setWallEdge(cst, edge.from, edge.to, 'door', true);
+  return { edge };
+}
+
 /** `DefaultableField`'s camelCase name -> the wire's snake_case key —
  * one lookup table so `setRefDefault`/`clearRefDefault` share a single
  * mapping instead of hand-rolling it twice. */
@@ -1552,6 +1910,20 @@ export function stripToV1Subset(yamlText: string): V1SubsetResult {
     );
   }
   cst.delete('holes');
+
+  // Cell-authored semantic regions (rpg-project#180) have no v1
+  // representation at all — dungeonspec only knows the declared `rooms:`
+  // chain. Dropped entirely, counted honestly like every other
+  // target-dialect construct here. A door edge a `connectRegions` call
+  // placed on a region's boundary is a SEPARATE `walls:` entry (see
+  // `connectRegions`'s own doc comment) and is stripped independently by
+  // the `walls:` handling above — deleting `regions:` here never touches it.
+  if (doc.regions.length > 0) {
+    dropped.push(
+      `${doc.regions.length} region${doc.regions.length === 1 ? '' : 's'}`
+    );
+  }
+  cst.delete('regions');
 
   if (doc.start || doc.end) dropped.push('start/end');
   cst.delete('start');

--- a/src/concepts/dungeon-builder/markerStyle.ts
+++ b/src/concepts/dungeon-builder/markerStyle.ts
@@ -36,6 +36,26 @@ export interface MarkerStyle {
 export const START_COLOR = '#5fd1c9';
 export const END_COLOR = '#c9a227';
 
+/** Cell-authored semantic region overlay color (rpg-project#180), by
+ * `RegionDoc.archetype` — the SAME vocabulary `RoomDoc.archetype` uses
+ * (entrance|chamber|corridor|boss), reusing that alignment rather than
+ * inventing a second color scheme. Shared by `Board.tsx`'s read-only edit-
+ * mode overlay and `creation/CreationBoard.tsx`'s interactive one, so a
+ * region reads as the same archetype in both boards. Falls back to a
+ * neutral gray for an archetype string outside this vocabulary (nothing
+ * validates `archetype` against an enum client-side — see
+ * `setRegionArchetype`'s own doc comment). */
+const REGION_ARCHETYPE_COLOR: Record<string, string> = {
+  entrance: '#5fd1c9',
+  chamber: '#3a9b6a',
+  corridor: '#c9a227',
+  boss: '#a02020',
+};
+
+export function regionArchetypeColor(archetype: string): string {
+  return REGION_ARCHETYPE_COLOR[archetype] ?? '#8a7a5a';
+}
+
 export function resolveMarkerStyle(
   ref: string,
   opts: { isBoss?: boolean } = {}

--- a/src/concepts/dungeon-builder/regionGeometry.test.ts
+++ b/src/concepts/dungeon-builder/regionGeometry.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cellsAdjacent,
+  cellsAreContiguous,
+  cellsEqual,
+  pickAttachmentEdge,
+  regionCentroid,
+  sharedBoundaryEdges,
+  type RegionEdge,
+} from './regionGeometry';
+
+describe('cellsEqual', () => {
+  it('compares [col,row] pairs by value', () => {
+    expect(cellsEqual([1, 2], [1, 2])).toBe(true);
+    expect(cellsEqual([1, 2], [2, 1])).toBe(false);
+  });
+});
+
+describe('cellsAdjacent', () => {
+  it('is true for orthogonal neighbors only', () => {
+    expect(cellsAdjacent([1, 1], [2, 1])).toBe(true);
+    expect(cellsAdjacent([1, 1], [1, 2])).toBe(true);
+    expect(cellsAdjacent([1, 1], [0, 1])).toBe(true);
+    expect(cellsAdjacent([1, 1], [1, 0])).toBe(true);
+  });
+
+  it('is false for diagonal neighbors', () => {
+    expect(cellsAdjacent([1, 1], [2, 2])).toBe(false);
+    expect(cellsAdjacent([1, 1], [0, 0])).toBe(false);
+  });
+
+  it('is false for the same cell or a non-adjacent cell', () => {
+    expect(cellsAdjacent([1, 1], [1, 1])).toBe(false);
+    expect(cellsAdjacent([1, 1], [5, 5])).toBe(false);
+  });
+});
+
+describe('cellsAreContiguous', () => {
+  it('is false for an empty list', () => {
+    expect(cellsAreContiguous([])).toBe(false);
+  });
+
+  it('is true for a single cell', () => {
+    expect(cellsAreContiguous([[3, 3]])).toBe(true);
+  });
+
+  it('is true for an orthogonally connected run, any authoring order', () => {
+    expect(
+      cellsAreContiguous([
+        [9, 4],
+        [9, 2],
+        [9, 3],
+        [10, 3],
+        [10, 2],
+        [10, 4],
+      ])
+    ).toBe(true);
+  });
+
+  it('is false for two disconnected islands', () => {
+    expect(
+      cellsAreContiguous([
+        [0, 0],
+        [1, 0],
+        [5, 5],
+        [6, 5],
+      ])
+    ).toBe(false);
+  });
+
+  it('is false for cells that only touch diagonally', () => {
+    expect(
+      cellsAreContiguous([
+        [0, 0],
+        [1, 1],
+      ])
+    ).toBe(false);
+  });
+});
+
+describe('sharedBoundaryEdges', () => {
+  it('finds every orthogonal edge between two cell sets', () => {
+    // A 2x1 region at col 0-1, row 0, next to a 2x1 region at col 0-1, row 1.
+    const a: [number, number][] = [
+      [0, 0],
+      [1, 0],
+    ];
+    const b: [number, number][] = [
+      [0, 1],
+      [1, 1],
+    ];
+    const edges = sharedBoundaryEdges(a, b);
+    expect(edges).toHaveLength(2);
+    expect(edges).toEqual(
+      expect.arrayContaining([
+        { from: [0, 0], to: [0, 1] },
+        { from: [1, 0], to: [1, 1] },
+      ])
+    );
+  });
+
+  it('is empty when the two regions are not adjacent at all', () => {
+    const a: [number, number][] = [[0, 0]];
+    const b: [number, number][] = [[5, 5]];
+    expect(sharedBoundaryEdges(a, b)).toEqual([]);
+  });
+
+  it('is empty for two regions that only touch diagonally', () => {
+    const a: [number, number][] = [[0, 0]];
+    const b: [number, number][] = [[1, 1]];
+    expect(sharedBoundaryEdges(a, b)).toEqual([]);
+  });
+});
+
+describe('pickAttachmentEdge', () => {
+  it('returns null for an empty edge list', () => {
+    expect(pickAttachmentEdge([])).toBeNull();
+  });
+
+  it('deterministically picks the same edge every call for the same input', () => {
+    const edges: RegionEdge[] = [
+      { from: [0, 0], to: [0, 1] },
+      { from: [1, 0], to: [1, 1] },
+      { from: [2, 0], to: [2, 1] },
+    ];
+    const first = pickAttachmentEdge(edges);
+    const second = pickAttachmentEdge([...edges]);
+    expect(first).toEqual(second);
+    expect(first).toEqual({ from: [1, 0], to: [1, 1] }); // the middle of 3, sorted by (row, col)
+  });
+
+  it('picks a real member of the input list, not a synthesized midpoint', () => {
+    const edges: RegionEdge[] = [
+      { from: [0, 0], to: [0, 1] },
+      { from: [4, 0], to: [4, 1] },
+    ];
+    const picked = pickAttachmentEdge(edges);
+    expect(edges).toContainEqual(picked);
+  });
+});
+
+describe('regionCentroid', () => {
+  it('is the arithmetic mean of the cell list', () => {
+    expect(
+      regionCentroid([
+        [0, 0],
+        [2, 0],
+      ])
+    ).toEqual({ col: 1, row: 0 });
+  });
+
+  it('is {0,0} for an empty list rather than NaN', () => {
+    expect(regionCentroid([])).toEqual({ col: 0, row: 0 });
+  });
+});

--- a/src/concepts/dungeon-builder/regionGeometry.ts
+++ b/src/concepts/dungeon-builder/regionGeometry.ts
@@ -1,0 +1,141 @@
+/**
+ * regionGeometry — pure geometry for cell-authored semantic regions
+ * (rpg-project#180, "cell-authored semantic room regions"). Kept separate
+ * from `dungeonYaml.ts`'s CST layer, the same split `boardGeometry.ts`/
+ * `creationGeometry.ts` already use for every other pure-math concern in
+ * this concept: unit-testable without a CST document, and reusable by
+ * both the creation board (rectangular canvas) and the edit-mode hex
+ * board's read-only overlay, since a region's membership is expressed in
+ * the same abstract absolute [col,row] cell space regardless of which
+ * board renders it. Deliberately has NO dependency on `DungeonDoc`/
+ * `RegionDoc` (dungeonYaml.ts) — every function here takes plain cell
+ * arrays, so dungeonYaml.ts can import this module without creating a
+ * cycle.
+ */
+
+export type Cell = [number, number];
+
+function cellKey(c: Cell): string {
+  return `${c[0]},${c[1]}`;
+}
+
+export function cellsEqual(a: Cell, b: Cell): boolean {
+  return a[0] === b[0] && a[1] === b[1];
+}
+
+/** Orthogonal (4-neighbor) adjacency — the same adjacency `walls:`'s own
+ * "from/to must be orthogonally adjacent cells" rule assumes
+ * (TARGET-YAML.md's annotated example), and the one `cellsAreContiguous`/
+ * `sharedBoundaryEdges` below both build on. Diagonal neighbors don't
+ * count: there is no orthogonal wall/door edge to author between two
+ * cells that only touch at a corner. */
+export function cellsAdjacent(a: Cell, b: Cell): boolean {
+  const dc = Math.abs(a[0] - b[0]);
+  const dr = Math.abs(a[1] - b[1]);
+  return (dc === 1 && dr === 0) || (dc === 0 && dr === 1);
+}
+
+/** BFS connectivity over a cell list's own orthogonal adjacency —
+ * rpg-project#180's own acceptance criterion: "Overlapping, disconnected,
+ * empty, and invalid cell sets fail with author-facing validation
+ * errors." A single cell is trivially contiguous; an empty list is
+ * deliberately NOT contiguous here (there's nothing to connect) — callers
+ * that need a distinct "empty" message should check `cells.length === 0`
+ * separately (see `dungeonYaml.ts`'s `validateRegionCells`, which folds
+ * both checks into one author-facing string). */
+export function cellsAreContiguous(cells: readonly Cell[]): boolean {
+  if (cells.length === 0) return false;
+  const seen = new Set<string>([cellKey(cells[0])]);
+  const stack: Cell[] = [cells[0]];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    for (const c of cells) {
+      const key = cellKey(c);
+      if (seen.has(key)) continue;
+      if (cellsAdjacent(cur, c)) {
+        seen.add(key);
+        stack.push(c);
+      }
+    }
+  }
+  return seen.size === cells.length;
+}
+
+export interface RegionEdge {
+  /** The cell on the first region's side. */
+  from: Cell;
+  /** The cell on the second region's side, orthogonally adjacent to `from`. */
+  to: Cell;
+}
+
+/** Every orthogonal edge with one cell in `cellsA` and the other in
+ * `cellsB` — the candidate set for "attach these two regions with a door"
+ * (TARGET-YAML.md's "region attachment" section). Deliberately does not
+ * consult `walls:` at all: per the settled early-authoring model
+ * (rpg-project#175), a region's membership carries no implied wall on its
+ * own boundary — two regions can be adjacent with an open (wall-free)
+ * boundary today, same as two hand-declared rooms can be. O(|cellsA| *
+ * |cellsB|); both lists are small (a handful to a few dozen cells for any
+ * region this concept has authored), so the brute-force pairing is simpler
+ * to verify than a spatial index and cheap enough to run on every click. */
+export function sharedBoundaryEdges(
+  cellsA: readonly Cell[],
+  cellsB: readonly Cell[]
+): RegionEdge[] {
+  const edges: RegionEdge[] = [];
+  for (const a of cellsA) {
+    for (const b of cellsB) {
+      if (cellsAdjacent(a, b)) edges.push({ from: a, to: b });
+    }
+  }
+  return edges;
+}
+
+/** Picks ONE edge from a shared boundary to place the "connect regions"
+ * door on — the MIDPOINT edge along the boundary run, not an
+ * author-clicked one. TARGET-YAML.md's "region attachment" section
+ * records this as the deliberate first-pass choice: simplest to implement
+ * and explain, at the cost of not letting the author pick a specific edge
+ * when a boundary is long or L-shaped. Picking a specific edge
+ * interactively (e.g. hovering the shared boundary and clicking one
+ * segment) is a natural follow-up, not attempted this round.
+ *
+ * Deterministic: edges are sorted by their `to` cell's (row, then col) —
+ * a stable, reproducible order for any given pair of regions, NOT a
+ * physical-distance-along-the-boundary ordering (which would need the
+ * boundary's own shape traced out as a path). This is a documented
+ * simplification, good enough for the common case of one contiguous
+ * straight or near-straight shared run; a boundary with multiple
+ * disjoint segments (an author drew two regions that touch in two
+ * separate places) will pick from whichever segment sorts into the
+ * middle, not necessarily "the biggest" one. `null` when the two regions
+ * share no boundary at all — the caller should surface this as a
+ * rejection ("these regions aren't adjacent"), not a silent no-op. */
+export function pickAttachmentEdge(
+  edges: readonly RegionEdge[]
+): RegionEdge | null {
+  if (edges.length === 0) return null;
+  const sorted = [...edges].sort((x, y) => {
+    if (x.to[1] !== y.to[1]) return x.to[1] - y.to[1]; // row
+    return x.to[0] - y.to[0]; // col
+  });
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+/** The centroid (arithmetic mean) of a region's cells — used for the
+ * board's label placement only. Not a claim about the region's geometric
+ * "center" for a non-rectangular shape: a mean is a reasonable, cheap
+ * label anchor, but is not guaranteed to itself be a member cell for a
+ * concave region — callers don't need it to be, since it's a label
+ * position, not a click target. */
+export function regionCentroid(cells: readonly Cell[]): {
+  col: number;
+  row: number;
+} {
+  if (cells.length === 0) return { col: 0, row: 0 };
+  const sum = cells.reduce(
+    (acc, c) => ({ col: acc.col + c[0], row: acc.row + c[1] }),
+    { col: 0, row: 0 }
+  );
+  return { col: sum.col / cells.length, row: sum.row / cells.length };
+}

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -1,8 +1,9 @@
 # Dungeon Builder — specimen pack
 
-**Specimen pack version: v0.2** (2026-08-03). Posted in full on
+**Specimen pack version: v0.3** (2026-08-03). v0.1 was posted in full on
 [rpg-project#175](https://github.com/KirkDiggler/rpg-project/issues/175)
-for the backend session implementing YAML processing.
+for the backend session implementing YAML processing; this and later
+versions post as short diffs on the same issue.
 
 **Versioning note — read this before touching anything here.** The
 number above is the _specimen pack's own_ version. It is NOT the
@@ -16,6 +17,27 @@ addition. Never conflate the two numbers.
 
 ## Changelog
 
+- **v0.3** (2026-08-03) — `+ regions: construct (proposed, rpg-project#180)`:
+  `kitchen-sink.yaml` now declares two cell-authored semantic regions
+  (`hall-inner`, `hall-annex`) inside the `hall` room's absolute column
+  range, connected via `connectRegions` — the door edge it places shows up
+  as a THIRD entry in `walls:` (`{ from: [10,3], to: [11,3], kind: door }`),
+  alongside the two hand-drawn ones. `kitchen-sink.v1-subset.dropped.json`
+  now carries a `"2 regions"` entry (regions have no v1 representation of
+  any kind), and the region-attachment door is counted under the existing
+  `"3 walls"` entry — a region-attachment door is architecturally just
+  another `walls:` entry, not a separate wire concept; see
+  `TARGET-YAML.md`'s "regions:" section for the shape, invariants, and the
+  region-attachment-vs-chain-connector distinction.
+  `+ holes moved to exploration appendix`: the v0.1/v0.2 kitchen-sink doc
+  inconsistently carried a `holes:` entry despite holes being deliberately
+  deferred from the near-term dialect (TARGET-YAML.md's own framing) —
+  fixed by dropping `holes:` from `kitchen-sink.yaml` entirely and adding
+  `exploration/holes.yaml`, a small standalone specimen (also generated via
+  the real serializer, not hand-typed) demonstrating the construct without
+  implying it carries the same status as the main pack's contents.
+  `defaults: (v0.2)` — unchanged, still present on `kitchen-sink.yaml`
+  exactly as v0.2 left it.
 - **v0.2** (2026-08-03) — `+ height on any placement (#688)`: the
   top-level `candles` placement now carries an explicit `height: 0.4`
   with NO `mount:` key at all — the decoupled floor-standing/floating
@@ -39,12 +61,13 @@ of them)"` entry names both outcomes explicitly.
 
 ## Files
 
-| File                                  | What it is                                                                                                                                                                                                                                     |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kitchen-sink.yaml`                   | One document exercising every construct + field variation the builder can emit today (3-room chain, locked connector, every `place:` field combo, boss facing+targeting, both wall kinds, a hole, start/end, lighting, count-based obstacles). |
-| `kitchen-sink.v1-subset.yaml`         | The same document run through `stripToV1Subset` — exactly what Save & Play would persist right now.                                                                                                                                            |
-| `kitchen-sink.v1-subset.dropped.json` | What `stripToV1Subset` dropped from the kitchen-sink doc, and whether the result is `compilable` (≥2 rooms).                                                                                                                                   |
-| `canvas.yaml`                         | What creation mode ("New Dungeon," a blank canvas) emits after a few walls/doors/placements/start/end — the second real document shape (`rooms: []` + `canvas: {width,height}`, so every placement is top-level).                              |
+| File                                  | What it is                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kitchen-sink.yaml`                   | One document exercising every construct + field variation the builder can emit today (3-room chain, locked connector, every `place:` field combo, boss facing+targeting, both wall kinds including a region-attachment door, two cell-authored regions, start/end, lighting, count-based obstacles). No `holes:` as of v0.3 — see `exploration/holes.yaml`. |
+| `kitchen-sink.v1-subset.yaml`         | The same document run through `stripToV1Subset` — exactly what Save & Play would persist right now.                                                                                                                                                                                                                                                         |
+| `kitchen-sink.v1-subset.dropped.json` | What `stripToV1Subset` dropped from the kitchen-sink doc, and whether the result is `compilable` (≥2 rooms).                                                                                                                                                                                                                                                |
+| `canvas.yaml`                         | What creation mode ("New Dungeon," a blank canvas) emits after a few walls/doors/placements/start/end — the second real document shape (`rooms: []` + `canvas: {width,height}`, so every placement is top-level). Unchanged since v0.2.                                                                                                                     |
+| `exploration/holes.yaml`              | v0.3+. A minimal standalone specimen for the retained Hole prototype — deliberately deferred from the near-term dialect (TARGET-YAML.md), kept out of the main kitchen-sink doc so it doesn't read as carrying the same status as everything else in it.                                                                                                    |
 
 **Live-verified, not just claimed**: `kitchen-sink.v1-subset.yaml` was
 run through a real `PutDungeon(validate_only: true)` against an isolated
@@ -79,6 +102,8 @@ import { resolve } from 'node:path';
 import { describe, it } from 'vitest';
 import {
   clearPlacementFlag,
+  connectRegions,
+  createRegion,
   moveBoss,
   parseDungeon,
   placeItem,
@@ -98,11 +123,13 @@ import {
   setStart,
   setWallEdge,
   stripToV1Subset,
+  toDungeonDoc,
   toggleHole,
 } from './dungeonYaml';
 import { emptyCanvasYaml, DEFAULT_CANVAS } from './creation/emptyCanvasDoc';
 
 const OUT_DIR = resolve(__dirname, 'specimens');
+const EXPLORATION_DIR = resolve(__dirname, 'specimens/exploration');
 
 describe('specimen generator', () => {
   it('kitchen-sink', () => {
@@ -143,10 +170,10 @@ connectors:
     placeItem(cst, 'entry', 'dnd5e:props:statue-reaper', [3, 1]);
     setPlacementFacing(cst, 'entry', 1, 2); // NW
 
-    // v0.2: a placement lacking blocks_movement/blocks_los entirely
-    // (cleared right back off after placeItem's own auto-stamp) --
-    // exercises clearPlacementFlag AND gives `defaults:` below a REAL
-    // instance to inherit blocks_movement onto, materialized on strip.
+    // a placement lacking blocks_movement/blocks_los entirely (cleared
+    // right back off after placeItem's own auto-stamp) -- exercises
+    // clearPlacementFlag AND gives `defaults:` below a REAL instance to
+    // inherit blocks_movement onto, materialized on strip.
     placeItem(cst, 'entry', 'dnd5e:props:tomb-open', [5, 1]);
     clearPlacementFlag(cst, 'entry', 2, 'blocksMovement');
     clearPlacementFlag(cst, 'entry', 2, 'blocksLos');
@@ -162,7 +189,25 @@ connectors:
     setWallEdge(cst, [7, 1], [8, 0], 'solid', true);
     setWallEdge(cst, [7, 3], [8, 2], 'door', true);
 
-    toggleHole(cst, 10, 4);
+    // v0.3 (rpg-project#180): two cell-authored semantic regions inside
+    // "hall"'s absolute column range (hall's start_column = entry's width
+    // 6 + the reserved connector gap column = 7, so hall = [7,19)),
+    // connected via connectRegions -- the door edge it places lands in
+    // walls: as a THIRD entry, alongside the two hand-drawn ones above.
+    const docForRegions = toDungeonDoc(cst);
+    createRegion(cst, docForRegions, 'hall-inner', 'chamber', [
+      [9, 2],
+      [9, 3],
+      [10, 2],
+      [10, 3],
+    ]);
+    const docWithFirstRegion = toDungeonDoc(cst);
+    createRegion(cst, docWithFirstRegion, 'hall-annex', 'chamber', [
+      [11, 2],
+      [11, 3],
+    ]);
+    const docWithBothRegions = toDungeonDoc(cst);
+    connectRegions(cst, docWithBothRegions, 'hall-inner', 'hall-annex');
 
     // row 4 is the reserved door row (height/2) -- avoid it.
     moveBoss(cst, 'sanctum', [4, 3]);
@@ -180,9 +225,9 @@ connectors:
       blocksMovement: false,
       blocksLos: false,
     });
-    // v0.2 (#688): height decoupled from mount -- a FLOOR-standing
-    // placement (no mount: key at all) carrying its own height, the
-    // "floating candle" case the decoupling exists for.
+    // height decoupled from mount -- a FLOOR-standing placement (no
+    // mount: key at all) carrying its own height, the "floating candle"
+    // case the decoupling exists for.
     setPlacementHeight(cst, null, 1, 0.4);
 
     setConnectorLocked(cst, 0, { dc: 14, ability: 'dex' });
@@ -192,11 +237,16 @@ connectors:
     setEnd(cst, [4, 5]);
     setLightingAmbient(cst, 0.35);
 
-    // v0.2: defaults: map (this PR). Two different shapes on purpose --
-    // see this file's changelog entry above for the full explanation of
-    // what each one demonstrates (materialize-on-strip vs plain drop).
+    // defaults: map. Two different shapes on purpose -- see this file's
+    // changelog entry above for the full explanation of what each one
+    // demonstrates (materialize-on-strip vs plain drop).
     setRefDefault(cst, 'dnd5e:props:tomb-open', 'blocksMovement', true);
     setRefDefault(cst, 'dnd5e:props:statue-reaper', 'height', 1.0);
+
+    // v0.3: NO holes in the main kitchen-sink doc anymore -- see the
+    // separate exploration/holes.yaml specimen below for the deferred
+    // construct (this file's own "Holes moved to exploration appendix"
+    // changelog entry).
 
     const yaml = serializeDungeon(cst);
     writeFileSync(resolve(OUT_DIR, 'kitchen-sink.yaml'), yaml);
@@ -235,11 +285,40 @@ connectors:
     const yaml = serializeDungeon(cst);
     writeFileSync(resolve(OUT_DIR, 'canvas.yaml'), yaml);
   });
+
+  it('exploration/holes', () => {
+    // A minimal, standalone doc -- deliberately NOT folded into
+    // kitchen-sink.yaml (v0.3's "holes moved to exploration appendix"
+    // changelog entry) so demonstrating the retained Hole prototype never
+    // implies it carries the same status as the main pack's contents.
+    const skeleton = `version: 1
+key: specimen-holes-exploration
+name: Specimen — Holes (exploration)
+theme: crypt
+height: 8
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 6
+  - id: hall
+    archetype: chamber
+    width: 12
+connectors:
+  - { from: entry, to: hall }
+`;
+    const { cst } = parseDungeon(skeleton);
+    toggleHole(cst, 10, 4);
+    const yaml = serializeDungeon(cst);
+    writeFileSync(resolve(EXPLORATION_DIR, 'holes.yaml'), yaml);
+  });
 });
 ```
 
-When the next version adds new fields (e.g. v0.2's height-decouples-
-from-mount, or a `defaults:` map prototype), extend the script above
-with new mutator calls exercising them, add a "Regions section" example
-if #180 ever gains a real mutator (today it's proposed-shape-only, not
-emitted — see the rpg-project#175 comment), and re-run.
+When the next version adds new fields, extend the script above with new
+mutator calls exercising them and re-run. `regions:` (rpg-project#180) now
+has a real mutator set (`createRegion`/`addCellToRegion`/
+`removeCellFromRegion`/`renameRegion`/`setRegionArchetype`/`deleteRegion`/
+`connectRegions`) as of v0.3 — see `TARGET-YAML.md`'s "regions:" section
+for the full design; extend the kitchen-sink script's region block above,
+don't add a second one, if a future round adds more region field
+coverage.

--- a/src/concepts/dungeon-builder/specimens/exploration/holes.yaml
+++ b/src/concepts/dungeon-builder/specimens/exploration/holes.yaml
@@ -1,0 +1,16 @@
+version: 1
+key: specimen-holes-exploration
+name: Specimen — Holes (exploration)
+theme: crypt
+height: 8
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 6
+  - id: hall
+    archetype: chamber
+    width: 12
+connectors:
+  - { from: entry, to: hall }
+holes:
+  - [10, 4]

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
@@ -1,8 +1,8 @@
 {
   "dropped": [
     "defaults (2 refs; blocks_movement/blocks_los materialized onto 1 placement from 1 of them)",
-    "2 walls",
-    "1 hole",
+    "3 walls",
+    "2 regions",
     "start/end",
     "lighting",
     "2 top-level placements (mapped into rooms)",

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
@@ -29,8 +29,14 @@ connectors:
 walls:
   - { from: [ 7, 1 ], to: [ 8, 0 ], kind: solid }
   - { from: [ 7, 3 ], to: [ 8, 2 ], kind: door }
-holes:
-  - [ 10, 4 ]
+  - { from: [ 10, 3 ], to: [ 11, 3 ], kind: door }
+regions:
+  - id: hall-inner
+    archetype: chamber
+    cells: [ [ 9, 2 ], [ 9, 3 ], [ 10, 2 ], [ 10, 3 ] ]
+  - id: hall-annex
+    archetype: chamber
+    cells: [ [ 11, 2 ], [ 11, 3 ] ]
 place:
   - { ref: "dnd5e:props:wall-banner", at: [ 15, 3 ], blocks_movement: false, blocks_los: false, facing: E, mount: wall, height: 1.5, rotate_degrees: -8 }
   - { ref: "dnd5e:props:candles", at: [ 16, 3 ], blocks_movement: false, blocks_los: false, height: 0.4 }

--- a/src/concepts/dungeon-builder/types.ts
+++ b/src/concepts/dungeon-builder/types.ts
@@ -17,9 +17,13 @@ export type PlacementSelection =
 
 /** A board TOOL (as opposed to `PaletteSelection`'s draggable-item
  * selection) — target-dialect-only, proposed authoring actions from the
- * Structural (wall/door/hole) and Markers (start/end) palette categories. See
- * TARGET-YAML.md's "Structural palette category" section. Mutually
- * exclusive with `PaletteSelection`/`PlacementSelection`/connector
+ * Structural (wall/door/hole/region) and Markers (start/end) palette
+ * categories. See TARGET-YAML.md's "Structural palette category" section.
+ * Mutually exclusive with `PaletteSelection`/`PlacementSelection`/connector
  * selection — `DungeonBuilderConcept.tsx`'s `clearOtherSelections` keeps
- * that invariant. */
-export type BoardTool = 'wall' | 'door' | 'hole' | 'start' | 'end';
+ * that invariant. `'region'` (rpg-project#180, "cell-authored semantic
+ * room regions") is creation-mode-only this round — see
+ * `creation/CreationBoard.tsx`'s region-painting handling and
+ * `RegionPanel.tsx`; edit mode renders any authored `regions:` read-only,
+ * with no tool to create/edit them there yet. */
+export type BoardTool = 'wall' | 'door' | 'hole' | 'start' | 'end' | 'region';


### PR DESCRIPTION
## Summary

Prototype for **cell-authored semantic room regions** (rpg-project#180) in the Dungeon Builder concept, per Kirk's ask: "creating a region and ideally attaching it to the next region."

- **`regions:` construct** (proposed, not compiled server-side) — `RegionDoc { id, name?, archetype, cells: [col,row][] }`, matching the shape Kirk's own rpg-project#175 comment sketched. Full design writeup, alternatives considered, and open questions deliberately left undecided are in `TARGET-YAML.md`'s new "regions:" section.
- **Client-side validation** matching rpg-project#180's own acceptance criteria: non-empty, orthogonally contiguous, non-overlapping — enforced on create and on every membership edit, not just at creation.
- **Creation-mode UI**: a 4th Structural palette tool (Region), paint cells → auto-suggested id/name/archetype → Create; select an existing region to rename, change archetype, add/remove cells, or delete.
- **Attachment**: "Connect to '\<previous region\>'?" places a DOOR edge on the shared boundary (midpoint of the shared run) — mechanically just another `walls:` entry, **distinct from chain `connectors:`** (verified against the real `dungeonspec.Validate` source per rpg-project#175's spot-check finding: an authored door edge does not replace/satisfy a chain connector).
- **Edit-mode**: renders any authored `regions:` read-only (tinted hex overlay + label) — no create/edit affordance there this round.
- **`stripToV1Subset`** drops `regions:` entirely, with an honest count; the existing generic compile-badge UI picks it up automatically.

### Folded sync items (small, same PR)

- **Facing badge split**: a real backend probe (rpg-project#175) found floor-prop `facing` now compiles on Kirk's branch, but *only* for room-scoped, non-monster, non-wall-mounted placements. The Inspector now shows a distinct, more conservative badge for monster/boss/wall-mount facing controls, with the real validator's own rejection message in the tooltip.
- **Holes reconciled**: moved out of the main `kitchen-sink.yaml` specimen into a clearly-labeled `specimens/exploration/holes.yaml` appendix, so demonstrating the deferred Hole prototype no longer implies it carries the same status as the rest of the pack.
- **Status tracking note**: `start:`/floor-prop `facing` now compile on Kirk's *unreleased* authoring branch — recorded in `TARGET-YAML.md` so badges aren't flipped prematurely.

### Specimen pack v0.3

Regenerated via the real serializer (not hand-typed) — two connected regions added to `kitchen-sink.yaml`, holes removed. See `specimens/README.md`'s changelog.

## Test plan

- [x] `npm run ci-check` clean (format/lint/typecheck/build/test)
- [x] 162 dungeon-builder tests passing (45 new: parse/mutators/`connectRegions`/comment-safety/strip in `dungeonYaml.test.ts`; pure geometry in `regionGeometry.test.ts`)
- [x] Live-verified against a real dev server (own port, 5173): a region painted + labeled; two regions connected via the attachment-door flow; edit-mode's read-only region overlay — caught and fixed a real bug in the process (the "connect to previous region" prompt never rendering, missed by unit tests since they call mutators directly)
- [x] Posted a short follow-up comment on rpg-project#175 with the v0.3 changelog, the `regions:` shape, and the attachment-vs-connector distinction

— asset-pipeline agent, on behalf of KirkDiggler