### PR TITLE
unit: hex-true creation canvas (6-edge walls, region brush)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3189,3 +3189,192 @@ every mutator, `connectRegions`, comment-safety, and `stripToV1Subset`;
 17 in the new `regionGeometry.test.ts` covering the pure adjacency/
 contiguity/boundary-edge/centroid math directly). `ci-check` clean
 (format/lint/typecheck/build/test).
+
+## Hex-true creation canvas: kill the square-grid renderer (2026-08-03)
+
+Kirk, diagnosing the "New Dungeon" canvas directly: "that new dungeon is
+squares... our walls as we lay them out cannot follow along the edge...
+any hex that is not 100% uncovered would not be traversable by the
+players" — sharpened: a square grid draws only 4 of a hex's 6 real
+adjacencies, so a region that reads as fully enclosed on squares can have
+two INVISIBLE open edges in hex reality (players walk through the
+diagonals — false enclosure); and "walls look like vertical blinds along
+the side edges" — a square wall run between two rows is a set of
+disconnected parallel slats, where real hex edges share corners and chain
+into one continuous run. Edit mode went hex-true back in the
+flattened-vs-hex-true round ("Flattened layout mode: explored and
+rejected," above); creation mode's own square renderer survived that
+round as "genuinely separate, never claiming hex adjacency" — that
+exemption ends here.
+
+### What changed, mechanically
+
+`creation/creationGeometry.ts` is rebuilt on the SAME hex primitives
+`hexLayout.ts`/`boardGeometry.ts` already give edit mode
+(`cellCenter`/`cellCorners`/`edgeBetweenCells`/`worldToCube`/
+`neighborCell`) — one coordinate space for both boards now, not two.
+`FLAT_COL_SPACING`/`FLAT_ROW_SPACING` (square-grid pitch constants) are
+deleted from `hexLayout.ts` entirely, along with every `hEdgeGeometry`/
+`vEdgeGeometry` axis-aligned edge function. `CreationBoard.tsx` renders
+real hex polygons (`creationCellPolygon`) for the base grid, holes, and
+region overlays, and real edge segments (`edgeBetweenCells` via
+`wallGeometry`) for walls — replacing the old tiled-`<rect>` background
+pattern and axis-aligned wall `<line>`s. The canvas dimension semantics
+(a `{width,height}` grid of `[col,row]` cells, 20×30 by default) are
+UNCHANGED — only the geometry each cell resolves to is different.
+
+### The wall-drawing crenellated-comb bug does NOT reappear in hex — verified numerically, not assumed
+
+The square board's own bug (this file's "wall-drawing interaction"
+finding, way above): a per-pixel dx-vs-dy comparison flipped which of 2
+candidate edges was "nearest" at a point with no relationship to a real
+edge boundary, producing disconnected teeth instead of a straight wall.
+The obvious question for hex — does picking among a cell's 6 real edges
+have the same instability? — was checked directly (a small standalone
+script sampling points along a straight world-space line and calling the
+new `nearestEdge` at each one, before writing any test): every transition
+between distinct edges shared a real corner, with NO lock at all. This
+isn't a coincidence — a hex cell's 6 "nearest to this edge" regions tile
+the cell with shared boundaries exactly at the corners, unlike the
+square's 4-quadrant dx/dy split, which had a seam unrelated to any real
+edge. `creationGeometry.test.ts`'s own describe block ("hex-true fix for
+the square predecessor's crenellated-comb bug") re-proves this as a real
+vitest test, not just a one-off script. The drag-orientation lock
+(`dragFamily`, generalized from 2 axes to hex's 3 parallel-edge families)
+survives in the interaction, but for a WEAKER reason than before: not to
+prevent disconnection (nothing can produce a gap), but to hold one
+deliberate family choice for a long stroke so it can't drift onto an
+unrelated third family mid-drag.
+
+**Visual proof, not just geometry math**: `demoScript.ts`'s own divider
+wall used to be hand-transcribed as one `[col,14]-[col,15]` segment per
+column (`DIVIDER_COLS`) — a pattern that drew a straight, connected line
+under the OLD square geometry. Run through the new hex math as-is, it
+does NOT connect (consecutive segments land ~20px apart — a real gap,
+confirmed numerically). Rather than hand-picking new coordinates (which
+would just be a second, unverified guess), `creationGeometry.ts` grew
+`traceEdgeRun` — samples a straight world-space line through the SAME
+`nearestEdge` a live drag calls — and `demoScript.ts` now derives its
+wall run FROM that function. "Play the pitch," driven live in a real
+browser, produces a continuous zigzag wall with the door sitting cleanly
+in the middle of the run — screenshot evidence below.
+
+### Region brush: click-per-cell became drag-to-paint
+
+Kirk's ask, verbatim: "building a region should have us draw the shape.
+right now we have to click every square." The region tool's pointer
+handling used to fire exactly once per click
+(`useRegionEditing.ts`'s `togglePendingCell`/`handleToggleCellOnSelected`,
+both plain toggles). Drag-paint needed a DIFFERENT primitive, not just a
+pointer-move loop calling the same toggle repeatedly: a toggle re-applied
+to a cell the drag revisits (normal for a slow real mouse-move, which
+fires many events per cell) would flip it back off mid-stroke, and a
+toggle's direction depends on the CELL's own pre-drag state, not the
+stroke's — inconsistent the moment a drag crosses a mix of already-member
+and non-member cells. Fixed by adding idempotent siblings,
+`setPendingCellMembership`/`setSelectedRegionCellMembership` (`included:
+boolean`, only mutates if it would actually change something), with the
+add-vs-erase MODE decided once, from the drag's first cell (Shift forces
+erase regardless of that cell's own state — the "a modifier... removes"
+affordance), then held for the whole stroke via a per-drag `touched`
+dedup set in `CreationBoard.tsx`. Live-verified: one continuous
+pointer-down+drag+up gesture painted a real 9-cell pending region ("9
+cells selected" in the panel) — screenshot evidence below.
+
+### Enclosure honesty: an OPEN-boundary overlay, Kirk's false-enclosure worry made visible
+
+New `creationGeometry.ts` function, `openBoundaryEdges(cells, walls)`:
+for every member cell's up-to-6 real hex edges, skip the ones bordering
+ANOTHER member of the same region (internal, membership-only, never
+"open" regardless of walls), then flag whichever of the remaining
+boundary edges has no matching `walls:` entry. Cheap by construction (at
+most 6 neighbor checks per member cell, a flat `walls` scan per candidate
+edge — same budget `sharedBoundaryEdges` already spends). `CreationBoard.tsx`
+renders the result as a hot red/orange line overlay for EVERY region on
+the board, not just the selected one — an author scanning the whole
+canvas should see at a glance which regions are actually sealed, not have
+to select each one in turn. Four new `creationGeometry.test.ts` cases
+cover: an isolated cell's all-6-open baseline, one wall closing exactly
+one edge, all 6 walls fully sealing a cell (zero open edges), and — the
+one that most directly answers Kirk's worry — the shared internal edge
+between two same-region members is NEVER open, wall or no wall, because
+it was never a boundary edge to begin with.
+
+### The 4-vs-6 adjacency finding: `regionGeometry.ts`'s `cellsAdjacent` was under-counting
+
+`regionGeometry.ts`'s `cellsAdjacent` used to be a plain 4-neighbor
+orthogonal check (`|dcol|+|drow| === 1`), inherited from the square
+canvas #694 built regions against. Real hex adjacency
+(`hexDistance(cubeAtColRow(a), cubeAtColRow(b)) === 1`) is a STRICTLY
+WIDER relation: every same-row-±1-col or same-col-±1-row pair is still
+hex-adjacent (verified algebraically — the parity-correction term in
+`cubeAtColRow` cancels identically for both cases), so nothing that
+validated as contiguous under the old rule stops validating. What
+changes is that a hex cell has 6 neighbors, not 4 — exactly 2 of a square
+grid's 4 "diagonal" directions turn out to be genuine hex neighbors
+(which 2 depends on column parity; verified numerically: `[1,1]`-`[2,2]`
+is hex-distance 1 — a real neighbor — while `[1,1]`-`[0,0]` stays
+hex-distance 2, even though both read identically as "diagonal" on the
+square grid). Concretely, on a real fixture:
+`connectRegions` between two 2-cell regions (`dungeonYaml.test.ts`'s own
+test) used to find exactly 2 candidate shared-boundary edges under
+4-adjacency; the SAME two regions have 3 under real hex adjacency (a
+genuinely new `[1,1]-[2,2]` edge neither region's own square-grid
+authoring anticipated) — which shifts `pickAttachmentEdge`'s
+midpoint-of-N pick from `{from:[2,1],to:[2,2]}` to `{from:[1,1],to:[2,2]}`.
+Fixed the one test that hard-coded the old 2-edge answer; every other
+region test (contiguity, overlap, the 6-cell block, the two-disconnected-
+islands case) needed no change, since 6-adjacency is additive, never
+subtractive, relative to what #694 already validated. `TARGET-YAML.md`'s
+"Invariants" section under `regions:` now says "hex-contiguous," not
+"orthogonally contiguous," with the same finding recorded there.
+
+### Live verification
+
+Real browser, real dev server (`npm run dev -- --port 5175`, this
+concept's own `/concepts?concept=dungeon-builder` route,
+`New Dungeon` tab), driven via throwaway Playwright scripts
+(`game-dev/tools/browser/_unit_hexcreate_*.mjs`, gitignored scratch
+pattern, not this repo — same convention the region-authoring unit
+above used). Screenshots:
+
+1. The blank "New Dungeon" canvas rendering as real hexagons, not
+   squares — the core visual claim this whole round makes.
+2. "Play the pitch" run to completion: a continuous zigzag divider wall
+   with a door at its midpoint, a monster and a facing-rotated reaper
+   statue, START/END markers — all at their real hex positions. The SVG's
+   own viewBox for a 20-column canvas is ~1321×1490 board units (the
+   canvas GENUINELY shears diagonally across 20 columns, same
+   already-accepted finding this file's "the floor plan shears
+   diagonally" section describes for edit mode's compiled boards, now
+   also visible on creation mode's wider canvas) — confirmed by
+   inspecting the live DOM (11 wall `<line>`s, 5 marker `<circle>`s, all
+   genuinely present) before scrolling the container to frame a close-up
+   of the wall run itself.
+3. A single pointer-down+drag+up gesture over the Region tool painting a
+   real 9-cell pending region — no per-cell clicking.
+4. A freshly-created, unwalled region rendered with its ENTIRE boundary
+   traced in the new open-edge red highlight — the false-enclosure
+   affordance, directly answering Kirk's worry.
+5. A second region created elsewhere on the canvas, correctly and
+   HONESTLY reported as not sharing a boundary with the first ("region-1"
+   doesn't share a boundary with this region — nothing to connect
+   automatically") — the connect-flow's rejection path, re-verified
+   under real hex adjacency. The POSITIVE connect-success path (a door
+   correctly placed on the pickAttachmentEdge midpoint) is not
+   separately screenshotted this round — it's the exact case
+   `dungeonYaml.test.ts`'s `connectRegions` test already covers post-fix,
+   including the specific 4-vs-6-adjacency edge-count change above.
+
+The two expected `PutDungeon`/authoring-service console errors
+(`[unimplemented] unknown service ...AuthoringService`) are this
+concept's normal FIXTURES-MODE behavior against a dev server with no
+local `rpg-api` running — unrelated to this round's changes.
+
+170 dungeon-builder tests passing (up from 162 — 8 new: 6 in
+`creation/creationGeometry.test.ts`'s `nearestEdge`/`traceEdgeRun`/
+`nearestCreationCell`/`dragFamily` coverage of the new hex math, plus a
+4-case `openBoundaryEdges` block; `regionGeometry.test.ts`'s existing
+adjacency/boundary tests were updated in place, not added to, to assert
+the new hex-true answers). `ci-check` clean
+(format/lint/typecheck/build/test).

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -176,6 +176,15 @@ connectors:
 # (sum of room widths + gaps, by height) and this becomes redundant —
 # it exists only to give a blank document something to draw walls inside
 # of before any room has been declared.
+#
+# HEX-TRUE (2026-08-03): width/height are cell-count DIMENSIONS only —
+# unchanged by this note. What changed is the GEOMETRY every [col,row] in
+# this dialect resolves to when rendered: the creation canvas now uses the
+# SAME real hex math (hexLayout.ts's cellCenter/edgeBetweenCells) the
+# compiled edit-mode board renders with, not a second, square-grid
+# coordinate system. One coordinate space, one rendering, for both boards
+# — see CONTRACT.md's "hex-true creation canvas" ledger entry for the full
+# finding (false enclosure, disconnected wall segments) that drove this.
 canvas:
   width: 20
   height: 30
@@ -898,13 +907,22 @@ produce a region shape the eventual real #180 validator is already known
 to reject:
 
 - **Non-empty** — a region needs at least one cell.
-- **Orthogonally contiguous** — every cell must be reachable from every
-  other cell in the same region via 4-neighbor (not diagonal) adjacency
-  (`regionGeometry.ts`'s `cellsAreContiguous`, a plain BFS/flood-fill).
-  Diagonal-only adjacency doesn't count, matching `walls:`'s own
-  "orthogonally adjacent cells" requirement — there is no diagonal edge to
-  ever author a wall/door on between two cells that only touch at a
-  corner.
+- **Hex-contiguous** (updated 2026-08-03; was 4-neighbor-only) — every
+  cell must be reachable from every other cell in the same region via
+  REAL hex adjacency (`regionGeometry.ts`'s `cellsAreContiguous`, a plain
+  BFS/flood-fill over `cellsAdjacent`'s `hexDistance === 1` check), not
+  the 4-neighbor orthogonal check this concept used before the creation
+  board went hex-true. The old rule undercounted: a hex cell has 6 real
+  neighbors, and exactly 2 of a square grid's 4 "diagonal" directions
+  turn out to be genuine hex neighbors (which 2 depends on column
+  parity — verified numerically, see `regionGeometry.test.ts`). This is a
+  strictly WIDER relation — every cell set that validated as contiguous
+  under the old rule still does (4-adjacency was always a subset of real
+  hex adjacency), so no previously-authored valid region breaks; the
+  change only lets a previously-rejected (diagonal-only-touching) cell
+  set validate correctly now. `walls:`'s own "orthogonally adjacent
+  cells" phrasing (this file's annotated example, above) means the same
+  thing: hex-adjacent, not axis-aligned-only.
 - **Non-overlapping** — no cell may belong to more than one region at
   once (`cellsOverlapAnotherRegion`). Enforced on create AND on every
   membership edit (`addCellToRegion`), not just at creation time.

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -10,10 +10,28 @@
  * with zero rooms needs to fake — see TARGET-YAML.md's "top-level
  * placement" section; an earlier round briefly tried a synthetic
  * `archetype: canvas` bridge room instead, rejected, see CONTRACT.md).
- * Still its own specialized renderer, not `Board.tsx` itself — a
- * rectangular free canvas and a compiled hex room-chain are genuinely
- * different geometries, and one component branching between both would
- * likely be worse than two focused renderers sharing one data model.
+ * Still its own specialized renderer, not `Board.tsx` itself — creation
+ * mode's own tools (edge-painting walls with a live stroke, the Region
+ * paint brush, start/end/hole markers) are genuinely different
+ * interactions from the compiled edit board's click-to-place/drag-to-move
+ * — but the underlying CELL GEOMETRY is now identical (see
+ * "HEX-TRUE" below), not a second coordinate system.
+ *
+ * **HEX-TRUE (2026-08-03)**: this board used to render a plain rectangular
+ * grid (`FLAT_COL_SPACING`/`FLAT_ROW_SPACING`, axis-aligned cells/edges).
+ * Kirk, diagnosing it directly: "that new dungeon is squares... our walls
+ * as we lay them out cannot follow along the edge... any hex that is not
+ * 100% uncovered would not be traversable by the players" — a square grid
+ * only exposes 4 of a hex's 6 real adjacencies, so a region that reads as
+ * fully enclosed on squares can have two invisible open edges in hex
+ * reality (players walk through the diagonals — false enclosure); and
+ * "walls look like vertical blinds along the side edges" — disconnected
+ * parallel slats where real hex edges share corners and chain into a
+ * continuous run. This board now renders every cell/edge/marker through
+ * `creationGeometry.ts`'s hex functions, which build on the SAME
+ * `hexLayout.ts` math the compiled edit-mode `Board.tsx` renders with —
+ * one coordinate space, not two. The canvas dimension semantics (a
+ * `{width,height}` grid of `[col,row]` cells) are unchanged.
  *
  * Client-side only in the sense that matters — no server call happens
  * here (design.md defers wall/shape authoring to P4+; there is no real
@@ -30,7 +48,12 @@
  * literally described ("draw the walls") and the shape that maps onto
  * the real wire type without translation. Click-drag paints a stroke of
  * same-state edges (first edge touched decides add-vs-erase for the
- * whole stroke), same interaction grammar as any paint tool.
+ * whole stroke), same interaction grammar as any paint tool. See
+ * `creationGeometry.ts`'s `nearestEdge` doc comment for why the hex
+ * version of this drag no longer needs an orientation lock to stay
+ * CONNECTED (unlike the square predecessor's crenellated-comb bug) — the
+ * lock (`dragFamily`) survives here only to hold one deliberate "which of
+ * the 3 parallel-edge families" choice for the whole stroke.
  */
 import {
   facingDirection,
@@ -39,7 +62,7 @@ import {
 import { cubeToWorld } from '@/components/hex-grid/hexMath';
 import { useRef, useState, type ReactElement } from 'react';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
-import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
+import { BOARD_HEX_SIZE, cellCenter } from '../hexLayout';
 import {
   END_COLOR,
   regionArchetypeColor,
@@ -52,10 +75,12 @@ import type { BoardTool, PlacementSelection } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import {
   creationCellCenter,
-  hEdgeGeometry,
+  creationCellPolygon,
+  dragFamily,
   nearestCreationCell,
   nearestEdge,
-  vEdgeGeometry,
+  openBoundaryEdges,
+  wallGeometry,
   type EdgeGeometry,
 } from './creationGeometry';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
@@ -87,15 +112,12 @@ interface CreationBoardProps {
 }
 
 // Same 6-direction convention authorGridHelpers.ts already defines for
-// hex grids (HEX_FACING_LABELS, order E,NE,NW,W,SW,SE) — reused directly
-// rather than inventing a rectangular-grid compass (a finding in its own
-// right: creation mode's rectangular canvas doesn't map 1:1 onto 6 hex
-// directions, but reusing the one real convention in the codebase beats
-// inventing a second, incompatible one — see CONTRACT.md). The screen
-// angle for each direction is computed through the SAME cubeToWorld math
-// hex-true mode uses (a unit step in that direction, projected to 2D
-// screen space), not a hand-typed table, so it stays provably consistent
-// even though this canvas has no cube coordinates of its own.
+// hex grids (HEX_FACING_LABELS, order E,NE,NW,W,SW,SE) — the facing arrow
+// convention was never square-canvas-specific in the first place (it
+// already used real hex angles even when the canvas underneath it was
+// still flat squares — TARGET-YAML.md's "reused the existing 6-direction
+// convention, not a rectangular compass" finding), so it's unchanged by
+// the hex-true rendering round.
 const FACING_ANGLES_DEG = HEX_FACING_LABELS.map((_, i) => {
   const dir = facingDirection(i);
   const world = cubeToWorld(dir, 1);
@@ -120,16 +142,7 @@ function wallAtEdge(
   );
 }
 
-/** A wall's line geometry from its stored `from`/`to` — detects
- * horizontal vs. vertical from the coordinate delta rather than trusting
- * a separately-stored orientation, since `WallDoc` (the real, shared
- * shape) doesn't carry one; `hEdgeGeometry`/`vEdgeGeometry` both key off
- * the SAME (col, row) `from` anchor `setWallEdge` was called with. */
-function wallGeometry(wall: WallDoc): EdgeGeometry {
-  const [fc, fr] = wall.from;
-  const [tc] = wall.to;
-  return tc === fc ? hEdgeGeometry(fc, fr) : vEdgeGeometry(fc, fr);
-}
+const CELL_SIZE = BOARD_HEX_SIZE - 1.5;
 
 export function CreationBoard({
   doc,
@@ -147,19 +160,30 @@ export function CreationBoard({
   const [stroke, setStroke] = useState<{
     addMode: boolean;
     startPoint: { x: number; y: number };
-    /** null until the drag has moved far enough to tell direction —
-     * see handlePointerMove's own comment for why this can't just be the
-     * first touched edge's orientation. */
-    orientation: 'h' | 'v' | null;
+    /** `null` until the drag has moved far enough to tell direction — see
+     * `handlePointerMove`'s own comment. One of the 3 parallel-edge
+     * families (`creationGeometry.ts`'s `dragFamily`), not an 'h'/'v'
+     * pair — a hex cell has 3 edge orientations, not 2. */
+    family: 0 | 1 | 2 | null;
   } | null>(null);
   const [dragPlacement, setDragPlacement] = useState<PlacementSelection | null>(
     null
   );
+  /** Region-brush drag state (Kirk's ask: "building a region should have
+   * us draw the shape. right now we have to click every square") — `mode`
+   * is decided ONCE, from the FIRST cell's own membership (or a Shift
+   * override, the "modifier... removes" eraser), then held for the whole
+   * stroke, mirroring the wall stroke's own `addMode`. `touched` is a
+   * per-stroke, once-per-cell dedup set — without it, a slow drag firing
+   * many pointer-move events over the SAME cell would call the mutator
+   * repeatedly for no reason (each call is already idempotent against
+   * `mode`, so this is a perf/no-op guard, not a correctness one). */
+  const [regionStroke, setRegionStroke] = useState<{
+    mode: 'add' | 'erase';
+    touched: Set<string>;
+  } | null>(null);
 
   const grid = doc.canvas ?? DEFAULT_CANVAS;
-  const width = grid.width * FLAT_COL_SPACING;
-  const height = grid.height * FLAT_ROW_SPACING;
-  const pad = FLAT_COL_SPACING;
 
   const toBoardPoint = (clientX: number, clientY: number) => {
     const svg = svgRef.current;
@@ -238,12 +262,29 @@ export function CreationBoard({
     }
     if (tool === 'region') {
       const cell = nearestCreationCell(p, grid);
+      const cellKey = `${cell[0]},${cell[1]}`;
       if (regionEdit.selectedRegionId) {
-        // Editing an existing region's membership — every click toggles
-        // this cell in/out of THAT region, regardless of whether it
-        // belongs to some other region already (addCellToRegion's own
-        // overlap validation catches that case and surfaces a toast).
-        regionEdit.handleToggleCellOnSelected(cell);
+        // Editing an existing region's membership. Mode for the WHOLE
+        // drag is decided here, from this first cell — Shift forces
+        // erase (the "modifier... removes" affordance) regardless of
+        // this cell's own state; otherwise erase iff this cell is
+        // already a member, matching the pre-drag-brush single-click
+        // toggle feel. `addCellToRegion`'s own overlap validation still
+        // catches a cell that belongs to another region (surfaces a
+        // toast), same as before.
+        const region = doc.regions.find(
+          (r) => r.id === regionEdit.selectedRegionId
+        );
+        const isMember =
+          region?.cells.some((c) => c[0] === cell[0] && c[1] === cell[1]) ??
+          false;
+        const mode: 'add' | 'erase' = e.shiftKey
+          ? 'erase'
+          : isMember
+            ? 'erase'
+            : 'add';
+        regionEdit.setSelectedRegionCellMembership(cell, mode === 'add');
+        setRegionStroke({ mode, touched: new Set([cellKey]) });
         return;
       }
       // No region selected yet: a click on an EXISTING region's cell
@@ -252,8 +293,12 @@ export function CreationBoard({
       // this cell into the region I'm painting," even if it happens to
       // land on another region's territory, since createRegion's own
       // overlap check is what should catch that, not a silent
-      // reinterpretation of the click). Otherwise, toggle the cell into
-      // the pending (not-yet-created) region.
+      // reinterpretation of the click). A SELECT click never starts a
+      // paint stroke — it's a discrete action, not a drag gesture; the
+      // author drags to paint on a SEPARATE gesture after selecting.
+      // Otherwise, this is the first cell of a pending-region paint
+      // stroke — same add-vs-erase mode decision as the selected-region
+      // branch above.
       const hit =
         regionEdit.pendingCells.length === 0
           ? doc.regions.find((r) =>
@@ -262,16 +307,25 @@ export function CreationBoard({
           : undefined;
       if (hit) {
         regionEdit.selectRegion(hit.id);
-      } else {
-        regionEdit.togglePendingCell(cell);
+        return;
       }
+      const isPending = regionEdit.pendingCells.some(
+        (c) => c[0] === cell[0] && c[1] === cell[1]
+      );
+      const mode: 'add' | 'erase' = e.shiftKey
+        ? 'erase'
+        : isPending
+          ? 'erase'
+          : 'add';
+      regionEdit.setPendingCellMembership(cell, mode === 'add');
+      setRegionStroke({ mode, touched: new Set([cellKey]) });
       return;
     }
     const edge = nearestEdge(p, grid);
     if (!edge) return;
     if (tool === 'wall') {
       const existing = wallAtEdge(doc, edge.cellA, edge.cellB);
-      setStroke({ addMode: !existing, startPoint: p, orientation: null });
+      setStroke({ addMode: !existing, startPoint: p, family: null });
       applyEdgeAction(edge, !existing);
     } else if (tool === 'door') {
       applyEdgeAction(edge);
@@ -280,8 +334,10 @@ export function CreationBoard({
 
   // A quarter cell of movement before committing to a direction — small
   // enough to feel immediate, large enough not to fire on hand-tremor.
-  const DIRECTION_LOCK_THRESHOLD =
-    Math.min(FLAT_COL_SPACING, FLAT_ROW_SPACING) * 0.25;
+  // Board-space, not tied to any one axis (hex has 3 edge families, not
+  // 2), so this compares against the hex radius directly rather than a
+  // per-axis spacing constant the square predecessor had.
+  const DIRECTION_LOCK_THRESHOLD = BOARD_HEX_SIZE * 0.5;
 
   const handlePointerMove: React.PointerEventHandler<SVGSVGElement> = (e) => {
     const p = toBoardPoint(e.clientX, e.clientY);
@@ -292,25 +348,26 @@ export function CreationBoard({
     }
     if (tool === 'wall' || tool === 'door') {
       if (stroke && tool === 'wall') {
-        let orientation = stroke.orientation;
-        if (orientation === null) {
-          // A horizontal drag draws a horizontal wall (consecutive 'h'
-          // edges share endpoints and connect end-to-end into one
-          // straight line); a vertical drag draws a vertical one — this
-          // is the OPPOSITE of "whichever edge the pointer happens to be
-          // closest to right now" (that's a function of exactly where
-          // inside a cell the cursor sits, not of which way the user is
-          // dragging, and using it produced a crenellated comb instead
-          // of a straight wall — see CONTRACT.md's wall-interaction
-          // finding for the concrete before/after).
+        let family = stroke.family;
+        if (family === null) {
+          // A drag along one of the 3 hex edge families draws a wall in
+          // that family (dragFamily picks whichever family's own edge
+          // LINE is most nearly parallel to the drag vector — tracing a
+          // wall means dragging roughly along it). Locked once per
+          // stroke so a long drag can't wander onto an unrelated third
+          // family mid-way — see creationGeometry.ts's `nearestEdge` doc
+          // comment for why this is a stabilizer, not (like the square
+          // predecessor's h/v lock) a correctness fix: a hex cell's 6
+          // nearest-edge regions already tile with no gap, so a plain
+          // unlocked pick can't produce the old crenellated-comb bug.
           const dx = p.x - stroke.startPoint.x;
           const dy = p.y - stroke.startPoint.y;
           if (Math.hypot(dx, dy) >= DIRECTION_LOCK_THRESHOLD) {
-            orientation = Math.abs(dx) >= Math.abs(dy) ? 'h' : 'v';
-            setStroke({ ...stroke, orientation });
+            family = dragFamily(dx, dy);
+            setStroke({ ...stroke, family });
           }
         }
-        const edge = nearestEdge(p, grid, orientation ?? undefined);
+        const edge = nearestEdge(p, grid, family ?? undefined);
         setHoverEdge(edge);
         if (edge)
           onToggleWallEdge(edge.cellA, edge.cellB, 'solid', stroke.addMode);
@@ -321,16 +378,78 @@ export function CreationBoard({
     } else {
       setHoverEdge(null);
     }
+    if (tool === 'region' && regionStroke) {
+      const cell = nearestCreationCell(p, grid);
+      const key = `${cell[0]},${cell[1]}`;
+      if (!regionStroke.touched.has(key)) {
+        regionStroke.touched.add(key);
+        if (regionEdit.selectedRegionId) {
+          regionEdit.setSelectedRegionCellMembership(
+            cell,
+            regionStroke.mode === 'add'
+          );
+        } else {
+          regionEdit.setPendingCellMembership(
+            cell,
+            regionStroke.mode === 'add'
+          );
+        }
+      }
+    }
   };
 
   const handlePointerUp: React.PointerEventHandler<SVGSVGElement> = () => {
     setStroke(null);
     setDragPlacement(null);
+    setRegionStroke(null);
   };
+
+  // --- base grid: one hex polygon per cell, replacing the square
+  // predecessor's tiled-rect pattern background. Also the extent-tracking
+  // pass the viewBox below is computed from — a hex canvas' true bounding
+  // box isn't a clean `width*height` rectangle the way a square grid's
+  // was (see hexLayout.ts's own "the floor plan shears diagonally"
+  // finding, CONTRACT.md), so it's derived from real corner positions
+  // like Board.tsx's compiled-board viewBox already does, not recomputed
+  // by a second, parallel formula.
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity;
+  const trackExtent = (x: number, y: number) => {
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  };
+  const trackCellExtent = (col: number, row: number) => {
+    creationCellPolygon(col, row).forEach(([x, y]) => trackExtent(x, y));
+  };
+
+  const cellEls: ReactElement[] = [];
+  for (let col = 0; col < grid.width; col++) {
+    for (let row = 0; row < grid.height; row++) {
+      const corners = creationCellPolygon(col, row);
+      corners.forEach(([x, y]) => trackExtent(x, y));
+      const points = corners
+        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+        .join(' ');
+      cellEls.push(
+        <polygon
+          key={`cell-${col}-${row}`}
+          points={points}
+          fill="#1a1512"
+          stroke="#2a2521"
+          strokeWidth={1}
+          pointerEvents="none"
+        />
+      );
+    }
+  }
 
   const wallEls: ReactElement[] = [];
   for (const wall of doc.walls) {
-    const edge = wallGeometry(wall);
+    const edge = wallGeometry(wall.from, wall.to);
     wallEls.push(
       <line
         key={`${wall.from.join(',')}-${wall.to.join(',')}`}
@@ -360,17 +479,15 @@ export function CreationBoard({
 
   // Same dark/dashed treatment Board.tsx (edit mode) uses for a target-
   // dialect hole — one visual language for "no floor here" across both
-  // boards.
+  // boards. Hex polygon now, not an axis-aligned rect.
   const holeEls: ReactElement[] = doc.holes.map(([col, row]) => {
-    const center = creationCellCenter(col, row);
-    const half = { x: FLAT_COL_SPACING * 0.42, y: FLAT_ROW_SPACING * 0.42 };
+    const corners = creationCellPolygon(col, row, CELL_SIZE * 0.75)
+      .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+      .join(' ');
     return (
-      <rect
+      <polygon
         key={`hole-${col}-${row}`}
-        x={center.x - half.x}
-        y={center.y - half.y}
-        width={half.x * 2}
-        height={half.y * 2}
+        points={corners}
         fill="#050403"
         stroke="#2a1a33"
         strokeWidth={1.5}
@@ -380,10 +497,10 @@ export function CreationBoard({
     );
   });
 
-  // Cell-authored semantic regions (rpg-project#180) — a tinted rect per
-  // member cell (archetype-colored via `regionArchetypeColor`, the SAME
-  // color the edit-mode hex board's read-only overlay uses) plus one
-  // label at the region's centroid. `pointerEvents="none"` throughout:
+  // Cell-authored semantic regions (rpg-project#180) — a tinted hex
+  // polygon per member cell (archetype-colored via `regionArchetypeColor`,
+  // the SAME color the edit-mode hex board's read-only overlay uses) plus
+  // one label at the region's centroid. `pointerEvents="none"` throughout:
   // the board's own `handlePointerDown` already resolves "was an existing
   // region clicked" via `nearestCreationCell` + a `doc.regions` scan, so
   // these elements are purely visual, not a second independent hit-test
@@ -393,15 +510,13 @@ export function CreationBoard({
     const color = regionArchetypeColor(region.archetype);
     const selected = regionEdit.selectedRegionId === region.id;
     for (const [col, row] of region.cells) {
-      const center = creationCellCenter(col, row);
-      const half = { x: FLAT_COL_SPACING * 0.46, y: FLAT_ROW_SPACING * 0.46 };
+      const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
+        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+        .join(' ');
       regionEls.push(
-        <rect
+        <polygon
           key={`region-${region.id}-${col}-${row}`}
-          x={center.x - half.x}
-          y={center.y - half.y}
-          width={half.x * 2}
-          height={half.y * 2}
+          points={corners}
           fill={color}
           fillOpacity={selected ? 0.32 : 0.18}
           stroke={color}
@@ -428,23 +543,46 @@ export function CreationBoard({
         {region.name ?? region.id}
       </text>
     );
+
+    // OPEN boundary edges — Kirk's false-enclosure worry made visible
+    // (creationGeometry.ts's `openBoundaryEdges` doc comment has the full
+    // rationale). Drawn for EVERY region, not just the selected one — an
+    // author scanning the whole board should be able to see at a glance
+    // which regions are actually sealed, not have to select each one in
+    // turn to find out. A hot, unmissable red/orange, deliberately louder
+    // than the region's own archetype-colored fill (this file's "loud
+    // beats subtle" precedent, CONTRACT.md) — a gap in a boundary is a
+    // correctness fact, not a decoration.
+    for (const edge of openBoundaryEdges(region.cells, doc.walls)) {
+      regionEls.push(
+        <line
+          key={`region-${region.id}-open-${edge.cellA.join(',')}-${edge.cellB.join(',')}`}
+          x1={edge.a.x}
+          y1={edge.a.y}
+          x2={edge.b.x}
+          y2={edge.b.y}
+          stroke="#ff5a3a"
+          strokeWidth={3}
+          strokeLinecap="round"
+          pointerEvents="none"
+        />
+      );
+    }
   }
 
   // The in-progress, not-yet-created region's own pending cells — same
-  // rect treatment, dashed amber to read as "not committed yet" (matching
-  // this file's own hover-edge/wall-drawing amber-for-provisional
-  // convention elsewhere in this component).
+  // hex-polygon treatment, dashed amber to read as "not committed yet"
+  // (matching this file's own hover-edge/wall-drawing amber-for-
+  // provisional convention elsewhere in this component).
   const pendingRegionEls: ReactElement[] = regionEdit.pendingCells.map(
     ([col, row]) => {
-      const center = creationCellCenter(col, row);
-      const half = { x: FLAT_COL_SPACING * 0.46, y: FLAT_ROW_SPACING * 0.46 };
+      const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
+        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+        .join(' ');
       return (
-        <rect
+        <polygon
           key={`region-pending-${col}-${row}`}
-          x={center.x - half.x}
-          y={center.y - half.y}
-          width={half.x * 2}
-          height={half.y * 2}
+          points={corners}
           fill="#ffb347"
           fillOpacity={0.28}
           stroke="#ffb347"
@@ -462,10 +600,7 @@ export function CreationBoard({
     facing: number | null,
     sel: PlacementSelection
   ) => {
-    const center = {
-      x: at[0] * FLAT_COL_SPACING,
-      y: at[1] * FLAT_ROW_SPACING,
-    };
+    const center = creationCellCenter(at[0], at[1]);
     const style = resolveMarkerStyle(ref);
     // roomId comparison matters here even though every creation-mode
     // placement shares roomId: null today — matches Board.tsx's own
@@ -514,12 +649,21 @@ export function CreationBoard({
     renderPlacement(p.ref, p.at, p.facing, { roomId: null, index })
   );
 
+  if (doc.start) trackCellExtent(doc.start[0], doc.start[1]);
+  if (doc.end) trackCellExtent(doc.end[0], doc.end[1]);
+
+  const pad = BOARD_HEX_SIZE * 1.6;
+  const vx = minX - pad;
+  const vy = minY - pad;
+  const vw = maxX - minX + pad * 2;
+  const vh = maxY - minY + pad * 2;
+
   return (
     <svg
       ref={svgRef}
-      viewBox={`${-pad} ${-pad} ${width + pad * 2} ${height + pad * 2}`}
-      width={Math.max(width + pad * 2, 600)}
-      height={Math.max(height + pad * 2, 420)}
+      viewBox={`${vx} ${vy} ${vw} ${vh}`}
+      width={Math.max(vw, 600)}
+      height={Math.max(vh, 420)}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
@@ -531,43 +675,7 @@ export function CreationBoard({
             : 'default',
       }}
     >
-      <defs>
-        <pattern
-          id="creation-grid"
-          width={FLAT_COL_SPACING}
-          height={FLAT_ROW_SPACING}
-          patternUnits="userSpaceOnUse"
-        >
-          <rect
-            width={FLAT_COL_SPACING}
-            height={FLAT_ROW_SPACING}
-            fill="#1a1512"
-          />
-          <path
-            d={`M ${FLAT_COL_SPACING} 0 L 0 0 0 ${FLAT_ROW_SPACING}`}
-            fill="none"
-            stroke="#2a2521"
-            strokeWidth={1}
-          />
-        </pattern>
-      </defs>
-
-      <rect
-        x={-FLAT_COL_SPACING / 2}
-        y={-FLAT_ROW_SPACING / 2}
-        width={width}
-        height={height}
-        fill="url(#creation-grid)"
-      />
-      <rect
-        x={-FLAT_COL_SPACING / 2}
-        y={-FLAT_ROW_SPACING / 2}
-        width={width}
-        height={height}
-        fill="none"
-        stroke="#c9a227"
-        strokeWidth={3}
-      />
+      {cellEls}
 
       {regionEls}
       {pendingRegionEls}
@@ -588,52 +696,60 @@ export function CreationBoard({
         />
       )}
 
-      {doc.start && (
-        <g pointerEvents="none">
-          <circle
-            cx={doc.start[0] * FLAT_COL_SPACING}
-            cy={doc.start[1] * FLAT_ROW_SPACING}
-            r={13}
-            fill="none"
-            stroke={START_COLOR}
-            strokeWidth={2.5}
-            strokeDasharray="4 3"
-          />
-          <text
-            x={doc.start[0] * FLAT_COL_SPACING}
-            y={doc.start[1] * FLAT_ROW_SPACING - 18}
-            textAnchor="middle"
-            fill="#8fe8e0"
-            fontSize={10}
-            fontWeight={700}
-          >
-            START
-          </text>
-        </g>
-      )}
-      {doc.end && (
-        <g pointerEvents="none">
-          <circle
-            cx={doc.end[0] * FLAT_COL_SPACING}
-            cy={doc.end[1] * FLAT_ROW_SPACING}
-            r={13}
-            fill="none"
-            stroke={END_COLOR}
-            strokeWidth={2.5}
-            strokeDasharray="4 3"
-          />
-          <text
-            x={doc.end[0] * FLAT_COL_SPACING}
-            y={doc.end[1] * FLAT_ROW_SPACING - 18}
-            textAnchor="middle"
-            fill="#ffd76a"
-            fontSize={10}
-            fontWeight={700}
-          >
-            END
-          </text>
-        </g>
-      )}
+      {doc.start &&
+        (() => {
+          const c = cellCenter(doc.start[0], doc.start[1]);
+          return (
+            <g pointerEvents="none">
+              <circle
+                cx={c.x}
+                cy={c.y}
+                r={13}
+                fill="none"
+                stroke={START_COLOR}
+                strokeWidth={2.5}
+                strokeDasharray="4 3"
+              />
+              <text
+                x={c.x}
+                y={c.y - 18}
+                textAnchor="middle"
+                fill="#8fe8e0"
+                fontSize={10}
+                fontWeight={700}
+              >
+                START
+              </text>
+            </g>
+          );
+        })()}
+      {doc.end &&
+        (() => {
+          const c = cellCenter(doc.end[0], doc.end[1]);
+          return (
+            <g pointerEvents="none">
+              <circle
+                cx={c.x}
+                cy={c.y}
+                r={13}
+                fill="none"
+                stroke={END_COLOR}
+                strokeWidth={2.5}
+                strokeDasharray="4 3"
+              />
+              <text
+                x={c.x}
+                y={c.y - 18}
+                textAnchor="middle"
+                fill="#ffd76a"
+                fontSize={10}
+                fontWeight={700}
+              >
+                END
+              </text>
+            </g>
+          );
+        })()}
 
       {placementEls}
     </svg>

--- a/src/concepts/dungeon-builder/creation/creationGeometry.test.ts
+++ b/src/concepts/dungeon-builder/creation/creationGeometry.test.ts
@@ -1,98 +1,225 @@
 import { describe, expect, it } from 'vitest';
-import { FLAT_COL_SPACING, FLAT_ROW_SPACING } from '../hexLayout';
-import { nearestCreationCell, nearestEdge } from './creationGeometry';
+import { cellCenter } from '../hexLayout';
+import {
+  canonicalHexEdge,
+  dragFamily,
+  nearestCreationCell,
+  nearestEdge,
+  openBoundaryEdges,
+  traceEdgeRun,
+} from './creationGeometry';
 import type { CreationGrid } from './creationTypes';
 
 const grid: CreationGrid = { width: 20, height: 20 };
 
-// A point built from fractional (col, row) coordinates, the same way
-// nearestEdge internally divides point.x/point.y by FLAT_COL_SPACING/
-// FLAT_ROW_SPACING to recover them -- keeps these tests independent of
-// the actual spacing constant values.
-function pointAt(colF: number, rowF: number) {
-  return { x: colF * FLAT_COL_SPACING, y: rowF * FLAT_ROW_SPACING };
+function dist(
+  a: { x: number; y: number },
+  b: { x: number; y: number }
+): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
 }
 
 describe('nearestEdge', () => {
-  it('resolves the horizontal edge for a point centered in a cell, closer to the row boundary below', () => {
-    const edge = nearestEdge(pointAt(5, 5.5), grid);
-    expect(edge?.orientation).toBe('h');
-    expect(edge?.cellA).toEqual([5, 5]);
-    expect(edge?.cellB).toEqual([5, 6]);
+  it('resolves to the SAME canonical edge at its own midpoint, for all 6 facings of an interior cell', () => {
+    for (let facing = 0; facing < 6; facing++) {
+      const expected = canonicalHexEdge(10, 10, facing);
+      const found = nearestEdge(expected.mid, grid);
+      expect(found?.cellA).toEqual(expected.cellA);
+      expect(found?.cellB).toEqual(expected.cellB);
+    }
   });
 
-  it('resolves the vertical edge for a point centered in a cell, closer to the column boundary to the right', () => {
-    const edge = nearestEdge(pointAt(5.5, 5), grid);
-    expect(edge?.orientation).toBe('v');
-    expect(edge?.cellA).toEqual([5, 5]);
-    expect(edge?.cellB).toEqual([6, 5]);
+  it("canonicalizes to the SAME cellA/cellB pair whichever of the edge's two cells a query point sits nearest to — matching dungeonYaml.ts's wallIndexAtEdge contract of ONE canonical from/to order per physical edge", () => {
+    const facing = 1; // NE — a "primary" facing (0-2)
+    const edge = canonicalHexEdge(10, 10, facing);
+    const hereCenter = cellCenter(10, 10);
+    const thereCenter = cellCenter(edge.cellB[0], edge.cellB[1]);
+    const nearHereSide = {
+      x: hereCenter.x * 0.4 + edge.mid.x * 0.6,
+      y: hereCenter.y * 0.4 + edge.mid.y * 0.6,
+    };
+    const nearThereSide = {
+      x: thereCenter.x * 0.4 + edge.mid.x * 0.6,
+      y: thereCenter.y * 0.4 + edge.mid.y * 0.6,
+    };
+    const foundHere = nearestEdge(nearHereSide, grid);
+    const foundThere = nearestEdge(nearThereSide, grid);
+    expect(foundHere?.cellA).toEqual(edge.cellA);
+    expect(foundHere?.cellB).toEqual(edge.cellB);
+    expect(foundThere?.cellA).toEqual(edge.cellA);
+    expect(foundThere?.cellB).toEqual(edge.cellB);
   });
 
-  it('returns null off the canvas perimeter (no togglable internal edge there)', () => {
-    expect(nearestEdge(pointAt(-0.5, 5), grid)).toBeNull();
-    expect(nearestEdge(pointAt(5, grid.height - 0.5 + 0.6), grid)).toBeNull();
+  it('returns null once the nearest cell itself falls outside the grid — the perimeter is an always-on boundary, not togglable (creationTypes.ts)', () => {
+    expect(nearestEdge(cellCenter(-1, 5), grid)).toBeNull();
+    expect(nearestEdge(cellCenter(5, grid.height), grid)).toBeNull();
   });
 
-  describe("orientation lock (CONTRACT.md's wall-interaction finding: a straight drag must hold one orientation)", () => {
-    // row=5, y fixed 0.4 of a row-height off the row-5/row-6 boundary
-    // (deliberately NOT exactly on it -- see this test's own assertion
-    // below for why the exact-boundary case doesn't actually surface the
-    // bug). Sweeping colF across a single cell's width (3.0 -> 3.49)
-    // means dx grows from 0 toward 0.5 while dy stays fixed at 0.4, so dx
-    // overtakes dy partway across the cell -- exactly the "the pointer
-    // crosses a cell boundary" moment CONTRACT.md describes.
-    const row = 5;
-    const rowF = row + 0.4;
-    const colFsAcrossOneCell = [3.0, 3.1, 3.2, 3.3, 3.45, 3.49];
+  it('lockFamily restricts candidates to exactly one of the 3 parallel-edge families', () => {
+    for (let family = 0 as 0 | 1 | 2; family < 3; family++) {
+      const edge = canonicalHexEdge(10, 10, family);
+      const found = nearestEdge(edge.mid, grid, family);
+      expect(found?.cellA).toEqual(edge.cellA);
+      expect(found?.cellB).toEqual(edge.cellB);
+    }
+    // Locked to family 0 (E/W), a point sitting exactly on family 1's own
+    // edge midpoint must NOT resolve to that family-1 edge.
+    const family1Edge = canonicalHexEdge(10, 10, 1);
+    const lockedToFamily0 = nearestEdge(family1Edge.mid, grid, 0);
+    expect(lockedToFamily0).not.toEqual(
+      expect.objectContaining({
+        cellA: family1Edge.cellA,
+        cellB: family1Edge.cellB,
+      })
+    );
+  });
 
-    it('WITHOUT a lock, a straight horizontal drag flips to a vertical edge as the pointer nears each column boundary -- the bug the lock exists to fix', () => {
-      const orientations = colFsAcrossOneCell.map(
-        (colF) => nearestEdge(pointAt(colF, rowF), grid)?.orientation
-      );
-      // Starts horizontal (pointer away from the column boundary)...
-      expect(orientations[0]).toBe('h');
-      // ...and flips to vertical once dx (growing toward 0.5) overtakes
-      // the fixed dy=0.4, well before the drag has actually left the row.
-      expect(orientations[orientations.length - 1]).toBe('v');
-      expect(new Set(orientations).size).toBeGreaterThan(1);
-    });
-
-    it('WITH lockOrientation: "h", the SAME straight horizontal drag stays on the SAME (row 5) horizontal edge the whole way -- never alternates', () => {
-      const edges = colFsAcrossOneCell.map((colF) =>
-        nearestEdge(pointAt(colF, rowF), grid, 'h')
-      );
-      expect(edges.every((e) => e?.orientation === 'h')).toBe(true);
-      expect(
-        edges.every((e) => e?.cellA[1] === row && e?.cellB[1] === row + 1)
-      ).toBe(true);
-    });
-
-    it('WITH lockOrientation: "v", a straight vertical drag stays vertical even where the unlocked comparison would pick horizontal', () => {
-      const col = 5;
-      const colFAcrossOneCell = col + 0.4;
-      const rowFsAcrossOneCell = [3.0, 3.1, 3.2, 3.3, 3.45, 3.49];
-      const edges = rowFsAcrossOneCell.map((rf) =>
-        nearestEdge(pointAt(colFAcrossOneCell, rf), grid, 'v')
-      );
-      expect(edges.every((e) => e?.orientation === 'v')).toBe(true);
-      expect(
-        edges.every((e) => e?.cellA[0] === col && e?.cellB[0] === col + 1)
-      ).toBe(true);
+  describe("hex-true fix for the square predecessor's crenellated-comb bug (CONTRACT.md's wall-interaction finding)", () => {
+    // The square board's `nearestEdge` picked between exactly 2 candidate
+    // edges via a dx-vs-dy comparison that flipped mid-cell, at a point
+    // with no relationship to a real edge boundary — producing a
+    // disconnected "comb" instead of a straight wall. This hex version
+    // picks among a cell's up to 6 REAL edges by point-to-segment
+    // distance; unlike the square case, that partition tiles the cell
+    // with no gap, so a plain (unlocked) sweep along a straight
+    // world-space line never produces a disconnected pick. Verified here
+    // the same way the bug was originally diagnosed: sweep a straight
+    // line and check every transition connects.
+    it('a straight horizontal sweep near a row boundary never produces two DISCONNECTED consecutive edges, even with no lock at all', () => {
+      const boundaryY = canonicalHexEdge(8, 14, 5).mid.y; // row14/row15 boundary near col 8
+      let prev: ReturnType<typeof nearestEdge> = null;
+      let sawMultipleEdges = false;
+      for (let x = cellCenter(3, 14).x; x <= cellCenter(12, 14).x; x += 2) {
+        const found = nearestEdge({ x, y: boundaryY }, grid);
+        if (!found) continue;
+        if (
+          prev &&
+          (prev.cellA[0] !== found.cellA[0] ||
+            prev.cellA[1] !== found.cellA[1] ||
+            prev.cellB[0] !== found.cellB[0] ||
+            prev.cellB[1] !== found.cellB[1])
+        ) {
+          sawMultipleEdges = true;
+          // The transition itself must be corner-connected — a shared
+          // endpoint between the previous edge and this one.
+          const shared =
+            dist(prev.a, found.a) < 0.5 ||
+            dist(prev.a, found.b) < 0.5 ||
+            dist(prev.b, found.a) < 0.5 ||
+            dist(prev.b, found.b) < 0.5;
+          expect(shared).toBe(true);
+        }
+        prev = found;
+      }
+      // Sanity: the sweep actually crossed more than one edge (otherwise
+      // the connectivity assertion above never ran).
+      expect(sawMultipleEdges).toBe(true);
     });
   });
 });
 
+describe('traceEdgeRun', () => {
+  it('produces a fully connected sequence of edges for a straight world-space drag', () => {
+    const boundaryY = canonicalHexEdge(8, 14, 5).mid.y;
+    const run = traceEdgeRun(
+      { x: cellCenter(5, 14).x, y: boundaryY },
+      { x: cellCenter(12, 14).x, y: boundaryY },
+      grid
+    );
+    expect(run.length).toBeGreaterThan(1);
+    for (let i = 1; i < run.length; i++) {
+      const prev = run[i - 1];
+      const cur = run[i];
+      const shared =
+        dist(prev.a, cur.a) < 0.5 ||
+        dist(prev.a, cur.b) < 0.5 ||
+        dist(prev.b, cur.a) < 0.5 ||
+        dist(prev.b, cur.b) < 0.5;
+      expect(shared).toBe(true);
+    }
+  });
+
+  it('is empty for a degenerate (zero-length) drag entirely off-grid', () => {
+    expect(
+      traceEdgeRun({ x: -9999, y: -9999 }, { x: -9999, y: -9999 }, grid)
+    ).toEqual([]);
+  });
+});
+
 describe('nearestCreationCell', () => {
-  it('rounds to the nearest cell', () => {
-    expect(nearestCreationCell(pointAt(5.4, 5.4), grid)).toEqual([5, 5]);
-    expect(nearestCreationCell(pointAt(5.6, 5.6), grid)).toEqual([6, 6]);
+  it("resolves a point at a cell's own exact center back to that cell", () => {
+    const c = cellCenter(7, 7);
+    expect(nearestCreationCell(c, grid)).toEqual([7, 7]);
   });
 
   it('clamps to the grid bounds', () => {
-    expect(nearestCreationCell(pointAt(-3, -3), grid)).toEqual([0, 0]);
-    expect(nearestCreationCell(pointAt(99, 99), grid)).toEqual([
+    expect(nearestCreationCell({ x: -9999, y: -9999 }, grid)).toEqual([0, 0]);
+    expect(nearestCreationCell({ x: 9999, y: 9999 }, grid)).toEqual([
       grid.width - 1,
       grid.height - 1,
     ]);
+  });
+});
+
+describe('dragFamily', () => {
+  it('is stable (mod PI) for a drag and its exact opposite — an edge is an undirected line', () => {
+    expect(dragFamily(10, 3)).toEqual(dragFamily(-10, -3));
+  });
+
+  it('picks a different family for drag directions ~90° apart', () => {
+    const horizontal = dragFamily(10, 0);
+    const vertical = dragFamily(0, 10);
+    expect(horizontal).not.toEqual(vertical);
+  });
+});
+
+describe("openBoundaryEdges (Kirk's false-enclosure worry, made visible)", () => {
+  it('an isolated single cell has all 6 of its edges open when no walls exist', () => {
+    expect(openBoundaryEdges([[10, 10]], [])).toHaveLength(6);
+  });
+
+  it('a wall on one boundary edge removes exactly that edge from the open list', () => {
+    const edge = canonicalHexEdge(10, 10, 2); // NW
+    const open = openBoundaryEdges(
+      [[10, 10]],
+      [{ from: edge.cellA, to: edge.cellB }]
+    );
+    expect(open).toHaveLength(5);
+    expect(
+      open.some(
+        (e) =>
+          e.cellA[0] === edge.cellA[0] &&
+          e.cellA[1] === edge.cellA[1] &&
+          e.cellB[0] === edge.cellB[0] &&
+          e.cellB[1] === edge.cellB[1]
+      )
+    ).toBe(false);
+  });
+
+  it('walling all 6 boundary edges of an isolated cell fully seals it — zero open edges', () => {
+    const walls = Array.from({ length: 6 }, (_, facing) => {
+      const e = canonicalHexEdge(10, 10, facing);
+      return { from: e.cellA, to: e.cellB };
+    });
+    expect(openBoundaryEdges([[10, 10]], walls)).toEqual([]);
+  });
+
+  it('the shared internal edge between two members of the SAME region is never open, wall or no wall — a real hex boundary claim, not a square-grid one', () => {
+    const shared = canonicalHexEdge(10, 10, 0); // E
+    const neighbor = shared.cellB;
+    const cells: [number, number][] = [[10, 10], neighbor];
+    const open = openBoundaryEdges(cells, []);
+    const sharedIsOpen = open.some(
+      (e) =>
+        e.cellA[0] === shared.cellA[0] &&
+        e.cellA[1] === shared.cellA[1] &&
+        e.cellB[0] === shared.cellB[0] &&
+        e.cellB[1] === shared.cellB[1]
+    );
+    expect(sharedIsOpen).toBe(false);
+    // Each cell contributes 5 non-internal edges (its 6th, shared with
+    // the other member, is excluded) — 10 total, none coinciding, since
+    // an edge is uniquely identified by ITS OWN two cells and A !== B.
+    expect(open).toHaveLength(10);
   });
 });

--- a/src/concepts/dungeon-builder/creation/creationGeometry.ts
+++ b/src/concepts/dungeon-builder/creation/creationGeometry.ts
@@ -2,111 +2,325 @@
  * creationGeometry — pure position/hit-testing math for the creation
  * board. Kept separate from rendering per the same split as
  * `boardGeometry.ts`/`Board.tsx`.
+ *
+ * **HEX-TRUE (2026-08-03)**: this used to be a flat rectangular-canvas
+ * renderer's own geometry (`FLAT_COL_SPACING`/`FLAT_ROW_SPACING`, an
+ * axis-aligned dx-vs-dy pick between a horizontal/vertical edge) — see
+ * `hexLayout.ts`'s own header comment for Kirk's diagnosis of why that
+ * was wrong (a square grid only draws 4 of a hex's 6 real adjacencies,
+ * and produces disconnected "vertical blinds" wall segments instead of a
+ * continuous run). This module now builds every position from the SAME
+ * hex math the compiled edit-mode board renders with (`hexLayout.ts`'s
+ * `cellCenter`/`edgeBetweenCells`/`worldToCube`, `boardGeometry.ts`'s
+ * `neighborCell`) — one coordinate space for both boards. The canvas
+ * dimension semantics (a `{width,height}` grid of `[col,row]` cells,
+ * `CreationGrid`) are UNCHANGED; only the geometry each `[col,row]`
+ * resolves to is different.
+ *
+ * A hex cell has 6 edges, not 4 — `EdgeGeometry` below is keyed by a
+ * canonical `cellA`/`cellB` pair (see `canonicalHexEdge`'s own doc
+ * comment) rather than an 'h'/'v' orientation tag, which had no hex
+ * analog once a cell stopped having exactly two edge orientations.
  */
-import { FLAT_COL_SPACING, FLAT_ROW_SPACING, type CellPos } from '../hexLayout';
+import { neighborCell } from '../boardGeometry';
+import {
+  BOARD_HEX_SIZE,
+  cellCenter,
+  cellCorners,
+  edgeBetweenCells,
+  hexColumn,
+  hexRow,
+  worldToCube,
+  type CellPos,
+} from '../hexLayout';
+import type { Cell } from '../regionGeometry';
 import { type CreationGrid } from './creationTypes';
 
 export function creationCellCenter(col: number, row: number): CellPos {
-  return { x: col * FLAT_COL_SPACING, y: row * FLAT_ROW_SPACING };
+  return cellCenter(col, row);
+}
+
+/** The hex polygon (as SVG-ready `[x,y]` pairs) for one canvas cell —
+ * used by `CreationBoard.tsx` for the base grid, region overlays, and
+ * hole markers, all of which used to draw an axis-aligned `<rect>`. */
+export function creationCellPolygon(
+  col: number,
+  row: number,
+  size: number = BOARD_HEX_SIZE - 1.5
+): [number, number][] {
+  return cellCorners(cellCenter(col, row), size);
 }
 
 export interface EdgeGeometry {
-  orientation: 'h' | 'v';
-  /** The two cells the edge sits between. */
   cellA: [number, number];
   cellB: [number, number];
-  /** Line endpoints in board space. */
   a: CellPos;
   b: CellPos;
   mid: CellPos;
 }
 
-export function hEdgeGeometry(col: number, row: number): EdgeGeometry {
-  const y = (row + 0.5) * FLAT_ROW_SPACING;
-  const x0 = (col - 0.5) * FLAT_COL_SPACING;
-  const x1 = (col + 0.5) * FLAT_COL_SPACING;
-  return {
-    orientation: 'h',
-    cellA: [col, row],
-    cellB: [col, row + 1],
-    a: { x: x0, y },
-    b: { x: x1, y },
-    mid: { x: (x0 + x1) / 2, y },
-  };
+function inBounds(col: number, row: number, grid: CreationGrid): boolean {
+  return col >= 0 && col < grid.width && row >= 0 && row < grid.height;
 }
 
-export function vEdgeGeometry(col: number, row: number): EdgeGeometry {
-  const x = (col + 0.5) * FLAT_COL_SPACING;
-  const y0 = (row - 0.5) * FLAT_ROW_SPACING;
-  const y1 = (row + 0.5) * FLAT_ROW_SPACING;
-  return {
-    orientation: 'v',
-    cellA: [col, row],
-    cellB: [col + 1, row],
-    a: { x, y: y0 },
-    b: { x, y: y1 },
-    mid: { x, y: (y0 + y1) / 2 },
-  };
+/** The edge between `(col,row)` and its `facing` (0-5) neighbor, in the
+ * ONE canonical `cellA`/`cellB` order regardless of which of the two
+ * cells this call started from — matching `dungeonYaml.ts`'s
+ * `wallIndexAtEdge` contract ("callers are responsible for passing
+ * from/to in ONE canonical order"; it does not check the reverse
+ * pairing). Facings 0-2 (E, NE, NW) are treated as PRIMARY: `cellA =
+ * (col,row)`, `cellB = neighbor`. Facings 3-5 (W, SW, SE) are the exact
+ * same three physical edges seen from the opposite cell (facing `f` and
+ * `f-3` are opposite directions — `authorGridHelpers.ts`'s
+ * `HEX_DIRECTIONS`), so they're normalized to their primary form
+ * (`cellA = neighbor`, `cellB = (col,row)`) instead of being treated as
+ * three more distinct edges — a hex cell has 6 neighbor directions but
+ * only 3 distinct edges shared with THIS cell's own 6 neighbors once
+ * both sides collapse to one canonical form. */
+export function canonicalHexEdge(
+  col: number,
+  row: number,
+  facing: number
+): EdgeGeometry {
+  const n = neighborCell(col, row, facing);
+  const [cellA, cellB]: [[number, number], [number, number]] =
+    facing < 3
+      ? [
+          [col, row],
+          [n.col, n.row],
+        ]
+      : [
+          [n.col, n.row],
+          [col, row],
+        ];
+  const edge = edgeBetweenCells(cellA[0], cellA[1], cellB[0], cellB[1]);
+  return { cellA, cellB, a: edge.a, b: edge.b, mid: edge.mid };
 }
 
-/** Nearest internal edge to a board-space point — computed analytically
- * (O(1)) rather than by scanning every edge, since this runs on every
- * pointer-move during a wall-drawing drag: on a 20x30 grid that's ~1150
- * edges recomputed per pixel of mouse movement with a brute-force scan,
- * easily enough to feel laggy. A regular grid makes the direct form
- * cheap: round to the nearest cell, then use the point's fractional
- * offset within that cell to decide whether it's closer to a vertical or
- * horizontal edge, and which side. Returns null for the canvas perimeter
- * (not a togglable internal edge) or genuinely out-of-grid points. */
+/** A stored wall's own line geometry, from its `from`/`to` cells directly
+ * — no orientation to detect (unlike the square predecessor's
+ * `wallGeometry`, which had to sniff h-vs-v from the coordinate delta):
+ * `edgeBetweenCells` takes any two adjacent cells as-is. */
+export function wallGeometry(
+  from: [number, number],
+  to: [number, number]
+): EdgeGeometry {
+  const edge = edgeBetweenCells(from[0], from[1], to[0], to[1]);
+  return { cellA: from, cellB: to, a: edge.a, b: edge.b, mid: edge.mid };
+}
+
+function pointToSegmentDistSq(p: CellPos, a: CellPos, b: CellPos): number {
+  const abx = b.x - a.x;
+  const aby = b.y - a.y;
+  const apx = p.x - a.x;
+  const apy = p.y - a.y;
+  const len2 = abx * abx + aby * aby;
+  let t = len2 > 0 ? (apx * abx + apy * aby) / len2 : 0;
+  t = Math.max(0, Math.min(1, t));
+  const cx = a.x + t * abx;
+  const cy = a.y + t * aby;
+  return (p.x - cx) ** 2 + (p.y - cy) ** 2;
+}
+
 /**
- * `lockOrientation`, when passed, skips the dx-vs-dy comparison and
- * always resolves to an edge of that orientation. `CreationBoard.tsx`
- * uses this to hold a wall-drawing stroke to one orientation for its
- * whole duration once the drag direction is known — without it, the
- * per-point dx/dy comparison flips which axis "wins" every time the
- * pointer crosses a cell boundary, turning a straight drag into a
- * crenellated comb instead of a straight wall (see CONTRACT.md's
- * wall-interaction finding for the concrete before/after).
+ * Nearest hex edge to a board-space point — used to resolve a wall/door
+ * click or drag. Nearest CELL is found in O(1) via the real inverse hex
+ * transform (`worldToCube`), then whichever of that cell's (up to) 6
+ * edges is nearest by real point-to-segment distance wins — cheap enough
+ * to run on every pointer-move (at most 6 segment-distance checks, never
+ * a scan over the grid's full edge set).
+ *
+ * Only INTERNAL edges (both cells inside `grid`) are returned — the same
+ * "canvas perimeter is an always-on boundary, not togglable" rule the
+ * square predecessor used (`creationTypes.ts`'s own doc comment), now
+ * expressed as a hex bounds check on the neighbor cell instead of a
+ * col/row range clamp.
+ *
+ * **No dx-vs-dy orientation heuristic is needed here, unlike the square
+ * predecessor** — and that's not an oversight, it's the actual fix for
+ * the bug `lockOrientation` existed to paper over. The square version's
+ * crenellated-comb bug (CONTRACT.md's wall-interaction finding) came from
+ * comparing a point's fractional offset within ONE cell along two
+ * independent axes (dx, dy) and picking whichever was larger — a
+ * comparison that flips mid-cell, at a point with no relationship to any
+ * real edge boundary, producing a disconnected tooth. A hex cell's 6
+ * "nearest to this edge" regions instead TILE the cell with shared
+ * boundaries at the corners themselves (verified numerically while
+ * building this: sampling points along a straight world-space line and
+ * calling this function at each one produces a sequence of edges where
+ * every consecutive pair shares a real corner, for a plain nearest-edge
+ * pick with no lock at all — see this unit's PR description for the
+ * check). `lockFamily` below still exists, but for a different, weaker
+ * reason than the square lock had: not to prevent disconnection (nothing
+ * here can produce a gap), but to hold a long stroke to one deliberate
+ * "which of the 3 parallel-edge families" choice so it can't drift onto
+ * an unrelated third family over a long drag.
  */
 export function nearestEdge(
   point: CellPos,
   grid: CreationGrid,
-  lockOrientation?: 'h' | 'v'
+  lockFamily?: 0 | 1 | 2
 ): EdgeGeometry | null {
-  const colF = point.x / FLAT_COL_SPACING;
-  const rowF = point.y / FLAT_ROW_SPACING;
-  const c0 = Math.round(colF);
-  const r0 = Math.round(rowF);
-  const dx = colF - c0;
-  const dy = rowF - r0;
+  const cube = worldToCube(point);
+  const col = hexColumn(cube);
+  const row = hexRow(cube);
+  if (!inBounds(col, row, grid)) return null;
 
-  const wantVertical = lockOrientation
-    ? lockOrientation === 'v'
-    : Math.abs(dx) > Math.abs(dy);
-
-  if (wantVertical) {
-    const col = dx > 0 ? c0 : c0 - 1;
-    if (col < 0 || col > grid.width - 2 || r0 < 0 || r0 > grid.height - 1)
-      return null;
-    return vEdgeGeometry(col, r0);
+  let best: EdgeGeometry | null = null;
+  let bestDist = Infinity;
+  for (let facing = 0; facing < 6; facing++) {
+    if (lockFamily !== undefined && facing % 3 !== lockFamily) continue;
+    const n = neighborCell(col, row, facing);
+    if (!inBounds(n.col, n.row, grid)) continue;
+    const edge = canonicalHexEdge(col, row, facing);
+    const d = pointToSegmentDistSq(point, edge.a, edge.b);
+    if (d < bestDist) {
+      bestDist = d;
+      best = edge;
+    }
   }
-  const row = dy > 0 ? r0 : r0 - 1;
-  if (row < 0 || row > grid.height - 2 || c0 < 0 || c0 > grid.width - 1)
-    return null;
-  return hEdgeGeometry(c0, row);
+  return best;
 }
 
+// The screen-space direction of each of the 3 parallel-edge families,
+// computed once from the SAME `canonicalHexEdge`/`edgeBetweenCells`
+// geometry every wall segment renders with (a real derivation, not a
+// hand-typed angle table). Translation-invariant — a hex grid's 6
+// neighbor directions don't depend on which cell you start from, so
+// deriving all 3 from cell (0,0) gives the same 3 angles anywhere on the
+// canvas.
+const FAMILY_EDGE_ANGLE: readonly [number, number, number] = (() => {
+  const angleOf = (facing: 0 | 1 | 2) => {
+    const e = canonicalHexEdge(0, 0, facing);
+    return Math.atan2(e.b.y - e.a.y, e.b.x - e.a.x);
+  };
+  return [angleOf(0), angleOf(1), angleOf(2)];
+})();
+
+/**
+ * Which of the 3 edge families (0/1/2) a drag vector most likely
+ * intends — the family whose own edge LINE is most nearly PARALLEL to
+ * the drag (tracing a wall means dragging roughly along it, the same
+ * "which way is the user tracing" question the square predecessor's
+ * `Math.abs(dx) >= Math.abs(dy)` answered for its 2 axes, generalized to
+ * hex's 3). `CreationBoard.tsx` calls this once, at the drag's
+ * direction-lock threshold, and holds the result for the rest of the
+ * stroke via `nearestEdge`'s `lockFamily`.
+ */
+export function dragFamily(dx: number, dy: number): 0 | 1 | 2 {
+  const dragAngle = Math.atan2(dy, dx);
+  let best: 0 | 1 | 2 = 0;
+  let bestScore = Infinity;
+  for (const f of [0, 1, 2] as const) {
+    // Circular distance mod PI — an edge is an undirected LINE, so an
+    // angle and its +180° opposite are the same orientation.
+    let d = Math.abs(dragAngle - FAMILY_EDGE_ANGLE[f]) % Math.PI;
+    d = Math.min(d, Math.PI - d);
+    if (d < bestScore) {
+      bestScore = d;
+      best = f;
+    }
+  }
+  return best;
+}
+
+/**
+ * Traces the connected sequence of hex edges a straight world-space drag
+ * from `from` to `to` would draw — samples points along the segment and
+ * calls `nearestEdge` at each one, deduping consecutive repeats. Used by
+ * `demoScript.ts` to derive a REAL, connected wall run programmatically
+ * (via this same function a live drag uses) rather than hand-transcribing
+ * `[col,row]` pairs that a hex-true board might not actually connect —
+ * see this module's own `nearestEdge` doc comment for why a plain
+ * (unlocked) nearest-edge trace is already gap-free for a straight line.
+ */
+export function traceEdgeRun(
+  from: CellPos,
+  to: CellPos,
+  grid: CreationGrid,
+  samples = 400
+): EdgeGeometry[] {
+  const run: EdgeGeometry[] = [];
+  let prevKey: string | null = null;
+  for (let i = 0; i <= samples; i++) {
+    const t = i / samples;
+    const p = {
+      x: from.x + (to.x - from.x) * t,
+      y: from.y + (to.y - from.y) * t,
+    };
+    const edge = nearestEdge(p, grid);
+    if (!edge) continue;
+    const key = `${edge.cellA.join(',')}-${edge.cellB.join(',')}`;
+    if (key !== prevKey) {
+      run.push(edge);
+      prevKey = key;
+    }
+  }
+  return run;
+}
+
+/**
+ * Every OPEN (wall-free) boundary edge of a region's own cell set —
+ * Kirk's "false enclosure" worry, made directly visible instead of left
+ * for the author to notice by accident: "any hex that is not 100%
+ * uncovered would not be traversable by the players." A boundary edge is
+ * one of a member cell's 6 real hex edges whose neighbor is NOT another
+ * member of the same region (an internal edge, membership-only, never
+ * "open" regardless of walls); it's OPEN specifically when no `walls`
+ * entry covers it. `CreationBoard.tsx` renders the result as a distinct
+ * highlighted overlay on the currently-selected/just-created region, so
+ * "is this region actually sealed" is a board fact, not something the
+ * author has to reconstruct from the cell shape by eye — directly
+ * relevant now that 6-adjacency is real (`regionGeometry.ts`'s own header
+ * comment): an edge that a square-grid mental model wouldn't even know to
+ * check.
+ *
+ * Cheap by construction: at most 6 neighbor checks per member cell (a
+ * region this concept has authored is a handful to a few dozen cells),
+ * plus a flat `walls` scan per candidate boundary edge, deduped by
+ * canonical `cellA`/`cellB` so a boundary edge bordering two DIFFERENT
+ * non-member cells that happen to be mutual neighbors (a thin region,
+ * one cell wide) isn't double-counted. Same complexity budget
+ * `sharedBoundaryEdges` already accepts for this concept's region sizes.
+ */
+export function openBoundaryEdges(
+  cells: readonly Cell[],
+  walls: readonly { from: [number, number]; to: [number, number] }[]
+): EdgeGeometry[] {
+  const memberKeys = new Set(cells.map((c) => `${c[0]},${c[1]}`));
+  const seenEdges = new Set<string>();
+  const open: EdgeGeometry[] = [];
+  for (const [col, row] of cells) {
+    for (let facing = 0; facing < 6; facing++) {
+      const n = neighborCell(col, row, facing);
+      if (memberKeys.has(`${n.col},${n.row}`)) continue; // internal, not boundary
+      const edge = canonicalHexEdge(col, row, facing);
+      const edgeKey = `${edge.cellA.join(',')}|${edge.cellB.join(',')}`;
+      if (seenEdges.has(edgeKey)) continue;
+      seenEdges.add(edgeKey);
+      const hasWall = walls.some(
+        (w) =>
+          w.from[0] === edge.cellA[0] &&
+          w.from[1] === edge.cellA[1] &&
+          w.to[0] === edge.cellB[0] &&
+          w.to[1] === edge.cellB[1]
+      );
+      if (!hasWall) open.push(edge);
+    }
+  }
+  return open;
+}
+
+/** Nearest board cell to a point, clamped independently per axis to the
+ * grid bounds — same clamping shape the square predecessor used (round,
+ * then clamp each of col/row to `[0, dimension)`), now driven by the real
+ * inverse hex transform instead of a linear divide. */
 export function nearestCreationCell(
   point: CellPos,
   grid: CreationGrid
 ): [number, number] {
-  const col = Math.max(
-    0,
-    Math.min(grid.width - 1, Math.round(point.x / FLAT_COL_SPACING))
-  );
-  const row = Math.max(
-    0,
-    Math.min(grid.height - 1, Math.round(point.y / FLAT_ROW_SPACING))
-  );
+  const cube = worldToCube(point);
+  const col = Math.max(0, Math.min(grid.width - 1, hexColumn(cube)));
+  const row = Math.max(0, Math.min(grid.height - 1, hexRow(cube)));
   return [col, row];
 }

--- a/src/concepts/dungeon-builder/creation/creationTypes.ts
+++ b/src/concepts/dungeon-builder/creation/creationTypes.ts
@@ -20,11 +20,12 @@ export interface CreationGrid {
   height: number;
 }
 
-/** Internal edge between two orthogonally adjacent cells: the edge BELOW
- * cell (c,r) (shared with (c,r+1)) is horizontal; the edge RIGHT of cell
- * (c,r) (shared with (c+1,r)) is vertical. The canvas perimeter is an
- * always-on boundary, not a member of this set — only internal edges are
- * toggleable, matching "carve the space into rooms" (you start inside a
- * bounded room and cut it up, you don't have to draw the outer walls).
- * Geometry-only — the actual authored wall lives in `doc.walls`
- * (`WallDoc[]`, dungeonYaml.ts), addressed by `from`/`to` cells directly. */
+/** An internal edge is the shared boundary between two hex-adjacent cells
+ * — HEX-TRUE since 2026-08-03 (`creationGeometry.ts`'s own header
+ * comment), so a cell has up to 6 of these, not the 4 (h/v) a square grid
+ * would have. The canvas perimeter is an always-on boundary, not a member
+ * of this set — only internal edges are toggleable, matching "carve the
+ * space into rooms" (you start inside a bounded region and cut it up, you
+ * don't have to draw the outer walls). Geometry-only — the actual
+ * authored wall lives in `doc.walls` (`WallDoc[]`, dungeonYaml.ts),
+ * addressed by `from`/`to` cells directly. */

--- a/src/concepts/dungeon-builder/creation/demoScript.ts
+++ b/src/concepts/dungeon-builder/creation/demoScript.ts
@@ -11,8 +11,28 @@
  * "20x30 room -> 2d top down board -> draw the walls in place -> start
  * here, end there -> add door here, monster there, reaper statue there
  * facing this way -> load up and play."
+ *
+ * **HEX-TRUE (2026-08-03)**: the divider wall used to be hand-transcribed
+ * as one `[col,DIVIDER_ROW]`-`[col,DIVIDER_ROW+1]` segment per column in
+ * `DIVIDER_COLS` — a pattern that drew a straight, fully-connected line
+ * under the old square-grid geometry. Under real hex geometry it does
+ * NOT connect (verified numerically while building this unit: consecutive
+ * segments in that pattern land ~20px apart, a genuine gap, not a
+ * continuous run) — a square-grid assumption baked into hand-picked
+ * coordinates, exactly the kind of thing this round's brief called out.
+ * The fix is to stop hand-picking coordinates at all: `traceEdgeRun`
+ * (`creationGeometry.ts`) samples a straight world-space line through the
+ * SAME `nearestEdge` a live drag calls, so the wall run this script draws
+ * is provably whatever the interactive tool would draw for the same
+ * gesture, not a second, independently-maintained approximation of it.
  */
 import type { WallKind } from '../dungeonYaml';
+import {
+  creationCellCenter,
+  traceEdgeRun,
+  wallGeometry,
+} from './creationGeometry';
+import type { CreationGrid } from './creationTypes';
 
 export interface DemoActions {
   resetGrid: (width: number, height: number) => void;
@@ -41,13 +61,13 @@ export interface DemoStep {
 }
 
 const DIVIDER_ROW = 14;
-const DIVIDER_COLS = [5, 6, 7, 8, 9, 10, 11, 12];
+const SPAN_COL_START = 5;
+const SPAN_COL_END = 12;
+// Kept for the caption/reference sense of "roughly in the middle" — no
+// longer used to hand-derive a wall coordinate (see `traceEdgeRun` below).
 const DOOR_COL = 8;
 
-export function buildDemoScript(grid: {
-  width: number;
-  height: number;
-}): DemoStep[] {
+export function buildDemoScript(grid: CreationGrid): DemoStep[] {
   const steps: DemoStep[] = [];
 
   steps.push({
@@ -56,34 +76,51 @@ export function buildDemoScript(grid: {
     run: (actions) => actions.resetGrid(grid.width, grid.height),
   });
 
+  // The REAL connected hex wall run a straight drag from (SPAN_COL_START,
+  // DIVIDER_ROW) to (SPAN_COL_END, DIVIDER_ROW) would draw — traced
+  // through the same `nearestEdge` a live drag calls (see this file's own
+  // header comment for why hand-picking coordinates broke under hex).
+  // `boundaryY` anchors the trace to the actual world-space boundary
+  // between row DIVIDER_ROW and DIVIDER_ROW+1 near the span's middle —
+  // `wallGeometry` is pure geometry (it doesn't check `doc.walls`), so
+  // this works whether or not that specific edge ends up drawn.
+  const boundaryY = wallGeometry(
+    [DOOR_COL, DIVIDER_ROW],
+    [DOOR_COL, DIVIDER_ROW + 1]
+  ).mid.y;
+  const spanStart = creationCellCenter(SPAN_COL_START, DIVIDER_ROW);
+  const spanEnd = creationCellCenter(SPAN_COL_END, DIVIDER_ROW);
+  const dividerRun = traceEdgeRun(
+    { x: spanStart.x, y: boundaryY },
+    { x: spanEnd.x, y: boundaryY },
+    grid
+  );
+
   // "Draw the walls in place" — one segment at a time, so it visibly
   // draws rather than snapping in all at once.
-  DIVIDER_COLS.forEach((col, i) => {
+  dividerRun.forEach((edge, i) => {
     steps.push({
       caption: 'Draw the walls in place — carving the room in two.',
-      holdMs: 90,
+      holdMs: i === dividerRun.length - 1 ? 500 : 90,
       run: (actions) =>
-        actions.toggleWallEdge(
-          [col, DIVIDER_ROW],
-          [col, DIVIDER_ROW + 1],
-          'solid',
-          true
-        ),
+        actions.toggleWallEdge(edge.cellA, edge.cellB, 'solid', true),
     });
-    if (i === DIVIDER_COLS.length - 1) steps[steps.length - 1].holdMs = 500;
   });
 
-  steps.push({
-    caption: 'A door between the two halves.',
-    holdMs: 900,
-    run: (actions) =>
-      actions.toggleWallEdge(
-        [DOOR_COL, DIVIDER_ROW],
-        [DOOR_COL, DIVIDER_ROW + 1],
-        'door',
-        true
-      ),
-  });
+  // A door roughly in the middle of the traced run — same "pick the
+  // midpoint" discipline `regionGeometry.ts`'s `pickAttachmentEdge` uses
+  // for a region-attachment door, rather than assuming a specific column
+  // is on the run (the traced sequence's exact cells depend on real hex
+  // geometry, not a hand-picked coordinate).
+  const doorEdge = dividerRun[Math.floor(dividerRun.length / 2)];
+  if (doorEdge) {
+    steps.push({
+      caption: 'A door between the two halves.',
+      holdMs: 900,
+      run: (actions) =>
+        actions.toggleWallEdge(doorEdge.cellA, doorEdge.cellB, 'door', true),
+    });
+  }
 
   steps.push({
     caption: 'Start here —',
@@ -127,4 +164,4 @@ export function buildDemoScript(grid: {
   return steps;
 }
 
-export { DIVIDER_COLS, DIVIDER_ROW, DOOR_COL };
+export { DIVIDER_ROW, DOOR_COL, SPAN_COL_END, SPAN_COL_START };

--- a/src/concepts/dungeon-builder/creation/useRegionEditing.ts
+++ b/src/concepts/dungeon-builder/creation/useRegionEditing.ts
@@ -67,6 +67,32 @@ export function useRegionEditing(
     );
   };
 
+  /** IDEMPOTENT pending-cell membership setter — `included: true` adds
+   * only if absent, `false` removes only if present, a no-op otherwise.
+   * Exists alongside `togglePendingCell` for a genuinely different
+   * caller shape: a DRAG (`CreationBoard.tsx`'s region-brush pointer-move
+   * loop, 2026-08-03 — Kirk's ask, "building a region should have us draw
+   * the shape... right now we have to click every square") decides ONE
+   * add-vs-erase mode for the whole stroke up front (mirroring the
+   * wall-drawing stroke's own `addMode`, decided from the first edge
+   * touched) and then needs to apply that SAME mode to every cell the
+   * pointer passes over — a bare toggle would flip a cell back off the
+   * instant the drag re-enters one it already painted, or paint the WRONG
+   * direction for a cell that happened to already be a member before the
+   * drag started. A single click still reads as a toggle to the author
+   * (`CreationBoard.tsx` computes `included = !cellIn(pendingCells, cell)`
+   * for the drag's own first cell), so this doesn't change single-click
+   * behavior — it only makes the multi-cell case correct. */
+  const setPendingCellMembership = (cell: Cell, included: boolean) => {
+    setPendingCells((prev) => {
+      const has = cellIn(prev, cell);
+      if (included === has) return prev;
+      return included
+        ? [...prev, cell]
+        : prev.filter((c) => !(c[0] === cell[0] && c[1] === cell[1]));
+    });
+  };
+
   const clearPending = () => setPendingCells([]);
 
   /** Select an existing region for membership/metadata editing, or `null`
@@ -103,6 +129,32 @@ export function useRegionEditing(
         removeCellFromRegion(cst, doc, selectedRegionId, cell);
       } else {
         addCellToRegion(cst, doc, selectedRegionId, cell);
+      }
+      syncFromCst(cst);
+    } catch (err) {
+      reportError(err);
+    }
+  };
+
+  /** IDEMPOTENT sibling of `handleToggleCellOnSelected`, same reason
+   * `setPendingCellMembership` exists alongside `togglePendingCell` — the
+   * region-brush drag needs to apply ONE decided mode across every cell a
+   * stroke crosses, not re-toggle each one. A rejected `addCellToRegion`/
+   * `removeCellFromRegion` (contiguity/overlap) surfaces as a toast per
+   * cell, same as the single-click path — a drag that crosses into
+   * another region's territory rejects THAT cell and keeps going, rather
+   * than aborting the whole stroke. */
+  const setSelectedRegionCellMembership = (cell: Cell, included: boolean) => {
+    if (!selectedRegionId) return;
+    const region = doc.regions.find((r) => r.id === selectedRegionId);
+    if (!region) return;
+    const has = cellIn(region.cells, cell);
+    if (included === has) return;
+    try {
+      if (included) {
+        addCellToRegion(cst, doc, selectedRegionId, cell);
+      } else {
+        removeCellFromRegion(cst, doc, selectedRegionId, cell);
       }
       syncFromCst(cst);
     } catch (err) {
@@ -156,12 +208,14 @@ export function useRegionEditing(
   return {
     pendingCells,
     togglePendingCell,
+    setPendingCellMembership,
     clearPending,
     selectedRegionId,
     selectRegion,
     justCreatedId,
     handleCreate,
     handleToggleCellOnSelected,
+    setSelectedRegionCellMembership,
     handleRename,
     handleSetArchetype,
     handleDelete,

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -1312,15 +1312,20 @@ regions:
 
       const result = connectRegions(cst, doc3, 'north', 'south');
       expect(result.edge).not.toBeNull();
-      // Two candidate edges ([1,1]-[1,2] and [2,1]-[2,2]) sorted by
-      // (row, col) of `to` — the midpoint of 2 picks the SECOND
-      // (index 1) per pickAttachmentEdge's own floor(n/2) rule.
-      expect(result.edge).toEqual({ from: [2, 1], to: [2, 2] });
+      // HEX-TRUE (2026-08-03): real hex adjacency finds THREE candidate
+      // edges here, not the two a square-grid 4-adjacency check would —
+      // [1,1]-[1,2] and [2,1]-[2,2] (same-column, row+1, real under
+      // either rule) PLUS [1,1]-[2,2], a genuine hex neighbor
+      // (regionGeometry.ts's own `cellsAdjacent` — verified numerically
+      // while building this unit) that a square grid has no way to
+      // represent at all. Sorted by (row, col) of `to`, the middle of 3
+      // (pickAttachmentEdge's own floor(n/2) rule) is now the new edge.
+      expect(result.edge).toEqual({ from: [1, 1], to: [2, 2] });
 
       const finalDoc = toDungeonDoc(cst);
       expect(finalDoc.walls).toHaveLength(1);
       expect(finalDoc.walls[0]).toEqual({
-        from: [2, 1],
+        from: [1, 1],
         to: [2, 2],
         kind: 'door',
       });

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -276,7 +276,7 @@ export interface RegionDoc {
 
 export type WallKind = 'solid' | 'door';
 
-/** Edge-native: `from`/`to` are orthogonally-adjacent absolute [col,row]
+/** Edge-native: `from`/`to` are hex-adjacent absolute [col,row]
  * cells, the wall sits on the shared edge between them. target dialect, proposed —
  * see TARGET-YAML.md's annotated example for the full rationale (mirrors
  * the real `EncounterService.Space.walls` wire type). Not compiled
@@ -1411,7 +1411,7 @@ export function validateRegionCells(
     seen.add(key);
   }
   if (!cellsAreContiguous(cells)) {
-    return 'cells must be orthogonally contiguous (rpg-project#180)';
+    return 'cells must be hex-contiguous (rpg-project#180)';
   }
   if (cellsOverlapAnotherRegion(doc, cells, excludeRegionId)) {
     return 'one or more cells already belong to another region';

--- a/src/concepts/dungeon-builder/hexLayout.ts
+++ b/src/concepts/dungeon-builder/hexLayout.ts
@@ -18,30 +18,53 @@
  * real hex geometry, just no longer treated as a legibility problem
  * worth a second mode to work around.
  *
- * `FLAT_COL_SPACING`/`FLAT_ROW_SPACING` below are UNRELATED to that
- * removed toggle, despite the similar naming — they're creation mode's
- * own rectangular-canvas spacing (`CreationBoard.tsx`/
- * `creationGeometry.ts`), a deliberately separate, still-live renderer
- * for a freeform drawing canvas that was never claiming hex adjacency in
- * the first place (see CONTRACT.md: "CreationBoard.tsx is still its own
- * renderer, not Board.tsx itself — two genuinely different geometries").
+ * **HEX-TRUE CREATION CANVAS (2026-08-03)**: creation mode's own
+ * rectangular-canvas spacing, `FLAT_COL_SPACING`/`FLAT_ROW_SPACING`, USED
+ * to live here — a deliberately separate square-grid renderer for a
+ * freeform drawing canvas that (per this file's own header comment,
+ * before this round) was "never claiming hex adjacency in the first
+ * place." That exemption is retired: Kirk, diagnosing the square canvas
+ * directly, "that new dungeon is squares... our walls as we lay them out
+ * cannot follow along the edge... any hex that is not 100% uncovered
+ * would not be traversable by the players" — a square grid only exposes
+ * 4 of a hex's 6 real adjacencies, so a region that reads as fully
+ * enclosed on squares can have two invisible open edges in hex reality,
+ * and "walls look like vertical blinds along the side edges" (disconnected
+ * parallel slats, where real hex edges share corners and chain into a
+ * continuous run). `creation/creationGeometry.ts` now builds its geometry
+ * from this file's own `cellCenter`/`cellCorners`/`edgeBetweenCells` —
+ * the SAME functions this hex-true edit board renders with — instead of
+ * a second, square coordinate system. One board geometry, not two.
  */
 import {
   cubeToWorld,
   hexEdgeBetween,
   hexCorners as realHexCorners,
+  worldToCube as realWorldToCube,
 } from '@/components/hex-grid/hexMath';
 import { cubeAtColRow, hexColumn, hexRow } from '@/hooks/wallRuns';
 
 /** Board-space hex radius. Smaller than the 3D game's world-unit
  * `HEX_SIZE` (which is 1.0 world unit) — this is a 2D SVG pixel radius,
  * a purely local rendering choice with no wire representation (see
- * CONTRACT.md's "cell-size/aspect for rendering" finding). */
+ * CONTRACT.md's "cell-size/aspect for rendering" finding). Shared by
+ * BOTH boards now (creation mode included) — one hex size, not two. */
 export const BOARD_HEX_SIZE = 24;
 
 export interface CellPos {
   x: number;
   y: number;
+}
+
+/** The inverse of `cellCenter`: the cube coordinate nearest a board-space
+ * point, at this file's own `BOARD_HEX_SIZE`. Exposed here (rather than
+ * making every caller import `hexMath.ts`'s `worldToCube` directly and
+ * juggle the `{x,z}`/`{x,y}` naming difference itself) so hit-testing
+ * code — `boardGeometry.ts`'s drag-drop resolution, `creationGeometry.ts`'s
+ * `nearestEdge`/`nearestCreationCell` — has one real inverse-transform
+ * entry point at the SAME size every renderer draws with. */
+export function worldToCube(point: CellPos) {
+  return realWorldToCube({ x: point.x, z: point.y }, BOARD_HEX_SIZE);
 }
 
 /** Same odd-q pointy-top math the real 3D floor renders with — edit
@@ -90,14 +113,6 @@ export function edgeBetweenCells(
     mid: { x: edge.mid.x, y: edge.mid.z },
   };
 }
-
-/** Creation mode's rectangular-canvas spacing — see this file's header
- * doc comment for why these live here despite the "FLAT" naming echo of
- * the removed edit-mode toggle. Spacing values unchanged from before the
- * removal (chosen to roughly match hex-true's average column/row pitch,
- * a purely cosmetic choice with no bearing on this decision). */
-export const FLAT_COL_SPACING = BOARD_HEX_SIZE * Math.sqrt(3);
-export const FLAT_ROW_SPACING = BOARD_HEX_SIZE * 1.5;
 
 // Re-exported so callers doing manual col/row bookkeeping (e.g. nearest-cell
 // hit testing during a drag) use the same real conversion, never a second

--- a/src/concepts/dungeon-builder/regionGeometry.test.ts
+++ b/src/concepts/dungeon-builder/regionGeometry.test.ts
@@ -16,20 +16,32 @@ describe('cellsEqual', () => {
   });
 });
 
-describe('cellsAdjacent', () => {
-  it('is true for orthogonal neighbors only', () => {
+describe("cellsAdjacent (HEX-TRUE, 2026-08-03 — see this module's own header comment for the 4-to-6-adjacency widening)", () => {
+  it('is true for the 4 old "orthogonal" neighbors — every one of them is still a real hex neighbor', () => {
     expect(cellsAdjacent([1, 1], [2, 1])).toBe(true);
     expect(cellsAdjacent([1, 1], [1, 2])).toBe(true);
     expect(cellsAdjacent([1, 1], [0, 1])).toBe(true);
     expect(cellsAdjacent([1, 1], [1, 0])).toBe(true);
   });
 
-  it('is false for diagonal neighbors', () => {
-    expect(cellsAdjacent([1, 1], [2, 2])).toBe(false);
+  it('is true for ONE of a square grid\'s two "diagonal" directions — a real hex neighbor square adjacency couldn\'t represent', () => {
+    // [1,1]-[2,2]: a genuine hex neighbor (verified numerically while
+    // building this unit — hex distance 1, not the "false" the old
+    // 4-neighbor-only rule gave it). This is exactly the kind of pair
+    // Kirk's finding named: a square grid only draws 4 of a hex's 6 real
+    // adjacencies, so a region that read as enclosed on squares could
+    // have an invisible open edge here in hex reality.
+    expect(cellsAdjacent([1, 1], [2, 2])).toBe(true);
+  });
+
+  it('is false for the OTHER "diagonal" direction — column parity means not every square-diagonal pair becomes a hex neighbor', () => {
+    // [1,1]-[0,0]: hex distance 2, still non-adjacent — the widening
+    // isn't "all diagonals now count," it's "exactly the diagonal that
+    // is a real hex neighbor now counts."
     expect(cellsAdjacent([1, 1], [0, 0])).toBe(false);
   });
 
-  it('is false for the same cell or a non-adjacent cell', () => {
+  it('is false for the same cell or a genuinely non-adjacent cell', () => {
     expect(cellsAdjacent([1, 1], [1, 1])).toBe(false);
     expect(cellsAdjacent([1, 1], [5, 5])).toBe(false);
   });
@@ -44,7 +56,7 @@ describe('cellsAreContiguous', () => {
     expect(cellsAreContiguous([[3, 3]])).toBe(true);
   });
 
-  it('is true for an orthogonally connected run, any authoring order', () => {
+  it('is true for a hex-connected run, any authoring order', () => {
     expect(
       cellsAreContiguous([
         [9, 4],
@@ -79,7 +91,7 @@ describe('cellsAreContiguous', () => {
 });
 
 describe('sharedBoundaryEdges', () => {
-  it('finds every orthogonal edge between two cell sets', () => {
+  it('finds every hex edge between two cell sets — including a genuinely NEW one 4-adjacency missed (HEX-TRUE, 2026-08-03)', () => {
     // A 2x1 region at col 0-1, row 0, next to a 2x1 region at col 0-1, row 1.
     const a: [number, number][] = [
       [0, 0],
@@ -90,11 +102,21 @@ describe('sharedBoundaryEdges', () => {
       [1, 1],
     ];
     const edges = sharedBoundaryEdges(a, b);
-    expect(edges).toHaveLength(2);
+    // The old 4-adjacency rule found exactly 2 edges here ([0,0]-[0,1],
+    // [1,0]-[1,1] — same-column, consecutive-row pairs). Real hex
+    // adjacency finds a THIRD: [1,0]-[0,1] is a genuine hex neighbor
+    // (verified numerically while building this unit) even though it
+    // reads as "diagonal" on the square grid these cells were originally
+    // authored against — one more candidate boundary edge
+    // `pickAttachmentEdge` now has to choose among, never fewer (6-
+    // adjacency is a strict superset, so a boundary that validated before
+    // still does).
+    expect(edges).toHaveLength(3);
     expect(edges).toEqual(
       expect.arrayContaining([
         { from: [0, 0], to: [0, 1] },
         { from: [1, 0], to: [1, 1] },
+        { from: [1, 0], to: [0, 1] },
       ])
     );
   });
@@ -105,7 +127,7 @@ describe('sharedBoundaryEdges', () => {
     expect(sharedBoundaryEdges(a, b)).toEqual([]);
   });
 
-  it('is empty for two regions that only touch diagonally', () => {
+  it('is empty for two cells that are hex-distance 2 apart, even though they read as "diagonal" neighbors on a square grid', () => {
     const a: [number, number][] = [[0, 0]];
     const b: [number, number][] = [[1, 1]];
     expect(sharedBoundaryEdges(a, b)).toEqual([]);

--- a/src/concepts/dungeon-builder/regionGeometry.ts
+++ b/src/concepts/dungeon-builder/regionGeometry.ts
@@ -4,14 +4,34 @@
  * from `dungeonYaml.ts`'s CST layer, the same split `boardGeometry.ts`/
  * `creationGeometry.ts` already use for every other pure-math concern in
  * this concept: unit-testable without a CST document, and reusable by
- * both the creation board (rectangular canvas) and the edit-mode hex
- * board's read-only overlay, since a region's membership is expressed in
- * the same abstract absolute [col,row] cell space regardless of which
- * board renders it. Deliberately has NO dependency on `DungeonDoc`/
- * `RegionDoc` (dungeonYaml.ts) — every function here takes plain cell
- * arrays, so dungeonYaml.ts can import this module without creating a
- * cycle.
+ * both the creation board (now hex-true, see `creationGeometry.ts`) and
+ * the edit-mode hex board's read-only overlay, since a region's
+ * membership is expressed in the same abstract absolute [col,row] cell
+ * space regardless of which board renders it. Deliberately has NO
+ * dependency on `DungeonDoc`/`RegionDoc` (dungeonYaml.ts) — every
+ * function here takes plain cell arrays, so dungeonYaml.ts can import
+ * this module without creating a cycle.
+ *
+ * **HEX-TRUE (2026-08-03)**: `cellsAdjacent` used to be plain 4-neighbor
+ * orthogonal adjacency (`|dcol|+|drow| === 1`), inherited from the
+ * creation board's own now-retired square-canvas geometry. It's now REAL
+ * hex adjacency (`hexDistance === 1` on the same `cubeAtColRow`/
+ * `hexDistance` math every other renderer in this codebase uses) — a hex
+ * cell has 6 neighbors, not 4, and which two of a square's 4 "diagonal"
+ * neighbors are real hex neighbors depends on column parity (verified
+ * numerically while building this: `[1,1]`-`[2,2]` is a real hex
+ * neighbor, `[1,1]`-`[0,0]` isn't, despite both reading as "diagonal" on
+ * a square grid). This is a strictly WIDER relation than the old one —
+ * every pair that was 4-adjacent is still hex-adjacent (verified: a
+ * same-row ±1-col or same-col ±1-row step is always exactly hex-distance
+ * 1, regardless of parity), so no region that validated as contiguous
+ * under the old rule stops validating; hex adjacency can only make a
+ * previously-rejected (diagonal-only, disconnected) cell set newly
+ * valid, never invalidate an existing one. See this module's own test
+ * file for the concrete before/after case.
  */
+import { hexDistance } from '@/components/hex-grid/hexMath';
+import { cubeAtColRow } from './hexLayout';
 
 export type Cell = [number, number];
 
@@ -23,19 +43,15 @@ export function cellsEqual(a: Cell, b: Cell): boolean {
   return a[0] === b[0] && a[1] === b[1];
 }
 
-/** Orthogonal (4-neighbor) adjacency — the same adjacency `walls:`'s own
- * "from/to must be orthogonally adjacent cells" rule assumes
- * (TARGET-YAML.md's annotated example), and the one `cellsAreContiguous`/
- * `sharedBoundaryEdges` below both build on. Diagonal neighbors don't
- * count: there is no orthogonal wall/door edge to author between two
- * cells that only touch at a corner. */
+/** Real hex adjacency (distance exactly 1 in cube coordinates) — the
+ * relation `cellsAreContiguous`/`sharedBoundaryEdges` below both build
+ * on. See this file's own header comment for the 4-neighbor-to-hex
+ * widening this represents. */
 export function cellsAdjacent(a: Cell, b: Cell): boolean {
-  const dc = Math.abs(a[0] - b[0]);
-  const dr = Math.abs(a[1] - b[1]);
-  return (dc === 1 && dr === 0) || (dc === 0 && dr === 1);
+  return hexDistance(cubeAtColRow(a[0], a[1]), cubeAtColRow(b[0], b[1])) === 1;
 }
 
-/** BFS connectivity over a cell list's own orthogonal adjacency —
+/** BFS connectivity over a cell list's own hex adjacency —
  * rpg-project#180's own acceptance criterion: "Overlapping, disconnected,
  * empty, and invalid cell sets fail with author-facing validation
  * errors." A single cell is trivially contiguous; an empty list is
@@ -64,11 +80,11 @@ export function cellsAreContiguous(cells: readonly Cell[]): boolean {
 export interface RegionEdge {
   /** The cell on the first region's side. */
   from: Cell;
-  /** The cell on the second region's side, orthogonally adjacent to `from`. */
+  /** The cell on the second region's side, hex-adjacent to `from`. */
   to: Cell;
 }
 
-/** Every orthogonal edge with one cell in `cellsA` and the other in
+/** Every hex edge with one cell in `cellsA` and the other in
  * `cellsB` — the candidate set for "attach these two regions with a door"
  * (TARGET-YAML.md's "region attachment" section). Deliberately does not
  * consult `walls:` at all: per the settled early-authoring model


### PR DESCRIPTION
## Summary

Kills the Dungeon Builder's "New Dungeon" creation canvas's square-grid rendering, which Kirk diagnosed as geometrically lying to authors:

- "our walls as we lay them out cannot follow along the edge... any hex that is not 100% uncovered would not be traversable by the players" — a square grid only draws 4 of a hex's 6 real adjacencies, so a region that reads as fully enclosed on squares can have invisible open edges in hex reality (false enclosure).
- "walls look like vertical blinds along the side edges" — a square wall run is disconnected parallel slats; real hex edges share corners and chain into a continuous run.
- "building a region should have us draw the shape. right now we have to click every square" — region authoring needed a drag brush.

The creation board's rectangular renderer had survived the earlier edit-mode hex-true round as "genuinely separate, never claiming hex adjacency" — that exemption ends here. It now renders through the exact same hex primitives (`hexLayout.ts`/`boardGeometry.ts`) the compiled edit-mode board already uses.

## What changed

- `creationGeometry.ts` rebuilt on real hex math (`cellCenter`/`cellCorners`/`edgeBetweenCells`/`worldToCube`/`neighborCell`); `FLAT_COL_SPACING`/`FLAT_ROW_SPACING` and every axis-aligned edge function deleted from `hexLayout.ts`.
- Wall drawing: `nearestEdge` picks among a cell's real 6 edges by point-to-segment distance. Verified numerically (and now covered by a test) that this is inherently corner-connected for a smooth drag — the square predecessor's crenellated-comb bug does not reappear in hex; the orientation lock (`dragFamily`, 3 families instead of 2 axes) survives only as a stroke stabilizer, not a correctness fix.
- `demoScript.ts`'s divider wall is now derived via a new `traceEdgeRun` helper (the same `nearestEdge` a live drag calls) instead of hand-picked `[col,row]` pairs that turned out not to connect under real hex geometry.
- Region tool: added drag-to-paint via idempotent membership setters (`setPendingCellMembership`/`setSelectedRegionCellMembership`) plus a per-stroke dedup set, replacing click-per-cell only. Shift forces erase mode.
- `regionGeometry.ts`'s `cellsAdjacent` is now real hex adjacency (`hexDistance === 1`), not 4-neighbor-orthogonal — a strictly wider relation (every previously-valid region stays valid; some previously-rejected diagonal-touching sets now correctly validate). One `dungeonYaml.test.ts` case needed its expected edge updated since `sharedBoundaryEdges` now finds a genuinely new candidate boundary edge between two regions.
- New `openBoundaryEdges` affordance: highlights every region's unwalled boundary edges directly on the board in red — answers Kirk's false-enclosure worry visually, not just structurally.

## Test plan

- [x] `npm run ci-check` clean (format/lint/typecheck/build/test)
- [x] 170 dungeon-builder tests passing (up from 162 on `dev`)
- [x] Live-verified in a real browser (dev server + Playwright screenshots): hex-true canvas rendering, a continuous zigzag wall + door from "Play the pitch," a 9-cell region painted from a single drag gesture, the open-boundary red highlight on an unsealed region, and the connect-regions honest-rejection path under real hex adjacency
- [x] `CONTRACT.md`/`TARGET-YAML.md` updated with the full finding (ledger section + the 4-vs-6 adjacency writeup)

— asset-pipeline agent, on behalf of KirkDiggler