### PR TITLE
unit: corner-anchored straight walls + line doors

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3485,3 +3485,207 @@ new `dungeonYaml.test.ts` cases (`wallLines:` add/remove/toggle mutators,
 round-trip through real YAML text, `stripToV1Subset` dropping it
 separately from `walls:`). 196 dungeon-builder tests passing overall (up
 from 170). `ci-check` clean (format/lint/typecheck/build/test).
+
+## Corner-anchored straight walls + line doors (2026-08-03, rpg-project#169 follow-up unit)
+
+Kirk's live feedback on the straight-wall prototype above, verbatim: "I
+could not get the edges quite right. would be nice if I could fine tune
+the edges — oh I could edit the yaml directly, right. It always hangs
+over a little. Doors still follow the hex edges. It is really coming
+along." Two real gaps, both closed this round: (1) `wallLines:`
+endpoints were anchored at cell CENTERS, so every wall overshot its
+intended extent by up to half a hex at each end, by construction, with no
+finer lattice to fine-tune into even by hand-editing the YAML; (2)
+`kind: door` lived on the WHOLE line — a "door" wallLine was cosmetically
+re-colored amber but exactly as impassable as a "solid" one (the
+footprint math never read `kind` at all), so doors never got a real
+carved opening anywhere.
+
+### What shipped
+
+**Corner-anchored endpoints.** `wallLines[].from`/`.to` are now
+`CornerRef` (`creation/hexCorner.ts`, new module): `{cell: [c, r], corner:
+0..5}`, `corner` matching `hexCorners`' own `30° + 60°·i` convention. A
+hex vertex is shared by up to 3 cells, so `hexCorner.ts` also owns the
+dedup rule — **canonical = the owner with the lexicographically smallest
+`[col, row]`** — and the geometric-neighbor search (`cornerOwners`) that
+implements it, verified directly (not assumed) that every interior corner
+really does have exactly 3 owners. `nearestCorner` is the snap target for
+drawing/dragging; `migrateLegacyCenterEndpoint` is the parse-time
+migration for a PRE-corner-anchoring document (see "Migration," below).
+`straightWallGeometry.ts`'s own clip math (`clipSegmentToShrunkHex`/
+`isCellClipped`/`candidateCells`) needed ZERO changes — it already
+operated on raw world-space points; only the higher-level functions that
+resolved `from`/`to` via `cellCenter` now resolve them via `cornerPoint`.
+
+**Endpoint fine-tuning.** Selecting a straight wall (click its line) shows
+two draggable handle circles at its `from`/`to` corners; dragging one
+snaps corner-to-corner (`nearestCorner`) with the footprint/crossing
+overlay updating live during the drag, committed via a new
+`setWallLineEndpoint` mutator. Dropping a handle onto the line's own
+OTHER endpoint (collapsing it to zero length) is rejected with a toast,
+not silently clamped elsewhere. **A necessary UX trade-off**: click on an
+existing line now SELECTS (shows handles) instead of deleting — deleting
+a selected wall moved to the Delete/Backspace key
+(`CreationBoard.tsx`'s own keydown effect), mirroring the existing global
+delete gesture edit-mode placements already use. Click-to-select and
+click-to-delete are mutually exclusive interpretations of the same
+gesture, and fine-tuning is only reachable through selection.
+
+**Doors: a carved opening at a cell, not a property of the whole line.**
+New shape: `doors: [{cell: [c, r]}]` on each wallLine, zero or more,
+each referencing one of the line's own footprint cells. **Traversability
+semantic, exact**: a door's cell is excluded from THIS line's footprint
+entirely (`straightWallFootprint`'s new `doorCells` exclusion parameter)
+— as if the line never clipped it — and because `straightWallCrossedEdges`
+reads the SAME (now-excluded) footprint set, the door cell automatically
+participates in movement semantic (b)'s crossing-check as an ordinary
+clear cell too, no separate door-crossing mechanism needed. A door only
+reverses THIS line's own claim on that cell — something else can still
+block it independently. The Door tool, applied to a straight wall,
+resolves a click to the nearest real footprint cell along the line
+(`wallLineDoorCellAt`: project the click onto the line, find which cell's
+own `[t0,t1]` clip interval contains it) and toggles a door there
+(`toggleWallLineDoorAt`) — add if absent, remove if present. Rejected
+clicks (landing on a touch-only stretch, no real footprint cell) show a
+toast rather than silently no-opping — verified live, see below. A door
+stranded by a subsequent endpoint drag (its cell fell out of the raw
+footprint) renders a ⚠ marker instead of a hinge, flagged not silently
+dropped, same discipline this file's placement/start/end/region footprint
+checks already follow.
+
+**Alternative door shape considered and rejected**: `doors: [{at: t}]`, a
+continuous parametric position. A real compiler already walks the line's
+own clip intervals cell-by-cell to derive the footprint, so mapping `t`
+to "which cell" would reuse that machinery — but rejected anyway: a `t`
+value's meaning depends on the line's exact parameterization, so an
+endpoint fine-tune (the handle-drag feature, same round) could silently
+drift a stored `t` onto a DIFFERENT cell than the author meant. A `cell:`
+reference stays anchored to a real, named cell regardless of small
+endpoint adjustments, and is consistent with every other coordinate in
+this whole dialect already being `[col, row]` cell-space.
+
+**Migration.** A PRE-corner-anchoring `wallLines:` entry (bare `[c, r]`
+endpoints, the original unit's own shape) is picked up at PARSE time —
+`migrateLegacyCenterEndpoint` picks whichever of the cell's own 6 corners
+sits nearest the OTHER endpoint's resolved position, so the migrated line
+keeps pointing the direction it always drew. A legacy whole-line
+`kind: door` materializes into a single door at the cell nearest the
+line's own midpoint. **Heals the in-memory `doc` immediately; does NOT
+rewrite the underlying CST/YAML text by itself** — consistent with this
+file's own CST-preservation discipline, an untouched legacy entry's saved
+text stays legacy until a mutator actually touches it (a drag, a door
+toggle), at which point `normalizeWallLineItem` (new, called at the top
+of both `setWallLineEndpoint`/`toggleWallLineDoorAt`) converges the WHOLE
+entry — both endpoints, not just the one being edited — and drops the
+now-meaningless `kind:` key. Given how little `wallLines:` content
+existed anywhere at the time of this change, this self-healing break was
+judged cheaper and more honest than carrying two live representations
+through every downstream consumer indefinitely.
+
+**A real circular-import bug, hit and fixed, not theorized.** `hexCorner.ts`
+originally imported `boardGeometry.ts`'s own `neighborCell`; `dungeonYaml.ts`
+needs `hexCorner.ts` for parse-time migration; `boardGeometry.ts` imports
+`dungeonYaml.ts` for `resolvePlacement`/`DungeonDoc`. That's a genuine
+`dungeonYaml.ts -> hexCorner.ts -> boardGeometry.ts -> dungeonYaml.ts`
+cycle — crashed with "Cannot access '**vite_ssr_import_N**' before
+initialization" under Vite's ESM interop the moment `hexCorner.ts` was
+imported from `dungeonYaml.ts`, confirmed by actually running the test
+suite, not predicted. Fixed by duplicating `neighborCell` (6 lines, built
+from the same lower-level `hexLayout.ts` primitives) directly inside
+`hexCorner.ts` instead of importing it, keeping that module leaf-level —
+and by NOT importing `straightWallGeometry.ts` (same transitive cycle
+via `creationGeometry.ts` → `boardGeometry.ts`) into `dungeonYaml.ts` for
+the legacy door-migration path either; that path uses a simpler,
+self-contained "nearest cell to the line's own midpoint" computation
+instead of the Door tool's own exact footprint-cell resolution (fine for
+a rare, one-time legacy-migration fallback; the live Door tool itself
+stays exact).
+
+**A second real bug, caught by a failing test, not by inspection**:
+`toggleWallLineDoorAt`'s first draft compared a door node's `cell` field
+via `Array.isArray(c) && c[0] === cell[0] ...` — but `YAMLMap.get('cell')`
+returns a live `YAMLSeq`, not a plain array (same reason `wallIndexAtEdge`/
+`holeIndexAt` elsewhere in this file use `.get(0)`/`.get(1)`), so the
+comparison silently never matched and every "toggle" appended a duplicate
+door instead of ever removing one. Caught by
+`dungeonYaml.test.ts`'s own "adds a door, then removes it on a second
+call" test failing with two identical door entries instead of zero — fixed
+by matching the established `isSeq(c) && c.get(0) === ... && c.get(1) ===
+...` pattern instead.
+
+### Live verification
+
+Own dev server (`vite --port 5181`, never `:3001`), driven via a
+throwaway Playwright script (gitignored scratch pattern — this repo has
+no blanket scratch-script gitignore rule the prior straight-walls round's
+own script relied on, so the file was deleted after the run rather than
+left in place). Board-space coordinates computed with the same ported hex
+math as the original straight-walls unit's own script, converted to
+screen pixels via the SVG's `getScreenCTM()` forward transform — the
+exact inverse of `CreationBoard.tsx`'s own `toBoardPoint` — rather than a
+hand-rolled linear viewBox/rect ratio, after the naive version's clicks
+landed just outside the endpoint-handle's tight hit-test radius and
+silently fell through to "draw a new wall" instead of selecting one (a
+real bug in the VERIFICATION SCRIPT, caught by the wall count
+incrementing when it shouldn't have — not a product bug).
+
+- A multi-cell corner-anchored straight wall, drawn end to end, its
+  footprint hatch spanning exactly the cells its line clips — confirmed
+  live in both the rendered board and the live YAML pane
+  (`wallLines: [ { from: { cell: [...], corner: N }, to: {...} } ]`, no
+  `kind:` key).
+- A second wall drawn sharing the FIRST wall's own `to` corner exactly —
+  a clean, gapless L-join, Kirk's original red-lines picture, now at the
+  corner lattice.
+- A zoomed close-up on a wall's own endpoint showing it terminates
+  EXACTLY at a hex corner — no hangover into the neighboring hex, the
+  fix Kirk asked for, directly visible.
+- Selecting a wall shows a real teal endpoint handle; dragging it shows
+  the LIVE amber preview (updated footprint hatch included) while the
+  pointer is still down, and after release the wall's endpoint moved to
+  the new corner with the `wallLines:` COUNT unchanged (2, not 3) —
+  confirming this is a real in-place endpoint edit, not a fall-through to
+  drawing a new wall (the exact failure mode the verification script's
+  own coordinate-mapping bug, above, produced before it was fixed).
+- The Door tool: a click that doesn't land on a real footprint cell
+  produces the honest reject toast ("doors can only open a cell the
+  wall's own line actually blocks"), live, not just as a code path;
+  a click that does land on one carves a real door — the YAML pane shows
+  `doors: [ { cell: [...] } ]` on that line, and the rendered wall shows
+  a genuine GAP in the solid stroke with an amber hinge dot, the flanking
+  footprint cells still hatched, the door's own cell visibly NOT hatched.
+
+No unexpected console errors — the only ones present are the established
+FIXTURES-MODE `[unimplemented] unknown service
+...AuthoringService` (no local `rpg-api` running against this dev
+server), same as every prior round's live-verification note.
+
+### Tests
+
+16 new tests in `creation/hexCorner.test.ts` (every interior corner has
+exactly 3 owners, verified directly; canonicalization picks the smallest
+`[col,row]` — including the case where that ISN'T the cell you drew from;
+every owner of one vertex canonicalizes to the identical answer;
+canvas-boundary corners with fewer valid owners; `sameCorner` identity
+across differently-chosen owners; corner/L continuity at the lattice
+level; `nearestCorner` snapping, including off-canvas clamping; legacy
+migration picks the direction-correct corner and is itself already
+canonical). `creation/straightWallGeometry.test.ts` rewritten for corner
+refs: the two new boundary cases this round exists to prove correct (a
+segment that IS one cell's own true edge clips nothing; a segment ending
+at a corner shared with OTHER cells clips only the cell it actually
+threads through, not the ones merely touching that shared point) plus
+door-exclusion footprint/crossing tests (a door cell removed from the
+footprint, its own boundary crossings surfacing via the SAME (b)
+mechanism), `footprintCellAtParam`/`wallLineDoorCellAt`/`isValidDoorCell`
+coverage, and the corner-based `snapStraightEndpoint` axis lock — the
+prior round's low-level `clipSegmentToShrunkHex`/`isCellClipped` epsilon
+tests carry over unchanged (that math never needed to change). 15 new/
+rewritten cases in `dungeonYaml.test.ts`'s `wallLines:` describe block
+(`setWallLineEndpoint`/`toggleWallLineDoorAt` mutators including the
+duplicate-door bug fix above; canonicalization on write; legacy migration
+of both the endpoint shape and the whole-line `kind: door` shape; the
+CST-untouched-until-mutated migration behavior, both directions).
+221 dungeon-builder tests passing overall (up from 196). `ci-check`
+clean (format/lint/typecheck/build/test).

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3689,3 +3689,120 @@ of both the endpoint shape and the whole-line `kind: door` shape; the
 CST-untouched-until-mutated migration behavior, both directions).
 221 dungeon-builder tests passing overall (up from 196). `ci-check`
 clean (format/lint/typecheck/build/test).
+
+### Polish addendum: angle snapping + region-edit discoverability (same day, on this branch)
+
+Two more items of Kirk's live feedback on the round above, closed without
+a new ledger section.
+
+**Angle snapping.** Kirk: "aaahhh my line was angled ever so slightly" —
+an unintentionally off-axis wall clipped a halo of cells at their points.
+The straight-wall draw used to force EVERY drag onto one of only 2 axes
+(`pickStraightAxis`'s old vertical/horizontal split, no tolerance, no
+bypass) — and the endpoint-drag fine-tuning from the round above had NO
+axis awareness at all (`nearestCorner`, literally the closest lattice
+point), which is almost certainly the actual source of the "angled ever
+so slightly" line: a fine-tune drag snapping to the nearest corner rather
+than the nearest ON-AXIS corner. Replaced both with one shared mechanism
+(`straightWallGeometry.ts`'s `nearestWallAngleFamily`/
+`WALL_ANGLE_FAMILIES_DEG`): the 3 REAL hex-edge orientations (30°/90°/150°
+— not the old horizontal axis, which never matched a real edge at all,
+see this file's own header comment) become the default snap targets, but
+only within `WALL_ANGLE_SNAP_TOLERANCE_DEG` (6°, the middle of Kirk's own
+"~5-8°" range) of the raw drag direction — outside that, the draw stays a
+genuinely free angle (falls through to plain `nearestCorner`) rather than
+being forced onto a family it was never aimed at. Holding **Alt** bypasses
+snapping entirely for the whole drag (checked live via `e.altKey` on every
+pointer-move, not just decided once — releasing Alt mid-drag lets a real
+family lock in from wherever the drag is aimed at that point); Alt, not
+Shift, because Shift is already the region tool's own eraser modifier.
+Applied to BOTH the initial draw (`straightStroke`'s new `lockedFamily`/
+`snapped` fields, decided once past the existing direction-lock threshold,
+same shape as the zigzag tool's own `family`) and the endpoint-drag
+fine-tune (`draggingEndpoint`'s own `snapped` field, recomputed fresh
+every move since the line's OTHER endpoint is already fixed and gives a
+stable reference immediately, unlike a brand-new stroke's noisy first
+few pixels). Snapped state is subtly visible per Kirk's own ask: a locked
+preview renders solid and full-opacity bright amber
+(`straightWallLineElements`'s new `snapped` parameter); an unsnapped one
+keeps the tool's original dashed, dimmer amber — no visual regression to
+the free-angle case, only an ADDED treatment for the locked one.
+
+**A real test-script trap, worth recording**: the live-verification
+script's first attempt at proving this (`game-dev/tools/browser/
+_job_wallpolish_verify.mjs`) used "same column, different row" as its
+"obviously vertical" test pair — WRONG on this coordinate system, where
+`hexRow`'s parity correction means worldX drifts with row even at a fixed
+column (verified by directly computing both cells' `cellCenter`). The
+actual verified-vertical pairs are `(col+2,row-3)`-style deltas (derived
+algebraically from `hexRow`'s own formula, and empirically the SAME pair
+CONTRACT.md's own "straight walls" round above used:
+`[4,4]`→`[6,1]`). A second trap on top of that: a small nudge (10-32 board
+units) off a genuinely vertical pair sometimes committed to the exact same
+corner regardless of whether snapping was engaged, because the corner
+LATTICE itself is coarser than the nudge in that direction — an
+inconclusive test, not a bug. Fixed by using a longer (3-step chained) span and
+a deliberately large (120-unit) nudge for the free-angle case specifically
+— large enough to force the nearest-corner search off the vertical corner
+regardless, cleanly isolating "Alt genuinely bypasses" from "the lattice
+just wasn't fine enough to move." A third, unrelated trap in the SAME
+script: clicking near column 15 at this viewport size lands past the
+board SVG's own visible edge, on the sibling YAML textarea instead
+(`document.elementFromPoint` confirmed it directly) — region-cell clicks
+in the verification script were kept at columns ≤2 after that.
+
+**Region-edit discoverability.** Kirk: "is there a way to add the region
+after we create it?" The capability already existed (Region tool + click
+an existing region selects it; paint adds, Shift-drag removes) but was
+never surfaced, AND — the likely actual root cause — creating the FIRST
+region ever authored (no earlier region to offer a "connect" callout for)
+left `RegionPanel.tsx` rendering `null` outright: `justCreatedId` stayed
+set (only cleared by selecting/deleting/connecting), the callout's own
+`if (created && prev)` had no `prev` and no `else`, and the old
+"nothing pending/selected" branch's `!justCreatedId` guard skipped its own
+render too — a genuine dead end, not just an undiscoverable feature.
+Fixed by precomputing `showConnectCallout` (true only when a real `prev`
+exists) and gating BOTH branches on it instead of on `justCreatedId`
+directly, so the "nothing pending, nothing selected, nothing to connect"
+case now falls through to a NEW compact region list (name/archetype/cell
+count, click-to-select) instead of rendering nothing — the "region list"
+the callout's own copy, dating back to the original region-authoring
+unit ("Use the region list to connect any two regions manually once more
+exist"), already promised but never actually shipped. When a region IS selected, the status hint text
+now matches Kirk's own wording closely: "editing `<name>` — paint to add,
+⇧ drag to remove, Esc to deselect (`N` cells)." Esc actually deselecting
+was missing entirely — added as a keydown effect mirroring the existing
+Delete/Backspace-on-selected-wall pattern (same TEXTAREA/INPUT-target
+guard), also clearing an in-progress pending paint when nothing is
+selected yet.
+
+**Tests.** 6 net new in `straightWallGeometry.test.ts`: `pickStraightAxis`'s
+old 2-case describe block replaced by `nearestWallAngleFamily` (7 cases —
+each of the 3 families, direction-agnosticism, the tolerance boundary on
+both sides, the former "horizontal" axis now correctly staying free, a
+zero-length vector); `snapStraightEndpoint`'s existing 2 cases updated for
+the numeric `WallAxisFamily` type plus 1 new case for the `axis: null`
+free-angle path matching `nearestCorner` exactly. 227 dungeon-builder
+tests passing overall (up from 221). `ci-check` clean (format/lint/
+typecheck/build/test) — a first pass caught a `npm run format` diff on
+both touched files (pure Prettier line-wrap, no semantic change).
+
+**Live verification.** Own dev server (`vite --port 5182`, never `:3001`),
+driven via `game-dev/tools/browser/_job_wallpolish_verify.mjs` (kept, per
+this repo's `/tools/browser/_job_*.mjs` gitignore convention — unlike
+rpg-dnd5e-web's own scripts, this one didn't need deleting after the run).
+A near-miss drag (~4° off a verified-vertical `[2,9]`→`[8,0]`-style span)
+committed to an EXACTLY vertical wallLine (`from`/`to` corner points'
+world X matching to floating-point precision) with a solid bright preview
+mid-drag; the same drag with Alt held and a much larger (120-unit) nudge
+committed to a visibly different, non-vertical endpoint (world X differing
+by ~104 board units) with a dashed dimmer preview mid-drag — both
+screenshotted mid-gesture, not just asserted from the final YAML. For
+regions: painting a first-ever region then deselecting showed the NEW
+compact list (`region list shows created region: true`), clicking the
+list entry showed the exact hint text ("editing Hint Check Vault — paint
+to add, ⇧ drag to remove, Esc to deselect (4 cells)."), and Esc correctly
+returned to the list. No unexpected console errors — only the established
+FIXTURES-MODE `[unimplemented] unknown service ...AuthoringService` (no
+local `rpg-api` running against this dev server), same as every prior
+round's live-verification note.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -13,6 +13,7 @@ import { ConnectorInspector } from './ConnectorInspector';
 import { CreationConcept } from './creation/CreationConcept';
 import type { DemoActions } from './creation/demoScript';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
+import type { CornerRef } from './creation/hexCorner';
 import { useRegionEditing } from './creation/useRegionEditing';
 import './DungeonBuilderConcept.css';
 import {
@@ -28,12 +29,13 @@ import {
   setPlacementFacing,
   setStart,
   setWallEdge,
+  setWallLineEndpoint,
   stripToV1Subset,
   toDungeonDoc,
   toggleHole,
   toggleWall,
   toggleWallKind,
-  toggleWallLineKindAt,
+  toggleWallLineDoorAt,
   type DungeonDoc,
   type LockedDoc,
   type WallKind,
@@ -298,12 +300,8 @@ export function DungeonBuilderConcept() {
     syncFromCreationCst(creationCst);
   };
 
-  const handleCreationAddStraightWall = (
-    from: [number, number],
-    to: [number, number],
-    kind: WallKind
-  ) => {
-    addWallLine(creationCst, from, to, kind);
+  const handleCreationAddStraightWall = (from: CornerRef, to: CornerRef) => {
+    addWallLine(creationCst, from, to);
     syncFromCreationCst(creationCst);
   };
 
@@ -312,8 +310,20 @@ export function DungeonBuilderConcept() {
     syncFromCreationCst(creationCst);
   };
 
-  const handleCreationToggleStraightWallKindAt = (index: number) => {
-    toggleWallLineKindAt(creationCst, index);
+  const handleCreationSetStraightWallEndpoint = (
+    lineIndex: number,
+    which: 'from' | 'to',
+    corner: CornerRef
+  ) => {
+    setWallLineEndpoint(creationCst, lineIndex, which, corner);
+    syncFromCreationCst(creationCst);
+  };
+
+  const handleCreationToggleStraightWallDoorAt = (
+    lineIndex: number,
+    cell: [number, number]
+  ) => {
+    toggleWallLineDoorAt(creationCst, lineIndex, cell);
     syncFromCreationCst(creationCst);
   };
 
@@ -493,7 +503,8 @@ export function DungeonBuilderConcept() {
           onToggleWallEdge={handleCreationToggleWallEdge}
           onAddStraightWall={handleCreationAddStraightWall}
           onRemoveStraightWallAt={handleCreationRemoveStraightWallAt}
-          onToggleStraightWallKindAt={handleCreationToggleStraightWallKindAt}
+          onSetStraightWallEndpoint={handleCreationSetStraightWallEndpoint}
+          onToggleStraightWallDoorAt={handleCreationToggleStraightWallDoorAt}
           onToggleHole={handleCreationToggleHole}
           onSetPoint={handleCreationSetPoint}
           onNewCanvas={handleNewCanvas}

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -219,16 +219,25 @@ walls:
   - { from: [7, 4], to: [7, 5], kind: door }
 
 # STRAIGHT walls — a separate sibling construct, NOT a variant of walls:
-# above. from/to here are typically several cells apart, not adjacent — the
-# wall is the straight WORLD-SPACE line between their centers, which clips
-# through every hex it passes over (a footprint, not just a boundary). See
-# this file's own "Straight walls" section, below, for the full rule
-# (Kirk's "any hex not 100% uncovered would not be traversable"), the
-# epsilon that makes touch-vs-clip precise, and why this needed a new list
-# rather than a style: discriminator on walls: above.
+# above. from/to are hex CORNERS (not cells — see this file's own
+# "Straight walls" section for why corner anchoring replaced the original
+# cell-center anchoring, Kirk's "it always hangs over a little" finding),
+# typically several corners apart — the wall is the straight WORLD-SPACE
+# line between them, which clips through every hex it passes over (a
+# footprint, not just a boundary). A door is a CARVED OPENING at a
+# specific footprint cell along the line (doors:), not a property of the
+# whole line — see this file's own "Straight walls" section, below, for
+# the full footprint rule (Kirk's "any hex not 100% uncovered would not be
+# traversable"), the corner-lattice addressing/dedup convention, the door
+# traversability semantic, and why this needed a new list rather than a
+# style: discriminator on walls: above.
 wallLines:
-  - { from: [10, 5], to: [10, 12], kind: solid }
-  - { from: [3, 3], to: [8, 3], kind: door }
+  - { from: { cell: [10, 5], corner: 0 }, to: { cell: [10, 12], corner: 3 } }
+  - {
+      from: { cell: [3, 3], corner: 1 },
+      to: { cell: [8, 3], corner: 4 },
+      doors: [{ cell: [5, 3] }],
+    }
 
 # No `holes:` in the early dialect. Use an obstacle/prop for a collapsed
 # visual; a true no-floor cell waits for mechanics that require one.
@@ -307,9 +316,12 @@ wall's true geometry is the straight WORLD-SPACE line between their centers
 
 ### Schema shape chosen, and the alternative rejected
 
-**Chosen: a separate sibling list, `wallLines: [{from: [c,r], to: [c,r],
-kind: solid|door}]`** — same field names as `walls:` for a familiar shape,
-but a DIFFERENT construct, not a variant of the same one.
+**Chosen: a separate sibling list, `wallLines: [{from: CornerRef, to:
+CornerRef, doors: [{cell:[c,r]}]}]`** — same "sibling list, not a variant of
+`walls:`" shape as originally chosen, now with corner-anchored endpoints and
+a real doors model (both this section's own subsections below cover the
+"why", each following a follow-up round after Kirk played with the first
+prototype).
 
 **Rejected: overloading `walls:` with a `style: edge|straight` discriminator**
 on the existing `WallDoc` shape. Weighed and rejected because `from`/`to`
@@ -322,6 +334,82 @@ to keep working unchanged. A sibling list needed zero changes to any
 existing `walls:` consumer — `doc.wallLines` is simply empty on every
 document that doesn't use it, the same "additive, absent by default" shape
 every other target-dialect field in this file already follows.
+
+### Corner anchoring — endpoints are hex CORNERS, not cell centers (follow-up round)
+
+Kirk, playing with the first prototype: "I could not get the edges quite
+right. would be nice if I could fine tune the edges — oh I could edit the
+yaml directly, right. It always hangs over a little." Two related, but
+distinct, complaints:
+
+1. **The hangover** — a wall drawn cell-center-to-cell-center OVERSHOOTS its
+   intended extent by up to half a hex at EACH end, always, by construction.
+   A cell center is never where a real room boundary actually sits; it's the
+   MIDDLE of a hex, which is at best a rough approximation of where an
+   author meant a wall to stop.
+2. **No fine-tuning path** — even editing the YAML directly (Kirk's own
+   proposed workaround) couldn't fix it: the only addressable points were
+   cell centers, one per hex. There was no finer lattice to move an endpoint
+   INTO. Precision was capped at "which hex," never "where in/around that
+   hex."
+
+**The fix**: `from`/`to` are hex CORNERS — the finest lattice this grid
+actually has, and the one a real wall run's own boundary geometry already
+lives on (`hexEdgeBetween`'s edges are corner-to-corner). A corner is where
+a hex wall belongs; a cell center never was.
+
+```yaml
+wallLines:
+  - { from: { cell: [10, 5], corner: 0 }, to: { cell: [10, 12], corner: 3 } }
+```
+
+**Corner-ref shape**: `{cell: [c, r], corner: 0..5}` — `corner` matches
+`hexCorners`' own `30° + 60°·i` indexing (`hexMath.ts`), the SAME convention
+every other hex-corner consumer in this codebase already uses; no new
+convention invented. The alternative considered — a dedicated corner-lattice
+coordinate system with one intrinsic address per vertex — was rejected as
+more mathematically demanding to justify and implement for the actual gain:
+`{cell, corner}` plus a canonicalization rule (below) gets the same "one
+address per real point" property with far less new machinery, and is
+directly testable against the existing per-cell hex math this concept
+already has.
+
+**Dedup convention — canonicalization.** A hex vertex is shared by exactly 3
+cells in the tiling's interior (1 or 2 at a canvas boundary — verified
+directly, not assumed: `hexCorner.test.ts`'s `cornerOwners` cases). So the
+same real point has up to 3 equally valid `{cell, corner}` spellings. Two
+authors drawing toward the same corner from different sides — or the same
+corner shared by two DIFFERENT wallLines forming an L-join — need to agree
+on ONE spelling for equality/hit-testing to work without a geometry
+comparison every time. **The rule: canonical = the owner with the
+lexicographically smallest `[col, row]`**, candidates restricted to
+`col >= 0 && row >= 0` (an off-canvas geometric co-owner is real math but not
+a cell any author could have drawn from, so it can never BE the canonical
+address). Every `wallLines:` mutator canonicalizes on write
+(`addWallLine`/`setWallLineEndpoint` in `dungeonYaml.ts`) — a document never
+carries a corner reference in a non-canonical form once anything has
+written to it.
+
+**Migration — a deliberate, honest, self-healing break, not a permanently
+dual-supported format.** A PRE-corner-anchoring `wallLines:` entry (`from`/
+`to` as a bare `[c, r]` cell — the shape the very first prototype round
+shipped) is picked up at PARSE time: `migrateLegacyCenterEndpoint` chooses
+whichever of that cell's own 6 corners sits nearest the OTHER endpoint's
+resolved position, so the migrated line keeps pointing the direction it
+always drew rather than snapping to an arbitrary corner. This heals the
+in-memory `doc` immediately — every consumer (footprint/crossing math,
+rendering) only ever sees the corner-anchored shape, regardless of source.
+**It does NOT rewrite the underlying CST/YAML text by itself** — consistent
+with this concept's own CST-preservation discipline (untouched content is
+never silently rewritten), a legacy line's saved text stays legacy until
+some mutator actually touches that entry (dragging an endpoint, adding a
+door), at which point it converges to the corner-anchored shape as a side
+effect of that write. Given how little real `wallLines:` content existed
+anywhere at the time of this change, this was judged cheaper and more
+honest than carrying two live representations through every downstream
+consumer indefinitely — the same "break in place while consumers are few"
+trigger CLAUDE.md's proto-versioning section names, applied to this
+concept's own client-only document shape rather than a real wire proto.
 
 ### Footprint rule and the epsilon that makes it precise
 
@@ -340,6 +428,16 @@ than the floating-point noise `Math.cos`/`Math.sin` introduce computing hex
 corners (~1e-13 at this scale — verified, not assumed), so it can't be
 fooled by trig rounding, and small enough to be visually and physically
 meaningless at render/gameplay scale.
+
+**Still true after corner anchoring, unchanged.** The clip math below
+(`clipSegmentToShrunkHex`/`isCellClipped`/`candidateCells`) operates on raw
+world-space points, not on cell/corner addressing — corner anchoring only
+changed HOW `from`/`to` resolve to those points (`cornerPoint` instead of
+`cellCenter`), not the clipping itself. The two cases below were originally
+demonstrated with cell-center fixtures; the underlying epsilon/touch-vs-clip
+behavior they illustrate is exactly as true for corner-anchored endpoints —
+see this section's own "corner anchoring" boundary case, below, for what's
+GENUINELY new once endpoints stopped being forced to cell centers.
 
 Two concrete cases worth naming directly, both covered by
 `creation/straightWallGeometry.test.ts`:
@@ -366,6 +464,23 @@ Two concrete cases worth naming directly, both covered by
   different result from the naive "same row" attempt. Both are exercised
   side by side in the test file specifically so this distinction is
   provable, not asserted on faith.
+- **A wall ENDING at a corner shared with a cell does not clip that
+  cell** — the boundary case corner anchoring specifically makes possible
+  (a cell-center-anchored endpoint was ALWAYS deep inside its own cell,
+  hence always clipped; a corner-anchored one can legitimately terminate
+  at a point three cells share, clipping zero, one, or two of them
+  depending on approach direction). Verified with the shortest possible
+  non-trivial case: a segment from one corner of a hex to its
+  DIAMETRICALLY OPPOSITE corner (corners 2 and 5 are 180° apart) is a full
+  diameter of that ONE hex — it clips that cell dead-center but never
+  enters either of the OTHER two cells that also own its terminal corner,
+  even though the line visibly "ends at" a point they touch too. The
+  simplest case of all — a segment that IS one cell's own true edge
+  (corner `i` to corner `i+1`) — clips nothing at all, the purest form of
+  "ending at a shared corner blocks nothing." Both cases are exercised
+  directly in `straightWallGeometry.test.ts`'s own "corner-anchored
+  endpoint boundary cases" describe block, not just asserted from the
+  general epsilon rule above.
 
 ### Movement semantics
 
@@ -394,24 +509,32 @@ line can't graze a shared edge between two clear cells without having
 entered one of the two cells bordering that edge's own neighborhood first).
 The mechanism is still real and implemented, not dead code — it's exercised
 directly in the test file against a hand-placed segment collinear with one
-real hex edge (bypassing the cell-center anchoring), and it becomes load-
-bearing the moment a wall's endpoints are no longer forced to cell centers —
-e.g. a server-side compiler working from raw board/world coordinates instead
-of this prototype's `[col,row]`-only representation.
+real hex edge. **Update, corner-anchoring round**: this prediction — "load-
+bearing the moment a wall's endpoints are no longer forced to cell
+centers" — has now come true for real, not just as a forward-looking note.
+Corner-anchored endpoints CAN produce a genuine both-clear-cells crossing
+that the original cell-center-anchored representation never could (see this
+section's own "a wall ending at a corner shared with a cell does not clip
+that cell" boundary case, above) — mechanism (b) is exercised by real,
+reachable `wallLines:` geometry now, not only by a hand-constructed edge
+segment bypassing the normal endpoint representation.
 
 ### Corners: no special-case joining logic needed
 
 Kirk's red-lines picture showed clean L corners where two segments meet.
-This "just works" by construction: consecutive straight-wall segments that
-SHARE AN ENDPOINT CELL (draw one from A to the corner cell, a second from the
-corner cell to C) both resolve that shared cell to the exact same
-`cellCenter(...)` world point — the two lines touch exactly, with no gap and
-no special corner-detection code. `straightWallGeometry.test.ts`'s
-"corner/L continuity" test asserts this directly (both segments' own
-resolved endpoint at the shared cell are `toEqual` the same point) rather
+This "just works" by construction, now at the finer corner lattice:
+consecutive straight-wall segments that SHARE AN ENDPOINT CORNER (draw one
+from A to the corner, a second from that same corner to C) resolve to the
+exact same `cornerPoint(...)` world point — the two lines touch exactly,
+with no gap and no special corner-detection code, EVEN when the two
+segments address that corner via DIFFERENT (but canonically equivalent)
+owner cells (`hexCorner.ts`'s `sameCorner`/`canonicalCorner` — see this
+file's own "corner anchoring" section above for the dedup rule).
+`straightWallGeometry.test.ts`'s "corner/L continuity" test and
+`hexCorner.test.ts`'s own dedicated coverage assert this directly rather
 than trusting it by construction alone.
 
-### Interaction: axis snap, then closest-available approximation
+### Interaction: axis snap, then closest-available corner
 
 Drag locks to whichever of 2 screen-space axes (vertical/horizontal) the
 drag's own direction is closer to, past a small movement threshold (mirrors
@@ -423,14 +546,131 @@ same scoring search) but not needed to prove the footprint mechanic, which
 is this unit's actual point.
 
 Because this is a discrete hex grid, an EXACT vertical/horizontal line
-generally isn't reachable between two integer cell centers at all (see
-above — no edge family is horizontal, and vertical only lines up exactly for
+generally isn't reachable between two lattice corners at all (see above —
+no edge family is horizontal, and vertical only lines up exactly for
 specific from/to pairs). `snapStraightEndpoint` searches a small window of
-columns/rows around the pointer's own nearest cell and picks whichever
-candidate keeps the locked axis's OTHER world coordinate closest to the
-starting cell's own — the closest AVAILABLE approximation, not a
+cells around the pointer's own nearest corner — checking all 6 of each
+candidate cell's own corners, not just cell centers — and picks whichever
+candidate corner keeps the locked axis's OTHER world coordinate closest to
+the starting corner's own — the closest AVAILABLE approximation, not a
 mathematically exact one. The footprint is always computed honestly from
 whatever line actually results, never from a pretended-exact one.
+
+### Endpoint fine-tuning: draggable handles, corner-to-corner snapped
+
+The second half of Kirk's "it always hangs over" feedback — corner
+anchoring fixes the coarseness of the anchor lattice, but an author still
+needs a way to move an already-drawn wall's endpoint onto a DIFFERENT
+corner without deleting and redrawing the whole line. Selecting a straight
+wall (click its line — no longer deletes, see below) shows two small
+draggable handle circles at its `from`/`to` corners; dragging one snaps it,
+corner-to-corner, to the nearest lattice point under the pointer
+(`nearestCorner`), with the footprint/crossing overlay updating live during
+the drag. Dropping a handle onto the line's OTHER endpoint (collapsing it to
+a single point) is rejected, not silently clamped elsewhere — the author
+sees why nothing moved rather than the handle jumping somewhere unrequested.
+The YAML pane remains the exact-edit path underneath all of this — corner
+coordinates are meaningfully hand-editable now, not just drag-adjustable.
+
+**A necessary UX trade-off, named explicitly**: the original prototype's
+click-on-an-existing-line-to-delete-it gesture is retired — a click now
+SELECTS (shows the handles) instead. Deleting a selected straight wall moved
+to the Delete/Backspace key, mirroring the existing global delete gesture
+this concept's edit-mode placements already use
+(`DungeonBuilderConcept.tsx`'s own keydown handler) rather than inventing a
+new convention. This was necessary, not incidental: click-to-select and
+click-to-delete are mutually exclusive interpretations of the same gesture,
+and endpoint fine-tuning is only reachable through selection.
+
+### Doors: a carved OPENING at a specific cell, not a property of the whole line
+
+The original prototype's `kind: solid | door` lived on the WHOLE line — Kirk,
+directly: "I cannot set a wall or a door — just realized the gashes are
+walls," and separately, after seeing a `kind: door` line rendered: doors were
+"still visually/semantically hex-edge creatures" — a whole long wall segment
+re-colored amber, with no real opening carved anywhere along it (the
+footprint math never read `kind` at all; a "door" wallLine was exactly as
+impassable as a "solid" one). An entire multi-cell wall being "a door" never
+made physical sense in the first place — a door is a point-sized opening IN
+a wall, not a wall that IS a door.
+
+**Chosen shape: `doors: [{cell: [c, r]}]`** — a list on each `wallLines:`
+entry, each referencing ONE footprint cell the line otherwise blocks. Zero
+or more per line (a list, not a single optional field) so a wider opening —
+double doors spanning 2 cells — is just two entries, no special case.
+
+**Alternative considered and rejected: `doors: [{at: t}]`**, a continuous
+parametric position (0..1) along the line. Weighed seriously — a server
+compiler already has to walk the line's own `[t0,t1]` clip intervals
+cell-by-cell to derive the footprint in the first place
+(`clipSegmentToShrunkHex`), so mapping a `t` to "which cell" would be a
+direct reuse of that same machinery, not new complexity. Rejected anyway for
+two reasons that outweighed that convenience:
+
+- **Editing robustness.** A `t` value's meaning depends on exactly how the
+  line is parameterized end-to-end. The moment an author fine-tunes an
+  endpoint (the handle-drag feature above), the line's geometry changes and
+  a stored `t` could silently drift to point at a DIFFERENT cell than the
+  one the author actually meant — a real, if narrow, class of "the edit
+  moved something the author didn't touch" bug. A `cell:` reference stays
+  anchored to a real, named cell regardless of small endpoint adjustments;
+  if the edit shrinks the footprint enough that the door's cell falls out of
+  it entirely, that's a detectable, FLAGGABLE state (see below), not a
+  silent repositioning.
+- **Author-UX and consistency.** Every other coordinate in this whole
+  dialect (`place.at`, `start`, `end`, `walls:`, wallLine `from`/`to`
+  themselves) is `[col, row]` cell-space. A `t`-parameterized door would be
+  the one construct in the file an author can't reason about by looking at
+  cell coordinates — clicking a point on the rendered line and resolving it
+  to the nearest real cell (`wallLineDoorCellAt`) is both simpler to
+  implement AND simpler for a hand-editor typing directly into the YAML
+  pane to understand and adjust.
+
+**Exact traversability semantic, precisely, for whoever compiles this**: a
+door's `cell` is excluded from ITS OWN wallLine's footprint entirely — as if
+that line's clip never touched it. Mechanically: `straightWallFootprint`
+takes an optional `doorCells` exclusion set; a door cell is removed from the
+raw clipped result. Because `straightWallCrossedEdges`'s own "skip a crossing
+if either side is footprint-blocked" rule (movement semantic (b), above)
+reads the SAME footprint set, a door cell excluded from the footprint
+automatically participates in the (b) crossing-check as an ordinary CLEAR
+cell too — its boundary crossings toward neighboring cells become subject to
+the normal both-clear-cells test, no separate "door crossing" mechanism
+needed. **The whole semantic is "this cell acts as though the wall line
+never clipped it at all," nothing more, and nothing less** — a door only
+reverses THIS line's own claim on that cell; something else (another
+wallLine, an edge wall, an obstacle prop) can still legitimately block it
+independently.
+
+**A door must reference one of the line's own RAW (door-blind) footprint
+cells to mean anything** — `isValidDoorCell` is the exact check. A door left
+STRANDED by a subsequent endpoint drag (the footprint shrank out from under
+it) is FLAGGED with a ⚠ marker at that cell, not silently dropped — same
+"flag, never silently delete or move" discipline this section's own
+"Interactions with everything else" subsection already follows for
+placements/start/end/regions.
+
+**Rendering**: the solid line stroke is simply not drawn across a door's own
+clip interval (a visible gap), with a small amber hinge-dot marker at the
+opening's midpoint — the same hinge-dot visual language the edge Wall/Door
+pair's own per-edge door already uses, now placed mid-line instead of at an
+edge's own midpoint. The Door tool, with a straight wall's line clicked,
+resolves the click to the nearest real footprint cell along the line
+(`wallLineDoorCellAt`: project the click onto the line, then find which
+cell's own `[t0,t1]` clip interval contains that point) and toggles a door
+there — add if absent, remove if present, the same symmetric affordance the
+edge Wall/Door pair already gives `doc.walls`.
+
+**A genuine, honestly-recorded gap, not silently ignored**: this round's
+door model is scoped to footprint CELLS only. Corner anchoring is exactly
+the change that makes movement semantic (b) reachable in isolation — a wall
+segment that merely GRAZES a shared edge between two clear cells without
+clipping either one (see "Honestly-recorded finding," above, now updated) —
+and `doors:` has no address for THAT case: an opening on a purely-grazed
+EDGE with no clipped cell to reference. Scoped out deliberately this round
+(the common, expected case — an author punching a cell-wide opening in a
+wall — is what `doors:` covers), named here so whoever picks this up next
+doesn't rediscover the gap from scratch.
 
 ### Interactions with everything else on the board: flag, never silently delete or move
 
@@ -450,6 +690,11 @@ content is FLAGGED, not silently deleted or relocated:
   never rewritten by a wall mutator, per the settled model's own "an inner
   wall never splits a semantic region" rule (this file's "regions:"
   section).
+- **A door stranded by an endpoint drag** (its `cell` no longer part of the
+  line's own raw footprint) gets its own ⚠ marker at that cell — see the
+  "Doors" subsection above. The `doors:` entry itself is left untouched,
+  same principle as every other case here: flag, don't silently repair or
+  delete.
 
 ### Compiler responsibilities (server-authoritative, this is a preview)
 
@@ -460,6 +705,11 @@ way `walls:` compiling to canonical `HexRecord.edges` is already the
 documented plan for edge-native walls. This concept's client-side
 `straightWallGeometry.ts` is that computation done once, client-side, for
 live visual feedback — not a claim that the client is the source of truth.
+This now includes the door-exclusion step (`doorCells` parameters on
+`straightWallFootprint`/`straightWallCrossedEdges`) and the corner-lattice
+resolution (`hexCorner.ts`'s `cornerPoint`) a real compiler would need too —
+see the "Doors" and "Corner anchoring" subsections above for the exact
+semantics/addressing a server-side implementation should match.
 
 ### `stripToV1Subset`
 
@@ -467,7 +717,12 @@ live visual feedback — not a claim that the client is the source of truth.
 all), counted and reported SEPARATELY in the compile-badge/dropped summary
 ("N straight walls", never folded into the edge-wall "N walls" count) —
 they're genuinely different constructs, and conflating their counts would
-misrepresent which tool an author actually used.
+misrepresent which tool an author actually used. A line's own `doors:`
+entries are nested data on a construct that already has no v1 analog at
+all — they drop along with their parent line, with no separate count of
+their own (counting "doors" as a sibling tally to "straight walls" would
+misrepresent them as an independent authoring action, when they only ever
+exist attached to a wallLine that's already being dropped).
 
 ## Top-level placement: rooms are semantic, not placement containers
 

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -60,7 +60,7 @@ import {
   HEX_FACING_LABELS,
 } from '@/components/hex-grid/authorGridHelpers';
 import { cubeToWorld } from '@/components/hex-grid/hexMath';
-import { useRef, useState, type ReactElement } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 import type { DungeonDoc, WallDoc, WallKind } from '../dungeonYaml';
 import { BOARD_HEX_SIZE, cellCenter, type CellPos } from '../hexLayout';
 import {
@@ -84,13 +84,23 @@ import {
   wallGeometry,
   type EdgeGeometry,
 } from './creationGeometry';
+import type { CreationGrid } from './creationTypes';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
 import {
+  cornerPoint,
+  nearestCorner,
+  sameCorner,
+  type CornerRef,
+} from './hexCorner';
+import {
+  clipSegmentToShrunkHex,
+  isValidDoorCell,
   pickStraightAxis,
   snapStraightEndpoint,
   straightWallCrossedEdges,
   straightWallFootprint,
   straightWallsFootprintSet,
+  wallLineDoorCellAt,
   type StraightAxis,
 } from './straightWallGeometry';
 import type { RegionEditing } from './useRegionEditing';
@@ -111,23 +121,31 @@ interface CreationBoardProps {
     kind: WallKind,
     on: boolean
   ) => void;
-  /** Straight Wall tool (this unit) — commits one new `wallLines:` entry
-   * per stroke, unlike `onToggleWallEdge`'s per-edge painting. See
-   * `straightWallGeometry.ts`. */
-  onAddStraightWall: (
-    from: [number, number],
-    to: [number, number],
-    kind: WallKind
-  ) => void;
-  /** Click (no drag) on an existing straight wall's line deletes it —
-   * the straight-wall tool's own "click to add/remove" affordance,
-   * mirroring the edge Wall tool's `wallCount`× drawn — click a wall
-   * cell to add/remove" language in `Palette.tsx`. */
+  /** Straight Wall tool: commits one new `wallLines:` entry per stroke,
+   * corner-anchored (unlike `onToggleWallEdge`'s per-edge, cell-adjacent
+   * painting). See `hexCorner.ts`/`straightWallGeometry.ts`. */
+  onAddStraightWall: (from: CornerRef, to: CornerRef) => void;
+  /** The Delete-key affordance on a SELECTED straight wall (see this
+   * component's own selection-vs-endpoint-drag interaction model,
+   * `selectedWallLineIndex`/`draggingEndpoint` below) — click no longer
+   * deletes on its own; it selects. */
   onRemoveStraightWallAt: (index: number) => void;
-  /** Door tool, applied to a straight wall — flips `solid`/`door` by
-   * index, same "click an existing wall to flip solid ↔ door" gesture
-   * the edge Wall/Door pair already gives `doc.walls`. */
-  onToggleStraightWallKindAt: (index: number) => void;
+  /** Endpoint-drag commit: fine-tune one end of an EXISTING straight wall
+   * to a new corner, snapped corner-to-corner. */
+  onSetStraightWallEndpoint: (
+    lineIndex: number,
+    which: 'from' | 'to',
+    corner: CornerRef
+  ) => void;
+  /** Door tool, applied to a straight wall — toggles a door AT the
+   * clicked footprint cell (add if absent, remove if present), same
+   * "click an existing wall to flip its state" gesture the edge Wall/
+   * Door pair already gives `doc.walls`, now cell-addressed instead of
+   * line-wide. See TARGET-YAML.md's "Straight walls: doors" section. */
+  onToggleStraightWallDoorAt: (
+    lineIndex: number,
+    cell: [number, number]
+  ) => void;
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
   /** Cell-authored semantic region editing (rpg-project#180) — only
@@ -170,10 +188,10 @@ function wallAtEdge(
 
 /** Index of the `doc.wallLines` entry nearest `point`, within `maxDist`
  * board units, or `null` if none is close enough — the straight-wall
- * tool's own click-to-delete hit test, and (with a tighter radius) the
+ * tool's own click-to-SELECT hit test, and (with a tighter radius) the
  * Door tool's "click an existing straight wall" test. Point-to-segment
- * distance against the wall's own world-space line (`cellCenter(from)`
- * to `cellCenter(to)`), same primitive `creationGeometry.ts`'s
+ * distance against the wall's own world-space line (`cornerPoint(from)`
+ * to `cornerPoint(to)`), same primitive `creationGeometry.ts`'s
  * `nearestEdge` uses internally, exported from there for this purpose. */
 function straightWallLineIndexNear(
   doc: DungeonDoc,
@@ -183,8 +201,8 @@ function straightWallLineIndexNear(
   let best: number | null = null;
   let bestDistSq = maxDist * maxDist;
   doc.wallLines.forEach((line, i) => {
-    const a = cellCenter(line.from[0], line.from[1]);
-    const b = cellCenter(line.to[0], line.to[1]);
+    const a = cornerPoint(line.from);
+    const b = cornerPoint(line.to);
     const d = pointToSegmentDistSq(point, a, b);
     if (d < bestDistSq) {
       bestDistSq = d;
@@ -194,7 +212,183 @@ function straightWallLineIndexNear(
   return best;
 }
 
+/** Which endpoint HANDLE (if any) of the SELECTED straight wall `point`
+ * landed on — a tighter, dedicated hit test distinct from
+ * `straightWallLineIndexNear`'s whole-line distance, since a handle is a
+ * small target at a specific corner, not "closest to the line anywhere
+ * along its length." Checked before line-select/new-draw resolution on
+ * pointer-down so grabbing a handle always wins over redrawing/
+ * reselecting when the two targets overlap (a handle sits ON the line by
+ * construction). */
+function straightWallHandleHit(
+  doc: DungeonDoc,
+  lineIndex: number,
+  point: CellPos,
+  maxDist = 10
+): 'from' | 'to' | null {
+  const line = doc.wallLines[lineIndex];
+  if (!line) return null;
+  const fromPt = cornerPoint(line.from);
+  const toPt = cornerPoint(line.to);
+  const dFrom = Math.hypot(point.x - fromPt.x, point.y - fromPt.y);
+  const dTo = Math.hypot(point.x - toPt.x, point.y - toPt.y);
+  if (dFrom > maxDist && dTo > maxDist) return null;
+  return dFrom <= dTo ? 'from' : 'to';
+}
+
 const CELL_SIZE = BOARD_HEX_SIZE - 1.5;
+
+/**
+ * Every visual element for ONE straight wall's own line — footprint
+ * hatch, blocked-crossing dashes (movement semantics (a)/(b), see
+ * `straightWallGeometry.ts`'s own doc comments), and the line itself,
+ * carved into segments around any `doors:` openings (a gap where the
+ * solid stroke simply isn't drawn, plus a small hinge marker at each
+ * opening's own midpoint — TARGET-YAML.md's "Straight walls: doors"
+ * section for the exact traversability semantic this renders). A door
+ * whose cell has fallen OUT of the line's own raw footprint (e.g. an
+ * endpoint drag shrank it) renders a ⚠ warning instead of a hinge —
+ * flagged, never silently dropped, same discipline this file's other
+ * footprint-interaction checks already follow.
+ *
+ * Shared between the committed `wallLines:` render pass and the live
+ * "drawing a brand-new wall" stroke preview — a wall being actively
+ * drawn always passes an empty `doors` list (it has none of its own
+ * yet), and `provisional` swaps the amber/dashed "not committed"
+ * treatment this component uses everywhere else for in-progress content.
+ */
+function straightWallLineElements(
+  keyPrefix: string,
+  from: CornerRef,
+  to: CornerRef,
+  doors: readonly { cell: [number, number] }[],
+  grid: CreationGrid,
+  provisional: boolean
+): ReactElement[] {
+  const els: ReactElement[] = [];
+  const a = cornerPoint(from);
+  const b = cornerPoint(to);
+  const doorCells = doors.map((d) => d.cell);
+  const footprintColor = provisional ? '#ffb347' : '#c94f4f';
+  const lineColor = provisional ? '#ffb347' : '#e8e2d8';
+  const footprint = straightWallFootprint(from, to, grid, doorCells);
+
+  for (const [col, row] of footprint) {
+    const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
+      .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+      .join(' ');
+    els.push(
+      <polygon
+        key={`${keyPrefix}-fp-${col}-${row}`}
+        points={corners}
+        fill="url(#db-footprint-hatch)"
+        stroke={footprintColor}
+        strokeWidth={1.5}
+        strokeDasharray={provisional ? '3 2' : undefined}
+        pointerEvents="none"
+      />
+    );
+  }
+
+  for (const edge of straightWallCrossedEdges(from, to, grid, footprint)) {
+    els.push(
+      <line
+        key={`${keyPrefix}-cross-${edge.cellA.join(',')}-${edge.cellB.join(',')}`}
+        x1={edge.a.x}
+        y1={edge.a.y}
+        x2={edge.b.x}
+        y2={edge.b.y}
+        stroke={footprintColor}
+        strokeWidth={2.5}
+        strokeDasharray="2 2"
+        pointerEvents="none"
+      />
+    );
+  }
+
+  const lerp = (t: number) => ({
+    x: a.x + (b.x - a.x) * t,
+    y: a.y + (b.y - a.y) * t,
+  });
+  // The geometric [t0,t1] interval the line spans through each door's
+  // cell — unshrunk (epsilon 0), since this is a visual gap, not the
+  // footprint-membership test (`straightWallFootprint` above already
+  // handles that with the real epsilon). Carves the solid stroke into
+  // the complementary segments around every door.
+  const doorIntervals = doorCells
+    .map((cell) => clipSegmentToShrunkHex(a, b, cell[0], cell[1], 0))
+    .filter((iv): iv is [number, number] => iv !== null)
+    .sort((x, y) => x[0] - y[0]);
+  let cursor = 0;
+  const segments: [number, number][] = [];
+  for (const [t0, t1] of doorIntervals) {
+    if (t0 > cursor) segments.push([cursor, t0]);
+    cursor = Math.max(cursor, t1);
+  }
+  if (cursor < 1) segments.push([cursor, 1]);
+  segments.forEach(([t0, t1], i) => {
+    const p0 = lerp(t0);
+    const p1 = lerp(t1);
+    els.push(
+      <line
+        key={`${keyPrefix}-seg-${i}`}
+        x1={p0.x}
+        y1={p0.y}
+        x2={p1.x}
+        y2={p1.y}
+        stroke={lineColor}
+        strokeWidth={provisional ? 3 : 4}
+        strokeDasharray={provisional ? '5 3' : undefined}
+        strokeLinecap="round"
+        opacity={provisional ? 0.85 : 1}
+      />
+    );
+  });
+
+  // A hinge marker at each real door's own opening midpoint — same
+  // amber-dot visual language the edge Wall/Door pair's own door hinge
+  // already uses. A door whose cell no longer clips (stranded by an
+  // endpoint drag) gets a ⚠ instead, per this function's own doc
+  // comment.
+  doorCells.forEach((cell, i) => {
+    const valid = isValidDoorCell(from, to, grid, cell);
+    const interval = clipSegmentToShrunkHex(a, b, cell[0], cell[1], 0);
+    if (!valid || !interval) {
+      const c = creationCellCenter(cell[0], cell[1]);
+      els.push(
+        <text
+          key={`${keyPrefix}-door-${i}-stranded`}
+          x={c.x}
+          y={c.y + 3}
+          textAnchor="middle"
+          fill="#ff6a6a"
+          fontSize={11}
+          fontWeight={700}
+          pointerEvents="none"
+          style={{ paintOrder: 'stroke', stroke: '#100d0b', strokeWidth: 3 }}
+        >
+          ⚠
+        </text>
+      );
+      return;
+    }
+    const mid = lerp((interval[0] + interval[1]) / 2);
+    els.push(
+      <circle
+        key={`${keyPrefix}-door-${i}-hinge`}
+        cx={mid.x}
+        cy={mid.y}
+        r={3.5}
+        fill="#100d0b"
+        stroke="#ffb347"
+        strokeWidth={1.5}
+        pointerEvents="none"
+      />
+    );
+  });
+
+  return els;
+}
 
 export function CreationBoard({
   doc,
@@ -205,7 +399,8 @@ export function CreationBoard({
   onToggleWallEdge,
   onAddStraightWall,
   onRemoveStraightWallAt,
-  onToggleStraightWallKindAt,
+  onSetStraightWallEndpoint,
+  onToggleStraightWallDoorAt,
   onToggleHole,
   onSetPoint,
   regionEdit,
@@ -237,27 +432,67 @@ export function CreationBoard({
     mode: 'add' | 'erase';
     touched: Set<string>;
   } | null>(null);
-  /** Straight Wall tool's own drag state (this unit) — genuinely
-   * different shape from `stroke` above: an edge-wall stroke paints a
-   * whole CHAIN of edges as it goes; a straight-wall stroke has exactly
-   * ONE `from`/`to` pair, committed once on pointer-up. `axis` mirrors
+  /** Straight Wall tool's own drag state — genuinely different shape
+   * from `stroke` above: an edge-wall stroke paints a whole CHAIN of
+   * edges as it goes; a straight-wall stroke has exactly ONE `from`/`to`
+   * CORNER pair, committed once on pointer-up. `axis` mirrors
    * `stroke.family`'s "undecided until the drag clears a threshold"
    * shape, but with 2 screen-space choices (vertical/horizontal) instead
    * of 3 hex edge families — see `straightWallGeometry.ts`'s
-   * `pickStraightAxis`. `deleteCandidate` is resolved on pointer-DOWN
-   * (which existing straight wall, if any, was clicked) but only acted
-   * on at pointer-UP, and only if the whole gesture turns out to have
-   * been a CLICK rather than a real drag (see `handlePointerUp`) — a
-   * drag starting on top of an existing line still draws a new one,
+   * `pickStraightAxis`. `clickTarget` is resolved on pointer-DOWN (which
+   * existing straight wall, if any, was clicked) but only acted on at
+   * pointer-UP, and only if the whole gesture turns out to have been a
+   * CLICK rather than a real drag (see `handlePointerUp`) — a drag
+   * starting on top of an existing line still draws a new one,
    * consistent with every other tool's click-vs-drag split in this
-   * component. */
+   * component. A click on an existing line now SELECTS it (shows
+   * endpoint handles) rather than deleting it — delete moved to the
+   * Delete/Backspace key on a selection, see the keydown effect below. */
   const [straightStroke, setStraightStroke] = useState<{
-    fromCell: [number, number];
-    toCell: [number, number];
+    fromCorner: CornerRef;
+    toCorner: CornerRef;
     axis: StraightAxis | null;
     startPoint: CellPos;
-    deleteCandidate: number | null;
+    clickTarget: number | null;
   } | null>(null);
+  /** Which `doc.wallLines` entry is selected — shows draggable endpoint
+   * handles (fine-tuning by hand, corner-to-corner snapped) and becomes
+   * the target of the Delete/Backspace key. Only meaningful while
+   * `tool === 'straightWall'`; reset whenever the tool changes (see the
+   * effect below) so a stale selection can't linger into an unrelated
+   * tool's interactions. */
+  const [selectedWallLineIndex, setSelectedWallLineIndex] = useState<
+    number | null
+  >(null);
+  /** An endpoint HANDLE drag in progress — `current` is the live,
+   * corner-snapped position tracking the pointer, committed via
+   * `onSetStraightWallEndpoint` on pointer-up (unless it would collapse
+   * the line onto its own other endpoint, which is rejected instead —
+   * see `handlePointerUp`). */
+  const [draggingEndpoint, setDraggingEndpoint] = useState<{
+    lineIndex: number;
+    which: 'from' | 'to';
+    current: CornerRef;
+  } | null>(null);
+
+  useEffect(() => {
+    setSelectedWallLineIndex(null);
+    setDraggingEndpoint(null);
+  }, [tool]);
+
+  useEffect(() => {
+    if (tool !== 'straightWall' || selectedWallLineIndex === null) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.target as HTMLElement)?.tagName === 'TEXTAREA') return;
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        e.preventDefault();
+        onRemoveStraightWallAt(selectedWallLineIndex);
+        setSelectedWallLineIndex(null);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [tool, selectedWallLineIndex, onRemoveStraightWallAt]);
 
   const grid = doc.canvas ?? DEFAULT_CANVAS;
 
@@ -398,41 +633,68 @@ export function CreationBoard({
       return;
     }
     if (tool === 'straightWall') {
-      const cell = nearestCreationCell(p, grid);
+      // A handle on the CURRENTLY SELECTED wall always wins over
+      // redrawing/reselecting — it sits ON the line by construction, so
+      // this must be checked first, not as a fallback.
+      if (selectedWallLineIndex !== null) {
+        const handle = straightWallHandleHit(doc, selectedWallLineIndex, p);
+        if (handle) {
+          const line = doc.wallLines[selectedWallLineIndex];
+          setDraggingEndpoint({
+            lineIndex: selectedWallLineIndex,
+            which: handle,
+            current: handle === 'from' ? line.from : line.to,
+          });
+          return;
+        }
+      }
+      const corner = nearestCorner(p, grid);
       // Resolved now (which existing straight wall, if any, sits under
       // the click) but only ACTED on at pointer-up, and only if this
       // whole gesture turns out to have been a click rather than a real
-      // drag — see `straightStroke`'s own doc comment.
+      // drag — see `straightStroke`'s own doc comment. A click SELECTS
+      // (shows endpoint handles); it no longer deletes.
       const hit = straightWallLineIndexNear(doc, p);
       setStraightStroke({
-        fromCell: cell,
-        toCell: cell,
+        fromCorner: corner,
+        toCorner: corner,
         axis: null,
         startPoint: p,
-        deleteCandidate: hit,
+        clickTarget: hit,
       });
       return;
     }
     const edge = nearestEdge(p, grid);
+    if (tool === 'door') {
+      // A straight wall's own line rarely coincides with a hex edge (see
+      // straightWallGeometry.ts's own header comment), so a click meant
+      // to carve/remove a door on a STRAIGHT wall needs its own hit test
+      // rather than falling through to the edge-wall lookup below, which
+      // would usually just find the nearest (unrelated) edge-wall
+      // candidate instead. Tight radius, checked first: a straight wall
+      // directly under the click always wins over an edge-wall toggle.
+      const lineHit = straightWallLineIndexNear(doc, p, 8);
+      if (lineHit !== null) {
+        const line = doc.wallLines[lineHit];
+        const cell = wallLineDoorCellAt(line.from, line.to, grid, p);
+        if (cell) {
+          onToggleStraightWallDoorAt(lineHit, cell);
+        } else {
+          onReject(
+            'That spot on the wall doesn’t clip a cell — doors can only open a cell the wall’s own line actually blocks.'
+          );
+        }
+        return;
+      }
+      if (!edge) return;
+      applyEdgeAction(edge);
+      return;
+    }
     if (!edge) return;
     if (tool === 'wall') {
       const existing = wallAtEdge(doc, edge.cellA, edge.cellB);
       setStroke({ addMode: !existing, startPoint: p, family: null });
       applyEdgeAction(edge, !existing);
-    } else if (tool === 'door') {
-      // A straight wall's own line rarely coincides with a hex edge (see
-      // straightWallGeometry.ts's own header comment), so a click meant
-      // to flip a STRAIGHT wall's kind needs its own hit test rather than
-      // falling through to the edge-wall lookup below, which would
-      // usually just find the nearest (unrelated) edge-wall candidate
-      // instead. Tight radius, checked first: a straight wall directly
-      // under the click always wins over an edge-wall toggle.
-      const lineHit = straightWallLineIndexNear(doc, p, 8);
-      if (lineHit !== null) {
-        onToggleStraightWallKindAt(lineHit);
-        return;
-      }
-      applyEdgeAction(edge);
     }
   };
 
@@ -450,6 +712,13 @@ export function CreationBoard({
       edit.handleMove(dragPlacement, null, cell);
       return;
     }
+    if (draggingEndpoint) {
+      setDraggingEndpoint({
+        ...draggingEndpoint,
+        current: nearestCorner(p, grid),
+      });
+      return;
+    }
     if (tool === 'straightWall' && straightStroke) {
       const dx = p.x - straightStroke.startPoint.x;
       const dy = p.y - straightStroke.startPoint.y;
@@ -461,10 +730,10 @@ export function CreationBoard({
       if (axis === null && Math.hypot(dx, dy) >= DIRECTION_LOCK_THRESHOLD) {
         axis = pickStraightAxis(dx, dy);
       }
-      const toCell = axis
-        ? snapStraightEndpoint(straightStroke.fromCell, p, axis, grid)
-        : straightStroke.fromCell;
-      setStraightStroke({ ...straightStroke, axis, toCell });
+      const toCorner = axis
+        ? snapStraightEndpoint(straightStroke.fromCorner, p, axis, grid)
+        : straightStroke.fromCorner;
+      setStraightStroke({ ...straightStroke, axis, toCorner });
       return;
     }
     if (tool === 'wall' || tool === 'door') {
@@ -523,22 +792,51 @@ export function CreationBoard({
     setStroke(null);
     setDragPlacement(null);
     setRegionStroke(null);
-    if (straightStroke) {
-      const moved =
-        straightStroke.toCell[0] !== straightStroke.fromCell[0] ||
-        straightStroke.toCell[1] !== straightStroke.fromCell[1];
-      if (moved) {
-        onAddStraightWall(
-          straightStroke.fromCell,
-          straightStroke.toCell,
-          'solid'
+    if (draggingEndpoint) {
+      const line = doc.wallLines[draggingEndpoint.lineIndex];
+      const otherEnd =
+        draggingEndpoint.which === 'from' ? line?.to : line?.from;
+      if (line && otherEnd && sameCorner(draggingEndpoint.current, otherEnd)) {
+        // Dragging an endpoint onto its own line's other end would
+        // collapse it to a single point — rejected, not silently
+        // clamped to "closest different corner," so the author sees why
+        // nothing moved rather than the handle jumping somewhere
+        // unrequested.
+        onReject('A straight wall’s two ends can’t land on the same corner.');
+      } else {
+        onSetStraightWallEndpoint(
+          draggingEndpoint.lineIndex,
+          draggingEndpoint.which,
+          draggingEndpoint.current
         );
-      } else if (straightStroke.deleteCandidate !== null) {
+      }
+      setDraggingEndpoint(null);
+      return;
+    }
+    if (straightStroke) {
+      const moved = !sameCorner(
+        straightStroke.fromCorner,
+        straightStroke.toCorner
+      );
+      if (moved) {
+        onAddStraightWall(straightStroke.fromCorner, straightStroke.toCorner);
+        setSelectedWallLineIndex(null);
+      } else if (straightStroke.clickTarget !== null) {
         // A CLICK (no real drag) landing on an existing straight wall
-        // deletes it — a drag that merely STARTS on top of one still
-        // draws a new segment (the `moved` branch above), consistent
-        // with every other tool's click-vs-drag split in this component.
-        onRemoveStraightWallAt(straightStroke.deleteCandidate);
+        // SELECTS it (shows endpoint handles) — clicking the SAME
+        // already-selected wall again deselects it; a drag that merely
+        // STARTS on top of one still draws a new segment (the `moved`
+        // branch above), consistent with every other tool's
+        // click-vs-drag split in this component. Deleting a selected
+        // wall is now the Delete/Backspace key, not a click — see the
+        // keydown effect above.
+        setSelectedWallLineIndex((current) =>
+          current === straightStroke.clickTarget
+            ? null
+            : straightStroke.clickTarget
+        );
+      } else {
+        setSelectedWallLineIndex(null);
       }
       setStraightStroke(null);
     }
@@ -617,168 +915,129 @@ export function CreationBoard({
     }
   }
 
-  // Straight walls (this unit) — genuinely different rendering job from
-  // wallEls above: each entry ALSO needs its FOOTPRINT (every hex its
-  // line clips, per Kirk's "any hex that is not 100% uncovered would not
-  // be traversable" rule) drawn as a hatched overlay — deliberately
-  // distinct from both the plain wall line itself and the region
-  // open-boundary red LINE (`creationGeometry.ts`'s `openBoundaryEdges`
-  // below), and its blocked EDGE crossings (movement semantics (b) —
-  // straightWallGeometry.ts's `straightWallCrossedEdges`) as a dashed
-  // highlight across the specific grazed edge. Rendered BEFORE the wall's
-  // own line so the line draws on top of its footprint, matching how
-  // `wallEls` layers its door hinge on top of its own line above.
-  const committedFootprint = straightWallsFootprintSet(doc.wallLines, grid);
+  // Straight walls — genuinely different rendering job from wallEls
+  // above: each entry ALSO needs its FOOTPRINT (every hex its line
+  // clips, per Kirk's "any hex that is not 100% uncovered would not be
+  // traversable" rule) drawn as a hatched overlay, its blocked EDGE
+  // crossings, and now (this unit) its own `doors:` openings carved as
+  // real gaps — see `straightWallLineElements`'s own doc comment for the
+  // full rendering job, shared with the live "drawing a new wall"
+  // preview below.
+  //
+  // A line whose endpoint is CURRENTLY being drag-adjusted
+  // (`draggingEndpoint`) renders its LIVE (not-yet-committed) position —
+  // amber/provisional, same as any other in-progress content — instead
+  // of its last-committed one, so the drag itself gives real-time
+  // footprint feedback.
   const straightWallEls: ReactElement[] = [];
   doc.wallLines.forEach((line, index) => {
-    const a = creationCellCenter(line.from[0], line.from[1]);
-    const b = creationCellCenter(line.to[0], line.to[1]);
-    const footprint = straightWallFootprint(line.from, line.to, grid);
-    for (const [col, row] of footprint) {
-      const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
-        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
-        .join(' ');
-      straightWallEls.push(
-        <polygon
-          key={`swall-${index}-fp-${col}-${row}`}
-          points={corners}
-          fill="url(#db-footprint-hatch)"
-          stroke="#c94f4f"
-          strokeWidth={1.5}
-          pointerEvents="none"
-        />
-      );
-    }
-    for (const edge of straightWallCrossedEdges(
-      line.from,
-      line.to,
-      grid,
-      footprint
-    )) {
-      straightWallEls.push(
-        <line
-          key={`swall-${index}-cross-${edge.cellA.join(',')}-${edge.cellB.join(',')}`}
-          x1={edge.a.x}
-          y1={edge.a.y}
-          x2={edge.b.x}
-          y2={edge.b.y}
-          stroke="#c94f4f"
-          strokeWidth={2.5}
-          strokeDasharray="2 2"
-          pointerEvents="none"
-        />
-      );
-    }
+    const dragging =
+      draggingEndpoint && draggingEndpoint.lineIndex === index
+        ? draggingEndpoint
+        : null;
+    const from = dragging?.which === 'from' ? dragging.current : line.from;
+    const to = dragging?.which === 'to' ? dragging.current : line.to;
     straightWallEls.push(
-      <line
-        key={`swall-${index}`}
-        x1={a.x}
-        y1={a.y}
-        x2={b.x}
-        y2={b.y}
-        stroke={line.kind === 'door' ? '#ffb347' : '#e8e2d8'}
-        strokeWidth={line.kind === 'door' ? 3 : 4}
-        strokeLinecap="round"
-      />
+      ...straightWallLineElements(
+        `swall-${index}`,
+        from,
+        to,
+        line.doors,
+        grid,
+        !!dragging
+      )
     );
-    if (line.kind === 'door') {
-      straightWallEls.push(
-        <circle
-          key={`swall-${index}-hinge`}
-          cx={(a.x + b.x) / 2}
-          cy={(a.y + b.y) / 2}
-          r={3.5}
-          fill="#100d0b"
-          stroke="#ffb347"
-          strokeWidth={1.5}
-        />
-      );
-    }
   });
 
-  // Live drag preview — same footprint/crossing treatment, amber and
-  // dashed to read as "not committed yet" (this component's existing
-  // provisional-content convention — see `pendingRegionEls` below).
-  const straightPreviewEls: ReactElement[] = [];
-  let previewFootprint: [number, number][] = [];
-  const strokeHasMoved =
-    !!straightStroke &&
-    (straightStroke.toCell[0] !== straightStroke.fromCell[0] ||
-      straightStroke.toCell[1] !== straightStroke.fromCell[1]);
-  if (tool === 'straightWall' && straightStroke && strokeHasMoved) {
-    previewFootprint = straightWallFootprint(
-      straightStroke.fromCell,
-      straightStroke.toCell,
-      grid
-    );
-    for (const [col, row] of previewFootprint) {
-      const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
-        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
-        .join(' ');
-      straightPreviewEls.push(
-        <polygon
-          key={`swall-preview-fp-${col}-${row}`}
-          points={corners}
-          fill="url(#db-footprint-hatch)"
-          stroke="#ffb347"
-          strokeWidth={1.5}
-          strokeDasharray="3 2"
-          pointerEvents="none"
-        />
-      );
+  // Endpoint HANDLES for the SELECTED straight wall — draggable,
+  // corner-to-corner-snapped fine-tuning (Kirk: "it always hangs over a
+  // little" — this is the fix). Purely visual: the actual hit-test lives
+  // in `handlePointerDown`'s own `straightWallHandleHit` call, coordinate
+  // math against the same points these circles render at, matching how
+  // every other overlay in this component works (`pointerEvents="none"`
+  // throughout, hit-testing done once at the SVG root).
+  const straightWallHandleEls: ReactElement[] = [];
+  if (tool === 'straightWall' && selectedWallLineIndex !== null) {
+    const line = doc.wallLines[selectedWallLineIndex];
+    if (line) {
+      const dragging =
+        draggingEndpoint && draggingEndpoint.lineIndex === selectedWallLineIndex
+          ? draggingEndpoint
+          : null;
+      const handlePoints: [string, CornerRef][] = [
+        ['from', dragging?.which === 'from' ? dragging.current : line.from],
+        ['to', dragging?.which === 'to' ? dragging.current : line.to],
+      ];
+      for (const [label, corner] of handlePoints) {
+        const p = cornerPoint(corner);
+        straightWallHandleEls.push(
+          <circle
+            key={`swall-handle-${label}`}
+            cx={p.x}
+            cy={p.y}
+            r={6}
+            fill="#14110f"
+            stroke="#5fd1c9"
+            strokeWidth={2.5}
+            pointerEvents="none"
+          />
+        );
+      }
     }
-    for (const edge of straightWallCrossedEdges(
-      straightStroke.fromCell,
-      straightStroke.toCell,
-      grid,
-      previewFootprint
-    )) {
-      straightPreviewEls.push(
-        <line
-          key={`swall-preview-cross-${edge.cellA.join(',')}-${edge.cellB.join(',')}`}
-          x1={edge.a.x}
-          y1={edge.a.y}
-          x2={edge.b.x}
-          y2={edge.b.y}
-          stroke="#ffb347"
-          strokeWidth={2.5}
-          strokeDasharray="2 2"
-          pointerEvents="none"
-        />
-      );
-    }
-    const pa = creationCellCenter(
-      straightStroke.fromCell[0],
-      straightStroke.fromCell[1]
-    );
-    const pb = creationCellCenter(
-      straightStroke.toCell[0],
-      straightStroke.toCell[1]
-    );
-    straightPreviewEls.push(
-      <line
-        key="swall-preview-line"
-        x1={pa.x}
-        y1={pa.y}
-        x2={pb.x}
-        y2={pb.y}
-        stroke="#ffb347"
-        strokeWidth={3}
-        strokeDasharray="5 3"
-        strokeLinecap="round"
-        opacity={0.85}
-        pointerEvents="none"
-      />
-    );
   }
 
-  // Union of every straight wall's footprint — committed AND the live
-  // preview, if one is in progress — what placements/start/end/region
-  // cells below are checked against so a newly-drawn footprint FLAGS
-  // anything it now covers instead of silently deleting or moving it.
-  // Live preview is included deliberately: an author dragging a wall
-  // over an existing monster should see the warning appear before even
-  // releasing the pointer, not just after.
+  // Live drag preview for a brand-NEW wall being drawn (not an endpoint
+  // drag on an existing one, handled above) — same rendering job, amber/
+  // provisional, no doors of its own yet.
+  const strokeHasMoved =
+    !!straightStroke &&
+    !sameCorner(straightStroke.fromCorner, straightStroke.toCorner);
+  const straightPreviewEls: ReactElement[] =
+    tool === 'straightWall' && straightStroke && strokeHasMoved
+      ? straightWallLineElements(
+          'swall-preview',
+          straightStroke.fromCorner,
+          straightStroke.toCorner,
+          [],
+          grid,
+          true
+        )
+      : [];
+  const previewFootprint: [number, number][] =
+    tool === 'straightWall' && straightStroke && strokeHasMoved
+      ? straightWallFootprint(
+          straightStroke.fromCorner,
+          straightStroke.toCorner,
+          grid
+        )
+      : [];
+
+  // Union of every straight wall's footprint — committed (using each
+  // line's LIVE position if its endpoint is currently being drag-
+  // adjusted, not its last-committed one, so the flag system stays
+  // consistent with what the hatch overlay above is already showing)
+  // AND the live new-wall-draw preview, if one is in progress — what
+  // placements/start/end/region cells below are checked against so a
+  // newly-drawn footprint FLAGS anything it now covers instead of
+  // silently deleting or moving it. Live preview is included
+  // deliberately: an author dragging a wall over an existing monster
+  // should see the warning appear before even releasing the pointer, not
+  // just after.
+  const committedFootprint = straightWallsFootprintSet(
+    doc.wallLines.map((line, index) => {
+      const dragging =
+        draggingEndpoint && draggingEndpoint.lineIndex === index
+          ? draggingEndpoint
+          : null;
+      if (!dragging) return line;
+      return {
+        from: dragging.which === 'from' ? dragging.current : line.from,
+        to: dragging.which === 'to' ? dragging.current : line.to,
+        doors: line.doors,
+      };
+    }),
+    grid
+  );
   const footprintKeys = new Set(committedFootprint);
   for (const [col, row] of previewFootprint) {
     footprintKeys.add(`${col},${row}`);
@@ -1072,6 +1331,7 @@ export function CreationBoard({
       {wallEls}
       {straightWallEls}
       {straightPreviewEls}
+      {straightWallHandleEls}
       {holeEls}
 
       {hoverEdge && (tool === 'wall' || tool === 'door') && (

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -95,13 +95,13 @@ import {
 import {
   clipSegmentToShrunkHex,
   isValidDoorCell,
-  pickStraightAxis,
+  nearestWallAngleFamily,
   snapStraightEndpoint,
   straightWallCrossedEdges,
   straightWallFootprint,
   straightWallsFootprintSet,
   wallLineDoorCellAt,
-  type StraightAxis,
+  type WallAxisFamily,
 } from './straightWallGeometry';
 import type { RegionEditing } from './useRegionEditing';
 
@@ -256,6 +256,13 @@ const CELL_SIZE = BOARD_HEX_SIZE - 1.5;
  * drawn always passes an empty `doors` list (it has none of its own
  * yet), and `provisional` swaps the amber/dashed "not committed"
  * treatment this component uses everywhere else for in-progress content.
+ *
+ * `snapped` (only meaningful while `provisional`) is whether the CURRENT
+ * `to`/endpoint-drag position is actually locked to one of
+ * `straightWallGeometry.ts`'s 3 hex-edge angle families, vs. a free
+ * angle — Kirk's ask, "snapped state should be subtly visible": a locked
+ * preview reads solid and bright; a free one keeps the original dashed,
+ * dimmer amber this tool always had.
  */
 function straightWallLineElements(
   keyPrefix: string,
@@ -263,14 +270,15 @@ function straightWallLineElements(
   to: CornerRef,
   doors: readonly { cell: [number, number] }[],
   grid: CreationGrid,
-  provisional: boolean
+  provisional: boolean,
+  snapped: boolean = false
 ): ReactElement[] {
   const els: ReactElement[] = [];
   const a = cornerPoint(from);
   const b = cornerPoint(to);
   const doorCells = doors.map((d) => d.cell);
   const footprintColor = provisional ? '#ffb347' : '#c94f4f';
-  const lineColor = provisional ? '#ffb347' : '#e8e2d8';
+  const lineColor = !provisional ? '#e8e2d8' : snapped ? '#fff3c4' : '#ffb347';
   const footprint = straightWallFootprint(from, to, grid, doorCells);
 
   for (const [col, row] of footprint) {
@@ -338,9 +346,9 @@ function straightWallLineElements(
         y2={p1.y}
         stroke={lineColor}
         strokeWidth={provisional ? 3 : 4}
-        strokeDasharray={provisional ? '5 3' : undefined}
+        strokeDasharray={provisional && !snapped ? '5 3' : undefined}
         strokeLinecap="round"
-        opacity={provisional ? 0.85 : 1}
+        opacity={provisional ? (snapped ? 1 : 0.85) : 1}
       />
     );
   });
@@ -435,23 +443,34 @@ export function CreationBoard({
   /** Straight Wall tool's own drag state — genuinely different shape
    * from `stroke` above: an edge-wall stroke paints a whole CHAIN of
    * edges as it goes; a straight-wall stroke has exactly ONE `from`/`to`
-   * CORNER pair, committed once on pointer-up. `axis` mirrors
-   * `stroke.family`'s "undecided until the drag clears a threshold"
-   * shape, but with 2 screen-space choices (vertical/horizontal) instead
-   * of 3 hex edge families — see `straightWallGeometry.ts`'s
-   * `pickStraightAxis`. `clickTarget` is resolved on pointer-DOWN (which
-   * existing straight wall, if any, was clicked) but only acted on at
-   * pointer-UP, and only if the whole gesture turns out to have been a
-   * CLICK rather than a real drag (see `handlePointerUp`) — a drag
-   * starting on top of an existing line still draws a new one,
-   * consistent with every other tool's click-vs-drag split in this
-   * component. A click on an existing line now SELECTS it (shows
-   * endpoint handles) rather than deleting it — delete moved to the
-   * Delete/Backspace key on a selection, see the keydown effect below. */
+   * CORNER pair, committed once on pointer-up. `lockedFamily` mirrors
+   * `stroke.family`'s "undecided until the drag clears a threshold, then
+   * held for the rest of the stroke" shape — see
+   * `straightWallGeometry.ts`'s `nearestWallAngleFamily` for the 3 real
+   * hex-edge families it locks to, tolerance-gated (Kirk's fix for "my
+   * line was angled ever so slightly"). It persists through a transient
+   * Alt-held "free angle" override (`handlePointerMove` reads `e.altKey`
+   * live, every move — Shift is already the region tool's own eraser
+   * modifier, so this tool uses Alt instead) rather than being discarded
+   * by it: releasing Alt mid-drag restores whatever family was already
+   * locked in, rather than re-deciding from scratch. `snapped` is a pure
+   * render hint — whether the CURRENT `toCorner` actually came from a
+   * family snap (accounting for that live Alt override), driving the
+   * "brighter when locked" preview treatment. `clickTarget` is resolved
+   * on pointer-DOWN (which existing straight wall, if any, was clicked)
+   * but only acted on at pointer-UP, and only if the whole gesture turns
+   * out to have been a CLICK rather than a real drag (see
+   * `handlePointerUp`) — a drag starting on top of an existing line
+   * still draws a new one, consistent with every other tool's
+   * click-vs-drag split in this component. A click on an existing line
+   * now SELECTS it (shows endpoint handles) rather than deleting it —
+   * delete moved to the Delete/Backspace key on a selection, see the
+   * keydown effect below. */
   const [straightStroke, setStraightStroke] = useState<{
     fromCorner: CornerRef;
     toCorner: CornerRef;
-    axis: StraightAxis | null;
+    lockedFamily: WallAxisFamily | null;
+    snapped: boolean;
     startPoint: CellPos;
     clickTarget: number | null;
   } | null>(null);
@@ -465,14 +484,19 @@ export function CreationBoard({
     number | null
   >(null);
   /** An endpoint HANDLE drag in progress — `current` is the live,
-   * corner-snapped position tracking the pointer, committed via
-   * `onSetStraightWallEndpoint` on pointer-up (unless it would collapse
-   * the line onto its own other endpoint, which is rejected instead —
-   * see `handlePointerUp`). */
+   * angle-family-snapped position tracking the pointer (same 3-family/
+   * Alt-bypass rule the initial draw uses, recomputed fresh every move
+   * since the OTHER end of the line is already fixed — no "undecided,
+   * noisy short vector" phase to protect against the way a brand-new
+   * stroke has), committed via `onSetStraightWallEndpoint` on pointer-up
+   * (unless it would collapse the line onto its own other endpoint,
+   * which is rejected instead — see `handlePointerUp`). `snapped` is the
+   * same render hint `straightStroke` carries. */
   const [draggingEndpoint, setDraggingEndpoint] = useState<{
     lineIndex: number;
     which: 'from' | 'to';
     current: CornerRef;
+    snapped: boolean;
   } | null>(null);
 
   useEffect(() => {
@@ -493,6 +517,30 @@ export function CreationBoard({
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [tool, selectedWallLineIndex, onRemoveStraightWallAt]);
+
+  /** Esc deselects a region being edited (`RegionPanel.tsx`'s own status
+   * hint now advertises this — "Esc to deselect" — Kirk's discoverability
+   * ask, "is there a way to add the region after we create it?"). Also
+   * clears an in-progress NEW-region paint session when nothing is
+   * selected yet, the same "back out of what I'm doing" meaning Esc
+   * carries in the rest of this component. Mirrors the Delete/Backspace
+   * effect above: same TEXTAREA/INPUT-target guard so Esc while editing a
+   * region's name/id field doesn't unexpectedly blow away the selection. */
+  useEffect(() => {
+    if (tool !== 'region') return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      const targetTag = (e.target as HTMLElement)?.tagName;
+      if (targetTag === 'TEXTAREA' || targetTag === 'INPUT') return;
+      if (e.key !== 'Escape') return;
+      if (regionEdit.selectedRegionId) {
+        regionEdit.selectRegion(null);
+      } else if (regionEdit.pendingCells.length > 0) {
+        regionEdit.clearPending();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [tool, regionEdit]);
 
   const grid = doc.canvas ?? DEFAULT_CANVAS;
 
@@ -644,6 +692,7 @@ export function CreationBoard({
             lineIndex: selectedWallLineIndex,
             which: handle,
             current: handle === 'from' ? line.from : line.to,
+            snapped: false,
           });
           return;
         }
@@ -658,7 +707,8 @@ export function CreationBoard({
       setStraightStroke({
         fromCorner: corner,
         toCorner: corner,
-        axis: null,
+        lockedFamily: null,
+        snapped: false,
         startPoint: p,
         clickTarget: hit,
       });
@@ -713,27 +763,69 @@ export function CreationBoard({
       return;
     }
     if (draggingEndpoint) {
+      // The line's OTHER (fixed) endpoint anchors the angle-family check
+      // — always well-defined from the very first move, unlike a
+      // brand-new stroke's own `startPoint`, so this recomputes live on
+      // every move rather than locking once (see `draggingEndpoint`'s
+      // own doc comment). `e.altKey` is the free-angle bypass — Shift is
+      // already the region tool's own eraser modifier (see this
+      // component's region-tool pointer-down branch), so this tool uses
+      // Alt instead.
+      const line = doc.wallLines[draggingEndpoint.lineIndex];
+      const otherEnd =
+        draggingEndpoint.which === 'from' ? line?.to : line?.from;
+      let axis: WallAxisFamily | null = null;
+      if (otherEnd && !e.altKey) {
+        const otherPoint = cornerPoint(otherEnd);
+        axis = nearestWallAngleFamily(p.x - otherPoint.x, p.y - otherPoint.y);
+      }
+      const current =
+        otherEnd && axis
+          ? snapStraightEndpoint(otherEnd, p, axis, grid)
+          : nearestCorner(p, grid);
       setDraggingEndpoint({
         ...draggingEndpoint,
-        current: nearestCorner(p, grid),
+        current,
+        snapped: axis !== null,
       });
       return;
     }
     if (tool === 'straightWall' && straightStroke) {
       const dx = p.x - straightStroke.startPoint.x;
       const dy = p.y - straightStroke.startPoint.y;
-      let axis = straightStroke.axis;
-      // Same "undecided until the drag clears a threshold, then locked
-      // for the rest of the stroke" shape the edge-wall tool's `family`
-      // uses just below — see `pickStraightAxis`'s own doc comment for
-      // why this is 2-way (vertical/horizontal), not 3-way.
-      if (axis === null && Math.hypot(dx, dy) >= DIRECTION_LOCK_THRESHOLD) {
-        axis = pickStraightAxis(dx, dy);
+      const pastThreshold = Math.hypot(dx, dy) >= DIRECTION_LOCK_THRESHOLD;
+      let lockedFamily = straightStroke.lockedFamily;
+      // "Undecided until the drag clears a threshold, then locked for
+      // the rest of the stroke" — same shape the edge-wall tool's
+      // `family` uses just below, generalized from a forced 2-way pick
+      // to a tolerance-gated 3-family one that can also lock to "free"
+      // (`nearestWallAngleFamily` returning `null`, e.g. a drag aimed
+      // well off every family — see that function's own doc comment).
+      // Held-Alt at the moment of the lock decision skips it entirely,
+      // leaving `lockedFamily` re-triable on the NEXT move — releasing
+      // Alt mid-drag lets a real family lock in from wherever the drag
+      // is aimed at that point, rather than committing to "free"
+      // permanently just because Alt happened to be down at first.
+      if (lockedFamily === null && pastThreshold && !e.altKey) {
+        lockedFamily = nearestWallAngleFamily(dx, dy);
       }
-      const toCorner = axis
-        ? snapStraightEndpoint(straightStroke.fromCorner, p, axis, grid)
-        : straightStroke.fromCorner;
-      setStraightStroke({ ...straightStroke, axis, toCorner });
+      const effectiveAxis = e.altKey ? null : lockedFamily;
+      const toCorner = !pastThreshold
+        ? straightStroke.fromCorner
+        : effectiveAxis
+          ? snapStraightEndpoint(
+              straightStroke.fromCorner,
+              p,
+              effectiveAxis,
+              grid
+            )
+          : nearestCorner(p, grid);
+      setStraightStroke({
+        ...straightStroke,
+        lockedFamily,
+        toCorner,
+        snapped: pastThreshold && effectiveAxis !== null,
+      });
       return;
     }
     if (tool === 'wall' || tool === 'door') {
@@ -944,7 +1036,8 @@ export function CreationBoard({
         to,
         line.doors,
         grid,
-        !!dragging
+        !!dragging,
+        dragging?.snapped ?? false
       )
     );
   });
@@ -1000,7 +1093,8 @@ export function CreationBoard({
           straightStroke.toCorner,
           [],
           grid,
-          true
+          true,
+          straightStroke.snapped
         )
       : [];
   const previewFootprint: [number, number][] =

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -17,6 +17,7 @@ import type { BoardEditing } from '../useBoardEditing';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+import type { CornerRef } from './hexCorner';
 import { ProposedYamlPane } from './ProposedYamlPane';
 import { RegionPanel } from './RegionPanel';
 import { useDemoScript } from './useDemoScript';
@@ -36,13 +37,17 @@ interface CreationConceptProps {
     kind: WallKind,
     on: boolean
   ) => void;
-  onAddStraightWall: (
-    from: [number, number],
-    to: [number, number],
-    kind: WallKind
-  ) => void;
+  onAddStraightWall: (from: CornerRef, to: CornerRef) => void;
   onRemoveStraightWallAt: (index: number) => void;
-  onToggleStraightWallKindAt: (index: number) => void;
+  onSetStraightWallEndpoint: (
+    lineIndex: number,
+    which: 'from' | 'to',
+    corner: CornerRef
+  ) => void;
+  onToggleStraightWallDoorAt: (
+    lineIndex: number,
+    cell: [number, number]
+  ) => void;
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
   onNewCanvas: (width: number, height: number) => void;
@@ -73,7 +78,8 @@ export function CreationConcept({
   onToggleWallEdge,
   onAddStraightWall,
   onRemoveStraightWallAt,
-  onToggleStraightWallKindAt,
+  onSetStraightWallEndpoint,
+  onToggleStraightWallDoorAt,
   onToggleHole,
   onSetPoint,
   onNewCanvas,
@@ -322,7 +328,8 @@ export function CreationConcept({
             onToggleWallEdge={onToggleWallEdge}
             onAddStraightWall={onAddStraightWall}
             onRemoveStraightWallAt={onRemoveStraightWallAt}
-            onToggleStraightWallKindAt={onToggleStraightWallKindAt}
+            onSetStraightWallEndpoint={onSetStraightWallEndpoint}
+            onToggleStraightWallDoorAt={onToggleStraightWallDoorAt}
             onToggleHole={onToggleHole}
             onSetPoint={onSetPoint}
             regionEdit={regionEdit}

--- a/src/concepts/dungeon-builder/creation/RegionPanel.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.tsx
@@ -107,6 +107,26 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
     ? (doc.regions.find((r) => r.id === selectedRegionId) ?? null)
     : null;
 
+  // A "just created" region only gets a "connect to the previous region"
+  // callout when there genuinely IS a previous region to offer (idx > 0).
+  // The FIRST region anyone ever authors (idx === 0) has none — and this
+  // used to leave the panel rendering nothing at all once painting
+  // finished: no callout (nothing to connect to), no list (`justCreatedId`
+  // was still set, so the list branch below's old `!justCreatedId` guard
+  // skipped it too), no path back to the region just created. That dead
+  // end is very likely the actual shape of Kirk's "is there a way to add
+  // the region after we create it?" — precomputing this here lets the
+  // list branch's own condition fall through to it naturally instead of
+  // silently doing nothing.
+  const justCreatedIdx = justCreatedId
+    ? doc.regions.findIndex((r) => r.id === justCreatedId)
+    : -1;
+  const justCreatedRegion =
+    justCreatedIdx >= 0 ? doc.regions[justCreatedIdx] : null;
+  const connectCandidate =
+    justCreatedIdx > 0 ? doc.regions[justCreatedIdx - 1] : null;
+  const showConnectCallout = !!(justCreatedRegion && connectCandidate);
+
   const [draftId, setDraftId] = useState(() => suggestRegionId(doc));
   const [draftName, setDraftName] = useState('');
   const [draftArchetype, setDraftArchetype] = useState('chamber');
@@ -133,8 +153,54 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
     setRenameDraft(editingRegion?.name ?? '');
   }, [editingRegion?.id, editingRegion?.name]);
 
-  if (pendingCells.length === 0 && !editingRegion && !justCreatedId)
-    return null;
+  // --- Nothing pending/selected/just-created: the Region tool is active
+  // but there's nothing to say about the CURRENT gesture. Kirk's own ask
+  // ("is there a way to add the region after we create it?") is exactly
+  // this state — the capability (click an existing region on the board
+  // to select it for editing) already existed but was undiscoverable,
+  // since this panel used to render nothing at all here. A compact list
+  // of every existing region, click-to-select, fixes that without
+  // requiring the author to already know to click precisely on the
+  // board. Truly empty (no regions drawn yet either) still renders
+  // nothing — there's nothing useful to list. ---
+  if (pendingCells.length === 0 && !editingRegion && !showConnectCallout) {
+    if (doc.regions.length === 0) return null;
+    return (
+      <div role="dialog" aria-label="Regions" style={panelStyle}>
+        <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
+          Regions <TargetDialectBadge />
+        </h4>
+        <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
+          Click a region to edit it, or paint new board cells to start another.
+        </div>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+          {doc.regions.map((r) => (
+            <li key={r.id} style={{ marginBottom: 4 }}>
+              <button
+                onClick={() => selectRegion(r.id)}
+                style={{
+                  ...buttonStyle,
+                  width: '100%',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                  background: 'transparent',
+                  color: '#e8e2d8',
+                  border: '1px solid var(--border-primary)',
+                  fontWeight: 400,
+                }}
+              >
+                <span>{r.name ?? r.id}</span>
+                <span style={{ color: '#8a7a5a' }}>
+                  {r.archetype} · {r.cells.length}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
 
   // --- Create mode: painting a brand-new region ---
   if (pendingCells.length > 0) {
@@ -228,52 +294,49 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
     );
   }
 
-  // --- Just created: offer to connect to the previously-created region ---
-  if (justCreatedId) {
-    const idx = doc.regions.findIndex((r) => r.id === justCreatedId);
-    const created = doc.regions[idx];
-    const prev = idx > 0 ? doc.regions[idx - 1] : null;
-    if (created && prev) {
-      const edges = sharedBoundaryEdges(created.cells, prev.cells);
-      const adjacent = edges.length > 0;
-      return (
-        <div role="dialog" aria-label="Connect region" style={panelStyle}>
-          <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
-            Created "{created.name ?? created.id}"
-          </h4>
-          <p style={{ fontSize: 11, color: '#a89e90', lineHeight: 1.4 }}>
-            {adjacent
-              ? `Attach to "${prev.name ?? prev.id}"? Places a door edge on the shared boundary (${edges.length} candidate edge${edges.length === 1 ? '' : 's'}, midpoint chosen).`
-              : `"${prev.name ?? prev.id}" doesn't share a boundary with this region — nothing to connect automatically. Use the region list to connect any two regions manually once more exist.`}
-          </p>
-          <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
-            {adjacent && (
-              <button
-                style={{
-                  ...buttonStyle,
-                  background: '#3a9b6a',
-                  color: '#0d160f',
-                }}
-                onClick={() => handleConnect(created.id, prev.id)}
-              >
-                Connect
-              </button>
-            )}
+  // --- Just created, WITH a previous region to offer: connect callout ---
+  if (showConnectCallout && justCreatedRegion && connectCandidate) {
+    const created = justCreatedRegion;
+    const prev = connectCandidate;
+    const edges = sharedBoundaryEdges(created.cells, prev.cells);
+    const adjacent = edges.length > 0;
+    return (
+      <div role="dialog" aria-label="Connect region" style={panelStyle}>
+        <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
+          Created "{created.name ?? created.id}"
+        </h4>
+        <p style={{ fontSize: 11, color: '#a89e90', lineHeight: 1.4 }}>
+          {adjacent
+            ? `Attach to "${prev.name ?? prev.id}"? Places a door edge on the shared boundary (${edges.length} candidate edge${edges.length === 1 ? '' : 's'}, midpoint chosen).`
+            : `"${prev.name ?? prev.id}" doesn't share a boundary with this region — nothing to connect automatically. Use the region list to connect any two regions manually once more exist.`}
+        </p>
+        <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+          {adjacent && (
             <button
               style={{
                 ...buttonStyle,
-                background: 'transparent',
-                color: '#8a7a5a',
-                border: '1px solid var(--border-primary)',
+                background: '#3a9b6a',
+                color: '#0d160f',
               }}
-              onClick={() => selectRegion(null)}
+              onClick={() => handleConnect(created.id, prev.id)}
             >
-              Skip
+              Connect
             </button>
-          </div>
+          )}
+          <button
+            style={{
+              ...buttonStyle,
+              background: 'transparent',
+              color: '#8a7a5a',
+              border: '1px solid var(--border-primary)',
+            }}
+            onClick={() => selectRegion(null)}
+          >
+            Skip
+          </button>
         </div>
-      );
-    }
+      </div>
+    );
   }
 
   // --- Edit mode: an existing region is selected ---
@@ -284,10 +347,15 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
         <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
           Region: {editingRegion.id} <TargetDialectBadge />
         </h4>
+        {/* Kirk's own wording, closely matched — the discoverability gap
+            this addendum exists to close ("is there a way to add the
+            region after we create it?"): paint adds, ⇧-drag removes
+            (CreationBoard.tsx's region-tool pointer handlers), Esc
+            deselects (the keydown effect below). */}
         <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
-          {editingRegion.cells.length} cell
-          {editingRegion.cells.length === 1 ? '' : 's'} — click a board cell to
-          add/remove it from this region.
+          editing {editingRegion.name ?? editingRegion.id} — paint to add, ⇧
+          drag to remove, Esc to deselect ({editingRegion.cells.length} cell
+          {editingRegion.cells.length === 1 ? '' : 's'}).
         </div>
         <div style={fieldRowStyle}>
           <span style={{ width: 56 }}>name</span>

--- a/src/concepts/dungeon-builder/creation/hexCorner.test.ts
+++ b/src/concepts/dungeon-builder/creation/hexCorner.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import { BOARD_HEX_SIZE, cellCenter, cellCorners } from '../hexLayout';
+import {
+  canonicalCorner,
+  cornerOwners,
+  cornerPoint,
+  migrateLegacyCenterEndpoint,
+  nearestCorner,
+  sameCorner,
+  type CornerRef,
+} from './hexCorner';
+
+const GRID = { width: 20, height: 30 };
+
+describe('cornerOwners — every interior corner is shared by exactly 3 cells', () => {
+  // Verified directly (not assumed): corner 0 of (5,5) is also corner 2
+  // of (6,6) and corner 4 of (6,5) — all three resolve to the identical
+  // world point.
+  it('finds all 3 owners of an interior corner, all at the same world point', () => {
+    const owners = cornerOwners({ cell: [5, 5], corner: 0 });
+    expect(owners).toHaveLength(3);
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        { cell: [5, 5], corner: 0 },
+        { cell: [6, 6], corner: 2 },
+        { cell: [6, 5], corner: 4 },
+      ])
+    );
+    const points = owners.map((o) => cornerPoint(o));
+    for (const p of points) {
+      expect(p.x).toBeCloseTo(points[0].x, 6);
+      expect(p.y).toBeCloseTo(points[0].y, 6);
+    }
+  });
+
+  it('finds all 3 owners of a different interior corner (corner 1 of (5,5))', () => {
+    const owners = cornerOwners({ cell: [5, 5], corner: 1 });
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        { cell: [5, 5], corner: 1 },
+        { cell: [6, 5], corner: 3 },
+        { cell: [5, 4], corner: 5 },
+      ])
+    );
+    expect(owners).toHaveLength(3);
+  });
+
+  it('a canvas-corner vertex (0,0) has fewer owners once negative-cell candidates are excluded', () => {
+    // corner 3 of (0,0)'s true geometric co-owners are (-1,-1) and
+    // (-1,0) — both off-grid (negative column). Only (0,0) itself
+    // survives the col>=0/row>=0 filter.
+    const owners = cornerOwners({ cell: [0, 0], corner: 3 });
+    expect(owners).toEqual([{ cell: [0, 0], corner: 3 }]);
+  });
+
+  it('a canvas-edge vertex still finds its one valid in-grid co-owner', () => {
+    // corner 0 of (0,0)'s owners are (0,0)#0, (1,0)#2, (1,-1)#4 — the
+    // last is off-grid, the other two are real in-grid co-owners.
+    const owners = cornerOwners({ cell: [0, 0], corner: 0 });
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        { cell: [0, 0], corner: 0 },
+        { cell: [1, 0], corner: 2 },
+      ])
+    );
+    expect(owners).toHaveLength(2);
+  });
+});
+
+describe('canonicalCorner — deterministic single owner, smallest [col,row] wins', () => {
+  it('picks the smallest-column owner when columns differ', () => {
+    // (5,5)#0's owners are (5,5), (6,6), (6,5) — column 5 beats column 6.
+    expect(canonicalCorner({ cell: [5, 5], corner: 0 })).toEqual({
+      cell: [5, 5],
+      corner: 0,
+    });
+  });
+
+  it('picks the smallest-row owner when columns tie', () => {
+    // (5,5)#1's owners are (5,5) col5/row5, (6,5) col6, (5,4) col5/row4.
+    // Two candidates tie on column 5; row 4 beats row 5 — so the
+    // "obvious" owner (the cell you drew from) is NOT always canonical.
+    expect(canonicalCorner({ cell: [5, 5], corner: 1 })).toEqual({
+      cell: [5, 4],
+      corner: 5,
+    });
+  });
+
+  it('every owner of the same vertex canonicalizes to the identical answer', () => {
+    const owners = cornerOwners({ cell: [5, 5], corner: 1 });
+    const canonical = owners.map((o) => canonicalCorner(o));
+    for (const c of canonical) {
+      expect(c).toEqual(canonical[0]);
+    }
+  });
+
+  it('a canvas-boundary vertex with no valid alternate owner canonicalizes to itself', () => {
+    expect(canonicalCorner({ cell: [0, 0], corner: 3 })).toEqual({
+      cell: [0, 0],
+      corner: 3,
+    });
+  });
+});
+
+describe('sameCorner — identity across differently-chosen owners', () => {
+  it('recognizes two different (cell,corner) pairs as the same physical vertex', () => {
+    expect(
+      sameCorner({ cell: [5, 5], corner: 1 }, { cell: [5, 4], corner: 5 })
+    ).toBe(true);
+    expect(
+      sameCorner({ cell: [5, 5], corner: 1 }, { cell: [6, 5], corner: 3 })
+    ).toBe(true);
+  });
+
+  it('rejects two genuinely different vertices', () => {
+    expect(
+      sameCorner({ cell: [5, 5], corner: 0 }, { cell: [5, 5], corner: 1 })
+    ).toBe(false);
+  });
+});
+
+describe('corner/L continuity — two lines sharing a corner resolve to the identical world point', () => {
+  it('two independently-authored endpoints of the same vertex render at the same point', () => {
+    // One wallLine's `to` drawn as (5,5)#1; a second wallLine's `from`
+    // drawn from the OTHER side, as (6,5)#3 — both address the same real
+    // corner, per sameCorner above. A renderer must place them at the
+    // identical world point for the L-join to read as clean with zero
+    // gap, exactly like the original cell-center design's "shared cell
+    // center" guarantee, now at the finer corner lattice.
+    const a: CornerRef = { cell: [5, 5], corner: 1 };
+    const b: CornerRef = { cell: [6, 5], corner: 3 };
+    expect(cornerPoint(a)).toEqual(cornerPoint(b));
+  });
+});
+
+describe('nearestCorner — snapping a board-space point to the corner lattice', () => {
+  it('snaps exactly onto a known corner point', () => {
+    const target = cornerPoint({ cell: [5, 5], corner: 2 });
+    const snapped = nearestCorner(target, GRID);
+    expect(cornerPoint(snapped)).toEqual(target);
+  });
+
+  it('snaps a nearby-but-off point to the true nearest corner, not just the nearest cell’s own', () => {
+    // A point just outside (5,5) toward its corner-1 neighbor (5,4) — the
+    // true nearest corner is shared, but approaching from a slightly
+    // different angle should still resolve to the SAME canonical vertex.
+    const p = cornerPoint({ cell: [5, 5], corner: 1 });
+    const nudged = { x: p.x + 0.3, y: p.y - 0.2 };
+    const snapped = nearestCorner(nudged, GRID);
+    expect(sameCorner(snapped, { cell: [5, 5], corner: 1 })).toBe(true);
+  });
+
+  it('clamps to the grid when the point is off-canvas', () => {
+    const snapped = nearestCorner({ x: -5000, y: -5000 }, GRID);
+    expect(snapped.cell[0]).toBeGreaterThanOrEqual(0);
+    expect(snapped.cell[1]).toBeGreaterThanOrEqual(0);
+    expect(snapped.cell[0]).toBeLessThan(GRID.width);
+    expect(snapped.cell[1]).toBeLessThan(GRID.height);
+  });
+});
+
+describe('migrateLegacyCenterEndpoint — self-healing the pre-corner-anchoring shape', () => {
+  it('picks the corner of the cell closest to the other endpoint’s own position', () => {
+    // Legacy line was cell-center [4,4] -> [6,1]. Migrating the [4,4] end
+    // should pick whichever of (4,4)'s 6 corners sits nearest (6,1)'s
+    // center — i.e. the corner facing the wall's own direction, not an
+    // arbitrary one. The result is canonicalized, so the OWNER cell it
+    // reports may not be [4,4] itself (see canonicalCorner's own "not
+    // always the cell you drew from" finding above) — what must hold is
+    // that the resolved WORLD POINT is (4,4)'s own nearest corner.
+    const otherPoint = cellCenter(6, 1);
+    const migrated = migrateLegacyCenterEndpoint([4, 4], otherPoint);
+    const corners = cellCorners(cellCenter(4, 4), BOARD_HEX_SIZE);
+    const chosen = cornerPoint(migrated);
+    const distances = corners.map(
+      (c) => (c[0] - otherPoint.x) ** 2 + (c[1] - otherPoint.y) ** 2
+    );
+    const chosenDist =
+      (chosen.x - otherPoint.x) ** 2 + (chosen.y - otherPoint.y) ** 2;
+    expect(chosenDist).toBeCloseTo(Math.min(...distances), 6);
+    // And it must genuinely be one of (4,4)'s own corners (pre-canonical),
+    // not some unrelated point.
+    expect(
+      corners.some((c) => Math.hypot(c[0] - chosen.x, c[1] - chosen.y) < 1e-6)
+    ).toBe(true);
+  });
+
+  it('is already canonical (idempotent under canonicalCorner)', () => {
+    const migrated = migrateLegacyCenterEndpoint([4, 4], cellCenter(6, 1));
+    expect(canonicalCorner(migrated)).toEqual(migrated);
+  });
+});

