### PR TITLE
unit: straight walls with visible footprint (prototype)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3378,3 +3378,110 @@ local `rpg-api` running — unrelated to this round's changes.
 adjacency/boundary tests were updated in place, not added to, to assert
 the new hex-true answers). `ci-check` clean
 (format/lint/typecheck/build/test).
+
+## Straight walls with visible footprint — prototype unit (2026-08-03, rpg-project#169)
+
+Kirk's design direction, prototyped as a comparison: the hex-true creation
+canvas above ships an edge-painted zigzag Wall tool, but Kirk drew straight
+red lines across a room and said the walls should be straight — and stated
+the rule directly: **"any hex that is not 100% uncovered would not be
+traversable"** — a straight wall has a FOOTPRINT, clipped cells are spent.
+The real game's own wall renderer (`wallRuns.ts`/`WallRunMesh`) already
+draws straight modular wall runs along room envelopes — the zigzag is this
+concept's own outlier, not the game's established look. Full design
+writeup: TARGET-YAML.md's "Straight walls" section (schema shape decided
+and why the alternative — a `style:` discriminator on `walls:` — was
+rejected; the footprint epsilon derived and justified; the shoulder-
+clipping/every-other-hex cases; movement semantics (a) and (b); the
+touch-adjacent-to-footprint finding for (b); corner continuity; the
+compiler-responsibility note).
+
+### What shipped
+
+A new Structural-category tool, **Straight Wall**, alongside the existing
+Wall tool (both survive — the comparison is the point). Drag locks to
+whichever of 2 screen axes (vertical/horizontal) the drag is closer to,
+then snaps the endpoint to the closest AVAILABLE hex cell approximating
+that axis (`creation/straightWallGeometry.ts`'s `pickStraightAxis`/
+`snapStraightEndpoint` — a 2-way analog of the zigzag tool's own 3-way
+`dragFamily`). A click (no real drag) on an existing straight wall deletes
+it; the Door tool, applied to a straight wall's line, flips `solid`↔`door`
+by index. New document field `wallLines: WallLineDoc[]` (a sibling to
+`walls:`, not a variant — see TARGET-YAML.md for why), with its own
+mutators (`addWallLine`/`removeWallLineAt`/`toggleWallLineKindAt`,
+`dungeonYaml.ts`) and its own `stripToV1Subset` drop/count, reported
+separately from `walls:`'s own count.
+
+Footprint + crossing math is real Cyrus-Beck half-plane clipping (6
+half-planes per hex, shrunk inward by `FOOTPRINT_EPSILON =
+BOARD_HEX_SIZE * 1e-3`), not a sampling heuristic — computed live while
+dragging (the preview) and rendered for every committed `wallLines:` entry.
+Footprint cells render with a new crimson diagonal-hatch `<pattern>`
+(`db-footprint-hatch`), deliberately distinct from the region open-boundary
+overlay's plain solid red LINE (`openBoundaryEdges`) — a hatch reads as
+"this ground is gone," a line reads as "this boundary has a problem," and
+the two ARE different facts. Blocked edge-crossings (movement semantic (b))
+render as a dashed highlight across the specific grazed edge.
+
+**Existing content in a new footprint is FLAGGED, never silently deleted or
+moved**: placements get an extra warning ring + "⚠ IN WALL FOOTPRINT" label
+(live during the drag, not just after release); start/end reuse this file's
+own "⚠ ... (BLOCKED!)" visual language verbatim (`Board.tsx`'s entrance-
+blocked convention); region cells inside a footprint get a small ⚠ overlay,
+with the region's own `cells:` membership left untouched (per the settled
+model: an inner wall never splits a semantic region).
+
+### Live verification
+
+Real dev server (`vite --port 5180`, never `:3001`), driven via a throwaway
+Playwright script (`game-dev/tools/browser/_job_swall_verify.mjs`,
+gitignored scratch pattern, same convention the region-authoring/hex-
+creation units above used) — computed real hex-true board-space coordinates
+(the SAME `cellCenter` formula `hexLayout.ts` uses, ported into the script)
+and read the SVG's own live `viewBox` to convert board-space points to
+on-screen pixels for `page.mouse` drags, rather than assuming a fixed
+pixel-per-cell spacing (the OLD square-grid `FLAT_COL_SPACING`/
+`FLAT_ROW_SPACING` constants the region-authoring unit's own script used —
+those no longer exist post-hex-true).
+
+- `docs/evidence/straight-walls-vertical-footprint.png` — a genuinely
+  vertical straight wall (`[4,4]` → `[6,1]`, verified analytically to share
+  the same world X) rendered as a clean white line through exactly 3
+  hatched hexes, with the immediately flanking hexes visibly UN-hatched —
+  the shoulder-clipping case, seen live, not just asserted in a unit test.
+- `docs/evidence/straight-walls-l-corner.png` — a second segment drawn from
+  the SAME endpoint cell (`[6,1]` → `[10,3]`) forms a clean L corner with no
+  gap and no special-case code, exactly Kirk's red-lines picture.
+- `docs/evidence/straight-walls-vs-zigzag-comparison.png` — the same L
+  corner alongside an edge-zigzag Wall-tool run drawn over a similar span:
+  the straight wall reads as one clean, unbroken run with a visible
+  footprint; the zigzag run (real `dragFamily`-locked edge-painting, still
+  topologically correct) visibly breaks into short, disconnected-looking
+  segments once the drag isn't aligned with one of the hex grid's 3 real
+  edge families — the live, visual version of the finding TARGET-YAML.md's
+  "why this needs a genuinely different shape" section makes analytically.
+
+Confirmed via the live YAML pane (not just the screenshots' own claim):
+`wallLines: [ { from: [4, 4], to: [6, 1], kind: solid }, { from: [6, 1],
+to: [10, 3], kind: solid } ]` and a real 8-segment `walls:` zigzag run
+alongside it, both present in the same document. The only console errors
+are the expected FIXTURES-MODE `[unimplemented] unknown service
+...AuthoringService` (this dev server has no local `rpg-api` running —
+unrelated to this unit, same as every other round's live-verification
+note above).
+
+### Tests
+
+19 new tests in `creation/straightWallGeometry.test.ts` (footprint
+clipping incl. the shoulder-clipping vertical case and the every-other-hex
+"same row index is not horizontal" case, contrasted directly against a
+genuinely world-horizontal line; the epsilon touch-vs-clip boundary,
+verified both sides of it; the movement-semantics (b) mechanism exercised
+directly since no natural cell-to-cell wall in this unit's own testing —
+3 hand-derived cases plus 400 randomly sampled pairs — ever produces a
+both-clear crossing, a real, verified finding, not an assumption; corner
+continuity; the footprint-set union; axis-pick; endpoint-snapping) plus 7
+new `dungeonYaml.test.ts` cases (`wallLines:` add/remove/toggle mutators,
+round-trip through real YAML text, `stripToV1Subset` dropping it
+separately from `walls:`). 196 dungeon-builder tests passing overall (up
+from 170). `ci-check` clean (format/lint/typecheck/build/test).

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -16,10 +16,12 @@ import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import { useRegionEditing } from './creation/useRegionEditing';
 import './DungeonBuilderConcept.css';
 import {
+  addWallLine,
   buildWalkItYaml,
   DungeonParseError,
   parseDungeon,
   placeItem,
+  removeWallLineAt,
   serializeDungeon,
   setConnectorLocked,
   setEnd,
@@ -31,6 +33,7 @@ import {
   toggleHole,
   toggleWall,
   toggleWallKind,
+  toggleWallLineKindAt,
   type DungeonDoc,
   type LockedDoc,
   type WallKind,
@@ -295,6 +298,25 @@ export function DungeonBuilderConcept() {
     syncFromCreationCst(creationCst);
   };
 
+  const handleCreationAddStraightWall = (
+    from: [number, number],
+    to: [number, number],
+    kind: WallKind
+  ) => {
+    addWallLine(creationCst, from, to, kind);
+    syncFromCreationCst(creationCst);
+  };
+
+  const handleCreationRemoveStraightWallAt = (index: number) => {
+    removeWallLineAt(creationCst, index);
+    syncFromCreationCst(creationCst);
+  };
+
+  const handleCreationToggleStraightWallKindAt = (index: number) => {
+    toggleWallLineKindAt(creationCst, index);
+    syncFromCreationCst(creationCst);
+  };
+
   const handleCreationToggleHole = (col: number, row: number) => {
     toggleHole(creationCst, col, row);
     syncFromCreationCst(creationCst);
@@ -469,6 +491,9 @@ export function DungeonBuilderConcept() {
           selectedTool={creationSelectedTool}
           onSelectTool={setCreationSelectedTool}
           onToggleWallEdge={handleCreationToggleWallEdge}
+          onAddStraightWall={handleCreationAddStraightWall}
+          onRemoveStraightWallAt={handleCreationRemoveStraightWallAt}
+          onToggleStraightWallKindAt={handleCreationToggleStraightWallKindAt}
           onToggleHole={handleCreationToggleHole}
           onSetPoint={handleCreationSetPoint}
           onNewCanvas={handleNewCanvas}

--- a/src/concepts/dungeon-builder/Palette.tsx
+++ b/src/concepts/dungeon-builder/Palette.tsx
@@ -47,6 +47,12 @@ interface PaletteProps {
    * create/edit them yet. */
   showRegionTool?: boolean;
   regionCount?: number;
+  /** Straight Wall tool (this unit) — creation-mode-only, same reasoning
+   * as `showRegionTool`: a from-scratch canvas is the natural home for
+   * freeform straight-line drawing; edit mode has no reader for
+   * `wallLines:` yet. */
+  showStraightWallTool?: boolean;
+  straightWallCount?: number;
 }
 
 const CATEGORY_LABELS: Record<PaletteCategory, string> = {
@@ -265,6 +271,8 @@ export function Palette({
   holeCount,
   showRegionTool = false,
   regionCount = 0,
+  showStraightWallTool = false,
+  straightWallCount = 0,
 }: PaletteProps) {
   const [openCategories, setOpenCategories] = useState<Set<PaletteCategory>>(
     new Set<PaletteCategory>(['obstacles-props'])
@@ -390,7 +398,7 @@ export function Palette({
 
       <CategorySection
         category="structural"
-        count={showRegionTool ? 4 : 3}
+        count={3 + (showRegionTool ? 1 : 0) + (showStraightWallTool ? 1 : 0)}
         open={openCategories.has('structural')}
         onToggle={() => toggle('structural')}
       >
@@ -403,6 +411,17 @@ export function Palette({
           onClick={() => toggleTool('wall')}
           notCompiled
         />
+        {showStraightWallTool && (
+          <Row
+            color="#c94f4f"
+            short="SW"
+            label="Straight Wall"
+            sub={`${straightWallCount}× drawn — drag for a straight segment with a footprint`}
+            isSelected={selectedTool === 'straightWall'}
+            onClick={() => toggleTool('straightWall')}
+            notCompiled
+          />
+        )}
         <Row
           color="#9b7fd6"
           short="D"

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -218,6 +218,18 @@ walls:
   - { from: [7, 0], to: [7, 1], kind: solid }
   - { from: [7, 4], to: [7, 5], kind: door }
 
+# STRAIGHT walls — a separate sibling construct, NOT a variant of walls:
+# above. from/to here are typically several cells apart, not adjacent — the
+# wall is the straight WORLD-SPACE line between their centers, which clips
+# through every hex it passes over (a footprint, not just a boundary). See
+# this file's own "Straight walls" section, below, for the full rule
+# (Kirk's "any hex not 100% uncovered would not be traversable"), the
+# epsilon that makes touch-vs-clip precise, and why this needed a new list
+# rather than a style: discriminator on walls: above.
+wallLines:
+  - { from: [10, 5], to: [10, 12], kind: solid }
+  - { from: [3, 3], to: [8, 3], kind: door }
+
 # No `holes:` in the early dialect. Use an obstacle/prop for a collapsed
 # visual; a true no-floor cell waits for mechanics that require one.
 
@@ -261,6 +273,201 @@ defaults:
   'dnd5e:monsters:skeleton': { targeting: lowest-health }
   'dnd5e:props:candles': { blocks_movement: false, height: 1.2 }
 ```
+
+## Straight walls: `wallLines:` — a footprint-bearing alternative to `walls:`
+
+Target dialect, proposed — prototyped alongside the existing `walls:` edge-
+painting tool this round (rpg-project#169's "straight walls with visible
+footprint" unit), both survive in creation mode as the direct comparison
+Kirk asked for. Kirk's own diagnosis, verbatim, looking at the hex-true
+creation canvas's zigzag walls: "we talked about our walls being straight" —
+he drew straight red lines across a room envelope and stated the governing
+rule directly: **"any hex that is not 100% uncovered would not be
+traversable"** — a straight wall has a FOOTPRINT, not just a boundary.
+
+### Why this needs a genuinely different shape than `walls:`
+
+`walls:`'s `{from, to, kind}` is edge-native: `from`/`to` are always
+hex-ADJACENT cells, and the wall sits on the one shared edge between them —
+a chain of these, drawn one edge at a time, is how the existing zigzag Wall
+tool traces a boundary that hugs real hex edges.
+
+A straight wall is not that. Verified directly against this codebase's own
+hex math (`hexMath.ts`'s `hexCorners`, corners at `30° + 60°·i`): a
+pointy-top hex has exactly 3 edge-line orientations — 30°, 90° (vertical),
+and 150° from the board's horizontal axis. **There is no 0°/horizontal edge
+family at all.** So a straight wall drawn along board-space "horizontal" (one
+of the two axes Kirk asked to snap to) can never run along hex boundaries —
+it always cuts through hex interiors. Even "vertical" only coincides with
+real hex edges for specific endpoint pairs; in general it also clips through
+cell interiors ("shoulder-clipping" — see below). `from`/`to` on a straight
+wall are therefore typically SEVERAL cells apart, not adjacent, and the
+wall's true geometry is the straight WORLD-SPACE line between their centers
+— a structurally different claim than `walls:`'s "this exact shared edge."
+
+### Schema shape chosen, and the alternative rejected
+
+**Chosen: a separate sibling list, `wallLines: [{from: [c,r], to: [c,r],
+kind: solid|door}]`** — same field names as `walls:` for a familiar shape,
+but a DIFFERENT construct, not a variant of the same one.
+
+**Rejected: overloading `walls:` with a `style: edge|straight` discriminator**
+on the existing `WallDoc` shape. Weighed and rejected because `from`/`to`
+mean something incompatible depending on `style` (hex-adjacent-cell vs.
+arbitrary-cells-apart) — every existing `walls:` consumer (`wallAtEdge`,
+`openBoundaryEdges`, `connectRegions`'s shared-boundary search, the door
+tool's edge lookup) assumes adjacency and would need a style branch added to
+stay correct, for a prototype round where the zigzag tool's own code needed
+to keep working unchanged. A sibling list needed zero changes to any
+existing `walls:` consumer — `doc.wallLines` is simply empty on every
+document that doesn't use it, the same "additive, absent by default" shape
+every other target-dialect field in this file already follows.
+
+### Footprint rule and the epsilon that makes it precise
+
+**Kirk's rule, exactly**: every hex the wall's line genuinely passes through
+is BLOCKED (not just its crossed edge — the whole cell is impassable), UNLESS
+the line only touches a vertex or runs exactly along one of the hex's own
+edges (a touch, not a clip). "Genuinely passes through" needs a concrete
+boundary between a real clip and a floating-point-noise false positive —
+`creation/straightWallGeometry.ts`'s `FOOTPRINT_EPSILON` is
+`BOARD_HEX_SIZE * 1e-3` (~0.024 board units, under a fortieth of a percent of
+the hex's own radius): every one of a hex's 6 edges is shrunk inward by this
+much before testing for intersection (Cyrus-Beck half-plane clipping against
+the shrunk hexagon). A touch never survives that shrink; a genuine clip,
+however shallow, always does. This is several orders of magnitude larger
+than the floating-point noise `Math.cos`/`Math.sin` introduce computing hex
+corners (~1e-13 at this scale — verified, not assumed), so it can't be
+fooled by trig rounding, and small enough to be visually and physically
+meaningless at render/gameplay scale.
+
+Two concrete cases worth naming directly, both covered by
+`creation/straightWallGeometry.test.ts`:
+
+- **Shoulder-clipping (vertical).** A genuinely vertical line (constant
+  world X — e.g. `[4,4]` → `[6,1]`, verified analytically to share the same
+  world X) clips only the 3 cells whose CENTERS the line threads exactly
+  through, and merely GRAZES (touches, does not clip) the cells immediately
+  flanking them — their vertical edge sits exactly on the line. A vertical
+  wall does not clip "a whole column" in `[col,row]` terms — a `[col,row]`
+  column isn't vertical in world space at all (it's one of the 30°/150°
+  diagonal edge families); this is why the test fixture is two columns
+  apart with a compensating row offset, not a same-column pair.
+- **Every-other-hex (a "same row index" line is NOT horizontal).** Two
+  cells sharing a `row` index are NOT a horizontal line in world space —
+  `hexRow`'s own parity-correction formula (`z = row - trunc((col-(col&1))/2)`,
+  `wallRuns.ts`) means world-Y drifts substantially between them (the same
+  diagonal-shear fact CONTRACT.md already documents for compiled `FloorPlan`
+  rendering, showing up again here). Naively connecting two same-row cells
+  produces a footprint that clips exactly every OTHER column, skipping the
+  rest — confirmed directly, not assumed. A genuinely world-horizontal line
+  (two cells with the SAME cube `z`, hence the same world Y — e.g. `[0,3]`
+  → `[10,8]`) clips one cell per column with no skips, a structurally
+  different result from the naive "same row" attempt. Both are exercised
+  side by side in the test file specifically so this distinction is
+  provable, not asserted on faith.
+
+### Movement semantics
+
+Two distinct effects, both implemented:
+
+**(a) Every footprint cell is blocked entirely** — not traversable, full
+stop, regardless of which of its edges the line actually crossed.
+
+**(b) Every cell-to-cell edge the line crosses BETWEEN TWO CLEAR
+(non-footprint) cells is also blocked**, even though neither adjacent cell
+is itself footprint-blocked — a wall that only grazed their shared boundary
+still cuts off that specific step between them.
+`straightWallCrossedEdges` implements this: for every hex-adjacent pair of
+cells where NEITHER side is in the footprint, test whether the wall's line
+crosses their shared edge; a crossing (including a graze, via the same
+`FOOTPRINT_EPSILON` tolerance) blocks that edge.
+
+**Honestly-recorded finding**: for the CURRENT representation (`from`/`to`
+anchored to cell CENTERS), (b) is provably empty in every case this unit
+tested — 3 hand-derived geometric cases plus 400 randomly sampled cell pairs
+(`straightWallGeometry.test.ts`'s own search, done while building this unit)
+all produced zero both-clear crossings. This isn't a coincidence: a straight
+line's path through a hex tiling is continuous, and every point where it
+merely touches a boundary sits adjacent to a cell it's already clipping (the
+line can't graze a shared edge between two clear cells without having
+entered one of the two cells bordering that edge's own neighborhood first).
+The mechanism is still real and implemented, not dead code — it's exercised
+directly in the test file against a hand-placed segment collinear with one
+real hex edge (bypassing the cell-center anchoring), and it becomes load-
+bearing the moment a wall's endpoints are no longer forced to cell centers —
+e.g. a server-side compiler working from raw board/world coordinates instead
+of this prototype's `[col,row]`-only representation.
+
+### Corners: no special-case joining logic needed
+
+Kirk's red-lines picture showed clean L corners where two segments meet.
+This "just works" by construction: consecutive straight-wall segments that
+SHARE AN ENDPOINT CELL (draw one from A to the corner cell, a second from the
+corner cell to C) both resolve that shared cell to the exact same
+`cellCenter(...)` world point — the two lines touch exactly, with no gap and
+no special corner-detection code. `straightWallGeometry.test.ts`'s
+"corner/L continuity" test asserts this directly (both segments' own
+resolved endpoint at the shared cell are `toEqual` the same point) rather
+than trusting it by construction alone.
+
+### Interaction: axis snap, then closest-available approximation
+
+Drag locks to whichever of 2 screen-space axes (vertical/horizontal) the
+drag's own direction is closer to, past a small movement threshold (mirrors
+the existing zigzag Wall tool's family-lock UX, `pickStraightAxis` a 2-way
+analog of `dragFamily`'s 3-way pick). 60°/120° diagonal snapping was
+considered and skipped this round — cheap to add later (widen
+`pickStraightAxis`/`snapStraightEndpoint` to 4 target directions using the
+same scoring search) but not needed to prove the footprint mechanic, which
+is this unit's actual point.
+
+Because this is a discrete hex grid, an EXACT vertical/horizontal line
+generally isn't reachable between two integer cell centers at all (see
+above — no edge family is horizontal, and vertical only lines up exactly for
+specific from/to pairs). `snapStraightEndpoint` searches a small window of
+columns/rows around the pointer's own nearest cell and picks whichever
+candidate keeps the locked axis's OTHER world coordinate closest to the
+starting cell's own — the closest AVAILABLE approximation, not a
+mathematically exact one. The footprint is always computed honestly from
+whatever line actually results, never from a pretended-exact one.
+
+### Interactions with everything else on the board: flag, never silently delete or move
+
+Per this file's own discipline elsewhere (a mapped top-level placement, an
+inherited default) — a straight wall's footprint landing on existing
+content is FLAGGED, not silently deleted or relocated:
+
+- **Placements** (`doc.place`) inside a footprint render an extra warning
+  ring + "⚠ IN WALL FOOTPRINT" label, live, including while a wall is still
+  being dragged (not just after release) — the placement itself is
+  untouched.
+- **Start/End** reuse `Board.tsx`'s own "⚠ ... (BLOCKED!)" visual language
+  verbatim (the same convention edit mode's entrance-blocked check uses)
+  rather than inventing a new one.
+- **Region cells** (`doc.regions`) inside a footprint get a small ⚠ glyph
+  overlaid on the affected cell — the region's own `cells:` membership is
+  never rewritten by a wall mutator, per the settled model's own "an inner
+  wall never splits a semantic region" rule (this file's "regions:"
+  section).
+
+### Compiler responsibilities (server-authoritative, this is a preview)
+
+Per this file's own operating principle (client viz previews what a real
+compiler will own): a real implementation would derive footprint cells and
+blocked crossings SERVER-SIDE from the authored `wallLines:` list, the same
+way `walls:` compiling to canonical `HexRecord.edges` is already the
+documented plan for edge-native walls. This concept's client-side
+`straightWallGeometry.ts` is that computation done once, client-side, for
+live visual feedback — not a claim that the client is the source of truth.
+
+### `stripToV1Subset`
+
+`wallLines:` drops entirely, same treatment as `walls:` (no v1 analog at
+all), counted and reported SEPARATELY in the compile-badge/dropped summary
+("N straight walls", never folded into the edge-wall "N walls" count) —
+they're genuinely different constructs, and conflating their counts would
+misrepresent which tool an author actually used.
 
 ## Top-level placement: rooms are semantic, not placement containers
 
@@ -1099,16 +1306,16 @@ live `validate_only` preview call or a real `Save & Play`, the current
 document is stripped down to exactly what v1 compiles
 (`dungeonYaml.ts`'s `stripToV1Subset`):
 
-| Field                                              | v1 subset                                                                                                                                                                                          |
-| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`                                          | forced to `1` (never `2` — see the annotated example's own note)                                                                                                                                   |
-| `key`, `name`, `theme`, `height`                   | kept as-is                                                                                                                                                                                         |
-| `rooms:`                                           | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                                                              |
-| `connectors:`                                      | kept as-is, including `locked:`                                                                                                                                                                    |
-| top-level `place:`                                 | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                                                           |
-| `canvas:`, `walls:`, `start:`, `end:`, `lighting:` | dropped entirely                                                                                                                                                                                   |
-| `regions:`                                         | dropped entirely — no v1 representation of any kind (dungeonspec only knows the declared `rooms:` chain); a region-attachment door edge (`walls:`) is stripped independently, see "regions:" above |
-| `defaults:`                                        | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above                                 |
+| Field                                                            | v1 subset                                                                                                                                                                                          |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`                                                        | forced to `1` (never `2` — see the annotated example's own note)                                                                                                                                   |
+| `key`, `name`, `theme`, `height`                                 | kept as-is                                                                                                                                                                                         |
+| `rooms:`                                                         | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                                                              |
+| `connectors:`                                                    | kept as-is, including `locked:`                                                                                                                                                                    |
+| top-level `place:`                                               | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                                                           |
+| `canvas:`, `walls:`, `wallLines:`, `start:`, `end:`, `lighting:` | dropped entirely — `walls:`/`wallLines:` counted separately ("N walls" / "N straight walls"), see "Straight walls" above                                                                           |
+| `regions:`                                                       | dropped entirely — no v1 representation of any kind (dungeonspec only knows the declared `rooms:` chain); a region-attachment door edge (`walls:`) is stripped independently, see "regions:" above |
+| `defaults:`                                                      | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above                                 |
 
 If, after stripping, `rooms:` has fewer than 2 entries (dungeonspec's own
 `minRooms = 2`), there IS no compilable subset — a from-scratch canvas

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -62,7 +62,7 @@ import {
 import { cubeToWorld } from '@/components/hex-grid/hexMath';
 import { useRef, useState, type ReactElement } from 'react';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
-import { BOARD_HEX_SIZE, cellCenter } from '../hexLayout';
+import { BOARD_HEX_SIZE, cellCenter, type CellPos } from '../hexLayout';
 import {
   END_COLOR,
   regionArchetypeColor,
@@ -80,10 +80,19 @@ import {
   nearestCreationCell,
   nearestEdge,
   openBoundaryEdges,
+  pointToSegmentDistSq,
   wallGeometry,
   type EdgeGeometry,
 } from './creationGeometry';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+import {
+  pickStraightAxis,
+  snapStraightEndpoint,
+  straightWallCrossedEdges,
+  straightWallFootprint,
+  straightWallsFootprintSet,
+  type StraightAxis,
+} from './straightWallGeometry';
 import type { RegionEditing } from './useRegionEditing';
 
 interface CreationBoardProps {
@@ -102,6 +111,23 @@ interface CreationBoardProps {
     kind: WallKind,
     on: boolean
   ) => void;
+  /** Straight Wall tool (this unit) — commits one new `wallLines:` entry
+   * per stroke, unlike `onToggleWallEdge`'s per-edge painting. See
+   * `straightWallGeometry.ts`. */
+  onAddStraightWall: (
+    from: [number, number],
+    to: [number, number],
+    kind: WallKind
+  ) => void;
+  /** Click (no drag) on an existing straight wall's line deletes it —
+   * the straight-wall tool's own "click to add/remove" affordance,
+   * mirroring the edge Wall tool's `wallCount`× drawn — click a wall
+   * cell to add/remove" language in `Palette.tsx`. */
+  onRemoveStraightWallAt: (index: number) => void;
+  /** Door tool, applied to a straight wall — flips `solid`/`door` by
+   * index, same "click an existing wall to flip solid ↔ door" gesture
+   * the edge Wall/Door pair already gives `doc.walls`. */
+  onToggleStraightWallKindAt: (index: number) => void;
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
   /** Cell-authored semantic region editing (rpg-project#180) — only
@@ -142,6 +168,32 @@ function wallAtEdge(
   );
 }
 
+/** Index of the `doc.wallLines` entry nearest `point`, within `maxDist`
+ * board units, or `null` if none is close enough — the straight-wall
+ * tool's own click-to-delete hit test, and (with a tighter radius) the
+ * Door tool's "click an existing straight wall" test. Point-to-segment
+ * distance against the wall's own world-space line (`cellCenter(from)`
+ * to `cellCenter(to)`), same primitive `creationGeometry.ts`'s
+ * `nearestEdge` uses internally, exported from there for this purpose. */
+function straightWallLineIndexNear(
+  doc: DungeonDoc,
+  point: CellPos,
+  maxDist = 8
+): number | null {
+  let best: number | null = null;
+  let bestDistSq = maxDist * maxDist;
+  doc.wallLines.forEach((line, i) => {
+    const a = cellCenter(line.from[0], line.from[1]);
+    const b = cellCenter(line.to[0], line.to[1]);
+    const d = pointToSegmentDistSq(point, a, b);
+    if (d < bestDistSq) {
+      bestDistSq = d;
+      best = i;
+    }
+  });
+  return best;
+}
+
 const CELL_SIZE = BOARD_HEX_SIZE - 1.5;
 
 export function CreationBoard({
@@ -151,6 +203,9 @@ export function CreationBoard({
   onSelectPlacement,
   onReject,
   onToggleWallEdge,
+  onAddStraightWall,
+  onRemoveStraightWallAt,
+  onToggleStraightWallKindAt,
   onToggleHole,
   onSetPoint,
   regionEdit,
@@ -181,6 +236,27 @@ export function CreationBoard({
   const [regionStroke, setRegionStroke] = useState<{
     mode: 'add' | 'erase';
     touched: Set<string>;
+  } | null>(null);
+  /** Straight Wall tool's own drag state (this unit) — genuinely
+   * different shape from `stroke` above: an edge-wall stroke paints a
+   * whole CHAIN of edges as it goes; a straight-wall stroke has exactly
+   * ONE `from`/`to` pair, committed once on pointer-up. `axis` mirrors
+   * `stroke.family`'s "undecided until the drag clears a threshold"
+   * shape, but with 2 screen-space choices (vertical/horizontal) instead
+   * of 3 hex edge families — see `straightWallGeometry.ts`'s
+   * `pickStraightAxis`. `deleteCandidate` is resolved on pointer-DOWN
+   * (which existing straight wall, if any, was clicked) but only acted
+   * on at pointer-UP, and only if the whole gesture turns out to have
+   * been a CLICK rather than a real drag (see `handlePointerUp`) — a
+   * drag starting on top of an existing line still draws a new one,
+   * consistent with every other tool's click-vs-drag split in this
+   * component. */
+  const [straightStroke, setStraightStroke] = useState<{
+    fromCell: [number, number];
+    toCell: [number, number];
+    axis: StraightAxis | null;
+    startPoint: CellPos;
+    deleteCandidate: number | null;
   } | null>(null);
 
   const grid = doc.canvas ?? DEFAULT_CANVAS;
@@ -321,6 +397,22 @@ export function CreationBoard({
       setRegionStroke({ mode, touched: new Set([cellKey]) });
       return;
     }
+    if (tool === 'straightWall') {
+      const cell = nearestCreationCell(p, grid);
+      // Resolved now (which existing straight wall, if any, sits under
+      // the click) but only ACTED on at pointer-up, and only if this
+      // whole gesture turns out to have been a click rather than a real
+      // drag — see `straightStroke`'s own doc comment.
+      const hit = straightWallLineIndexNear(doc, p);
+      setStraightStroke({
+        fromCell: cell,
+        toCell: cell,
+        axis: null,
+        startPoint: p,
+        deleteCandidate: hit,
+      });
+      return;
+    }
     const edge = nearestEdge(p, grid);
     if (!edge) return;
     if (tool === 'wall') {
@@ -328,6 +420,18 @@ export function CreationBoard({
       setStroke({ addMode: !existing, startPoint: p, family: null });
       applyEdgeAction(edge, !existing);
     } else if (tool === 'door') {
+      // A straight wall's own line rarely coincides with a hex edge (see
+      // straightWallGeometry.ts's own header comment), so a click meant
+      // to flip a STRAIGHT wall's kind needs its own hit test rather than
+      // falling through to the edge-wall lookup below, which would
+      // usually just find the nearest (unrelated) edge-wall candidate
+      // instead. Tight radius, checked first: a straight wall directly
+      // under the click always wins over an edge-wall toggle.
+      const lineHit = straightWallLineIndexNear(doc, p, 8);
+      if (lineHit !== null) {
+        onToggleStraightWallKindAt(lineHit);
+        return;
+      }
       applyEdgeAction(edge);
     }
   };
@@ -344,6 +448,23 @@ export function CreationBoard({
     if (dragPlacement) {
       const cell = nearestCreationCell(p, grid);
       edit.handleMove(dragPlacement, null, cell);
+      return;
+    }
+    if (tool === 'straightWall' && straightStroke) {
+      const dx = p.x - straightStroke.startPoint.x;
+      const dy = p.y - straightStroke.startPoint.y;
+      let axis = straightStroke.axis;
+      // Same "undecided until the drag clears a threshold, then locked
+      // for the rest of the stroke" shape the edge-wall tool's `family`
+      // uses just below — see `pickStraightAxis`'s own doc comment for
+      // why this is 2-way (vertical/horizontal), not 3-way.
+      if (axis === null && Math.hypot(dx, dy) >= DIRECTION_LOCK_THRESHOLD) {
+        axis = pickStraightAxis(dx, dy);
+      }
+      const toCell = axis
+        ? snapStraightEndpoint(straightStroke.fromCell, p, axis, grid)
+        : straightStroke.fromCell;
+      setStraightStroke({ ...straightStroke, axis, toCell });
       return;
     }
     if (tool === 'wall' || tool === 'door') {
@@ -402,6 +523,25 @@ export function CreationBoard({
     setStroke(null);
     setDragPlacement(null);
     setRegionStroke(null);
+    if (straightStroke) {
+      const moved =
+        straightStroke.toCell[0] !== straightStroke.fromCell[0] ||
+        straightStroke.toCell[1] !== straightStroke.fromCell[1];
+      if (moved) {
+        onAddStraightWall(
+          straightStroke.fromCell,
+          straightStroke.toCell,
+          'solid'
+        );
+      } else if (straightStroke.deleteCandidate !== null) {
+        // A CLICK (no real drag) landing on an existing straight wall
+        // deletes it — a drag that merely STARTS on top of one still
+        // draws a new segment (the `moved` branch above), consistent
+        // with every other tool's click-vs-drag split in this component.
+        onRemoveStraightWallAt(straightStroke.deleteCandidate);
+      }
+      setStraightStroke(null);
+    }
   };
 
   // --- base grid: one hex polygon per cell, replacing the square
@@ -477,6 +617,175 @@ export function CreationBoard({
     }
   }
 
+  // Straight walls (this unit) — genuinely different rendering job from
+  // wallEls above: each entry ALSO needs its FOOTPRINT (every hex its
+  // line clips, per Kirk's "any hex that is not 100% uncovered would not
+  // be traversable" rule) drawn as a hatched overlay — deliberately
+  // distinct from both the plain wall line itself and the region
+  // open-boundary red LINE (`creationGeometry.ts`'s `openBoundaryEdges`
+  // below), and its blocked EDGE crossings (movement semantics (b) —
+  // straightWallGeometry.ts's `straightWallCrossedEdges`) as a dashed
+  // highlight across the specific grazed edge. Rendered BEFORE the wall's
+  // own line so the line draws on top of its footprint, matching how
+  // `wallEls` layers its door hinge on top of its own line above.
+  const committedFootprint = straightWallsFootprintSet(doc.wallLines, grid);
+  const straightWallEls: ReactElement[] = [];
+  doc.wallLines.forEach((line, index) => {
+    const a = creationCellCenter(line.from[0], line.from[1]);
+    const b = creationCellCenter(line.to[0], line.to[1]);
+    const footprint = straightWallFootprint(line.from, line.to, grid);
+    for (const [col, row] of footprint) {
+      const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
+        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+        .join(' ');
+      straightWallEls.push(
+        <polygon
+          key={`swall-${index}-fp-${col}-${row}`}
+          points={corners}
+          fill="url(#db-footprint-hatch)"
+          stroke="#c94f4f"
+          strokeWidth={1.5}
+          pointerEvents="none"
+        />
+      );
+    }
+    for (const edge of straightWallCrossedEdges(
+      line.from,
+      line.to,
+      grid,
+      footprint
+    )) {
+      straightWallEls.push(
+        <line
+          key={`swall-${index}-cross-${edge.cellA.join(',')}-${edge.cellB.join(',')}`}
+          x1={edge.a.x}
+          y1={edge.a.y}
+          x2={edge.b.x}
+          y2={edge.b.y}
+          stroke="#c94f4f"
+          strokeWidth={2.5}
+          strokeDasharray="2 2"
+          pointerEvents="none"
+        />
+      );
+    }
+    straightWallEls.push(
+      <line
+        key={`swall-${index}`}
+        x1={a.x}
+        y1={a.y}
+        x2={b.x}
+        y2={b.y}
+        stroke={line.kind === 'door' ? '#ffb347' : '#e8e2d8'}
+        strokeWidth={line.kind === 'door' ? 3 : 4}
+        strokeLinecap="round"
+      />
+    );
+    if (line.kind === 'door') {
+      straightWallEls.push(
+        <circle
+          key={`swall-${index}-hinge`}
+          cx={(a.x + b.x) / 2}
+          cy={(a.y + b.y) / 2}
+          r={3.5}
+          fill="#100d0b"
+          stroke="#ffb347"
+          strokeWidth={1.5}
+        />
+      );
+    }
+  });
+
+  // Live drag preview — same footprint/crossing treatment, amber and
+  // dashed to read as "not committed yet" (this component's existing
+  // provisional-content convention — see `pendingRegionEls` below).
+  const straightPreviewEls: ReactElement[] = [];
+  let previewFootprint: [number, number][] = [];
+  const strokeHasMoved =
+    !!straightStroke &&
+    (straightStroke.toCell[0] !== straightStroke.fromCell[0] ||
+      straightStroke.toCell[1] !== straightStroke.fromCell[1]);
+  if (tool === 'straightWall' && straightStroke && strokeHasMoved) {
+    previewFootprint = straightWallFootprint(
+      straightStroke.fromCell,
+      straightStroke.toCell,
+      grid
+    );
+    for (const [col, row] of previewFootprint) {
+      const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
+        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+        .join(' ');
+      straightPreviewEls.push(
+        <polygon
+          key={`swall-preview-fp-${col}-${row}`}
+          points={corners}
+          fill="url(#db-footprint-hatch)"
+          stroke="#ffb347"
+          strokeWidth={1.5}
+          strokeDasharray="3 2"
+          pointerEvents="none"
+        />
+      );
+    }
+    for (const edge of straightWallCrossedEdges(
+      straightStroke.fromCell,
+      straightStroke.toCell,
+      grid,
+      previewFootprint
+    )) {
+      straightPreviewEls.push(
+        <line
+          key={`swall-preview-cross-${edge.cellA.join(',')}-${edge.cellB.join(',')}`}
+          x1={edge.a.x}
+          y1={edge.a.y}
+          x2={edge.b.x}
+          y2={edge.b.y}
+          stroke="#ffb347"
+          strokeWidth={2.5}
+          strokeDasharray="2 2"
+          pointerEvents="none"
+        />
+      );
+    }
+    const pa = creationCellCenter(
+      straightStroke.fromCell[0],
+      straightStroke.fromCell[1]
+    );
+    const pb = creationCellCenter(
+      straightStroke.toCell[0],
+      straightStroke.toCell[1]
+    );
+    straightPreviewEls.push(
+      <line
+        key="swall-preview-line"
+        x1={pa.x}
+        y1={pa.y}
+        x2={pb.x}
+        y2={pb.y}
+        stroke="#ffb347"
+        strokeWidth={3}
+        strokeDasharray="5 3"
+        strokeLinecap="round"
+        opacity={0.85}
+        pointerEvents="none"
+      />
+    );
+  }
+
+  // Union of every straight wall's footprint — committed AND the live
+  // preview, if one is in progress — what placements/start/end/region
+  // cells below are checked against so a newly-drawn footprint FLAGS
+  // anything it now covers instead of silently deleting or moving it.
+  // Live preview is included deliberately: an author dragging a wall
+  // over an existing monster should see the warning appear before even
+  // releasing the pointer, not just after.
+  const footprintKeys = new Set(committedFootprint);
+  for (const [col, row] of previewFootprint) {
+    footprintKeys.add(`${col},${row}`);
+  }
+  const inFootprint = (col: number, row: number) =>
+    footprintKeys.has(`${col},${row}`);
+
   // Same dark/dashed treatment Board.tsx (edit mode) uses for a target-
   // dialect hole — one visual language for "no floor here" across both
   // boards. Hex polygon now, not an axis-aligned rect.
@@ -525,6 +834,29 @@ export function CreationBoard({
           pointerEvents="none"
         />
       );
+      // A straight wall's footprint landing inside a region's own cells
+      // is FLAGGED, never auto-removed from the region — Kirk's rule
+      // makes the cell impassable, but membership is an authoring fact
+      // this tool has no business silently rewriting (same "flag, don't
+      // delete" discipline the placement/start/end checks below follow).
+      if (inFootprint(col, row)) {
+        const c = creationCellCenter(col, row);
+        regionEls.push(
+          <text
+            key={`region-${region.id}-${col}-${row}-fp-warn`}
+            x={c.x}
+            y={c.y + 3}
+            textAnchor="middle"
+            fill="#ff6a6a"
+            fontSize={11}
+            fontWeight={700}
+            pointerEvents="none"
+            style={{ paintOrder: 'stroke', stroke: '#100d0b', strokeWidth: 3 }}
+          >
+            ⚠
+          </text>
+        );
+      }
     }
     const centroid = regionCentroid(region.cells);
     const labelPos = creationCellCenter(centroid.col, centroid.row);
@@ -614,6 +946,14 @@ export function CreationBoard({
       edit.selectedPlacement.roomId === sel.roomId &&
       edit.selectedPlacement.index === sel.index;
     const angle = facing !== null ? FACING_ANGLES_DEG[facing] : null;
+    // A straight wall's footprint landing on an EXISTING placement is
+    // FLAGGED, never silently deleted or moved — reusing the same "⚠,
+    // hot color, unmissable" visual language `Board.tsx`'s
+    // "⚠ PARTY SPAWN (BLOCKED!)" warning uses for edit mode's compiled
+    // entrance-blocked check, adapted here since a generic placement
+    // marker (unlike the START/END circle below) has no text label of
+    // its own to prefix.
+    const blocked = inFootprint(at[0], at[1]);
     return (
       <g
         key={sel.boss ? 'boss' : `place-${sel.index}`}
@@ -639,6 +979,34 @@ export function CreationBoard({
               stroke="#000"
               strokeWidth={0.5}
             />
+          </g>
+        )}
+        {blocked && (
+          <g pointerEvents="none">
+            <circle
+              cx={center.x}
+              cy={center.y}
+              r={16}
+              fill="none"
+              stroke="#ff3b3b"
+              strokeWidth={2}
+              strokeDasharray="3 2"
+            />
+            <text
+              x={center.x}
+              y={center.y - 20}
+              textAnchor="middle"
+              fill="#ff6a6a"
+              fontSize={10}
+              fontWeight={700}
+              style={{
+                paintOrder: 'stroke',
+                stroke: '#100d0b',
+                strokeWidth: 3,
+              }}
+            >
+              ⚠ IN WALL FOOTPRINT
+            </text>
           </g>
         )}
       </g>
@@ -670,16 +1038,40 @@ export function CreationBoard({
       onPointerLeave={handlePointerUp}
       style={{
         cursor:
-          tool === 'wall' || tool === 'door' || tool === 'region'
+          tool === 'wall' ||
+          tool === 'straightWall' ||
+          tool === 'door' ||
+          tool === 'region'
             ? 'crosshair'
             : 'default',
       }}
     >
+      <defs>
+        {/* Straight-wall footprint hatch — deliberately distinct from
+            the region open-boundary overlay's plain solid red LINE
+            (`openBoundaryEdges` above): a crimson diagonal HATCH fill
+            reads as "this ground is gone," not just "this line is a
+            problem," matching the task's own ask for a visually
+            distinct treatment from the region worry overlay. */}
+        <pattern
+          id="db-footprint-hatch"
+          patternUnits="userSpaceOnUse"
+          width={7}
+          height={7}
+          patternTransform="rotate(45)"
+        >
+          <rect width={7} height={7} fill="#2a0e0e" fillOpacity={0.55} />
+          <line x1={0} y1={0} x2={0} y2={7} stroke="#c94f4f" strokeWidth={3} />
+        </pattern>
+      </defs>
+
       {cellEls}
 
       {regionEls}
       {pendingRegionEls}
       {wallEls}
+      {straightWallEls}
+      {straightPreviewEls}
       {holeEls}
 
       {hoverEdge && (tool === 'wall' || tool === 'door') && (
@@ -699,6 +1091,12 @@ export function CreationBoard({
       {doc.start &&
         (() => {
           const c = cellCenter(doc.start[0], doc.start[1]);
+          // Reuses Board.tsx's exact "⚠ ... (BLOCKED!)" visual language
+          // (edit mode's isEntranceBlocked check) — a straight wall's
+          // footprint landing on the start cell is the creation-mode
+          // analog of that same fact, so it gets the same treatment
+          // rather than a new one invented for this tool.
+          const blocked = inFootprint(doc.start[0], doc.start[1]);
           return (
             <g pointerEvents="none">
               <circle
@@ -706,7 +1104,7 @@ export function CreationBoard({
                 cy={c.y}
                 r={13}
                 fill="none"
-                stroke={START_COLOR}
+                stroke={blocked ? '#ff3b3b' : START_COLOR}
                 strokeWidth={2.5}
                 strokeDasharray="4 3"
               />
@@ -714,11 +1112,11 @@ export function CreationBoard({
                 x={c.x}
                 y={c.y - 18}
                 textAnchor="middle"
-                fill="#8fe8e0"
+                fill={blocked ? '#ff6a6a' : '#8fe8e0'}
                 fontSize={10}
                 fontWeight={700}
               >
-                START
+                {blocked ? '⚠ START (BLOCKED!)' : 'START'}
               </text>
             </g>
           );
@@ -726,6 +1124,7 @@ export function CreationBoard({
       {doc.end &&
         (() => {
           const c = cellCenter(doc.end[0], doc.end[1]);
+          const blocked = inFootprint(doc.end[0], doc.end[1]);
           return (
             <g pointerEvents="none">
               <circle
@@ -733,7 +1132,7 @@ export function CreationBoard({
                 cy={c.y}
                 r={13}
                 fill="none"
-                stroke={END_COLOR}
+                stroke={blocked ? '#ff3b3b' : END_COLOR}
                 strokeWidth={2.5}
                 strokeDasharray="4 3"
               />
@@ -741,11 +1140,11 @@ export function CreationBoard({
                 x={c.x}
                 y={c.y - 18}
                 textAnchor="middle"
-                fill="#ffd76a"
+                fill={blocked ? '#ff6a6a' : '#ffd76a'}
                 fontSize={10}
                 fontWeight={700}
               >
-                END
+                {blocked ? '⚠ END (BLOCKED!)' : 'END'}
               </text>
             </g>
           );

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -36,6 +36,13 @@ interface CreationConceptProps {
     kind: WallKind,
     on: boolean
   ) => void;
+  onAddStraightWall: (
+    from: [number, number],
+    to: [number, number],
+    kind: WallKind
+  ) => void;
+  onRemoveStraightWallAt: (index: number) => void;
+  onToggleStraightWallKindAt: (index: number) => void;
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
   onNewCanvas: (width: number, height: number) => void;
@@ -64,6 +71,9 @@ export function CreationConcept({
   selectedTool,
   onSelectTool,
   onToggleWallEdge,
+  onAddStraightWall,
+  onRemoveStraightWallAt,
+  onToggleStraightWallKindAt,
   onToggleHole,
   onSetPoint,
   onNewCanvas,
@@ -294,6 +304,8 @@ export function CreationConcept({
             holeCount={doc.holes.length}
             showRegionTool
             regionCount={doc.regions.length}
+            showStraightWallTool
+            straightWallCount={doc.wallLines.length}
           />
         </CollapsibleSidePanel>
 
@@ -308,6 +320,9 @@ export function CreationConcept({
             }}
             onReject={toast}
             onToggleWallEdge={onToggleWallEdge}
+            onAddStraightWall={onAddStraightWall}
+            onRemoveStraightWallAt={onRemoveStraightWallAt}
+            onToggleStraightWallKindAt={onToggleStraightWallKindAt}
             onToggleHole={onToggleHole}
             onSetPoint={onSetPoint}
             regionEdit={regionEdit}

--- a/src/concepts/dungeon-builder/creation/creationGeometry.ts
+++ b/src/concepts/dungeon-builder/creation/creationGeometry.ts
@@ -109,7 +109,15 @@ export function wallGeometry(
   return { cellA: from, cellB: to, a: edge.a, b: edge.b, mid: edge.mid };
 }
 
-function pointToSegmentDistSq(p: CellPos, a: CellPos, b: CellPos): number {
+/** Exported so other hit-testing code (the straight-wall tool's own
+ * click-to-delete / Door-tool hit test, `straightWallGeometry.ts`/
+ * `CreationBoard.tsx`) shares this exact distance function rather than a
+ * second hand-rolled one. */
+export function pointToSegmentDistSq(
+  p: CellPos,
+  a: CellPos,
+  b: CellPos
+): number {
   const abx = b.x - a.x;
   const aby = b.y - a.y;
   const apx = p.x - a.x;

--- a/src/concepts/dungeon-builder/creation/emptyCanvasDoc.ts
+++ b/src/concepts/dungeon-builder/creation/emptyCanvasDoc.ts
@@ -41,6 +41,7 @@ canvas:
 rooms: []
 connectors: []
 walls: []
+wallLines: []
 holes: []
 start: null
 end: null

--- a/src/concepts/dungeon-builder/creation/straightWallGeometry.test.ts
+++ b/src/concepts/dungeon-builder/creation/straightWallGeometry.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'vitest';
+import { BOARD_HEX_SIZE, cellCenter } from '../hexLayout';
+import {
+  clipSegmentToShrunkHex,
+  isCellClipped,
+  pickStraightAxis,
+  snapStraightEndpoint,
+  straightWallCrossedEdges,
+  straightWallFootprint,
+  straightWallsFootprintSet,
+} from './straightWallGeometry';
+
+const GRID = { width: 20, height: 30 };
+
+describe('straightWallFootprint — shoulder-clipping vertical case', () => {
+  // (4,4) and (6,1) share the SAME world-space X (207.846...) — a
+  // genuinely vertical line in board space, verified analytically:
+  // worldX = size*sqrt3*(col + z/2), and cubeAtColRow's z = row -
+  // trunc((col-(col&1))/2) gives z(4,4)=2, z(6,1)=-2, so
+  // (4 + 2/2) === (6 + -2/2) === 5. NOT a same-column line — a "column"
+  // in [col,row] space is one of the diagonal edge families, not
+  // vertical at all (see straightWallGeometry.ts's own header comment).
+  const from: [number, number] = [4, 4];
+  const to: [number, number] = [6, 1];
+
+  it('has matching world X at both endpoints (sanity check the fixture)', () => {
+    expect(cellCenter(...from).x).toBeCloseTo(cellCenter(...to).x, 9);
+  });
+
+  it('clips exactly the 3 cells the line threads dead-center through', () => {
+    const footprint = straightWallFootprint(from, to, GRID);
+    expect(footprint).toEqual(
+      expect.arrayContaining([
+        [4, 4],
+        [5, 2],
+        [6, 1],
+      ])
+    );
+    expect(footprint).toHaveLength(3);
+  });
+
+  it('does NOT clip the cells the line merely grazes along their shoulder edge', () => {
+    // (4,3)/(5,1) sit exactly one half-width to the line's own side —
+    // their vertical edge lies ON the line (a touch), not through their
+    // interior. This is the concrete case Kirk's rule distinguishes:
+    // "any hex not 100% uncovered" would fail here if these were
+    // wrongly counted as clipped.
+    const grazedCells: [number, number][] = [
+      [4, 3],
+      [5, 1],
+      [5, 3],
+      [6, 0],
+    ];
+    for (const [col, row] of grazedCells) {
+      expect(
+        isCellClipped(cellCenter(...from), cellCenter(...to), col, row)
+      ).toBe(false);
+    }
+  });
+
+  it('produces no separate blocked-crossing edges — every touch here is adjacent to a footprint cell already', () => {
+    // Verified structurally, not asserted blindly: every grazed cell
+    // above borders a cell this test already confirmed IS footprint-
+    // blocked ((4,4), (5,2), or (6,1)), so straightWallCrossedEdges'
+    // own "skip if either side is footprint-blocked" rule (see its doc
+    // comment) correctly omits them — the touch is subsumed by the
+    // adjacent cell being wholly impassable already.
+    const footprint = straightWallFootprint(from, to, GRID);
+    expect(straightWallCrossedEdges(from, to, GRID, footprint)).toEqual([]);
+  });
+});
+
+describe('straightWallFootprint — "same row index" is NOT horizontal, and clips every other hex', () => {
+  // A naive author (or implementation) might assume two cells sharing a
+  // `row` index describe a horizontal line — they don't. z = row -
+  // trunc((col-(col&1))/2) drops roughly every 2 columns, so world-Y
+  // drifts substantially between these two "same row" endpoints (144 at
+  // col2 down to 0 at col10) — the SAME diagonal-shear fact CONTRACT.md
+  // already documents for compiled FloorPlan rendering, now showing up
+  // in the creation canvas's own coordinate space too.
+  const from: [number, number] = [2, 5];
+  const to: [number, number] = [10, 5];
+
+  it('endpoints do NOT share world Y (this line is not actually horizontal)', () => {
+    expect(cellCenter(...from).y).not.toBeCloseTo(cellCenter(...to).y, 3);
+  });
+
+  it('clips exactly every OTHER column between the endpoints', () => {
+    const footprint = straightWallFootprint(from, to, GRID);
+    expect(footprint).toEqual([
+      [2, 5],
+      [4, 5],
+      [6, 5],
+      [8, 5],
+      [10, 5],
+    ]);
+    // The odd columns in between are genuinely skipped, not merely
+    // absent because they were never candidates.
+    for (const col of [3, 5, 7, 9]) {
+      expect(footprint).not.toContainEqual([col, 5]);
+    }
+  });
+});
+
+describe('straightWallFootprint — a TRUE horizontal line (constant world Y) clips every column, no skips', () => {
+  // (0,3) and (10,8) share the same cube z (3), hence the same world Y
+  // — a genuinely horizontal line, unlike the "same row index" case
+  // above. Contrasting the two directly is the point: two endpoint
+  // pairs that both look like "an obvious horizontal draw" at the
+  // [col,row] level produce structurally different footprints,
+  // depending on whether the resulting WORLD-space line is actually
+  // horizontal.
+  const from: [number, number] = [0, 3];
+  const to: [number, number] = [10, 8];
+
+  it('endpoints share world Y (this line genuinely is horizontal)', () => {
+    expect(cellCenter(...from).y).toBeCloseTo(cellCenter(...to).y, 9);
+  });
+
+  it('clips one cell per column, every column, no every-other-hex gap', () => {
+    const footprint = straightWallFootprint(from, to, GRID);
+    const cols = footprint.map(([c]) => c).sort((a, b) => a - b);
+    expect(cols).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it('produces no separate blocked-crossing edges either', () => {
+    const footprint = straightWallFootprint(from, to, GRID);
+    expect(straightWallCrossedEdges(from, to, GRID, footprint)).toEqual([]);
+  });
+});
+
+describe('straightWallCrossedEdges — the movement-semantics (b) mechanism, exercised directly', () => {
+  // Every natural cell-to-cell straight wall this file tests (and 400
+  // randomly sampled pairs checked while building this unit — see this
+  // file's own git history / the unit's PR description for the search)
+  // produces ZERO both-clear crossings: every boundary touch a
+  // cell-center-anchored line produces sits adjacent to a cell that's
+  // ALREADY footprint-blocked (a straight line through a hex tiling
+  // can't graze a shared edge between two cells without having entered
+  // at least one of the two cells adjoining that edge's own endpoint
+  // region — the path is continuous and monotonic). This does NOT mean
+  // the mechanism is dead code: `clipSegmentToShrunkHex`'s underlying
+  // touch/clip distinction is the same primitive `isCellClipped` uses,
+  // and this test exercises it directly against a hand-placed segment
+  // that runs exactly along one real hex edge — the shape (b) exists to
+  // cover the moment a wall's endpoints are no longer forced to cell
+  // centers (e.g. a future server-side compiler operating on raw
+  // world/board coordinates).
+  it('a segment collinear with one hex edge does not clip either adjacent cell', () => {
+    const hexAt55 = cellCenter(5, 5);
+    // A pointy-top hex's two vertical edges sit at center.x ± half its
+    // flat-to-flat width — `size * sqrt(3) / 2` (hexMath.ts's own
+    // `hexCorners`: corners at 30°+60°·i, so the two corners nearest
+    // ±90° project to exactly this X offset). A vertical segment run
+    // exactly along the RIGHT one, spanning past the hex's own vertical
+    // extent, should clip neither (5,5) nor whichever cell sits across
+    // that edge.
+    const halfFlatWidth = (BOARD_HEX_SIZE * Math.sqrt(3)) / 2;
+    const a = { x: hexAt55.x + halfFlatWidth, y: hexAt55.y - 30 };
+    const b = { x: hexAt55.x + halfFlatWidth, y: hexAt55.y + 30 };
+    expect(isCellClipped(a, b, 5, 5)).toBe(false);
+  });
+
+  it('nudging that same segment 1 board unit INTO the hex clips it', () => {
+    // Same construction as above, but shifted just past
+    // FOOTPRINT_EPSILON to the inside — proves the epsilon boundary
+    // genuinely separates the two outcomes, not that `isCellClipped`
+    // just always returns false near an edge.
+    const hexAt55 = cellCenter(5, 5);
+    const halfFlatWidth = (BOARD_HEX_SIZE * Math.sqrt(3)) / 2;
+    const a = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y - 30 };
+    const b = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y + 30 };
+    expect(isCellClipped(a, b, 5, 5)).toBe(true);
+  });
+});
+
+describe('corner/L continuity — two segments sharing an endpoint cell touch exactly', () => {
+  it('both segments resolve the shared cell to the identical world point', () => {
+    const shared: [number, number] = [5, 5];
+    const seg1End: [number, number] = [2, 5];
+    const seg2End: [number, number] = [8, 2];
+    // Both "walls" are drawn independently (from their own endpoint to
+    // the shared cell) — the corner reads clean because both literally
+    // resolve to the SAME `cellCenter(shared)` point, not because of any
+    // special-case corner-joining logic.
+    const seg1SharedPoint = cellCenter(...shared);
+    const seg2SharedPoint = cellCenter(...shared);
+    expect(seg1SharedPoint).toEqual(seg2SharedPoint);
+    // And each segment's OWN footprint includes the shared cell itself
+    // (it's always an endpoint, hence always clipped).
+    const fp1 = straightWallFootprint(seg1End, shared, GRID);
+    const fp2 = straightWallFootprint(shared, seg2End, GRID);
+    expect(fp1).toContainEqual(shared);
+    expect(fp2).toContainEqual(shared);
+  });
+});
+
+describe('straightWallsFootprintSet — union across multiple drawn walls', () => {
+  it('unions every wall’s own footprint into one lookup set', () => {
+    const lines = [
+      { from: [4, 4] as [number, number], to: [6, 1] as [number, number] },
+      { from: [0, 3] as [number, number], to: [10, 8] as [number, number] },
+    ];
+    const set = straightWallsFootprintSet(lines, GRID);
+    expect(set.has('5,2')).toBe(true); // from the vertical wall
+    expect(set.has('5,5')).toBe(true); // from the horizontal wall
+    expect(set.has('4,3')).toBe(false); // a touch, in neither wall's footprint
+  });
+});
+
+describe('pickStraightAxis', () => {
+  it('picks horizontal when the drag is wider than tall', () => {
+    expect(pickStraightAxis(30, 5)).toBe('horizontal');
+  });
+  it('picks vertical when the drag is taller than wide', () => {
+    expect(pickStraightAxis(5, 30)).toBe('vertical');
+  });
+});
+
+describe('snapStraightEndpoint', () => {
+  it('holds worldX steady in vertical mode, searching near the pointer', () => {
+    const fromCell: [number, number] = [4, 4];
+    const pointer = cellCenter(6, 1); // pointer sitting right on a matching cell
+    const snapped = snapStraightEndpoint(fromCell, pointer, 'vertical', GRID);
+    expect(snapped).toEqual([6, 1]);
+  });
+
+  it('stays within the grid bounds', () => {
+    const fromCell: [number, number] = [0, 0];
+    const pointer = { x: -500, y: -500 };
+    const snapped = snapStraightEndpoint(fromCell, pointer, 'vertical', GRID);
+    expect(snapped[0]).toBeGreaterThanOrEqual(0);
+    expect(snapped[1]).toBeGreaterThanOrEqual(0);
+    expect(snapped[0]).toBeLessThan(GRID.width);
+    expect(snapped[1]).toBeLessThan(GRID.height);
+  });
+});
+
+describe('clipSegmentToShrunkHex — the touch-vs-clip epsilon rule directly', () => {
+  it('a segment passing well inside the hex clips it', () => {
+    const center = cellCenter(5, 5);
+    const result = clipSegmentToShrunkHex(
+      { x: center.x - 5, y: center.y },
+      { x: center.x + 5, y: center.y },
+      5,
+      5
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it('a segment that only touches a single corner does not clip', () => {
+    const center = cellCenter(5, 5);
+    // The hex's own top corner sits size units above center along Y at
+    // this orientation's own corner geometry — approach it tangentially
+    // from well outside instead of computing the exact corner, by using
+    // a segment that stays on the OUTWARD side of every half-plane
+    // except grazing one vertex. Simpler and robust: a segment entirely
+    // outside the hex (far to one side) never clips.
+    const result = clipSegmentToShrunkHex(
+      { x: center.x - 100, y: center.y },
+      { x: center.x - 90, y: center.y },
+      5,
+      5
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/concepts/dungeon-builder/creation/straightWallGeometry.ts
+++ b/src/concepts/dungeon-builder/creation/straightWallGeometry.ts
@@ -1,0 +1,411 @@
+/**
+ * straightWallGeometry — footprint + crossing math for STRAIGHT wall
+ * segments (rpg-project#169 dungeon-builder initiative, "straight walls
+ * with visible footprint" unit). Kept separate from `creationGeometry.ts`
+ * because it answers a genuinely different question: not "which hex EDGE
+ * is nearest a point" (the zigzag edge-wall tool's job) but "which hex
+ * CELLS does an arbitrary straight WORLD-SPACE line clip through, and
+ * which cell-to-cell EDGES does it cross without clipping either side."
+ *
+ * Kirk's rule, verbatim (CONTRACT.md's "Hex-true creation canvas"
+ * section — this module exists to implement it precisely): "any hex that
+ * is not 100% uncovered would not be traversable by the players." A
+ * straight wall has a FOOTPRINT: every hex the line's interior genuinely
+ * passes through is fully blocked — not just the edge it crosses, the
+ * whole cell — regardless of how little of the hex the line clips. A hex
+ * the line merely grazes (touches a vertex, or runs exactly along one of
+ * its edges) is NOT footprint-blocked as a cell, but the movement
+ * semantics this module also computes (`straightWallCrossedEdges`) still
+ * block stepping across that specific grazed edge.
+ *
+ * **Why a straight line generally does NOT follow hex edges, unlike the
+ * zigzag Wall tool's edge-painting** — worth stating plainly since it's
+ * the entire reason this module needs to exist rather than reusing
+ * `creationGeometry.ts`'s edge machinery: this grid's hexes are
+ * pointy-top (`hexMath.ts`'s `hexCorners`, corners at 30°+60°·i), which
+ * gives exactly 3 edge-line orientations — verified from the corner
+ * angles, not assumed — at 30°, 90° (vertical), and 150° from the
+ * horizontal board axis. **There is no 0°/horizontal edge family at
+ * all.** So a "horizontal" straight wall (Kirk's other natural drawing
+ * axis, alongside vertical) can never run along hex boundaries — it
+ * always clips through hex interiors, in the "every-other-hex" pattern
+ * this module's own tests demonstrate. Even "vertical" (which DOES match
+ * the 90° edge family) only runs exactly along edges for specific
+ * from/to combinations — a vertical line through a column of hex
+ * CENTERS instead clips every hex in that column full-width (the
+ * "shoulder-clipping" case), because a hex's own two vertical edges sit
+ * at ±(half the flat-to-flat width) from its center, not AT the center.
+ */
+import { neighborCell } from '../boardGeometry';
+import {
+  BOARD_HEX_SIZE,
+  cellCenter,
+  cellCorners,
+  hexColumn,
+  hexRow,
+  worldToCube,
+  type CellPos,
+} from '../hexLayout';
+import {
+  canonicalHexEdge,
+  nearestCreationCell,
+  type EdgeGeometry,
+} from './creationGeometry';
+import type { CreationGrid } from './creationTypes';
+
+/**
+ * How far (in board units) a half-plane is shrunk inward before testing
+ * for a genuine interior clip — the concrete answer to "pick a
+ * principled epsilon, document it." `BOARD_HEX_SIZE` is 24, so this is
+ * ~0.024 board units: several orders of magnitude larger than the
+ * floating-point noise `Math.cos`/`Math.sin` introduce computing hex
+ * corners (~1e-13 at this scale, verified — double precision trig error
+ * near this magnitude), so it reliably absorbs that noise, yet small
+ * enough to be visually and physically meaningless at render/gameplay
+ * scale (under a fortieth of a percent of the hex's own radius). A line
+ * that merely touches a true vertex or runs exactly along a true edge
+ * never penetrates a hex shrunk by this much; a line that genuinely
+ * cuts into the interior always does, however shallow the cut.
+ */
+export const FOOTPRINT_EPSILON = BOARD_HEX_SIZE * 1e-3;
+
+interface HalfPlane {
+  /** Unit inward normal. */
+  nx: number;
+  ny: number;
+  /** A point on this edge's line (one of the hex's own corners). */
+  cx: number;
+  cy: number;
+}
+
+/** The 6 inward-facing half-planes of the hex at (col,row), each unit-
+ * normalized so `FOOTPRINT_EPSILON` below means a real board-unit
+ * distance, not an arbitrary scale-dependent number. */
+function hexHalfPlanes(col: number, row: number): HalfPlane[] {
+  const center = cellCenter(col, row);
+  const corners = cellCorners(center, BOARD_HEX_SIZE);
+  const planes: HalfPlane[] = [];
+  for (let i = 0; i < 6; i++) {
+    const [x1, y1] = corners[i];
+    const [x2, y2] = corners[(i + 1) % 6];
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.hypot(dx, dy) || 1;
+    let nx = dy / len;
+    let ny = -dx / len;
+    // Orient inward: the hex's own center must satisfy nx*(center-c1) < 0.
+    if (nx * (center.x - x1) + ny * (center.y - y1) > 0) {
+      nx = -nx;
+      ny = -ny;
+    }
+    planes.push({ nx, ny, cx: x1, cy: y1 });
+  }
+  return planes;
+}
+
+/**
+ * Clips segment `a`->`b` against the hex at (col,row), shrunk inward by
+ * `epsilon` on every side (Cyrus-Beck half-plane clipping — 6 planes,
+ * not 4, since a hex has 6 edges). Returns the surviving `[t0,t1]`
+ * parametric interval along `a`->`b` if the segment enters the SHRUNK
+ * hex's interior, or `null` otherwise — `null` covers both "misses the
+ * hex entirely" and "only touches its TRUE boundary" (a vertex, or a run
+ * along one edge), which is exactly the distinction Kirk's footprint
+ * rule needs: a touch is not a clip.
+ */
+export function clipSegmentToShrunkHex(
+  a: CellPos,
+  b: CellPos,
+  col: number,
+  row: number,
+  epsilon: number = FOOTPRINT_EPSILON
+): [number, number] | null {
+  let tMin = 0;
+  let tMax = 1;
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  for (const plane of hexHalfPlanes(col, row)) {
+    const f0 =
+      plane.nx * (a.x - plane.cx) + plane.ny * (a.y - plane.cy) + epsilon;
+    const slope = plane.nx * dx + plane.ny * dy;
+    if (Math.abs(slope) < 1e-12) {
+      // Segment is parallel to this (shrunk) edge's line.
+      if (f0 > 0) return null; // entirely on the outside side — no clip.
+      continue; // entirely satisfies this plane — doesn't constrain t.
+    }
+    const tStar = -f0 / slope;
+    if (slope > 0) {
+      if (tStar < tMax) tMax = tStar;
+    } else {
+      if (tStar > tMin) tMin = tStar;
+    }
+    if (tMin > tMax) return null;
+  }
+  // A tiny positive-length floor (in t, not board units) so float noise
+  // at exactly tMin===tMax can't register as a clip — a real clip from a
+  // shrunk-by-FOOTPRINT_EPSILON hex always has materially more overlap
+  // than this once it happens at all.
+  return tMax - tMin > 1e-9 ? [tMin, tMax] : null;
+}
+
+/** Whether segment `a`->`b` genuinely clips (not merely touches) the hex
+ * at (col,row) — see `clipSegmentToShrunkHex`'s own doc comment. */
+export function isCellClipped(
+  a: CellPos,
+  b: CellPos,
+  col: number,
+  row: number,
+  epsilon: number = FOOTPRINT_EPSILON
+): boolean {
+  return clipSegmentToShrunkHex(a, b, col, row, epsilon) !== null;
+}
+
+/**
+ * Every candidate cell whose polygon could plausibly intersect segment
+ * `a`->`b` — derived from the segment's own bounding box (expanded by
+ * 1.5 hex radii) converted to a col/row range via the real inverse hex
+ * transform at the box's 4 corners, the same "derive the range from real
+ * geometry, don't hand-guess a formula" discipline `nearestEdge`/
+ * `nearestCreationCell` already follow elsewhere in this concept.
+ * Because `worldToCube` (before its final rounding step) is a LINEAR
+ * map, the box's 4 corners are always where its col/row extremes land —
+ * a box's interior can't map to a wider range than its corners under a
+ * linear transform — so checking only the 4 corners is exact up to the
+ * ±1 rounding slop this function already pads for. Clamped to the canvas
+ * grid: a straight wall's footprint only ever marks real canvas cells.
+ */
+function candidateCells(
+  a: CellPos,
+  b: CellPos,
+  grid: CreationGrid
+): [number, number][] {
+  const margin = BOARD_HEX_SIZE * 1.5;
+  const minX = Math.min(a.x, b.x) - margin;
+  const maxX = Math.max(a.x, b.x) + margin;
+  const minY = Math.min(a.y, b.y) - margin;
+  const maxY = Math.max(a.y, b.y) + margin;
+  const corners: CellPos[] = [
+    { x: minX, y: minY },
+    { x: maxX, y: minY },
+    { x: minX, y: maxY },
+    { x: maxX, y: maxY },
+  ];
+  let minCol = Infinity,
+    maxCol = -Infinity,
+    minRow = Infinity,
+    maxRow = -Infinity;
+  for (const c of corners) {
+    const cube = worldToCube(c);
+    const col = hexColumn(cube);
+    const row = hexRow(cube);
+    if (col < minCol) minCol = col;
+    if (col > maxCol) maxCol = col;
+    if (row < minRow) minRow = row;
+    if (row > maxRow) maxRow = row;
+  }
+  minCol = Math.max(0, minCol - 1);
+  maxCol = Math.min(grid.width - 1, maxCol + 1);
+  minRow = Math.max(0, minRow - 1);
+  maxRow = Math.min(grid.height - 1, maxRow + 1);
+  const cells: [number, number][] = [];
+  for (let col = minCol; col <= maxCol; col++) {
+    for (let row = minRow; row <= maxRow; row++) {
+      cells.push([col, row]);
+    }
+  }
+  return cells;
+}
+
+function inBoundsGrid(col: number, row: number, grid: CreationGrid): boolean {
+  return col >= 0 && col < grid.width && row >= 0 && row < grid.height;
+}
+
+/**
+ * Every hex cell a straight wall from endpoint cell `from` to endpoint
+ * cell `to` genuinely clips — the wall's own footprint, in Kirk's sense:
+ * "any hex that is not 100% uncovered would not be traversable." The
+ * line is the straight WORLD-SPACE segment between the two endpoint
+ * cells' centers (`cellCenter`), not a chain of hex edges — see this
+ * module's own header comment for why that line generally does NOT
+ * follow hex boundaries.
+ */
+export function straightWallFootprint(
+  from: [number, number],
+  to: [number, number],
+  grid: CreationGrid
+): [number, number][] {
+  const a = cellCenter(from[0], from[1]);
+  const b = cellCenter(to[0], to[1]);
+  const result: [number, number][] = [];
+  for (const [col, row] of candidateCells(a, b, grid)) {
+    if (isCellClipped(a, b, col, row)) result.push([col, row]);
+  }
+  return result;
+}
+
+/** Standard segment-vs-segment intersection test (parametric, with a
+ * small tolerance so a wall that just grazes an edge — passes within
+ * `FOOTPRINT_EPSILON` of it — still counts as crossing it; a graze is a
+ * real crossing for movement purposes even though it isn't a cell clip).
+ * Parallel (or near-parallel) segments are treated as NOT crossing: a
+ * straight wall exactly collinear with one hex edge runs ALONG it, which
+ * this module's footprint math already treats as a touch rather than a
+ * clip, and running along an edge is not "crossing" it either. */
+function segmentsIntersect(
+  a1: CellPos,
+  a2: CellPos,
+  b1: CellPos,
+  b2: CellPos,
+  epsilon: number = FOOTPRINT_EPSILON
+): boolean {
+  const d1x = a2.x - a1.x;
+  const d1y = a2.y - a1.y;
+  const d2x = b2.x - b1.x;
+  const d2y = b2.y - b1.y;
+  const denom = d1x * d2y - d1y * d2x;
+  if (Math.abs(denom) < 1e-9) return false;
+  const ex = b1.x - a1.x;
+  const ey = b1.y - a1.y;
+  const t = (ex * d2y - ey * d2x) / denom;
+  const u = (ex * d1y - ey * d1x) / denom;
+  const len1 = Math.hypot(d1x, d1y) || 1;
+  const len2 = Math.hypot(d2x, d2y) || 1;
+  const tol1 = epsilon / len1;
+  const tol2 = epsilon / len2;
+  return t >= -tol1 && t <= 1 + tol1 && u >= -tol2 && u <= 1 + tol2;
+}
+
+/**
+ * Movement semantics (b) from TARGET-YAML.md's "Straight walls" section:
+ * every cell-to-cell edge the wall's line crosses BETWEEN TWO CLEAR
+ * (non-footprint) cells — a crossing that blocks stepping between those
+ * two cells even though neither cell itself is footprint-blocked (the
+ * wall only grazed their shared boundary, per this module's own touch-
+ * vs-clip distinction). A crossing where either side IS footprint-
+ * blocked is deliberately omitted — it's already subsumed by that cell
+ * being wholly impassable, so surfacing it separately would just be
+ * noise on top of a fact the footprint already covers.
+ */
+export function straightWallCrossedEdges(
+  from: [number, number],
+  to: [number, number],
+  grid: CreationGrid,
+  footprint?: readonly [number, number][]
+): EdgeGeometry[] {
+  const a = cellCenter(from[0], from[1]);
+  const b = cellCenter(to[0], to[1]);
+  const resolvedFootprint = footprint ?? straightWallFootprint(from, to, grid);
+  const footprintSet = new Set(resolvedFootprint.map(([c, r]) => `${c},${r}`));
+  const candidates = candidateCells(a, b, grid);
+  const seen = new Set<string>();
+  const crossed: EdgeGeometry[] = [];
+  for (const [col, row] of candidates) {
+    if (footprintSet.has(`${col},${row}`)) continue;
+    for (let facing = 0; facing < 6; facing++) {
+      const n = neighborCell(col, row, facing);
+      if (!inBoundsGrid(n.col, n.row, grid)) continue;
+      if (footprintSet.has(`${n.col},${n.row}`)) continue;
+      const edge = canonicalHexEdge(col, row, facing);
+      const edgeKey = `${edge.cellA.join(',')}|${edge.cellB.join(',')}`;
+      if (seen.has(edgeKey)) continue;
+      seen.add(edgeKey);
+      if (segmentsIntersect(a, b, edge.a, edge.b)) crossed.push(edge);
+    }
+  }
+  return crossed;
+}
+
+/** The union of every drawn straight wall's own footprint, as a
+ * `"col,row"`-keyed Set — what `CreationBoard.tsx` checks placements/
+ * start/end/region cells against to flag (never silently delete/move)
+ * anything a newly-drawn footprint now covers. */
+export function straightWallsFootprintSet(
+  lines: readonly { from: [number, number]; to: [number, number] }[],
+  grid: CreationGrid
+): Set<string> {
+  const set = new Set<string>();
+  for (const line of lines) {
+    for (const [c, r] of straightWallFootprint(line.from, line.to, grid)) {
+      set.add(`${c},${r}`);
+    }
+  }
+  return set;
+}
+
+export function cellKey(col: number, row: number): string {
+  return `${col},${row}`;
+}
+
+export type StraightAxis = 'vertical' | 'horizontal';
+
+/**
+ * Which screen axis a drag most likely intends — a 2-way analog of
+ * `creationGeometry.ts`'s `dragFamily` (which picks among the hex grid's
+ * 3 EDGE families for the zigzag Wall tool). A straight wall's two
+ * "natural axes" are literal SCREEN/board-space axes, not hex edge
+ * families — see this module's own header comment for why board-space
+ * "horizontal" has no hex-edge analog at all (that absence is exactly
+ * why a horizontal straight wall clips hexes instead of running along
+ * their boundaries — it's the whole reason this tool exists). 60°/120°
+ * diagonal snapping was considered and skipped this round: cheap to add
+ * later (a 4-way `pickStraightAxis` instead of this 2-way one, using the
+ * same score-based `snapStraightEndpoint` search below with 4 target
+ * directions instead of 2) but not needed to prove the footprint
+ * mechanic, which is this unit's actual point.
+ */
+export function pickStraightAxis(dx: number, dy: number): StraightAxis {
+  return Math.abs(dx) >= Math.abs(dy) ? 'horizontal' : 'vertical';
+}
+
+/**
+ * The best "to" cell for continuing a straight wall from `fromCell`
+ * toward `pointer`, locked to `axis`. This is a DISCRETE hex grid, so an
+ * exactly vertical or horizontal line generally isn't reachable between
+ * two integer cell centers at all (see this module's own header comment:
+ * no edge family is horizontal, and "vertical" only lines up exactly for
+ * specific from/to combinations) — this searches a small window of
+ * columns/rows around the pointer's own nearest cell and picks whichever
+ * candidate keeps the OTHER world-space coordinate closest to
+ * `fromCell`'s own (vertical mode holds worldX as steady as the grid
+ * allows; horizontal mode holds worldY steady), tie-broken toward
+ * whichever candidate is nearest the pointer along the free axis. The
+ * result is the closest AVAILABLE approximation, not a mathematically
+ * exact one — `straightWallFootprint` above computes the footprint from
+ * whatever line actually results, honestly, rather than pretending the
+ * snap was exact.
+ */
+export function snapStraightEndpoint(
+  fromCell: [number, number],
+  pointer: CellPos,
+  axis: StraightAxis,
+  grid: CreationGrid
+): [number, number] {
+  const fromCenter = cellCenter(fromCell[0], fromCell[1]);
+  const [pCol, pRow] = nearestCreationCell(pointer, grid);
+  const WINDOW = 3;
+  let best: [number, number] = [pCol, pRow];
+  let bestScore = Infinity;
+  for (let dCol = -WINDOW; dCol <= WINDOW; dCol++) {
+    for (let dRow = -WINDOW; dRow <= WINDOW; dRow++) {
+      const col = pCol + dCol;
+      const row = pRow + dRow;
+      if (!inBoundsGrid(col, row, grid)) continue;
+      const center = cellCenter(col, row);
+      const alignDelta =
+        axis === 'vertical'
+          ? Math.abs(center.x - fromCenter.x)
+          : Math.abs(center.y - fromCenter.y);
+      const nearPointer =
+        axis === 'vertical' ? Math.abs(row - pRow) : Math.abs(col - pCol);
+      // Alignment to the locked axis dominates; nearness to the pointer
+      // along the free axis is only a tiebreak among near-equally-aligned
+      // candidates.
+      const score = alignDelta * 1000 + nearPointer;
+      if (score < bestScore) {
+        bestScore = score;
+        best = [col, row];
+      }
+    }
+  }
+  return best;
+}

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   addCellToRegion,
+  addWallLine,
   buildWalkItYaml,
   clearPlacementFlag,
   clearRefDefault,
@@ -17,6 +18,7 @@ import {
   placeItem,
   RegionValidationError,
   removeCellFromRegion,
+  removeWallLineAt,
   renameRegion,
   resolvePlacement,
   serializeDungeon,
@@ -40,6 +42,7 @@ import {
   toggleHole,
   toggleWall,
   toggleWallKind,
+  toggleWallLineKindAt,
   validateRegionCells,
   wallKindAtEdge,
 } from './dungeonYaml';
@@ -435,6 +438,95 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
     expect(toDungeonDoc(cst).walls).toEqual([
       { from: [7, 0], to: [8, 0], kind: 'solid' },
     ]);
+  });
+
+  describe('wallLines: straight walls (rpg-project#169, "straight walls with visible footprint" unit)', () => {
+    it('addWallLine appends a solid entry; removeWallLineAt removes it by index', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, [4, 4], [6, 1]);
+      let doc = toDungeonDoc(cst);
+      expect(doc.wallLines).toEqual([
+        { from: [4, 4], to: [6, 1], kind: 'solid' },
+      ]);
+      // Padded flow sequences again — this file's own known residual
+      // round-trip gap (see its top-of-file doc comment), same as the
+      // `walls:` toggleWall test above.
+      expect(serializeDungeon(cst)).toContain(
+        'wallLines:\n  - { from: [ 4, 4 ], to: [ 6, 1 ], kind: solid }'
+      );
+
+      removeWallLineAt(cst, 0);
+      doc = toDungeonDoc(cst);
+      expect(doc.wallLines).toEqual([]);
+    });
+
+    it('addWallLine accepts an explicit door kind directly', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, [0, 3], [10, 8], 'door');
+      expect(toDungeonDoc(cst).wallLines).toEqual([
+        { from: [0, 3], to: [10, 8], kind: 'door' },
+      ]);
+    });
+
+    it('toggleWallLineKindAt flips solid<->door by index, no-ops on an out-of-range index', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, [4, 4], [6, 1]);
+      toggleWallLineKindAt(cst, 0);
+      expect(toDungeonDoc(cst).wallLines[0].kind).toBe('door');
+      toggleWallLineKindAt(cst, 0);
+      expect(toDungeonDoc(cst).wallLines[0].kind).toBe('solid');
+
+      // Out-of-range index is a no-op, not a throw — see the function's
+      // own doc comment (a stale index is a UI race, not a program error).
+      expect(() => toggleWallLineKindAt(cst, 5)).not.toThrow();
+      expect(toDungeonDoc(cst).wallLines).toHaveLength(1);
+    });
+
+    it('removeWallLineAt is a no-op on an out-of-range index', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, [4, 4], [6, 1]);
+      expect(() => removeWallLineAt(cst, 5)).not.toThrow();
+      expect(() => removeWallLineAt(cst, -1)).not.toThrow();
+      expect(toDungeonDoc(cst).wallLines).toHaveLength(1);
+    });
+
+    it('multiple straight walls keep independent from/to/kind, round-tripped through YAML text', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, [4, 4], [6, 1], 'solid');
+      addWallLine(cst, [0, 3], [10, 8], 'door');
+      const reparsed = parseDungeon(serializeDungeon(cst));
+      expect(reparsed.doc.wallLines).toEqual([
+        { from: [4, 4], to: [6, 1], kind: 'solid' },
+        { from: [0, 3], to: [10, 8], kind: 'door' },
+      ]);
+    });
+
+    it('stripToV1Subset drops wallLines: entirely, reported separately from walls:', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      toggleWall(cst, 7, 0); // one edge wall
+      addWallLine(cst, [4, 4], [6, 1]); // one straight wall
+      addWallLine(cst, [0, 3], [10, 8], 'door'); // a second straight wall
+
+      const result = stripToV1Subset(serializeDungeon(cst));
+      expect(result.dropped).toEqual(
+        expect.arrayContaining(['1 wall', '2 straight walls'])
+      );
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.wallLines).toEqual([]);
+      // The real edge wall's own drop is untouched by this addition.
+      expect(stripped.walls).toEqual([]);
+    });
+
+    it('a document with only wallLines: (no edge walls) reports just the straight-wall count', () => {
+      // SHOWCASE_YAML is already confirmed pure-v1 (this describe block's
+      // sibling test above), so adding exactly one straight wall and
+      // nothing else should produce exactly this one dropped entry — no
+      // separate "N walls" (edge-wall) entry alongside it.
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, [4, 4], [6, 1]);
+      const result = stripToV1Subset(serializeDungeon(cst));
+      expect(result.dropped).toEqual(['1 straight wall']);
+    });
   });
 
   it('toggleHole adds then removes a hole', () => {

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -287,6 +287,23 @@ export interface WallDoc {
   kind: WallKind;
 }
 
+/** A STRAIGHT wall segment — `from`/`to` are the two endpoint cells the
+ * author dragged between (nearest-cell snapped), and the wall's true
+ * geometry is the straight WORLD-SPACE line between those cells'
+ * centers, unlike `WallDoc` above whose `from`/`to` are always
+ * hex-adjacent (one shared edge). `from`/`to` here are typically several
+ * cells apart and the line clips through every hex it passes over — see
+ * TARGET-YAML.md's "Straight walls" section for the full rationale
+ * (`wallLines:` vs. overloading `walls:`) and `creation/
+ * straightWallGeometry.ts` for the footprint/crossing math this implies.
+ * target dialect, proposed — not compiled server-side; stripped by
+ * `stripToV1Subset` like `walls:`. */
+export interface WallLineDoc {
+  from: [number, number];
+  to: [number, number];
+  kind: WallKind;
+}
+
 /** target dialect, proposed — dungeon-wide lighting config. See TARGET-YAML.md. */
 export interface LightingDoc {
   ambient: number;
@@ -335,6 +352,12 @@ export interface DungeonDoc {
   // drops every one before any live compile or Save & Play). ---
   canvas: CanvasDoc | null;
   walls: WallDoc[];
+  /** STRAIGHT wall segments — a sibling list to `walls:` above, not a
+   * variant within it (see `WallLineDoc`'s own doc comment for why they're
+   * kept separate). Empty in every document authored before this field
+   * existed and in any pure v1 document; not compiled server-side, dropped
+   * entirely by `stripToV1Subset`. */
+  wallLines: WallLineDoc[];
   /** Cell-native floor openings — absolute [col,row]. Kirk's 2026-08-02
    * Structural-category ask. See TARGET-YAML.md's "Structural palette
    * category" section for render/semantics. */
@@ -504,6 +527,14 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
       }))
     : [];
 
+  const wallLines: WallLineDoc[] = Array.isArray(raw.wallLines)
+    ? (raw.wallLines as Record<string, unknown>[]).map((w) => ({
+        from: w.from as [number, number],
+        to: w.to as [number, number],
+        kind: w.kind === 'door' ? 'door' : 'solid',
+      }))
+    : [];
+
   const holes: [number, number][] = Array.isArray(raw.holes)
     ? (raw.holes as [number, number][]).map(
         (h) => [h[0], h[1]] as [number, number]
@@ -589,6 +620,7 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
     connectors,
     canvas,
     walls,
+    wallLines,
     holes,
     start,
     end,
@@ -1283,6 +1315,64 @@ export function setWallEdge(
   walls.items.push(createWallNode(cst, { from, to, kind }));
 }
 
+function createWallLineNode(cst: Document, line: WallLineDoc): YAMLMap {
+  const node = cst.createNode({
+    from: line.from,
+    to: line.to,
+    kind: line.kind,
+  }) as YAMLMap;
+  node.flow = true;
+  const fromNode = node.get('from', true);
+  if (isSeq(fromNode)) fromNode.flow = true;
+  const toNode = node.get('to', true);
+  if (isSeq(toNode)) toNode.flow = true;
+  return node;
+}
+
+/** Straight-wall tool: append a new `wallLines:` entry — always `kind:
+ * solid`; use `toggleWallLineKindAt` to flip an existing one to a door.
+ * No add-vs-remove toggle at a single cell the way `toggleWall` has (a
+ * straight wall's identity is its whole from→to span, not one edge), so
+ * the creation board's own click-vs-drag distinction decides add
+ * (`addWallLine`) vs. remove (`removeWallLineAt`) instead of this
+ * function doing both. */
+export function addWallLine(
+  cst: Document,
+  from: [number, number],
+  to: [number, number],
+  kind: WallKind = 'solid'
+): void {
+  const lines = topSeq(cst, 'wallLines');
+  lines.items.push(createWallLineNode(cst, { from, to, kind }));
+}
+
+/** Remove a `wallLines:` entry by index — the creation board's "click an
+ * existing straight wall (no drag) to delete it" affordance, mirroring
+ * the edge Wall tool's own click-to-remove feel. No-ops on an
+ * out-of-range index rather than throwing, since a stale index (the line
+ * having already been removed by a concurrent interaction) is a UI race,
+ * not a program error worth crashing over. */
+export function removeWallLineAt(cst: Document, index: number): void {
+  const lines = cst.get('wallLines');
+  if (!isSeq(lines)) return;
+  if (index < 0 || index >= lines.items.length) return;
+  lines.items.splice(index, 1);
+}
+
+/** Door tool applied to a straight wall: flip an EXISTING `wallLines:`
+ * entry's `kind` between `solid`/`door`, by index — same "toggle an
+ * already-drawn wall's kind" shape `toggleWallKind` gives edge walls,
+ * addressed by index (a straight wall has no natural `from`/`to`
+ * edge-lookup identity the way an edge wall's exact adjacent-cell pair
+ * does) rather than a coordinate pair. */
+export function toggleWallLineKindAt(cst: Document, index: number): void {
+  const lines = cst.get('wallLines');
+  if (!isSeq(lines)) return;
+  const item = lines.items[index];
+  if (!isMap(item)) return;
+  item.set('kind', item.get('kind') === 'door' ? 'solid' : 'door');
+}
+
 /** A hole's index in `holes:`, matched by its [col,row] pair. */
 function holeIndexAt(cst: Document, col: number, row: number): number {
   const holes = cst.get('holes');
@@ -1903,6 +1993,18 @@ export function stripToV1Subset(yamlText: string): V1SubsetResult {
     );
   }
   cst.delete('walls');
+
+  // Straight walls (this unit) — a sibling target-dialect-only construct
+  // to `walls:` above, dropped the same honest way, counted separately
+  // ("N straight walls", not folded into the edge-wall tally) since the
+  // two are genuinely different authoring constructs (see
+  // `WallLineDoc`'s own doc comment).
+  if (doc.wallLines.length > 0) {
+    dropped.push(
+      `${doc.wallLines.length} straight wall${doc.wallLines.length === 1 ? '' : 's'}`
+    );
+  }
+  cst.delete('wallLines');
 
   if (doc.holes.length > 0) {
     dropped.push(

--- a/src/concepts/dungeon-builder/types.ts
+++ b/src/concepts/dungeon-builder/types.ts
@@ -25,5 +25,16 @@ export type PlacementSelection =
  * room regions") is creation-mode-only this round — see
  * `creation/CreationBoard.tsx`'s region-painting handling and
  * `RegionPanel.tsx`; edit mode renders any authored `regions:` read-only,
- * with no tool to create/edit them there yet. */
-export type BoardTool = 'wall' | 'door' | 'hole' | 'start' | 'end' | 'region';
+ * with no tool to create/edit them there yet. `'straightWall'`
+ * (creation-mode-only, same as `'region'`) draws a `WallLineDoc` —
+ * a STRAIGHT segment with a footprint, distinct from `'wall'`'s
+ * edge-painted zigzag — see `creation/straightWallGeometry.ts` and
+ * TARGET-YAML.md's "Straight walls" section. */
+export type BoardTool =
+  | 'wall'
+  | 'straightWall'
+  | 'door'
+  | 'hole'
+  | 'start'
+  | 'end'
+  | 'region';


### PR DESCRIPTION
## Summary

Prototypes STRAIGHT WALLS with a visible footprint in the Dungeon Builder concept's "New Dungeon" creation mode, alongside the existing edge-painted zigzag Wall tool (both survive — the comparison is the point).

Kirk's design direction: the hex-true creation canvas ships a zigzag Wall tool, but the real game's own wall renderer (`wallRuns.ts`/`WallRunMesh`) already draws straight modular wall runs along room envelopes — the zigzag is this concept's own outlier. Kirk drew straight red lines across a room and stated the governing rule directly: **"any hex that is not 100% uncovered would not be traversable"** — a straight wall has a FOOTPRINT, clipped cells are spent.

## What shipped

- **Straight Wall tool** (Structural palette category, beside Wall): drag snaps to whichever of 2 screen axes (vertical/horizontal) the drag is closer to, then finds the closest available hex-cell approximation of that axis. A click (no drag) on an existing straight wall deletes it; the Door tool applied to a straight wall flips `solid`↔`door`.
- **Footprint computation**, real Cyrus-Beck half-plane clipping (not sampling) — 6 half-planes per hex, shrunk inward by `FOOTPRINT_EPSILON = BOARD_HEX_SIZE * 1e-3` (documented, principled: several orders of magnitude above floating-point corner-computation noise, a fortieth of a percent of the hex's own radius). Computed live during drag and for every committed wall. Rendered as a crimson diagonal hatch, deliberately distinct from the region open-boundary overlay's plain red line.
- **Movement semantics**: (a) every footprint cell fully blocked; (b) every edge crossed between two otherwise-clear cells also blocked (`straightWallCrossedEdges`) — verified this never fires for a cell-center-anchored wall (3 hand cases + 400 random pairs), a real finding, not an assumption, documented in TARGET-YAML.md.
- **New schema**: `wallLines: [{from:[c,r], to:[c,r], kind:solid|door}]` — a **sibling list** to `walls:`, not a `style:` discriminator on it (weighed both, documented why in TARGET-YAML.md — the alternative would force every existing `walls:` consumer to branch on adjacency semantics). Full mutator set in `dungeonYaml.ts`, own `stripToV1Subset` handling/count.
- **Flag, never silently delete/move**: placements/start/end/region cells landing inside a new footprint get a warning (reusing `Board.tsx`'s own "⚠ ... (BLOCKED!)" language for start/end) — nothing is auto-removed.

## Design writeup

`TARGET-YAML.md`'s new "Straight walls" section — schema decision + rejected alternative, the epsilon derivation, the shoulder-clipping (vertical) and every-other-hex ("same row index ≠ horizontal") cases with the analytic proof, movement semantics (a)/(b), corner continuity, compiler-responsibility note. `CONTRACT.md` gets one ledger section with the live-verification writeup.

## Live verification

Real dev server (own port, never `:3001`), driven via Playwright computing real hex-true board coordinates from the SVG's own live viewBox:
- A genuinely vertical wall (`[4,4]`→`[6,1]`) renders as 3 hatched hexes with the flanking hexes visibly un-hatched (shoulder-clipping, confirmed live).
- A second segment from the same endpoint cell forms a clean L corner, no gap, no special-case code.
- The same corner alongside an edge-zigzag Wall-tool run for direct comparison — the straight wall reads as one clean run; the zigzag visibly breaks into disconnected segments once off a real hex-edge family.

Confirmed via the live YAML pane, not just the screenshots: both `wallLines:` entries and an 8-segment `walls:` zigzag run present in the same document.

## Test plan

- [x] `creation/straightWallGeometry.test.ts` — 19 new tests (footprint clipping incl. shoulder-clipping vertical + every-other-hex cases, epsilon touch-vs-clip boundary both sides, corner continuity, footprint-set union, axis-pick, endpoint-snapping)
- [x] `dungeonYaml.test.ts` — 7 new tests (`wallLines:` mutators, YAML round-trip, `stripToV1Subset`)
- [x] 196 dungeon-builder tests passing overall (up from 170)
- [x] `ci-check` clean (format/lint/typecheck/build/test)
- [x] Live-verified against real dev server, 3 screenshots (vertical footprint, L corner, zigzag comparison)

— asset-pipeline agent, on behalf of KirkDiggler