--- a/src/concepts/dungeon-builder/creation/hexCorner.ts
+++ b/src/concepts/dungeon-builder/creation/hexCorner.ts
@@ -1,0 +1,249 @@
+/**
+ * hexCorner — corner-lattice addressing for straight-wall (`wallLines:`)
+ * endpoints (rpg-project#169's "corner-anchored straight walls" unit).
+ *
+ * Straight walls used to anchor `from`/`to` at cell CENTERS
+ * (`straightWallGeometry.ts`'s original shape). Kirk's live feedback
+ * drawing them: "I could not get the edges quite right... it always
+ * hangs over a little." That hangover isn't a bug in the clipping math —
+ * it's the anchor lattice being too coarse: a wall meant to stop at a
+ * room's boundary can only ever start/end at whichever cell's CENTER is
+ * nearest that boundary, so it always overshoots by up to half a hex at
+ * each end, by construction, no matter how carefully it's drawn. Fine
+ * tuning was equally impossible for the same reason — there was no finer
+ * lattice to fine-tune INTO.
+ *
+ * The fix: anchor `from`/`to` at hex CORNERS instead — the finest lattice
+ * this hex grid actually has (a corner is where a real wall run's own
+ * boundary lives; `hexEdgeBetween`'s edge geometry is already
+ * corner-to-corner). A corner is where a hex wall belongs; a cell center
+ * never was.
+ *
+ * **Dedup convention.** Every interior corner is shared by exactly 3 hex
+ * cells (an edge/canvas-boundary corner by 1 or 2) — verified directly
+ * (`hexCorner.test.ts`'s `cornerOwners` cases), not assumed. So the same
+ * real-world point has up to 3 equally valid `{cell, corner}`
+ * representations, and two authors (or the same wallLine's own from/to
+ * drawn from either side) need to serialize the SAME physical corner
+ * IDENTICALLY for equality/hit-testing to work without a geometry
+ * comparison every time. The rule: **canonical = the owner with the
+ * lexicographically smallest `[col, row]`** (ties broken by the smaller
+ * corner index, though two owners never share a cell in practice).
+ * Candidates are restricted to `col >= 0 && row >= 0` — a corner's
+ * off-grid geometric owner (e.g. `col: -1` at the canvas edge) is a real
+ * point-of-agreement mathematically but not a cell any author could have
+ * drawn from, so it's never eligible to BE the canonical address (see
+ * `cornerOwners`'s own doc comment for why no upper bound is needed).
+ *
+ * **Dependency-free of `boardGeometry.ts`, deliberately.** This module
+ * sits BELOW `dungeonYaml.ts` in the dependency graph — `parseDungeon`
+ * calls `migrateLegacyCenterEndpoint` at parse time — while
+ * `boardGeometry.ts` sits ABOVE `dungeonYaml.ts` (it imports
+ * `resolvePlacement`/`DungeonDoc` from there). Importing
+ * `boardGeometry.ts`'s own `neighborCell` here would create
+ * `dungeonYaml.ts -> hexCorner.ts -> boardGeometry.ts -> dungeonYaml.ts`,
+ * an import cycle that crashes with "Cannot access ... before
+ * initialization" under Vite's ESM interop — hit directly while building
+ * this, not theorized. `neighborCell` below is a small, deliberate
+ * duplication of `boardGeometry.ts`'s own version, built from the same
+ * lower-level primitives, to keep this module leaf-level.
+ */
+import { facingDirection } from '@/components/hex-grid/authorGridHelpers';
+import {
+  BOARD_HEX_SIZE,
+  cellCenter,
+  cellCorners,
+  cubeAtColRow,
+  hexColumn,
+  hexRow,
+  worldToCube,
+  type CellPos,
+} from '../hexLayout';
+import type { CreationGrid } from './creationTypes';
+
+/** Duplicated from `boardGeometry.ts`'s own `neighborCell` — see this
+ * module's header comment for why it can't just import that one. */
+function neighborCell(
+  col: number,
+  row: number,
+  facing: number
+): { col: number; row: number } {
+  const here = cubeAtColRow(col, row);
+  const dir = facingDirection(facing);
+  const there = { x: here.x + dir.x, y: here.y + dir.y, z: here.z + dir.z };
+  return { col: hexColumn(there), row: hexRow(there) };
+}
+
+/** One (cell, corner-index) address of a hex-lattice vertex. `corner` is
+ * 0-5, matching `hexCorners`' own `30° + 60°·i` convention
+ * (`hexMath.ts`) — the SAME indexing every hex-corner consumer in this
+ * codebase already uses, not a new convention. */
+export interface CornerRef {
+  cell: [number, number];
+  corner: number;
+}
+
+/** Two floating-point evaluations of the exact same real corner (via
+ * `cubeToWorld`'s trig) agree to ~1e-13 at this board's scale (verified
+ * elsewhere in this concept — `straightWallGeometry.ts`'s own
+ * `FOOTPRINT_EPSILON` doc comment) — this is several orders of magnitude
+ * looser than that, just tight enough to never confuse two DIFFERENT
+ * corners (which sit `BOARD_HEX_SIZE`-scale board units apart) while
+ * comfortably absorbing trig noise. */
+const CORNER_MATCH_EPSILON = 1e-6;
+
+function normalizeCornerIndex(i: number): number {
+  return ((i % 6) + 6) % 6;
+}
+
+/** The board-space world point `ref` addresses. */
+export function cornerPoint(ref: CornerRef): CellPos {
+  const corners = cellCorners(
+    cellCenter(ref.cell[0], ref.cell[1]),
+    BOARD_HEX_SIZE
+  );
+  const p = corners[normalizeCornerIndex(ref.corner)];
+  return { x: p[0], y: p[1] };
+}
+
+/**
+ * Every `{cell, corner}` pair whose corner point coincides with `ref`'s
+ * own — geometric neighbors only (`ref.cell` plus its up to 6 hex
+ * neighbors, the only cells that CAN share a vertex with it), restricted
+ * to `col >= 0 && row >= 0`. No upper bound is needed: canonicalization
+ * always picks the SMALLEST `[col, row]`, and a candidate with a larger
+ * coordinate can never win that comparison regardless of any grid
+ * width/height — the only coordinates that need excluding are negative
+ * ones, which WOULD otherwise wrongly win by being "smaller."
+ */
+export function cornerOwners(ref: CornerRef): CornerRef[] {
+  const target = cornerPoint(ref);
+  const candidateCells: [number, number][] = [ref.cell];
+  for (let f = 0; f < 6; f++) {
+    const n = neighborCell(ref.cell[0], ref.cell[1], f);
+    candidateCells.push([n.col, n.row]);
+  }
+  const owners: CornerRef[] = [];
+  const seen = new Set<string>();
+  for (const [col, row] of candidateCells) {
+    if (col < 0 || row < 0) continue;
+    const key = `${col},${row}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const corners = cellCorners(cellCenter(col, row), BOARD_HEX_SIZE);
+    corners.forEach((p, ci) => {
+      if (Math.hypot(p[0] - target.x, p[1] - target.y) < CORNER_MATCH_EPSILON) {
+        owners.push({ cell: [col, row], corner: ci });
+      }
+    });
+  }
+  return owners;
+}
+
+/** The one canonical `{cell, corner}` representation of the point `ref`
+ * addresses — see this module's own header comment for the exact rule.
+ * Always returns at least `ref` itself (canonicalized), since `ref.cell`
+ * is always one of its own owners. */
+export function canonicalCorner(ref: CornerRef): CornerRef {
+  const normalized: CornerRef = {
+    cell: ref.cell,
+    corner: normalizeCornerIndex(ref.corner),
+  };
+  const owners = cornerOwners(normalized);
+  let best = owners[0] ?? normalized;
+  for (const o of owners) {
+    if (
+      o.cell[0] < best.cell[0] ||
+      (o.cell[0] === best.cell[0] &&
+        (o.cell[1] < best.cell[1] ||
+          (o.cell[1] === best.cell[1] && o.corner < best.corner)))
+    ) {
+      best = o;
+    }
+  }
+  return best;
+}
+
+/** Two `CornerRef`s addressing the identical real-world point, regardless
+ * of which of their (up to 3) equally-valid owner cells each happens to
+ * use — the equality a raw `{cell,corner}` deep-equal can't give across
+ * differently-chosen (but physically identical) owners. Compares
+ * canonical forms rather than world points directly so this stays exact
+ * (integer/tuple comparison) instead of an epsilon-tolerant float
+ * comparison at every call site. */
+export function sameCorner(a: CornerRef, b: CornerRef): boolean {
+  const ca = canonicalCorner(a);
+  const cb = canonicalCorner(b);
+  return (
+    ca.cell[0] === cb.cell[0] &&
+    ca.cell[1] === cb.cell[1] &&
+    ca.corner === cb.corner
+  );
+}
+
+function inBoundsGrid(col: number, row: number, grid: CreationGrid): boolean {
+  return col >= 0 && col < grid.width && row >= 0 && row < grid.height;
+}
+
+/**
+ * Nearest corner-lattice point to a board-space point, canonicalized —
+ * what drawing a new wallLine or dragging an existing endpoint handle
+ * snaps to. The nearest CELL (clamped to the canvas) anchors the search;
+ * that cell's own 6 corners plus its neighbors' cells' corners are
+ * checked by real distance, not just "the nearest cell's own corners" —
+ * a point near a cell boundary can have its TRUE nearest corner belong
+ * to a neighboring cell first.
+ */
+export function nearestCorner(point: CellPos, grid: CreationGrid): CornerRef {
+  const cube = worldToCube(point);
+  const col0 = Math.max(0, Math.min(grid.width - 1, hexColumn(cube)));
+  const row0 = Math.max(0, Math.min(grid.height - 1, hexRow(cube)));
+  const candidateCells: [number, number][] = [[col0, row0]];
+  for (let f = 0; f < 6; f++) {
+    const n = neighborCell(col0, row0, f);
+    candidateCells.push([n.col, n.row]);
+  }
+  let best: CornerRef = { cell: [col0, row0], corner: 0 };
+  let bestDistSq = Infinity;
+  for (const [col, row] of candidateCells) {
+    if (!inBoundsGrid(col, row, grid)) continue;
+    const corners = cellCorners(cellCenter(col, row), BOARD_HEX_SIZE);
+    corners.forEach((p, ci) => {
+      const d = (p[0] - point.x) ** 2 + (p[1] - point.y) ** 2;
+      if (d < bestDistSq) {
+        bestDistSq = d;
+        best = { cell: [col, row], corner: ci };
+      }
+    });
+  }
+  return canonicalCorner(best);
+}
+
+/**
+ * Parse-time migration for a PRE-corner-anchoring `wallLines:` endpoint
+ * (`from`/`to` was a bare `[col, row]` cell — the original rpg-project#169
+ * shape). Self-heals to the corner-anchored shape: picks whichever of
+ * `cell`'s own 6 corners sits closest to `otherEndpointPoint` (the OTHER
+ * end of the same line, already resolved to a world point) — the
+ * migrated line keeps pointing the same direction it always drew,
+ * rather than snapping to an arbitrary corner. See TARGET-YAML.md's
+ * "Straight walls: corner anchoring" section for the full migration
+ * writeup.
+ */
+export function migrateLegacyCenterEndpoint(
+  cell: [number, number],
+  otherEndpointPoint: CellPos
+): CornerRef {
+  const corners = cellCorners(cellCenter(cell[0], cell[1]), BOARD_HEX_SIZE);
+  let bestIdx = 0;
+  let bestDistSq = Infinity;
+  corners.forEach((p, i) => {
+    const d =
+      (p[0] - otherEndpointPoint.x) ** 2 + (p[1] - otherEndpointPoint.y) ** 2;
+    if (d < bestDistSq) {
+      bestDistSq = d;
+      bestIdx = i;
+    }
+  });
+  return canonicalCorner({ cell, corner: bestIdx });
+}

--- a/src/concepts/dungeon-builder/creation/straightWallGeometry.test.ts
+++ b/src/concepts/dungeon-builder/creation/straightWallGeometry.test.ts
@@ -1,210 +1,204 @@
 import { describe, expect, it } from 'vitest';
 import { BOARD_HEX_SIZE, cellCenter } from '../hexLayout';
+import { cornerPoint, type CornerRef } from './hexCorner';
 import {
   clipSegmentToShrunkHex,
+  footprintCellAtParam,
   isCellClipped,
+  isValidDoorCell,
   pickStraightAxis,
+  projectPointToLineParam,
   snapStraightEndpoint,
   straightWallCrossedEdges,
   straightWallFootprint,
   straightWallsFootprintSet,
+  wallLineDoorCellAt,
 } from './straightWallGeometry';
 
 const GRID = { width: 20, height: 30 };
 
-describe('straightWallFootprint — shoulder-clipping vertical case', () => {
-  // (4,4) and (6,1) share the SAME world-space X (207.846...) — a
-  // genuinely vertical line in board space, verified analytically:
-  // worldX = size*sqrt3*(col + z/2), and cubeAtColRow's z = row -
-  // trunc((col-(col&1))/2) gives z(4,4)=2, z(6,1)=-2, so
-  // (4 + 2/2) === (6 + -2/2) === 5. NOT a same-column line — a "column"
-  // in [col,row] space is one of the diagonal edge families, not
-  // vertical at all (see straightWallGeometry.ts's own header comment).
-  const from: [number, number] = [4, 4];
-  const to: [number, number] = [6, 1];
+describe('straightWallFootprint — corner-anchored endpoint boundary cases', () => {
+  // The whole point of corner anchoring (Kirk: "it always hangs over a
+  // little"): a wallLine's endpoint is now a hex CORNER, shared by up to
+  // 3 cells. These cases prove the footprint math correctly distinguishes
+  // "the line's interior genuinely enters this cell" from "the line
+  // merely TERMINATES at a point this cell also happens to own" — the
+  // latter must never clip, or corner-anchoring wouldn't actually fix the
+  // hangover it exists to fix.
 
-  it('has matching world X at both endpoints (sanity check the fixture)', () => {
-    expect(cellCenter(...from).x).toBeCloseTo(cellCenter(...to).x, 9);
+  it('a wall that is EXACTLY one cell’s own edge (corner i to corner i+1) clips nothing', () => {
+    // corners[0] and corners[1] of any cell are, by construction
+    // (hexHalfPlanes builds edge i from corners[i]/corners[i+1]), the two
+    // endpoints of one real hex edge — collinear with a true boundary,
+    // the purest possible "touch, not clip" case, now expressed at the
+    // corner-anchored level instead of via a hand-picked offset segment.
+    const from: CornerRef = { cell: [5, 5], corner: 0 };
+    const to: CornerRef = { cell: [5, 5], corner: 1 };
+    expect(straightWallFootprint(from, to, GRID)).toEqual([]);
   });
 
-  it('clips exactly the 3 cells the line threads dead-center through', () => {
+  it('a wall ENDING at a corner shared with a cell does not clip that cell', () => {
+    // (5,4)'s corner 5 is the SAME real vertex as (5,5)'s corner 1 and
+    // (6,5)'s corner 3 (verified in hexCorner.test.ts's cornerOwners
+    // coverage — three cells genuinely share this point). Corners 2 and 5
+    // of a pointy-top hex are diametrically opposite (150° and 330°, 180°
+    // apart), so a line between them is a full diameter of (5,4) alone —
+    // it clips (5,4) itself, dead center, but its approach to the shared
+    // endpoint stays entirely WITHIN (5,4)'s own hexagon the whole way,
+    // so it never enters (5,5) or (6,5)'s interior even though the
+    // terminal point is a corner all three cells own. This is the exact
+    // case this unit exists to get right: the wall's line "ends AT" a
+    // corner shared with (5,5)/(6,5), but must not clip either.
+    const from: CornerRef = { cell: [5, 4], corner: 2 };
+    const to: CornerRef = { cell: [5, 4], corner: 5 };
     const footprint = straightWallFootprint(from, to, GRID);
-    expect(footprint).toEqual(
-      expect.arrayContaining([
-        [4, 4],
-        [5, 2],
-        [6, 1],
-      ])
-    );
-    expect(footprint).toHaveLength(3);
+    expect(footprint).toEqual([[5, 4]]);
+    expect(footprint).not.toContainEqual([5, 5]);
+    expect(footprint).not.toContainEqual([6, 5]);
   });
 
-  it('does NOT clip the cells the line merely grazes along their shoulder edge', () => {
-    // (4,3)/(5,1) sit exactly one half-width to the line's own side —
-    // their vertical edge lies ON the line (a touch), not through their
-    // interior. This is the concrete case Kirk's rule distinguishes:
-    // "any hex not 100% uncovered" would fail here if these were
-    // wrongly counted as clipped.
-    const grazedCells: [number, number][] = [
-      [4, 3],
-      [5, 1],
-      [5, 3],
-      [6, 0],
-    ];
-    for (const [col, row] of grazedCells) {
-      expect(
-        isCellClipped(cellCenter(...from), cellCenter(...to), col, row)
-      ).toBe(false);
-    }
+  it('the shared-corner cells stay untouched by the movement-semantics (b) crossing check too', () => {
+    const from: CornerRef = { cell: [5, 4], corner: 2 };
+    const to: CornerRef = { cell: [5, 4], corner: 5 };
+    // The line never reaches (5,5)/(6,5)'s shared edge with anything —
+    // it terminates exactly at their mutual corner, which is a single
+    // point, not a crossing of any one of their edges.
+    expect(straightWallCrossedEdges(from, to, GRID)).toEqual([]);
   });
 
-  it('produces no separate blocked-crossing edges — every touch here is adjacent to a footprint cell already', () => {
-    // Verified structurally, not asserted blindly: every grazed cell
-    // above borders a cell this test already confirmed IS footprint-
-    // blocked ((4,4), (5,2), or (6,1)), so straightWallCrossedEdges'
-    // own "skip if either side is footprint-blocked" rule (see its doc
-    // comment) correctly omits them — the touch is subsumed by the
-    // adjacent cell being wholly impassable already.
-    const footprint = straightWallFootprint(from, to, GRID);
-    expect(straightWallCrossedEdges(from, to, GRID, footprint)).toEqual([]);
-  });
-});
-
-describe('straightWallFootprint — "same row index" is NOT horizontal, and clips every other hex', () => {
-  // A naive author (or implementation) might assume two cells sharing a
-  // `row` index describe a horizontal line — they don't. z = row -
-  // trunc((col-(col&1))/2) drops roughly every 2 columns, so world-Y
-  // drifts substantially between these two "same row" endpoints (144 at
-  // col2 down to 0 at col10) — the SAME diagonal-shear fact CONTRACT.md
-  // already documents for compiled FloorPlan rendering, now showing up
-  // in the creation canvas's own coordinate space too.
-  const from: [number, number] = [2, 5];
-  const to: [number, number] = [10, 5];
-
-  it('endpoints do NOT share world Y (this line is not actually horizontal)', () => {
-    expect(cellCenter(...from).y).not.toBeCloseTo(cellCenter(...to).y, 3);
-  });
-
-  it('clips exactly every OTHER column between the endpoints', () => {
+  it('a longer wall spanning several cells still clips the ones its line genuinely enters', () => {
+    // A general, non-boundary-case sanity check: a multi-cell corner-
+    // anchored wall behaves like the original cell-center-anchored
+    // module's own "every-other-hex" finding (CONTRACT.md/TARGET-YAML.md)
+    // — a line that looks like a natural single-row draw still doesn't
+    // clip a contiguous run, because "same row" isn't world-horizontal on
+    // this grid (hexRow's own parity correction, documented at the
+    // low-level clip tests below).
+    const from: CornerRef = { cell: [2, 5], corner: 0 };
+    const to: CornerRef = { cell: [10, 5], corner: 3 };
     const footprint = straightWallFootprint(from, to, GRID);
     expect(footprint).toEqual([
-      [2, 5],
       [4, 5],
       [6, 5],
       [8, 5],
-      [10, 5],
     ]);
-    // The odd columns in between are genuinely skipped, not merely
-    // absent because they were never candidates.
-    for (const col of [3, 5, 7, 9]) {
-      expect(footprint).not.toContainEqual([col, 5]);
-    }
   });
 });
 
-describe('straightWallFootprint — a TRUE horizontal line (constant world Y) clips every column, no skips', () => {
-  // (0,3) and (10,8) share the same cube z (3), hence the same world Y
-  // — a genuinely horizontal line, unlike the "same row index" case
-  // above. Contrasting the two directly is the point: two endpoint
-  // pairs that both look like "an obvious horizontal draw" at the
-  // [col,row] level produce structurally different footprints,
-  // depending on whether the resulting WORLD-space line is actually
-  // horizontal.
-  const from: [number, number] = [0, 3];
-  const to: [number, number] = [10, 8];
+describe('straightWallFootprint / straightWallCrossedEdges — door exclusion', () => {
+  // TARGET-YAML.md's "Straight walls: doors" traversability semantic:
+  // a door's cell is excluded from ITS OWN wallLine's footprint, as if
+  // the line never clipped it — and that cell's own boundary crossings
+  // then fall out of the SAME movement-semantics (b) mechanism any other
+  // clear cell uses, no separate "door crossing" code needed.
+  const from: CornerRef = { cell: [2, 5], corner: 0 };
+  const to: CornerRef = { cell: [10, 5], corner: 3 };
+  const DOOR_CELL: [number, number] = [6, 5]; // the middle footprint cell
 
-  it('endpoints share world Y (this line genuinely is horizontal)', () => {
-    expect(cellCenter(...from).y).toBeCloseTo(cellCenter(...to).y, 9);
+  it('a door cell is removed from the footprint entirely', () => {
+    const withoutDoor = straightWallFootprint(from, to, GRID);
+    expect(withoutDoor).toContainEqual(DOOR_CELL);
+
+    const withDoor = straightWallFootprint(from, to, GRID, [DOOR_CELL]);
+    expect(withDoor).not.toContainEqual(DOOR_CELL);
+    expect(withDoor).toEqual([
+      [4, 5],
+      [8, 5],
+    ]);
   });
 
-  it('clips one cell per column, every column, no every-other-hex gap', () => {
-    const footprint = straightWallFootprint(from, to, GRID);
-    const cols = footprint.map(([c]) => c).sort((a, b) => a - b);
-    expect(cols).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  it('a door cell’s own boundary crossings become blocked crossings, like any clear cell', () => {
+    const crossedNoDoor = straightWallCrossedEdges(from, to, GRID);
+    const doorFootprint = straightWallFootprint(from, to, GRID, [DOOR_CELL]);
+    const crossedWithDoor = straightWallCrossedEdges(
+      from,
+      to,
+      GRID,
+      doorFootprint
+    );
+    // Opening the door surfaces exactly 4 new crossings — the door cell's
+    // own edges toward its footprint-neighbor cells along the wall's
+    // path (both a full step INTO the door cell and a step back OUT the
+    // far side now register as real crossings, since the door cell no
+    // longer counts as "already wholly blocked").
+    expect(crossedWithDoor.length).toBe(crossedNoDoor.length + 4);
+    const doorCellEdges = crossedWithDoor.filter(
+      (e) =>
+        (e.cellA[0] === DOOR_CELL[0] && e.cellA[1] === DOOR_CELL[1]) ||
+        (e.cellB[0] === DOOR_CELL[0] && e.cellB[1] === DOOR_CELL[1])
+    );
+    expect(doorCellEdges).toHaveLength(4);
   });
 
-  it('produces no separate blocked-crossing edges either', () => {
-    const footprint = straightWallFootprint(from, to, GRID);
-    expect(straightWallCrossedEdges(from, to, GRID, footprint)).toEqual([]);
-  });
-});
-
-describe('straightWallCrossedEdges — the movement-semantics (b) mechanism, exercised directly', () => {
-  // Every natural cell-to-cell straight wall this file tests (and 400
-  // randomly sampled pairs checked while building this unit — see this
-  // file's own git history / the unit's PR description for the search)
-  // produces ZERO both-clear crossings: every boundary touch a
-  // cell-center-anchored line produces sits adjacent to a cell that's
-  // ALREADY footprint-blocked (a straight line through a hex tiling
-  // can't graze a shared edge between two cells without having entered
-  // at least one of the two cells adjoining that edge's own endpoint
-  // region — the path is continuous and monotonic). This does NOT mean
-  // the mechanism is dead code: `clipSegmentToShrunkHex`'s underlying
-  // touch/clip distinction is the same primitive `isCellClipped` uses,
-  // and this test exercises it directly against a hand-placed segment
-  // that runs exactly along one real hex edge — the shape (b) exists to
-  // cover the moment a wall's endpoints are no longer forced to cell
-  // centers (e.g. a future server-side compiler operating on raw
-  // world/board coordinates).
-  it('a segment collinear with one hex edge does not clip either adjacent cell', () => {
-    const hexAt55 = cellCenter(5, 5);
-    // A pointy-top hex's two vertical edges sit at center.x ± half its
-    // flat-to-flat width — `size * sqrt(3) / 2` (hexMath.ts's own
-    // `hexCorners`: corners at 30°+60°·i, so the two corners nearest
-    // ±90° project to exactly this X offset). A vertical segment run
-    // exactly along the RIGHT one, spanning past the hex's own vertical
-    // extent, should clip neither (5,5) nor whichever cell sits across
-    // that edge.
-    const halfFlatWidth = (BOARD_HEX_SIZE * Math.sqrt(3)) / 2;
-    const a = { x: hexAt55.x + halfFlatWidth, y: hexAt55.y - 30 };
-    const b = { x: hexAt55.x + halfFlatWidth, y: hexAt55.y + 30 };
-    expect(isCellClipped(a, b, 5, 5)).toBe(false);
-  });
-
-  it('nudging that same segment 1 board unit INTO the hex clips it', () => {
-    // Same construction as above, but shifted just past
-    // FOOTPRINT_EPSILON to the inside — proves the epsilon boundary
-    // genuinely separates the two outcomes, not that `isCellClipped`
-    // just always returns false near an edge.
-    const hexAt55 = cellCenter(5, 5);
-    const halfFlatWidth = (BOARD_HEX_SIZE * Math.sqrt(3)) / 2;
-    const a = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y - 30 };
-    const b = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y + 30 };
-    expect(isCellClipped(a, b, 5, 5)).toBe(true);
-  });
-});
-
-describe('corner/L continuity — two segments sharing an endpoint cell touch exactly', () => {
-  it('both segments resolve the shared cell to the identical world point', () => {
-    const shared: [number, number] = [5, 5];
-    const seg1End: [number, number] = [2, 5];
-    const seg2End: [number, number] = [8, 2];
-    // Both "walls" are drawn independently (from their own endpoint to
-    // the shared cell) — the corner reads clean because both literally
-    // resolve to the SAME `cellCenter(shared)` point, not because of any
-    // special-case corner-joining logic.
-    const seg1SharedPoint = cellCenter(...shared);
-    const seg2SharedPoint = cellCenter(...shared);
-    expect(seg1SharedPoint).toEqual(seg2SharedPoint);
-    // And each segment's OWN footprint includes the shared cell itself
-    // (it's always an endpoint, hence always clipped).
-    const fp1 = straightWallFootprint(seg1End, shared, GRID);
-    const fp2 = straightWallFootprint(shared, seg2End, GRID);
-    expect(fp1).toContainEqual(shared);
-    expect(fp2).toContainEqual(shared);
-  });
-});
-
-describe('straightWallsFootprintSet — union across multiple drawn walls', () => {
-  it('unions every wall’s own footprint into one lookup set', () => {
-    const lines = [
-      { from: [4, 4] as [number, number], to: [6, 1] as [number, number] },
-      { from: [0, 3] as [number, number], to: [10, 8] as [number, number] },
-    ];
+  it('straightWallsFootprintSet excludes a line’s own door cells from the union', () => {
+    const lines = [{ from, to, doors: [{ cell: DOOR_CELL }] }];
     const set = straightWallsFootprintSet(lines, GRID);
-    expect(set.has('5,2')).toBe(true); // from the vertical wall
-    expect(set.has('5,5')).toBe(true); // from the horizontal wall
-    expect(set.has('4,3')).toBe(false); // a touch, in neither wall's footprint
+    expect(set.has('6,5')).toBe(false);
+    expect(set.has('4,5')).toBe(true);
+    expect(set.has('8,5')).toBe(true);
+  });
+});
+
+describe('door placement resolution — projecting a click onto the line', () => {
+  const from: CornerRef = { cell: [2, 5], corner: 0 };
+  const to: CornerRef = { cell: [10, 5], corner: 3 };
+
+  it('footprintCellAtParam maps a mid-line t to the cell whose clip interval contains it', () => {
+    expect(footprintCellAtParam(from, to, GRID, 0.5)).toEqual([6, 5]);
+  });
+
+  it('wallLineDoorCellAt resolves a click point on the line to the same cell', () => {
+    const a = cornerPoint(from);
+    const b = cornerPoint(to);
+    const midPoint = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+    expect(wallLineDoorCellAt(from, to, GRID, midPoint)).toEqual([6, 5]);
+  });
+
+  it('projectPointToLineParam clamps to [0,1] for a click beyond either endpoint', () => {
+    const a = cornerPoint(from);
+    const b = cornerPoint(to);
+    const beyondA = { x: a.x - 1000, y: a.y - 1000 };
+    const beyondB = { x: b.x + 1000, y: b.y + 1000 };
+    expect(projectPointToLineParam(a, b, beyondA)).toBe(0);
+    expect(projectPointToLineParam(a, b, beyondB)).toBe(1);
+  });
+});
+
+describe('isValidDoorCell — a door must reference a real (raw, door-blind) footprint cell', () => {
+  const from: CornerRef = { cell: [2, 5], corner: 0 };
+  const to: CornerRef = { cell: [10, 5], corner: 3 };
+
+  it('accepts a cell the wall’s own line genuinely clips', () => {
+    expect(isValidDoorCell(from, to, GRID, [6, 5])).toBe(true);
+  });
+
+  it('rejects a cell the line never clips at all', () => {
+    expect(isValidDoorCell(from, to, GRID, [5, 5])).toBe(false);
+  });
+});
+
+describe('corner/L continuity — two lines sharing a corner still touch with no gap', () => {
+  it('both segments resolve their shared endpoint to the identical world point', () => {
+    // The corner-lattice analog of the original cell-center "L corner"
+    // test: two wallLines drawn from opposite sides of the SAME shared
+    // vertex both anchor there exactly, no special-case join logic
+    // needed — see hexCorner.ts's `sameCorner`/`canonicalCorner` for why
+    // this holds even when the two lines address the vertex via
+    // different (but equivalent) owner cells.
+    const shared: CornerRef = { cell: [5, 5], corner: 1 };
+    const sharedViaOtherOwner: CornerRef = { cell: [6, 5], corner: 3 };
+    const seg1End: CornerRef = { cell: [2, 5], corner: 0 };
+    const seg2End: CornerRef = { cell: [8, 2], corner: 4 };
+
+    expect(cornerPoint(shared)).toEqual(cornerPoint(sharedViaOtherOwner));
+
+    const fp1 = straightWallFootprint(seg1End, shared, GRID);
+    const fp2 = straightWallFootprint(sharedViaOtherOwner, seg2End, GRID);
+    // Both segments genuinely reach into the shared vertex's own
+    // neighborhood — sanity that this is a real, non-degenerate pair of
+    // walls, not just an identity check on `cornerPoint` alone.
+    expect(fp1.length).toBeGreaterThan(0);
+    expect(fp2.length).toBeGreaterThan(0);
   });
 });
 
@@ -217,24 +211,35 @@ describe('pickStraightAxis', () => {
   });
 });
 
-describe('snapStraightEndpoint', () => {
-  it('holds worldX steady in vertical mode, searching near the pointer', () => {
-    const fromCell: [number, number] = [4, 4];
-    const pointer = cellCenter(6, 1); // pointer sitting right on a matching cell
-    const snapped = snapStraightEndpoint(fromCell, pointer, 'vertical', GRID);
-    expect(snapped).toEqual([6, 1]);
+describe('snapStraightEndpoint — corner-lattice axis lock', () => {
+  it('holds worldX steady in vertical mode, snapping to a real corner', () => {
+    const fromCorner: CornerRef = { cell: [4, 4], corner: 0 };
+    const fromPoint = cornerPoint(fromCorner);
+    // A pointer well above and just off to the side — vertical lock
+    // should still find a corner whose world X matches fromPoint's own
+    // exactly (a real corner column exists here, unlike the old cell-
+    // center module's coarser search, which could only match at
+    // specific from/to cell pairs).
+    const pointer = { x: fromPoint.x + 2, y: fromPoint.y - 80 };
+    const snapped = snapStraightEndpoint(fromCorner, pointer, 'vertical', GRID);
+    expect(cornerPoint(snapped).x).toBeCloseTo(fromPoint.x, 6);
   });
 
   it('stays within the grid bounds', () => {
-    const fromCell: [number, number] = [0, 0];
+    const fromCorner: CornerRef = { cell: [0, 0], corner: 0 };
     const pointer = { x: -500, y: -500 };
-    const snapped = snapStraightEndpoint(fromCell, pointer, 'vertical', GRID);
-    expect(snapped[0]).toBeGreaterThanOrEqual(0);
-    expect(snapped[1]).toBeGreaterThanOrEqual(0);
-    expect(snapped[0]).toBeLessThan(GRID.width);
-    expect(snapped[1]).toBeLessThan(GRID.height);
+    const snapped = snapStraightEndpoint(fromCorner, pointer, 'vertical', GRID);
+    expect(snapped.cell[0]).toBeGreaterThanOrEqual(0);
+    expect(snapped.cell[1]).toBeGreaterThanOrEqual(0);
+    expect(snapped.cell[0]).toBeLessThan(GRID.width);
+    expect(snapped.cell[1]).toBeLessThan(GRID.height);
   });
 });
+
+// --- Low-level clip math: unchanged by corner anchoring (these operate
+// on raw world-space CellPos points, never on cell/corner addressing at
+// all), kept as direct evidence the underlying epsilon rule still holds
+// exactly as documented. ---
 
 describe('clipSegmentToShrunkHex — the touch-vs-clip epsilon rule directly', () => {
   it('a segment passing well inside the hex clips it', () => {
@@ -250,12 +255,6 @@ describe('clipSegmentToShrunkHex — the touch-vs-clip epsilon rule directly', (
 
   it('a segment that only touches a single corner does not clip', () => {
     const center = cellCenter(5, 5);
-    // The hex's own top corner sits size units above center along Y at
-    // this orientation's own corner geometry — approach it tangentially
-    // from well outside instead of computing the exact corner, by using
-    // a segment that stays on the OUTWARD side of every half-plane
-    // except grazing one vertex. Simpler and robust: a segment entirely
-    // outside the hex (far to one side) never clips.
     const result = clipSegmentToShrunkHex(
       { x: center.x - 100, y: center.y },
       { x: center.x - 90, y: center.y },
@@ -263,5 +262,21 @@ describe('clipSegmentToShrunkHex — the touch-vs-clip epsilon rule directly', (
       5
     );
     expect(result).toBeNull();
+  });
+
+  it('a segment collinear with one hex edge does not clip either adjacent cell', () => {
+    const hexAt55 = cellCenter(5, 5);
+    const halfFlatWidth = (BOARD_HEX_SIZE * Math.sqrt(3)) / 2;
+    const a = { x: hexAt55.x + halfFlatWidth, y: hexAt55.y - 30 };
+    const b = { x: hexAt55.x + halfFlatWidth, y: hexAt55.y + 30 };
+    expect(isCellClipped(a, b, 5, 5)).toBe(false);
+  });
+
+  it('nudging that same segment 1 board unit INTO the hex clips it', () => {
+    const hexAt55 = cellCenter(5, 5);
+    const halfFlatWidth = (BOARD_HEX_SIZE * Math.sqrt(3)) / 2;
+    const a = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y - 30 };
+    const b = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y + 30 };
+    expect(isCellClipped(a, b, 5, 5)).toBe(true);
   });
 });

--- a/src/concepts/dungeon-builder/creation/straightWallGeometry.test.ts
+++ b/src/concepts/dungeon-builder/creation/straightWallGeometry.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import { BOARD_HEX_SIZE, cellCenter } from '../hexLayout';
-import { cornerPoint, type CornerRef } from './hexCorner';
+import { cornerPoint, nearestCorner, type CornerRef } from './hexCorner';
 import {
   clipSegmentToShrunkHex,
   footprintCellAtParam,
   isCellClipped,
   isValidDoorCell,
-  pickStraightAxis,
+  nearestWallAngleFamily,
   projectPointToLineParam,
   snapStraightEndpoint,
   straightWallCrossedEdges,
   straightWallFootprint,
   straightWallsFootprintSet,
+  WALL_ANGLE_SNAP_TOLERANCE_DEG,
   wallLineDoorCellAt,
 } from './straightWallGeometry';
 
@@ -202,17 +203,65 @@ describe('corner/L continuity — two lines sharing a corner still touch with no
   });
 });
 
-describe('pickStraightAxis', () => {
-  it('picks horizontal when the drag is wider than tall', () => {
-    expect(pickStraightAxis(30, 5)).toBe('horizontal');
+/** A unit vector (scaled by `mag`) pointed `deg` degrees from the
+ * horizontal axis — the same `atan2`/degrees convention
+ * `nearestWallAngleFamily`/`snapStraightEndpoint` use internally, so a
+ * test can assert against an exact angle rather than a hand-picked
+ * dx/dy pair. */
+function vectorAtAngle(deg: number, mag = 100): [number, number] {
+  const rad = (deg * Math.PI) / 180;
+  return [Math.cos(rad) * mag, Math.sin(rad) * mag];
+}
+
+describe('nearestWallAngleFamily — the 3 real hex-edge orientations', () => {
+  // Kirk's live feedback that prompted this: "aaahhh my line was angled
+  // ever so slightly" — an unintentionally off-axis wall clipped a halo
+  // of cells at their points. The fix: snap to a REAL hex-edge family
+  // (30°/90°/150°, see straightWallGeometry.ts's own header comment) when
+  // the raw drag is close to one, and stay free otherwise — never force
+  // a family the drag wasn't actually aimed at.
+
+  it('picks 90° (vertical) for a drag pointed straight up or down', () => {
+    expect(nearestWallAngleFamily(0, -50)).toBe(90);
+    expect(nearestWallAngleFamily(0, 50)).toBe(90);
   });
-  it('picks vertical when the drag is taller than wide', () => {
-    expect(pickStraightAxis(5, 30)).toBe('vertical');
+
+  it('picks 30°/150° for a drag along either diagonal hex-edge family', () => {
+    const [dx30, dy30] = vectorAtAngle(30);
+    expect(nearestWallAngleFamily(dx30, dy30)).toBe(30);
+    const [dx150, dy150] = vectorAtAngle(150);
+    expect(nearestWallAngleFamily(dx150, dy150)).toBe(150);
+  });
+
+  it('is direction-agnostic — the reverse of a family vector still matches the same family', () => {
+    const [dx, dy] = vectorAtAngle(30);
+    expect(nearestWallAngleFamily(-dx, -dy)).toBe(30);
+  });
+
+  it('snaps just inside the tolerance boundary', () => {
+    const [dx, dy] = vectorAtAngle(90 + WALL_ANGLE_SNAP_TOLERANCE_DEG - 0.1);
+    expect(nearestWallAngleFamily(dx, dy)).toBe(90);
+  });
+
+  it('does not snap just outside the tolerance boundary', () => {
+    const [dx, dy] = vectorAtAngle(90 + WALL_ANGLE_SNAP_TOLERANCE_DEG + 0.1);
+    expect(nearestWallAngleFamily(dx, dy)).toBeNull();
+  });
+
+  it('a horizontal drag — equidistant from 30° and 150°, both ~30° away — stays free', () => {
+    // This is the module's own former "horizontal" axis, no longer a
+    // default snap target (see this module's header comment for why 0°
+    // matches no real hex edge at all).
+    expect(nearestWallAngleFamily(50, 0)).toBeNull();
+  });
+
+  it('a zero-length vector has no defined angle and stays free', () => {
+    expect(nearestWallAngleFamily(0, 0)).toBeNull();
   });
 });
 
 describe('snapStraightEndpoint — corner-lattice axis lock', () => {
-  it('holds worldX steady in vertical mode, snapping to a real corner', () => {
+  it('holds worldX steady in vertical (90°) mode, snapping to a real corner', () => {
     const fromCorner: CornerRef = { cell: [4, 4], corner: 0 };
     const fromPoint = cornerPoint(fromCorner);
     // A pointer well above and just off to the side — vertical lock
@@ -221,18 +270,31 @@ describe('snapStraightEndpoint — corner-lattice axis lock', () => {
     // center module's coarser search, which could only match at
     // specific from/to cell pairs).
     const pointer = { x: fromPoint.x + 2, y: fromPoint.y - 80 };
-    const snapped = snapStraightEndpoint(fromCorner, pointer, 'vertical', GRID);
+    const snapped = snapStraightEndpoint(fromCorner, pointer, 90, GRID);
     expect(cornerPoint(snapped).x).toBeCloseTo(fromPoint.x, 6);
   });
 
   it('stays within the grid bounds', () => {
     const fromCorner: CornerRef = { cell: [0, 0], corner: 0 };
     const pointer = { x: -500, y: -500 };
-    const snapped = snapStraightEndpoint(fromCorner, pointer, 'vertical', GRID);
+    const snapped = snapStraightEndpoint(fromCorner, pointer, 90, GRID);
     expect(snapped.cell[0]).toBeGreaterThanOrEqual(0);
     expect(snapped.cell[1]).toBeGreaterThanOrEqual(0);
     expect(snapped.cell[0]).toBeLessThan(GRID.width);
     expect(snapped.cell[1]).toBeLessThan(GRID.height);
+  });
+
+  it('a null axis (the modifier-key free-angle bypass) is the literal nearest corner, unconstrained', () => {
+    const fromCorner: CornerRef = { cell: [4, 4], corner: 0 };
+    const fromPoint = cornerPoint(fromCorner);
+    // Well off any of the 3 families relative to fromPoint — a locked
+    // snap here would pull sideways toward the nearest family; axis=null
+    // (what CreationBoard.tsx passes while the free-angle modifier is
+    // held) must not do that.
+    const pointer = { x: fromPoint.x + 40, y: fromPoint.y - 5 };
+    expect(snapStraightEndpoint(fromCorner, pointer, null, GRID)).toEqual(
+      nearestCorner(pointer, GRID)
+    );
   });
 });
 

--- a/src/concepts/dungeon-builder/creation/straightWallGeometry.ts
+++ b/src/concepts/dungeon-builder/creation/straightWallGeometry.ts
@@ -465,51 +465,101 @@ export function isValidDoorCell(
   );
 }
 
-export type StraightAxis = 'vertical' | 'horizontal';
+/**
+ * The hex grid's own 3 real edge-line orientations (degrees from the
+ * horizontal board axis, mod 180 — a line's ORIENTATION has no direction,
+ * so 30° and 210° are the same family). Pointy-top hex corners at
+ * 30°+60°·i give edges at exactly these 3 angles (see this module's own
+ * header comment) — these are the "natural families" a straight wall
+ * snaps to by default (Kirk: "vertical... plus the hex edge families").
+ * Superseding this module's former unconditional 2-way vertical/
+ * horizontal lock (every drag forced onto one of only 2 axes, one of
+ * which — horizontal, 0° — matches no real hex edge at all and so always
+ * clipped through hex interiors by construction): the fix for Kirk's
+ * "my line was angled ever so slightly" is a tolerance-gated snap to a
+ * REAL edge family, not a wider forced choice.
+ */
+export const WALL_ANGLE_FAMILIES_DEG = [30, 90, 150] as const;
+export type WallAxisFamily = (typeof WALL_ANGLE_FAMILIES_DEG)[number];
 
 /**
- * Which screen axis a drag most likely intends — a 2-way analog of
- * `creationGeometry.ts`'s `dragFamily` (which picks among the hex grid's
- * 3 EDGE families for the zigzag Wall tool). A straight wall's two
- * "natural axes" are literal SCREEN/board-space axes, not hex edge
- * families — see this module's own header comment for why board-space
- * "horizontal" has no hex-edge analog at all (that absence is exactly
- * why a horizontal straight wall clips hexes instead of running along
- * their boundaries — it's the whole reason this tool exists). 60°/120°
- * diagonal snapping was considered and skipped this round: cheap to add
- * later (a 4-way `pickStraightAxis` instead of this 2-way one, using the
- * same score-based `snapStraightEndpoint` search below with 4 target
- * directions instead of 2) but not needed to prove the footprint
- * mechanic, which is this unit's actual point.
+ * How close (in degrees) a drag/endpoint-adjustment must be to one of
+ * `WALL_ANGLE_FAMILIES_DEG` before it snaps — Kirk's own suggested range
+ * ("~5-8°"), picked at the middle. Wide enough to correct a near-miss
+ * without a steady hand; narrow enough that a drag genuinely AIMED
+ * somewhere else (a deliberate free diagonal) isn't dragged onto a family
+ * it was never actually close to.
  */
-export function pickStraightAxis(dx: number, dy: number): StraightAxis {
-  return Math.abs(dx) >= Math.abs(dy) ? 'horizontal' : 'vertical';
+export const WALL_ANGLE_SNAP_TOLERANCE_DEG = 6;
+
+function normalizeAngleDeg(deg: number): number {
+  const mod = deg % 180;
+  return mod < 0 ? mod + 180 : mod;
+}
+
+/** Circular distance between two line ORIENTATIONS (mod 180). */
+function angleFamilyDistance(a: number, b: number): number {
+  const diff = Math.abs(normalizeAngleDeg(a) - normalizeAngleDeg(b));
+  return Math.min(diff, 180 - diff);
 }
 
 /**
- * The best "to" CORNER for continuing a straight wall from `fromCorner`
- * toward `pointer`, locked to `axis`. This is a DISCRETE hex grid, so an
- * exactly vertical or horizontal line generally isn't reachable between
- * two lattice corners at all (see this module's own header comment: no
- * edge family is horizontal, and "vertical" only lines up exactly for
- * specific from/to combinations) — this searches a small window of cells
- * around the pointer's own nearest corner (checking all 6 of each
- * candidate cell's own corners, not just cell centers, now that the
- * anchor lattice is corners) and picks whichever candidate corner keeps
- * the OTHER world-space coordinate closest to `fromCorner`'s own
- * (vertical mode holds worldX as steady as the lattice allows; horizontal
- * mode holds worldY steady), tie-broken toward whichever candidate is
- * nearest the pointer itself. The result is the closest AVAILABLE
- * approximation, not a mathematically exact one — `straightWallFootprint`
- * above computes the footprint from whatever line actually results,
- * honestly, rather than pretending the snap was exact.
+ * Which of the 3 real hex-edge angle families (if any) a drag vector is
+ * close enough to snap to. Returns `null` when the raw direction isn't
+ * within `toleranceDeg` of any family — the caller then falls back to an
+ * unconstrained nearest-corner snap (a deliberate free angle), never
+ * forcing a family the drag wasn't actually close to. A zero-length
+ * vector has no defined angle and also returns `null`.
+ */
+export function nearestWallAngleFamily(
+  dx: number,
+  dy: number,
+  toleranceDeg: number = WALL_ANGLE_SNAP_TOLERANCE_DEG
+): WallAxisFamily | null {
+  if (dx === 0 && dy === 0) return null;
+  const angle = normalizeAngleDeg((Math.atan2(dy, dx) * 180) / Math.PI);
+  let best: WallAxisFamily = WALL_ANGLE_FAMILIES_DEG[0];
+  let bestDist = Infinity;
+  for (const family of WALL_ANGLE_FAMILIES_DEG) {
+    const dist = angleFamilyDistance(angle, family);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = family;
+    }
+  }
+  return bestDist <= toleranceDeg ? best : null;
+}
+
+/**
+ * The best "to" CORNER for continuing/fine-tuning a straight wall from
+ * `fromCorner` toward `pointer`. `axis`, when non-`null`, locks the
+ * result to whichever of `WALL_ANGLE_FAMILIES_DEG` the caller already
+ * decided (via `nearestWallAngleFamily`) — `null` means a free angle (the
+ * modifier-key bypass, or a drag too far from every family to snap),
+ * which falls straight through to `nearestCorner`'s plain nearest-point
+ * search with no direction constraint at all.
+ *
+ * This is a DISCRETE hex grid, so an exactly-`axis`-degree line generally
+ * isn't reachable between two lattice corners at all (see this module's
+ * own header comment: no edge family is horizontal, and even a real
+ * family only lines up exactly for specific from/to combinations) — the
+ * locked-axis branch searches a small window of cells around the
+ * pointer's own nearest corner (checking all 6 of each candidate cell's
+ * own corners, not just cell centers) and picks whichever candidate
+ * corner's direction from `fromCorner` deviates LEAST from `axis`,
+ * tie-broken toward whichever candidate is nearest the pointer itself.
+ * The result is the closest AVAILABLE approximation, not a
+ * mathematically exact one — `straightWallFootprint` above computes the
+ * footprint from whatever line actually results, honestly, rather than
+ * pretending the snap was exact.
  */
 export function snapStraightEndpoint(
   fromCorner: CornerRef,
   pointer: CellPos,
-  axis: StraightAxis,
+  axis: WallAxisFamily | null,
   grid: CreationGrid
 ): CornerRef {
+  if (axis === null) return nearestCorner(pointer, grid);
   const fromPoint = cornerPoint(fromCorner);
   const near = nearestCorner(pointer, grid);
   const [pCol, pRow] = near.cell;
@@ -524,10 +574,12 @@ export function snapStraightEndpoint(
       const corners = cellCorners(cellCenter(col, row), BOARD_HEX_SIZE);
       for (let corner = 0; corner < 6; corner++) {
         const point = { x: corners[corner][0], y: corners[corner][1] };
-        const alignDelta =
-          axis === 'vertical'
-            ? Math.abs(point.x - fromPoint.x)
-            : Math.abs(point.y - fromPoint.y);
+        if (point.x === fromPoint.x && point.y === fromPoint.y) continue;
+        const candAngle = normalizeAngleDeg(
+          (Math.atan2(point.y - fromPoint.y, point.x - fromPoint.x) * 180) /
+            Math.PI
+        );
+        const alignDelta = angleFamilyDistance(candAngle, axis);
         const nearPointer = Math.hypot(
           point.x - pointer.x,
           point.y - pointer.y

--- a/src/concepts/dungeon-builder/creation/straightWallGeometry.ts
+++ b/src/concepts/dungeon-builder/creation/straightWallGeometry.ts
@@ -1,11 +1,13 @@
 /**
  * straightWallGeometry — footprint + crossing math for STRAIGHT wall
  * segments (rpg-project#169 dungeon-builder initiative, "straight walls
- * with visible footprint" unit). Kept separate from `creationGeometry.ts`
- * because it answers a genuinely different question: not "which hex EDGE
- * is nearest a point" (the zigzag edge-wall tool's job) but "which hex
- * CELLS does an arbitrary straight WORLD-SPACE line clip through, and
- * which cell-to-cell EDGES does it cross without clipping either side."
+ * with visible footprint" unit; corner-anchored since the follow-up
+ * "corner-anchored straight walls + line doors" unit). Kept separate from
+ * `creationGeometry.ts` because it answers a genuinely different
+ * question: not "which hex EDGE is nearest a point" (the zigzag edge-wall
+ * tool's job) but "which hex CELLS does an arbitrary straight WORLD-SPACE
+ * line clip through, and which cell-to-cell EDGES does it cross without
+ * clipping either side."
  *
  * Kirk's rule, verbatim (CONTRACT.md's "Hex-true creation canvas"
  * section — this module exists to implement it precisely): "any hex that
@@ -35,6 +37,19 @@
  * CENTERS instead clips every hex in that column full-width (the
  * "shoulder-clipping" case), because a hex's own two vertical edges sit
  * at ±(half the flat-to-flat width) from its center, not AT the center.
+ *
+ * **Corner anchoring (this unit).** `from`/`to` are now `CornerRef`s
+ * (`hexCorner.ts`) — hex CORNERS, not cell centers. Kirk's live
+ * feedback: "it always hangs over a little" — a cell-center-anchored
+ * wall overshoots its intended extent by up to half a hex at each end,
+ * by construction, and there was no finer lattice to fine-tune into. All
+ * of this module's actual clipping math (`hexHalfPlanes`,
+ * `clipSegmentToShrunkHex`, `isCellClipped`, `candidateCells`) already
+ * operated on raw world-space `CellPos` points and needed ZERO changes —
+ * only the higher-level functions that used to resolve `from`/`to` via
+ * `cellCenter` now resolve them via `cornerPoint` instead. See
+ * `hexCorner.ts`'s own header comment for the corner-lattice addressing
+ * and dedup rule this implies.
  */
 import { neighborCell } from '../boardGeometry';
 import {
@@ -46,12 +61,14 @@ import {
   worldToCube,
   type CellPos,
 } from '../hexLayout';
-import {
-  canonicalHexEdge,
-  nearestCreationCell,
-  type EdgeGeometry,
-} from './creationGeometry';
+import { canonicalHexEdge, type EdgeGeometry } from './creationGeometry';
 import type { CreationGrid } from './creationTypes';
+import {
+  canonicalCorner,
+  cornerPoint,
+  nearestCorner,
+  type CornerRef,
+} from './hexCorner';
 
 /**
  * How far (in board units) a half-plane is shrunk inward before testing
@@ -221,23 +238,33 @@ function inBoundsGrid(col: number, row: number, grid: CreationGrid): boolean {
 }
 
 /**
- * Every hex cell a straight wall from endpoint cell `from` to endpoint
- * cell `to` genuinely clips — the wall's own footprint, in Kirk's sense:
- * "any hex that is not 100% uncovered would not be traversable." The
- * line is the straight WORLD-SPACE segment between the two endpoint
- * cells' centers (`cellCenter`), not a chain of hex edges — see this
- * module's own header comment for why that line generally does NOT
- * follow hex boundaries.
+ * Every hex cell a straight wall from corner `from` to corner `to`
+ * genuinely clips — the wall's own footprint, in Kirk's sense: "any hex
+ * that is not 100% uncovered would not be traversable." The line is the
+ * straight WORLD-SPACE segment between the two endpoint CORNERS
+ * (`cornerPoint`), not a chain of hex edges and not a cell-center-to-
+ * cell-center segment either (see this module's own header comment for
+ * the corner-anchoring change, and its top-of-file comment for why the
+ * line generally does NOT follow hex boundaries regardless).
+ *
+ * `doorCells` (a wallLine's own `doors: [{cell}]` entries — see
+ * `dungeonYaml.ts`'s `WallLineDoc`) are excluded from the result: a door
+ * punches its cell out of THIS wall's footprint entirely, as if the line
+ * never clipped it — see TARGET-YAML.md's "Straight walls: doors" section
+ * for the exact traversability semantic this gives a compiler.
  */
 export function straightWallFootprint(
-  from: [number, number],
-  to: [number, number],
-  grid: CreationGrid
+  from: CornerRef,
+  to: CornerRef,
+  grid: CreationGrid,
+  doorCells: readonly [number, number][] = []
 ): [number, number][] {
-  const a = cellCenter(from[0], from[1]);
-  const b = cellCenter(to[0], to[1]);
+  const a = cornerPoint(from);
+  const b = cornerPoint(to);
+  const doorSet = new Set(doorCells.map(([c, r]) => `${c},${r}`));
   const result: [number, number][] = [];
   for (const [col, row] of candidateCells(a, b, grid)) {
+    if (doorSet.has(`${col},${row}`)) continue;
     if (isCellClipped(a, b, col, row)) result.push([col, row]);
   }
   return result;
@@ -285,16 +312,27 @@ function segmentsIntersect(
  * blocked is deliberately omitted — it's already subsumed by that cell
  * being wholly impassable, so surfacing it separately would just be
  * noise on top of a fact the footprint already covers.
+ *
+ * `doorCells`, when `footprint` isn't already resolved by the caller, is
+ * forwarded to `straightWallFootprint` so a door cell is treated as
+ * "clear" here too — its own boundary crossings then fall out of the
+ * SAME (b) mechanism as any other clear cell, no separate door-crossing
+ * logic needed. If the caller already resolved `footprint` itself
+ * (e.g. `CreationBoard.tsx`'s render pass, which computes the footprint
+ * once and reuses it for both the hatch overlay and this call),
+ * `doorCells` is unused — pass a footprint that's already door-excluded.
  */
 export function straightWallCrossedEdges(
-  from: [number, number],
-  to: [number, number],
+  from: CornerRef,
+  to: CornerRef,
   grid: CreationGrid,
-  footprint?: readonly [number, number][]
+  footprint?: readonly [number, number][],
+  doorCells: readonly [number, number][] = []
 ): EdgeGeometry[] {
-  const a = cellCenter(from[0], from[1]);
-  const b = cellCenter(to[0], to[1]);
-  const resolvedFootprint = footprint ?? straightWallFootprint(from, to, grid);
+  const a = cornerPoint(from);
+  const b = cornerPoint(to);
+  const resolvedFootprint =
+    footprint ?? straightWallFootprint(from, to, grid, doorCells);
   const footprintSet = new Set(resolvedFootprint.map(([c, r]) => `${c},${r}`));
   const candidates = candidateCells(a, b, grid);
   const seen = new Set<string>();
@@ -315,17 +353,28 @@ export function straightWallCrossedEdges(
   return crossed;
 }
 
-/** The union of every drawn straight wall's own footprint, as a
- * `"col,row"`-keyed Set — what `CreationBoard.tsx` checks placements/
- * start/end/region cells against to flag (never silently delete/move)
- * anything a newly-drawn footprint now covers. */
+/** The union of every drawn straight wall's own footprint (door cells
+ * already excluded, per-line), as a `"col,row"`-keyed Set — what
+ * `CreationBoard.tsx` checks placements/start/end/region cells against to
+ * flag (never silently delete/move) anything a newly-drawn footprint now
+ * covers. */
 export function straightWallsFootprintSet(
-  lines: readonly { from: [number, number]; to: [number, number] }[],
+  lines: readonly {
+    from: CornerRef;
+    to: CornerRef;
+    doors?: readonly { cell: [number, number] }[];
+  }[],
   grid: CreationGrid
 ): Set<string> {
   const set = new Set<string>();
   for (const line of lines) {
-    for (const [c, r] of straightWallFootprint(line.from, line.to, grid)) {
+    const doorCells = (line.doors ?? []).map((d) => d.cell);
+    for (const [c, r] of straightWallFootprint(
+      line.from,
+      line.to,
+      grid,
+      doorCells
+    )) {
       set.add(`${c},${r}`);
     }
   }
@@ -334,6 +383,86 @@ export function straightWallsFootprintSet(
 
 export function cellKey(col: number, row: number): string {
   return `${col},${row}`;
+}
+
+/** Standard point-onto-segment projection, clamped to `[0,1]` — the
+ * straight-wall Door tool's own "where along this line did the author
+ * click" step, shared with `pointToSegmentDistSq`'s distance math in
+ * `creationGeometry.ts` (same clamp shape) but returning the parameter
+ * itself rather than a distance. */
+export function projectPointToLineParam(
+  a: CellPos,
+  b: CellPos,
+  p: CellPos
+): number {
+  const abx = b.x - a.x;
+  const aby = b.y - a.y;
+  const len2 = abx * abx + aby * aby;
+  if (len2 === 0) return 0;
+  const t = ((p.x - a.x) * abx + (p.y - a.y) * aby) / len2;
+  return Math.max(0, Math.min(1, t));
+}
+
+/**
+ * Which footprint cell (if any) a parametric position `t` along the
+ * wall's own `from`->`to` line falls inside — the exact mapping a real
+ * server compiler owns for a `doors: [{cell}]` entry's placement: walk
+ * every candidate cell's own clip interval (`clipSegmentToShrunkHex`,
+ * the SAME primitive `straightWallFootprint` uses) and return the one
+ * whose `[t0,t1]` contains `t`. `null` when `t` falls in an un-clipped
+ * (touch-only) stretch of the line, or outside every candidate — the
+ * caller (the Door tool's click handler) treats that as "no door placed,
+ * nothing there to carve an opening into."
+ */
+export function footprintCellAtParam(
+  from: CornerRef,
+  to: CornerRef,
+  grid: CreationGrid,
+  t: number
+): [number, number] | null {
+  const a = cornerPoint(from);
+  const b = cornerPoint(to);
+  for (const [col, row] of candidateCells(a, b, grid)) {
+    const interval = clipSegmentToShrunkHex(a, b, col, row);
+    if (interval && t >= interval[0] - 1e-9 && t <= interval[1] + 1e-9) {
+      return [col, row];
+    }
+  }
+  return null;
+}
+
+/** The straight-wall Door tool's own hit-resolution: a click at board
+ * point `point` on wallLine `from`->`to` resolves to the ONE footprint
+ * cell it landed on (projected onto the line, then mapped through
+ * `footprintCellAtParam`), or `null` if the click didn't land on any real
+ * footprint cell (an un-covered "touch" stretch of the line, or a miss).
+ */
+export function wallLineDoorCellAt(
+  from: CornerRef,
+  to: CornerRef,
+  grid: CreationGrid,
+  point: CellPos
+): [number, number] | null {
+  const a = cornerPoint(from);
+  const b = cornerPoint(to);
+  const t = projectPointToLineParam(a, b, point);
+  return footprintCellAtParam(from, to, grid, t);
+}
+
+/** Whether `cell` is one of this wall line's own RAW (door-blind)
+ * footprint cells — what a door entry must reference to mean anything.
+ * `CreationBoard.tsx` uses this to flag (not silently drop, per this
+ * file's own discipline) a door left stranded by an endpoint drag that
+ * shrank the footprint out from under it. */
+export function isValidDoorCell(
+  from: CornerRef,
+  to: CornerRef,
+  grid: CreationGrid,
+  cell: [number, number]
+): boolean {
+  return straightWallFootprint(from, to, grid).some(
+    ([c, r]) => c === cell[0] && r === cell[1]
+  );
 }
 
 export type StraightAxis = 'vertical' | 'horizontal';
@@ -358,54 +487,61 @@ export function pickStraightAxis(dx: number, dy: number): StraightAxis {
 }
 
 /**
- * The best "to" cell for continuing a straight wall from `fromCell`
+ * The best "to" CORNER for continuing a straight wall from `fromCorner`
  * toward `pointer`, locked to `axis`. This is a DISCRETE hex grid, so an
  * exactly vertical or horizontal line generally isn't reachable between
- * two integer cell centers at all (see this module's own header comment:
- * no edge family is horizontal, and "vertical" only lines up exactly for
- * specific from/to combinations) — this searches a small window of
- * columns/rows around the pointer's own nearest cell and picks whichever
- * candidate keeps the OTHER world-space coordinate closest to
- * `fromCell`'s own (vertical mode holds worldX as steady as the grid
- * allows; horizontal mode holds worldY steady), tie-broken toward
- * whichever candidate is nearest the pointer along the free axis. The
- * result is the closest AVAILABLE approximation, not a mathematically
- * exact one — `straightWallFootprint` above computes the footprint from
- * whatever line actually results, honestly, rather than pretending the
- * snap was exact.
+ * two lattice corners at all (see this module's own header comment: no
+ * edge family is horizontal, and "vertical" only lines up exactly for
+ * specific from/to combinations) — this searches a small window of cells
+ * around the pointer's own nearest corner (checking all 6 of each
+ * candidate cell's own corners, not just cell centers, now that the
+ * anchor lattice is corners) and picks whichever candidate corner keeps
+ * the OTHER world-space coordinate closest to `fromCorner`'s own
+ * (vertical mode holds worldX as steady as the lattice allows; horizontal
+ * mode holds worldY steady), tie-broken toward whichever candidate is
+ * nearest the pointer itself. The result is the closest AVAILABLE
+ * approximation, not a mathematically exact one — `straightWallFootprint`
+ * above computes the footprint from whatever line actually results,
+ * honestly, rather than pretending the snap was exact.
  */
 export function snapStraightEndpoint(
-  fromCell: [number, number],
+  fromCorner: CornerRef,
   pointer: CellPos,
   axis: StraightAxis,
   grid: CreationGrid
-): [number, number] {
-  const fromCenter = cellCenter(fromCell[0], fromCell[1]);
-  const [pCol, pRow] = nearestCreationCell(pointer, grid);
+): CornerRef {
+  const fromPoint = cornerPoint(fromCorner);
+  const near = nearestCorner(pointer, grid);
+  const [pCol, pRow] = near.cell;
   const WINDOW = 3;
-  let best: [number, number] = [pCol, pRow];
+  let best: CornerRef = near;
   let bestScore = Infinity;
   for (let dCol = -WINDOW; dCol <= WINDOW; dCol++) {
     for (let dRow = -WINDOW; dRow <= WINDOW; dRow++) {
       const col = pCol + dCol;
       const row = pRow + dRow;
       if (!inBoundsGrid(col, row, grid)) continue;
-      const center = cellCenter(col, row);
-      const alignDelta =
-        axis === 'vertical'
-          ? Math.abs(center.x - fromCenter.x)
-          : Math.abs(center.y - fromCenter.y);
-      const nearPointer =
-        axis === 'vertical' ? Math.abs(row - pRow) : Math.abs(col - pCol);
-      // Alignment to the locked axis dominates; nearness to the pointer
-      // along the free axis is only a tiebreak among near-equally-aligned
-      // candidates.
-      const score = alignDelta * 1000 + nearPointer;
-      if (score < bestScore) {
-        bestScore = score;
-        best = [col, row];
+      const corners = cellCorners(cellCenter(col, row), BOARD_HEX_SIZE);
+      for (let corner = 0; corner < 6; corner++) {
+        const point = { x: corners[corner][0], y: corners[corner][1] };
+        const alignDelta =
+          axis === 'vertical'
+            ? Math.abs(point.x - fromPoint.x)
+            : Math.abs(point.y - fromPoint.y);
+        const nearPointer = Math.hypot(
+          point.x - pointer.x,
+          point.y - pointer.y
+        );
+        // Alignment to the locked axis dominates; nearness to the
+        // pointer is only a tiebreak among near-equally-aligned
+        // candidates.
+        const score = alignDelta * 1000 + nearPointer;
+        if (score < bestScore) {
+          bestScore = score;
+          best = { cell: [col, row], corner };
+        }
       }
     }
   }
-  return best;
+  return canonicalCorner(best);
 }

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { canonicalCorner } from './creation/hexCorner';
 import {
   addCellToRegion,
   addWallLine,
@@ -36,13 +37,14 @@ import {
   setRegionArchetype,
   setStart,
   setWallEdge,
+  setWallLineEndpoint,
   stripMonsterPlacements,
   stripToV1Subset,
   toDungeonDoc,
   toggleHole,
   toggleWall,
   toggleWallKind,
-  toggleWallLineKindAt,
+  toggleWallLineDoorAt,
   validateRegionCells,
   wallKindAtEdge,
 } from './dungeonYaml';
@@ -440,19 +442,31 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
     ]);
   });
 
-  describe('wallLines: straight walls (rpg-project#169, "straight walls with visible footprint" unit)', () => {
-    it('addWallLine appends a solid entry; removeWallLineAt removes it by index', () => {
+  describe('wallLines: corner-anchored straight walls (rpg-project#169, follow-up "corner-anchored straight walls + line doors" unit)', () => {
+    // Canonicalized up front: addWallLine/setWallLineEndpoint both
+    // canonicalize on write (see their own doc comments), so a fixture
+    // built from a NON-canonical corner ref would round-trip to a
+    // different (but physically identical) representation than it was
+    // authored with — see this describe block's own dedicated
+    // "canonicalizing a non-canonical input" tests for that behavior
+    // demonstrated directly.
+    const A = canonicalCorner({ cell: [4, 4], corner: 0 });
+    const B = canonicalCorner({ cell: [6, 1], corner: 3 });
+
+    it('addWallLine appends a corner-anchored, door-free entry; removeWallLineAt removes it by index', () => {
       const { cst } = parseDungeon(SHOWCASE_YAML);
-      addWallLine(cst, [4, 4], [6, 1]);
+      addWallLine(cst, A, B);
       let doc = toDungeonDoc(cst);
-      expect(doc.wallLines).toEqual([
-        { from: [4, 4], to: [6, 1], kind: 'solid' },
-      ]);
+      expect(doc.wallLines).toEqual([{ from: A, to: B, doors: [] }]);
       // Padded flow sequences again — this file's own known residual
       // round-trip gap (see its top-of-file doc comment), same as the
-      // `walls:` toggleWall test above.
+      // `walls:` toggleWall test above. `B` canonicalizes to a DIFFERENT
+      // owner cell than the [6,1] it was defined from (see this describe
+      // block's own note on `A`/`B` above) — the serialized text reflects
+      // that canonical form, not the literal cell the test constant was
+      // written against.
       expect(serializeDungeon(cst)).toContain(
-        'wallLines:\n  - { from: [ 4, 4 ], to: [ 6, 1 ], kind: solid }'
+        `wallLines:\n  - { from: { cell: [ ${A.cell[0]}, ${A.cell[1]} ], corner: ${A.corner} }, to: { cell: [ ${B.cell[0]}, ${B.cell[1]} ], corner: ${B.corner} } }`
       );
 
       removeWallLineAt(cst, 0);
@@ -460,52 +474,167 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
       expect(doc.wallLines).toEqual([]);
     });
 
-    it('addWallLine accepts an explicit door kind directly', () => {
-      const { cst } = parseDungeon(SHOWCASE_YAML);
-      addWallLine(cst, [0, 3], [10, 8], 'door');
-      expect(toDungeonDoc(cst).wallLines).toEqual([
-        { from: [0, 3], to: [10, 8], kind: 'door' },
-      ]);
-    });
-
-    it('toggleWallLineKindAt flips solid<->door by index, no-ops on an out-of-range index', () => {
-      const { cst } = parseDungeon(SHOWCASE_YAML);
-      addWallLine(cst, [4, 4], [6, 1]);
-      toggleWallLineKindAt(cst, 0);
-      expect(toDungeonDoc(cst).wallLines[0].kind).toBe('door');
-      toggleWallLineKindAt(cst, 0);
-      expect(toDungeonDoc(cst).wallLines[0].kind).toBe('solid');
-
-      // Out-of-range index is a no-op, not a throw — see the function's
-      // own doc comment (a stale index is a UI race, not a program error).
-      expect(() => toggleWallLineKindAt(cst, 5)).not.toThrow();
-      expect(toDungeonDoc(cst).wallLines).toHaveLength(1);
-    });
-
     it('removeWallLineAt is a no-op on an out-of-range index', () => {
       const { cst } = parseDungeon(SHOWCASE_YAML);
-      addWallLine(cst, [4, 4], [6, 1]);
+      addWallLine(cst, A, B);
       expect(() => removeWallLineAt(cst, 5)).not.toThrow();
       expect(() => removeWallLineAt(cst, -1)).not.toThrow();
       expect(toDungeonDoc(cst).wallLines).toHaveLength(1);
     });
 
-    it('multiple straight walls keep independent from/to/kind, round-tripped through YAML text', () => {
+    it('setWallLineEndpoint overwrites one end in place, canonicalizing the new corner', () => {
       const { cst } = parseDungeon(SHOWCASE_YAML);
-      addWallLine(cst, [4, 4], [6, 1], 'solid');
-      addWallLine(cst, [0, 3], [10, 8], 'door');
+      addWallLine(cst, A, B);
+      // (5,5)#1 is NOT its own canonical form (canonicalizes to (5,4)#5 —
+      // see hexCorner.test.ts) — setWallLineEndpoint must store the
+      // canonical form regardless of what the caller passed in.
+      setWallLineEndpoint(cst, 0, 'to', { cell: [5, 5], corner: 1 });
+      expect(toDungeonDoc(cst).wallLines[0]).toEqual({
+        from: A,
+        to: { cell: [5, 4], corner: 5 },
+        doors: [],
+      });
+      // The other end is untouched by an endpoint-drag commit.
+      expect(toDungeonDoc(cst).wallLines[0].from).toEqual(A);
+    });
+
+    it('setWallLineEndpoint is a no-op on an out-of-range index', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, A, B);
+      expect(() =>
+        setWallLineEndpoint(cst, 5, 'to', { cell: [0, 0], corner: 0 })
+      ).not.toThrow();
+      expect(toDungeonDoc(cst).wallLines[0]).toEqual({
+        from: A,
+        to: B,
+        doors: [],
+      });
+    });
+
+    it('toggleWallLineDoorAt adds a door at a cell, then removes it on a second call', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, A, B);
+      toggleWallLineDoorAt(cst, 0, [5, 2]);
+      expect(toDungeonDoc(cst).wallLines[0].doors).toEqual([{ cell: [5, 2] }]);
+
+      toggleWallLineDoorAt(cst, 0, [5, 2]);
+      expect(toDungeonDoc(cst).wallLines[0].doors).toEqual([]);
+      // An emptied doors: list is deleted, not left as doors: [] — see
+      // the function's own doc comment.
+      expect(serializeDungeon(cst)).not.toContain('doors:');
+    });
+
+    it('toggleWallLineDoorAt supports more than one door on the same line', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, A, B);
+      toggleWallLineDoorAt(cst, 0, [5, 2]);
+      toggleWallLineDoorAt(cst, 0, [4, 4]);
+      expect(toDungeonDoc(cst).wallLines[0].doors).toEqual(
+        expect.arrayContaining([{ cell: [5, 2] }, { cell: [4, 4] }])
+      );
+      expect(toDungeonDoc(cst).wallLines[0].doors).toHaveLength(2);
+    });
+
+    it('toggleWallLineDoorAt is a no-op on an out-of-range line index', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, A, B);
+      expect(() => toggleWallLineDoorAt(cst, 5, [5, 2])).not.toThrow();
+      expect(toDungeonDoc(cst).wallLines[0].doors).toEqual([]);
+    });
+
+    it('multiple straight walls keep independent from/to/doors, round-tripped through YAML text', () => {
+      // Canonicalized up front — see this describe block's own note on
+      // the `A`/`B` constants above for why a non-canonical literal
+      // wouldn't round-trip to itself.
+      const C = canonicalCorner({ cell: [0, 3], corner: 0 });
+      const D = canonicalCorner({ cell: [10, 8], corner: 3 });
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, A, B);
+      addWallLine(cst, C, D);
+      toggleWallLineDoorAt(cst, 1, [5, 5]);
       const reparsed = parseDungeon(serializeDungeon(cst));
       expect(reparsed.doc.wallLines).toEqual([
-        { from: [4, 4], to: [6, 1], kind: 'solid' },
-        { from: [0, 3], to: [10, 8], kind: 'door' },
+        { from: A, to: B, doors: [] },
+        { from: C, to: D, doors: [{ cell: [5, 5] }] },
       ]);
+    });
+
+    describe('migrating a PRE-corner-anchoring document (legacy [col,row] endpoints)', () => {
+      it('self-heals a bare-cell wallLines entry into a corner-anchored one on parse', () => {
+        const { doc } = parseDungeon(
+          `${SHOWCASE_YAML}\nwallLines:\n  - { from: [4, 4], to: [6, 1], kind: solid }\n`
+        );
+        expect(doc.wallLines).toHaveLength(1);
+        const line = doc.wallLines[0];
+        // Migrated endpoints resolve to one of (4,4)'s / (6,1)'s own real
+        // corners — not the cell centers the legacy shape used.
+        expect(line.from.cell).toEqual(
+          expect.arrayContaining([expect.any(Number), expect.any(Number)])
+        );
+        expect(typeof line.from.corner).toBe('number');
+        expect(typeof line.to.corner).toBe('number');
+        expect(line.doors).toEqual([]);
+      });
+
+      it('a legacy whole-line kind: door materializes into a single midpoint door', () => {
+        const { doc } = parseDungeon(
+          `${SHOWCASE_YAML}\nwallLines:\n  - { from: [2, 5], to: [10, 5], kind: door }\n`
+        );
+        expect(doc.wallLines).toHaveLength(1);
+        expect(doc.wallLines[0].doors).toHaveLength(1);
+      });
+
+      it('a bare re-serialize (no edits) keeps the migrated line’s ORIGINAL legacy text untouched', () => {
+        // Migration heals the in-memory `doc`, not the CST by itself —
+        // per this file's own CST-preservation discipline, content
+        // nothing has explicitly mutated is never silently rewritten.
+        // See parseWallLineEndpoint's own doc comment.
+        const { cst } = parseDungeon(
+          `${SHOWCASE_YAML}\nwallLines:\n  - { from: [4, 4], to: [6, 1], kind: solid }\n`
+        );
+        const text = serializeDungeon(cst);
+        expect(text).toContain(
+          'wallLines:\n  - { from: [ 4, 4 ], to: [ 6, 1 ], kind: solid }'
+        );
+      });
+
+      it('a mutator touching just ONE endpoint of a migrated line converges BOTH endpoints and drops kind:', () => {
+        // The interesting case: setWallLineEndpoint only asks to change
+        // 'from', but normalizeWallLineItem (called first, inside every
+        // mutator that touches an existing entry) migrates the WHOLE
+        // entry — 'to' converges too, and the now-meaningless legacy
+        // `kind:` key is dropped — rather than leaving a half-migrated
+        // entry (one corner-anchored endpoint, one still bare-[c,r], a
+        // dangling kind: key nothing reads anymore).
+        const { cst, doc } = parseDungeon(
+          `${SHOWCASE_YAML}\nwallLines:\n  - { from: [4, 4], to: [6, 1], kind: solid }\n`
+        );
+        // Commits the SAME endpoint an endpoint-drag would (using the
+        // already-migrated doc's own corner as the "new" value), to
+        // isolate this test to the shape-rewrite behavior rather than an
+        // actual position change.
+        setWallLineEndpoint(cst, 0, 'from', doc.wallLines[0].from);
+        const text = serializeDungeon(cst);
+        expect(text).toContain('cell: [');
+        expect(text).not.toContain('kind: solid');
+        expect(text).not.toMatch(/to: \[ 6, 1 \]/);
+        // The re-parsed doc's 'to' end still addresses the identical
+        // real-world corner it did before — only its representation
+        // shape changed (bare `[6,1]` -> `{cell,corner}`), not the
+        // geometry itself.
+        expect(toDungeonDoc(cst).wallLines[0].to).toEqual(doc.wallLines[0].to);
+      });
     });
 
     it('stripToV1Subset drops wallLines: entirely, reported separately from walls:', () => {
       const { cst } = parseDungeon(SHOWCASE_YAML);
       toggleWall(cst, 7, 0); // one edge wall
-      addWallLine(cst, [4, 4], [6, 1]); // one straight wall
-      addWallLine(cst, [0, 3], [10, 8], 'door'); // a second straight wall
+      addWallLine(cst, A, B); // one straight wall
+      addWallLine(
+        cst,
+        { cell: [0, 3], corner: 0 },
+        { cell: [10, 8], corner: 3 }
+      ); // a second straight wall
 
       const result = stripToV1Subset(serializeDungeon(cst));
       expect(result.dropped).toEqual(
@@ -523,7 +652,7 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
       // nothing else should produce exactly this one dropped entry — no
       // separate "N walls" (edge-wall) entry alongside it.
       const { cst } = parseDungeon(SHOWCASE_YAML);
-      addWallLine(cst, [4, 4], [6, 1]);
+      addWallLine(cst, A, B);
       const result = stripToV1Subset(serializeDungeon(cst));
       expect(result.dropped).toEqual(['1 straight wall']);
     });

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -37,6 +37,19 @@ import {
   YAMLSeq,
 } from 'yaml';
 import {
+  canonicalCorner,
+  cornerPoint,
+  migrateLegacyCenterEndpoint,
+  type CornerRef,
+} from './creation/hexCorner';
+import {
+  cellCenter,
+  hexColumn,
+  hexRow,
+  worldToCube,
+  type CellPos,
+} from './hexLayout';
+import {
   cellsAreContiguous,
   cellsEqual,
   pickAttachmentEdge,
@@ -56,6 +69,118 @@ function facingLabel(facing: number): string {
 
 function parseMount(raw: unknown): Mount {
   return raw === 'wall' ? 'wall' : 'floor';
+}
+
+/** Resolves a `wallLines[].from`/`.to` raw value (either shape) to a
+ * board-space point, purely to give a legacy endpoint's migration a
+ * direction to point toward — see `parseWallLineEndpoint` below. */
+function resolveWallLineEndpointHintPoint(raw: unknown): CellPos {
+  if (Array.isArray(raw)) {
+    return cellCenter(raw[0] as number, raw[1] as number);
+  }
+  const obj = raw as Record<string, unknown>;
+  const cell = obj.cell as [number, number];
+  const corner = typeof obj.corner === 'number' ? obj.corner : 0;
+  return cornerPoint({ cell, corner });
+}
+
+/**
+ * Parses one `wallLines[].from`/`.to` endpoint. Accepts either shape:
+ *
+ * - **Current, corner-anchored**: `{ cell: [c, r], corner: 0..5 }` —
+ *   canonicalized on parse (`canonicalCorner`) so the same physical
+ *   corner always round-trips identically regardless of which of its
+ *   (up to 3) equally-valid owner cells the document happens to use.
+ * - **Legacy, PRE-corner-anchoring**: a bare `[c, r]` cell — the
+ *   original rpg-project#169 "straight walls with visible footprint"
+ *   unit's own shape, before Kirk's "it always hangs over a little"
+ *   feedback drove the corner-anchoring follow-up. Self-heals at the
+ *   `DungeonDoc` level: `migrateLegacyCenterEndpoint` picks whichever of
+ *   the cell's own 6 corners sits nearest the OTHER endpoint's resolved
+ *   position, so the migrated line keeps pointing the same direction it
+ *   always drew rather than snapping to an arbitrary corner — every
+ *   consumer of the PARSED doc (footprint/crossing math, rendering)
+ *   only ever sees the corner-anchored shape, immediately, regardless of
+ *   which shape the source YAML used.
+ *
+ *   **This heals the in-memory `doc`, not the underlying CST/YAML text
+ *   by itself.** Consistent with this file's own CST-preservation
+ *   discipline (content nothing has explicitly mutated is never silently
+ *   rewritten — see this file's top-of-file doc comment on comment
+ *   preservation), a legacy entry's CST node keeps its original bare-
+ *   `[c,r]` text until some MUTATOR actually touches that entry
+ *   (`setWallLineEndpoint`, `toggleWallLineDoorAt`) — at which point the
+ *   CST is rewritten to the corner-anchored shape as a side effect of
+ *   that write, same as any other mutator's own node replacement. A
+ *   migrated document that's loaded and re-saved with zero edits to its
+ *   `wallLines:` keeps its original (still valid, still correctly
+ *   interpreted) legacy text; one the author actually drags an endpoint
+ *   or adds a door on converges to the new shape. See TARGET-YAML.md's
+ *   "Straight walls: corner anchoring" section for the full writeup —
+ *   given how little `wallLines:` content existed anywhere at the time
+ *   of this change, this migration was judged cheaper and more honest
+ *   than carrying two live representations through every downstream
+ *   consumer indefinitely.
+ */
+function parseWallLineEndpoint(raw: unknown, otherRaw: unknown): CornerRef {
+  if (Array.isArray(raw)) {
+    const cell = [raw[0] as number, raw[1] as number] as [number, number];
+    const hint = resolveWallLineEndpointHintPoint(otherRaw);
+    return migrateLegacyCenterEndpoint(cell, hint);
+  }
+  const obj = raw as Record<string, unknown>;
+  const cell = obj.cell as [number, number];
+  const corner = typeof obj.corner === 'number' ? obj.corner : 0;
+  return canonicalCorner({ cell, corner });
+}
+
+/**
+ * Parses `wallLines[].doors:` — plus its own legacy migration: a
+ * PRE-doors-model whole-line `kind: door` (the original unit's shape,
+ * where an entire straight wall segment was cosmetically re-colored as
+ * "a door" with no real carved opening — Kirk's own diagnosis this unit
+ * exists to fix: "the gashes are walls... I cannot set a wall or a
+ * door") materializes into a single door at the cell nearest the line's
+ * own MIDPOINT — the closest a single-opening model can come to
+ * preserving "this line has a door" intent.
+ *
+ * Deliberately a simpler approximation than the real Door tool's own
+ * `straightWallGeometry.ts`-based cell resolution (which finds the exact
+ * footprint cell a parametric position falls inside, honoring the true
+ * Cyrus-Beck clip): that module transitively imports `boardGeometry.ts`,
+ * which imports THIS file (`resolvePlacement`/`DungeonDoc`) — reusing it
+ * here would create a `dungeonYaml.ts -> straightWallGeometry.ts ->
+ * boardGeometry.ts -> dungeonYaml.ts` import cycle, hit directly while
+ * building this (a "Cannot access ... before initialization" crash
+ * under Vite's ESM interop), not theorized. "Nearest cell to the line's
+ * literal midpoint" is a fine substitute for a one-time, rare legacy
+ * migration path — it isn't the live Door tool's own placement math,
+ * which stays exact. See TARGET-YAML.md's "Straight walls: doors"
+ * section.
+ */
+function parseWallLineDoors(
+  raw: unknown,
+  from: CornerRef,
+  to: CornerRef,
+  legacyKind: unknown
+): WallLineDoorDoc[] {
+  if (Array.isArray(raw)) {
+    const doors: WallLineDoorDoc[] = [];
+    for (const d of raw as Record<string, unknown>[]) {
+      if (Array.isArray(d.cell)) {
+        doors.push({ cell: [d.cell[0] as number, d.cell[1] as number] });
+      }
+    }
+    return doors;
+  }
+  if (legacyKind === 'door') {
+    const a = cornerPoint(from);
+    const b = cornerPoint(to);
+    const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+    const cube = worldToCube(mid);
+    return [{ cell: [hexColumn(cube), hexRow(cube)] }];
+  }
+  return [];
 }
 
 function parseHeight(raw: unknown): number | null {
@@ -287,21 +412,50 @@ export interface WallDoc {
   kind: WallKind;
 }
 
-/** A STRAIGHT wall segment — `from`/`to` are the two endpoint cells the
- * author dragged between (nearest-cell snapped), and the wall's true
- * geometry is the straight WORLD-SPACE line between those cells'
- * centers, unlike `WallDoc` above whose `from`/`to` are always
- * hex-adjacent (one shared edge). `from`/`to` here are typically several
- * cells apart and the line clips through every hex it passes over — see
- * TARGET-YAML.md's "Straight walls" section for the full rationale
- * (`wallLines:` vs. overloading `walls:`) and `creation/
- * straightWallGeometry.ts` for the footprint/crossing math this implies.
- * target dialect, proposed — not compiled server-side; stripped by
- * `stripToV1Subset` like `walls:`. */
+/** A carved opening on a straight wall's own line, addressed by the
+ * FOOTPRINT CELL it opens rather than a parametric position — see
+ * TARGET-YAML.md's "Straight walls: doors" section for why a cell
+ * reference (not `{at: t}`) is the chosen shape: it stays meaningful
+ * across an endpoint drag that shifts the line's exact geometry, and a
+ * server compiler already has to derive the footprint cell-by-cell to
+ * project `wallLines:` onto canonical edges in the first place, so
+ * "which cell is a door" is a natural reuse of that same machinery, not
+ * new math. `cell` must be one of the OWNING line's own raw (door-blind)
+ * footprint cells to mean anything — see `straightWallGeometry.ts`'s
+ * `isValidDoorCell`. */
+export interface WallLineDoorDoc {
+  cell: [number, number];
+}
+
+/** A STRAIGHT wall segment — `from`/`to` are hex CORNERS (`CornerRef`,
+ * `creation/hexCorner.ts`), and the wall's true geometry is the straight
+ * WORLD-SPACE line between those two corner points, unlike `WallDoc`
+ * above whose `from`/`to` are always hex-adjacent CELLS (one shared
+ * edge). `from`/`to` here are typically several cells apart and the line
+ * clips through every hex it passes over — see TARGET-YAML.md's
+ * "Straight walls" section for the full rationale (`wallLines:` vs.
+ * overloading `walls:`) and `creation/straightWallGeometry.ts` for the
+ * footprint/crossing math this implies.
+ *
+ * **Corner-anchored, not cell-center-anchored** (this unit, following
+ * Kirk's live feedback: "it always hangs over a little" — a cell-center
+ * anchor overshoots by up to half a hex at each end, by construction).
+ * `parseDungeon` self-heals any PRE-corner-anchoring document (`from`/`to`
+ * as a bare `[col,row]` cell, the original shape) into this form on
+ * parse — see `parseWallLineEndpoint`'s own doc comment.
+ *
+ * No `kind` field — a straight wall is always solid MATERIAL; a specific
+ * point along it becomes passable only via `doors:`, never by
+ * reclassifying the WHOLE line (the pre-doors-model shape this unit
+ * retires: `kind: door` recolored an entire line without actually
+ * carving an opening in it — see TARGET-YAML.md's "Straight walls:
+ * doors" section for the full writeup, including this shape's own
+ * migration). target dialect, proposed — not compiled server-side;
+ * stripped by `stripToV1Subset` like `walls:`. */
 export interface WallLineDoc {
-  from: [number, number];
-  to: [number, number];
-  kind: WallKind;
+  from: CornerRef;
+  to: CornerRef;
+  doors: WallLineDoorDoc[];
 }
 
 /** target dialect, proposed — dungeon-wide lighting config. See TARGET-YAML.md. */
@@ -528,11 +682,15 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
     : [];
 
   const wallLines: WallLineDoc[] = Array.isArray(raw.wallLines)
-    ? (raw.wallLines as Record<string, unknown>[]).map((w) => ({
-        from: w.from as [number, number],
-        to: w.to as [number, number],
-        kind: w.kind === 'door' ? 'door' : 'solid',
-      }))
+    ? (raw.wallLines as Record<string, unknown>[]).map((w) => {
+        const from = parseWallLineEndpoint(w.from, w.to);
+        const to = parseWallLineEndpoint(w.to, w.from);
+        return {
+          from,
+          to,
+          doors: parseWallLineDoors(w.doors, from, to, w.kind),
+        };
+      })
     : [];
 
   const holes: [number, number][] = Array.isArray(raw.holes)
@@ -1315,40 +1473,90 @@ export function setWallEdge(
   walls.items.push(createWallNode(cst, { from, to, kind }));
 }
 
-function createWallLineNode(cst: Document, line: WallLineDoc): YAMLMap {
+/** Builds a flow-style `{ cell: [c, r], corner: n }` node for one
+ * `wallLines[].from`/`.to` endpoint or `doors[].cell` reference. */
+function createCornerRefNode(cst: Document, ref: CornerRef): YAMLMap {
   const node = cst.createNode({
-    from: line.from,
-    to: line.to,
-    kind: line.kind,
+    cell: ref.cell,
+    corner: ref.corner,
   }) as YAMLMap;
   node.flow = true;
-  const fromNode = node.get('from', true);
-  if (isSeq(fromNode)) fromNode.flow = true;
-  const toNode = node.get('to', true);
-  if (isSeq(toNode)) toNode.flow = true;
+  const cellNode = node.get('cell', true);
+  if (isSeq(cellNode)) cellNode.flow = true;
   return node;
 }
 
-/** Straight-wall tool: append a new `wallLines:` entry — always `kind:
- * solid`; use `toggleWallLineKindAt` to flip an existing one to a door.
- * No add-vs-remove toggle at a single cell the way `toggleWall` has (a
- * straight wall's identity is its whole from→to span, not one edge), so
- * the creation board's own click-vs-drag distinction decides add
- * (`addWallLine`) vs. remove (`removeWallLineAt`) instead of this
- * function doing both. */
-export function addWallLine(
-  cst: Document,
-  from: [number, number],
-  to: [number, number],
-  kind: WallKind = 'solid'
-): void {
-  const lines = topSeq(cst, 'wallLines');
-  lines.items.push(createWallLineNode(cst, { from, to, kind }));
+function createWallLineNode(cst: Document, line: WallLineDoc): YAMLMap {
+  const node = cst.createNode({}) as YAMLMap;
+  node.flow = true;
+  node.set('from', createCornerRefNode(cst, line.from));
+  node.set('to', createCornerRefNode(cst, line.to));
+  if (line.doors.length > 0) {
+    const doorsSeq = new YAMLSeq(cst.schema);
+    doorsSeq.flow = true;
+    for (const door of line.doors) {
+      const doorNode = cst.createNode({ cell: door.cell }) as YAMLMap;
+      doorNode.flow = true;
+      const cellNode = doorNode.get('cell', true);
+      if (isSeq(cellNode)) cellNode.flow = true;
+      doorsSeq.items.push(doorNode);
+    }
+    node.set('doors', doorsSeq);
+  }
+  return node;
 }
 
-/** Remove a `wallLines:` entry by index — the creation board's "click an
- * existing straight wall (no drag) to delete it" affordance, mirroring
- * the edge Wall tool's own click-to-remove feel. No-ops on an
+/** Straight-wall tool: append a new `wallLines:` entry, corner-anchored,
+ * with no doors yet — use `toggleWallLineDoorAt` to carve one in after
+ * the fact. `from`/`to` are canonicalized before writing (defensively —
+ * a real drag-resolve path already returns canonical corners, but this
+ * keeps every `wallLines:` entry canonical regardless of caller), same
+ * discipline `setWallLineEndpoint` follows. No add-vs-remove toggle at a
+ * single cell the way `toggleWall` has (a straight wall's identity is
+ * its whole from→to span, not one edge), so the creation board's own
+ * click-vs-drag distinction decides add (`addWallLine`) vs. remove
+ * (`removeWallLineAt`) instead of this function doing both. */
+export function addWallLine(
+  cst: Document,
+  from: CornerRef,
+  to: CornerRef
+): void {
+  const lines = topSeq(cst, 'wallLines');
+  lines.items.push(
+    createWallLineNode(cst, {
+      from: canonicalCorner(from),
+      to: canonicalCorner(to),
+      doors: [],
+    })
+  );
+}
+
+/**
+ * Ensures a `wallLines:` CST entry's `from`/`to` are BOTH in the current
+ * corner-anchored shape (migrating either that's still the PRE-corner-
+ * anchoring legacy `[c,r]` form, same as `parseWallLineEndpoint`'s own
+ * migration) and drops any stale `kind:` key — the pre-doors-model field
+ * this unit retires. Called at the top of every mutator that touches an
+ * EXISTING wallLine entry (`setWallLineEndpoint`, `toggleWallLineDoorAt`)
+ * so a partial edit — e.g. dragging only ONE endpoint of a legacy entry
+ * — can never leave it half-migrated (one corner-anchored endpoint, one
+ * still-legacy endpoint, plus a now-meaningless dangling `kind:` key).
+ * The entry converges to the current shape as a whole, atomically with
+ * whatever edit touched it — a no-op (besides re-canonicalizing) on an
+ * entry that's already fully current.
+ */
+function normalizeWallLineItem(cst: Document, item: YAMLMap): void {
+  const raw = item.toJSON() as Record<string, unknown>;
+  const from = parseWallLineEndpoint(raw.from, raw.to);
+  const to = parseWallLineEndpoint(raw.to, raw.from);
+  item.set('from', createCornerRefNode(cst, from));
+  item.set('to', createCornerRefNode(cst, to));
+  item.delete('kind');
+}
+
+/** Remove a `wallLines:` entry by index — the creation board's Delete-key
+ * affordance on a SELECTED straight wall (see `CreationBoard.tsx`'s own
+ * selection-vs-endpoint-drag interaction model). No-ops on an
  * out-of-range index rather than throwing, since a stale index (the line
  * having already been removed by a concurrent interaction) is a UI race,
  * not a program error worth crashing over. */
@@ -1359,18 +1567,84 @@ export function removeWallLineAt(cst: Document, index: number): void {
   lines.items.splice(index, 1);
 }
 
-/** Door tool applied to a straight wall: flip an EXISTING `wallLines:`
- * entry's `kind` between `solid`/`door`, by index — same "toggle an
- * already-drawn wall's kind" shape `toggleWallKind` gives edge walls,
- * addressed by index (a straight wall has no natural `from`/`to`
- * edge-lookup identity the way an edge wall's exact adjacent-cell pair
- * does) rather than a coordinate pair. */
-export function toggleWallLineKindAt(cst: Document, index: number): void {
+/** Endpoint-drag commit: overwrite ONE end (`which`) of an EXISTING
+ * `wallLines:` entry with a new corner — the "draggable endpoint handle,
+ * snapped corner-to-corner" fine-tuning affordance TARGET-YAML.md's
+ * "Straight walls: corner anchoring" section describes. `corner` is
+ * canonicalized here defensively (every real drag-resolve path —
+ * `hexCorner.ts`'s `nearestCorner`, `straightWallGeometry.ts`'s
+ * `snapStraightEndpoint` — already returns canonical form, but this
+ * mutator doesn't trust that from an arbitrary caller). No-ops on an
+ * out-of-range index, same "stale index is a UI race" discipline every
+ * other index-addressed mutator here follows. Normalizes the WHOLE entry
+ * first (`normalizeWallLineItem`) — dragging one endpoint of a still-
+ * legacy line migrates both, not just the one being dragged. */
+export function setWallLineEndpoint(
+  cst: Document,
+  index: number,
+  which: 'from' | 'to',
+  corner: CornerRef
+): void {
   const lines = cst.get('wallLines');
   if (!isSeq(lines)) return;
   const item = lines.items[index];
   if (!isMap(item)) return;
-  item.set('kind', item.get('kind') === 'door' ? 'solid' : 'door');
+  normalizeWallLineItem(cst, item);
+  item.set(which, createCornerRefNode(cst, canonicalCorner(corner)));
+}
+
+/** The straight-wall Door tool applied to an EXISTING `wallLines:` entry:
+ * toggles a door AT `cell` — adds one if absent, removes it if present —
+ * the "click a point on the line to place/remove a door" symmetric
+ * affordance TARGET-YAML.md's "Straight walls: doors" section describes.
+ * `cell` is expected to already be validated against the line's own raw
+ * (door-blind) footprint by the caller (`straightWallGeometry.ts`'s
+ * `isValidDoorCell`) — this mutator itself is a plain toggle-by-value,
+ * no geometry. An emptied `doors:` list is deleted entirely rather than
+ * left as `doors: []`, matching this file's existing sparse-serialization
+ * discipline elsewhere (e.g. `defaults:`). Normalizes the WHOLE entry
+ * first (`normalizeWallLineItem`) — carving a door into a still-legacy
+ * line migrates its endpoints too, same as `setWallLineEndpoint`. */
+export function toggleWallLineDoorAt(
+  cst: Document,
+  lineIndex: number,
+  cell: [number, number]
+): void {
+  const lines = cst.get('wallLines');
+  if (!isSeq(lines)) return;
+  const item = lines.items[lineIndex];
+  if (!isMap(item)) return;
+  normalizeWallLineItem(cst, item);
+  const doorsNode = item.get('doors', true);
+  if (isSeq(doorsNode)) {
+    // `.get('cell')` returns a live `YAMLSeq`, not a plain array — see
+    // `wallIndexAtEdge`/`holeIndexAt`'s own `.get(0)`/`.get(1)` pattern
+    // above for why `Array.isArray` would silently never match here.
+    const idx = doorsNode.items.findIndex((d) => {
+      if (!isMap(d)) return false;
+      const c = d.get('cell');
+      return isSeq(c) && c.get(0) === cell[0] && c.get(1) === cell[1];
+    });
+    if (idx !== -1) {
+      doorsNode.items.splice(idx, 1);
+      if (doorsNode.items.length === 0) item.delete('doors');
+      return;
+    }
+    const doorNode = cst.createNode({ cell }) as YAMLMap;
+    doorNode.flow = true;
+    const cellNode = doorNode.get('cell', true);
+    if (isSeq(cellNode)) cellNode.flow = true;
+    doorsNode.items.push(doorNode);
+    return;
+  }
+  const doorsSeq = new YAMLSeq(cst.schema);
+  doorsSeq.flow = true;
+  const doorNode = cst.createNode({ cell }) as YAMLMap;
+  doorNode.flow = true;
+  const cellNode = doorNode.get('cell', true);
+  if (isSeq(cellNode)) cellNode.flow = true;
+  doorsSeq.items.push(doorNode);
+  item.set('doors', doorsSeq);
 }
 
 /** A hole's index in `holes:`, matched by its [col,row] pair. */


### PR DESCRIPTION
## Summary

Follow-up to #696 ("straight walls with visible footprint"), driven by Kirk's live feedback: "I could not get the edges quite right... it always hangs over a little. Doors still follow the hex edges."

- **Corner anchoring**: `wallLines:` endpoints move from cell-CENTER anchoring to hex-CORNER anchoring (`creation/hexCorner.ts`, new module — `CornerRef = {cell:[c,r], corner:0..5}`, canonicalized dedup rule for the up-to-3 cells sharing a vertex). Fixes the "hangs over" overshoot by construction.
- **Endpoint fine-tuning**: selecting a straight wall shows draggable endpoint handles, snapped corner-to-corner, with live footprint feedback during the drag. Click-to-delete is retired in favor of click-to-select (delete moves to Delete/Backspace on a selection).
- **Real doors**: `kind: door` on a whole line (cosmetic only — never actually passable) is retired for `doors: [{cell:[c,r]}]` — a carved opening at a specific footprint cell. A door's cell is excluded from its own line's footprint; the existing crossed-edge (movement semantic b) mechanism then naturally treats it as clear, with no new mechanism needed.
- **Migration**: a pre-corner-anchoring `wallLines:` entry self-heals at parse time; the underlying CST/YAML text converges to the new shape only once a mutator touches that entry (consistent with this concept's CST-preservation discipline).

Two real bugs hit and fixed while building this (not just theorized): a circular import (`dungeonYaml.ts -> hexCorner.ts -> boardGeometry.ts -> dungeonYaml.ts`, fixed by keeping `hexCorner.ts` dependency-free of `boardGeometry.ts`), and a door-toggle bug where comparing a `YAMLSeq` via `Array.isArray` silently never matched (caught by a failing test, fixed to match the codebase's established `.get(0)`/`.get(1)` pattern).

Full writeup: `CONTRACT.md`'s "Corner-anchored straight walls + line doors" ledger section; schema/semantics: `TARGET-YAML.md`'s "Straight walls" section (corner anchoring, endpoint fine-tuning, and doors subsections).

## Test plan

- [x] 221 dungeon-builder tests passing (up from 196): 16 new in `hexCorner.test.ts`, `straightWallGeometry.test.ts` rewritten for corner refs (incl. the "wall ending at a shared corner doesn't clip that cell" boundary case + door-exclusion footprint/crossing tests), 15 new/rewritten `wallLines:` cases in `dungeonYaml.test.ts` (mutators, canonicalization, migration both directions).
- [x] `ci-check` clean (format/lint/typecheck/build/test).
- [x] Live-verified against own dev server (`vite --port 5181`): corner-precise wall termination (no hangover, close-up screenshot), a clean gapless L-join at a shared corner, live endpoint-drag with real-time footprint feedback (screenshot mid-drag), and a visible door gap with the excluded cell correctly un-hatched. No unexpected console errors.

— asset-pipeline agent, on behalf of KirkDiggler