### PR TITLE
fix(dungeon-builder): validate canonical wall adjacency

### DIFF
--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -34,6 +34,7 @@ import {
   toggleWall,
   toggleWallKind,
   toggleWallLineKindAt,
+  WallEdgeValidationError,
   type DungeonDoc,
   type LockedDoc,
   type WallKind,
@@ -294,7 +295,24 @@ export function DungeonBuilderConcept() {
     kind: WallKind,
     on: boolean
   ) => {
-    setWallEdge(creationCst, from, to, kind, on);
+    // The creation board only ever passes real detected hex edges, so
+    // this should never actually reject today — but `setWallEdge` throws
+    // on any future edge-detection/geometry bug that hands it a
+    // non-adjacent pair, and an uncaught throw here would crash the
+    // whole concept rather than just this one stroke. Surface it through
+    // the same toast seam `handleToggleWallKind` above uses for its own
+    // "can't do that" case, and leave the board's cst/doc untouched
+    // (same as that case) rather than syncing a no-op.
+    try {
+      setWallEdge(creationCst, from, to, kind, on);
+    } catch (err) {
+      flashToast(
+        err instanceof WallEdgeValidationError
+          ? err.message
+          : 'Could not update that wall edge.'
+      );
+      return;
+    }
     syncFromCreationCst(creationCst);
   };
 

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -500,18 +500,25 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
       expect(toDungeonDoc(cst).walls).toEqual([]);
     });
 
-    it('lets the model remove legacy hand-authored non-adjacent walls for server validation to repair', () => {
+    it('parses legacy hand-authored non-adjacent walls losslessly and still lets the model remove them', () => {
       const { cst } = parseDungeon(
         `${SHOWCASE_YAML}\nwalls:\n  - { from: [7, 1], to: [8, 0], kind: solid }\n`
       );
       expect(hexDistanceBetween([7, 1], [8, 0])).toBe(2);
+      // Parsing does not reject or repair a malformed edge — it round-trips
+      // exactly as authored. Nothing downstream currently re-checks it
+      // either: `walls:` is target-dialect-only, so `stripToV1Subset`
+      // drops this entry before any real preview/Save & Play call, and the
+      // released PutDungeon API neither accepts nor validates it today.
+      // Direct, strict server-side validation of authored edges becomes
+      // authoritative only once rpg-toolkit#881 and rpg-api#768 land.
       expect(toDungeonDoc(cst).walls).toEqual([
         { from: [7, 1], to: [8, 0], kind: 'solid' },
       ]);
 
-      // Parsing leaves semantic validation to the server, but a caller can
-      // still clear a legacy malformed entry without being trapped by the
-      // model-side add/update guard.
+      // A caller can still clear a legacy malformed entry without being
+      // trapped by the model-side add/update guard (which only applies to
+      // `on: true`).
       expect(() =>
         setWallEdge(cst, [7, 1], [8, 0], 'solid', false)
       ).not.toThrow();

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -1,3 +1,4 @@
+import { hexDistance } from '@/components/hex-grid/hexMath';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -44,9 +45,11 @@ import {
   toggleWallKind,
   toggleWallLineKindAt,
   validateRegionCells,
+  WallEdgeValidationError,
   wallKindAtEdge,
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
+import { cubeAtColRow } from './hexLayout';
 
 describe('parseDungeon', () => {
   it('parses showcase.yaml into the expected room chain', () => {
@@ -378,6 +381,142 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
     expect(doc.rooms[0].place[0].rotationDegrees).toBeNull();
     expect(doc.rooms[0].place[0].targeting).toBeNull();
     expect(doc.rooms[2].boss?.targeting).toBeNull();
+  });
+
+  describe('edge-native wall adjacency', () => {
+    const hexDistanceBetween = (
+      from: [number, number],
+      to: [number, number]
+    ): number =>
+      hexDistance(cubeAtColRow(from[0], from[1]), cubeAtColRow(to[0], to[1]));
+
+    const originalInvalidKitchenSinkEdges: ReadonlyArray<{
+      label: string;
+      from: [number, number];
+      to: [number, number];
+    }> = [
+      {
+        label: 'odd-column solid edge',
+        from: [7, 1],
+        to: [8, 0],
+      },
+      {
+        label: 'odd-column door edge',
+        from: [7, 3],
+        to: [8, 2],
+      },
+    ];
+
+    it.each(originalInvalidKitchenSinkEdges)(
+      'rejects the original non-adjacent Kitchen Sink $label',
+      ({ from, to }) => {
+        // Use the real odd-q conversion rather than inferring adjacency
+        // from row/column deltas: both historical pairs are distance 2.
+        expect(hexDistanceBetween(from, to)).toBe(2);
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+
+        expect(() => setWallEdge(cst, from, to, 'solid', true)).toThrow(
+          WallEdgeValidationError
+        );
+        expect(toDungeonDoc(cst).walls).toEqual([]);
+      }
+    );
+
+    const validEdges: ReadonlyArray<{
+      label: string;
+      from: [number, number];
+      to: [number, number];
+      kind: 'solid' | 'door';
+    }> = [
+      // Kitchen Sink: odd-column origin to its real even-column neighbor.
+      {
+        label: 'corrected odd-column Kitchen Sink solid edge',
+        from: [7, 1],
+        to: [8, 1],
+        kind: 'solid',
+      },
+      {
+        label: 'corrected odd-column Kitchen Sink door edge',
+        from: [7, 3],
+        to: [8, 3],
+        kind: 'door',
+      },
+      // Blank-canvas specimen: exercise the even-column parity and the
+      // other valid real-hex edge directions its real mutator emits.
+      {
+        label: 'canvas diagonal edge from an even column',
+        from: [4, 4],
+        to: [5, 3],
+        kind: 'solid',
+      },
+      {
+        label: 'canvas same-column edge',
+        from: [4, 4],
+        to: [4, 5],
+        kind: 'solid',
+      },
+      {
+        label: 'canvas diagonal door edge from an odd column',
+        from: [5, 3],
+        to: [6, 4],
+        kind: 'door',
+      },
+    ];
+
+    it.each(validEdges)(
+      'accepts each real hex $label',
+      ({ from, to, kind }) => {
+        expect(hexDistanceBetween(from, to)).toBe(1);
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+
+        setWallEdge(cst, from, to, kind, true);
+        expect(toDungeonDoc(cst).walls).toEqual([{ from, to, kind }]);
+      }
+    );
+
+    it('keeps the generated Kitchen Sink YAML on real shared edges', () => {
+      const { doc } = parseDungeon(
+        readFileSync(join(__dirname, 'specimens', 'kitchen-sink.yaml'), 'utf8')
+      );
+      expect(doc.walls.slice(0, 2)).toEqual([
+        { from: [7, 1], to: [8, 1], kind: 'solid' },
+        { from: [7, 3], to: [8, 3], kind: 'door' },
+      ]);
+      for (const wall of doc.walls) {
+        expect(hexDistanceBetween(wall.from, wall.to)).toBe(1);
+      }
+    });
+
+    it('keeps valid setWallEdge add, kind-update, and removal semantics', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      const from: [number, number] = [7, 1];
+      const to: [number, number] = [8, 1];
+
+      setWallEdge(cst, from, to, 'solid', true);
+      setWallEdge(cst, from, to, 'door', true);
+      expect(toDungeonDoc(cst).walls).toEqual([{ from, to, kind: 'door' }]);
+
+      setWallEdge(cst, from, to, 'solid', false);
+      expect(toDungeonDoc(cst).walls).toEqual([]);
+    });
+
+    it('lets the model remove legacy hand-authored non-adjacent walls for server validation to repair', () => {
+      const { cst } = parseDungeon(
+        `${SHOWCASE_YAML}\nwalls:\n  - { from: [7, 1], to: [8, 0], kind: solid }\n`
+      );
+      expect(hexDistanceBetween([7, 1], [8, 0])).toBe(2);
+      expect(toDungeonDoc(cst).walls).toEqual([
+        { from: [7, 1], to: [8, 0], kind: 'solid' },
+      ]);
+
+      // Parsing leaves semantic validation to the server, but a caller can
+      // still clear a legacy malformed entry without being trapped by the
+      // model-side add/update guard.
+      expect(() =>
+        setWallEdge(cst, [7, 1], [8, 0], 'solid', false)
+      ).not.toThrow();
+      expect(toDungeonDoc(cst).walls).toEqual([]);
+    });
   });
 
   it('toggleWall adds a solid wall, then removes it on a second toggle', () => {
@@ -1413,6 +1552,9 @@ regions:
       // represent at all. Sorted by (row, col) of `to`, the middle of 3
       // (pickAttachmentEdge's own floor(n/2) rule) is now the new edge.
       expect(result.edge).toEqual({ from: [1, 1], to: [2, 2] });
+      // The connector's odd-column -> even-column diagonal is a real
+      // shared hex edge under the same cube conversion setWallEdge uses.
+      expect(hexDistance(cubeAtColRow(1, 1), cubeAtColRow(2, 2))).toBe(1);
 
       const finalDoc = toDungeonDoc(cst);
       expect(finalDoc.walls).toHaveLength(1);

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -1290,8 +1290,14 @@ export function wallKindAtEdge(
 
 /** Raised when a caller tries to create or update a `walls:` entry that
  * does not identify one real shared hex edge. This is a model-side guard
- * for generated edits, not a replacement for the server's validation of
- * hand-authored YAML. */
+ * for generated edits. It is NOT today backed by any server-side check:
+ * `walls:` is target-dialect-only and `stripToV1Subset` drops it before
+ * every real preview/Save & Play call, and the released PutDungeon API
+ * neither accepts nor validates it. Parsing itself stays lossless — a
+ * malformed hand-authored edge round-trips through the CST unchanged —
+ * so this guard is the only check a caller gets until rpg-toolkit#881
+ * and rpg-api#768 land and direct, strict server-side validation of
+ * authored edges becomes authoritative. */
 export class WallEdgeValidationError extends Error {}
 
 /** Set (add/update) or clear a wall on one real shared hex edge, with an
@@ -1303,8 +1309,10 @@ export class WallEdgeValidationError extends Error {}
  * through a separate lookup + toggleWallKind-style call).
  *
  * The adjacency guard applies only to `on: true`: an existing malformed
- * hand-authored entry must still be removable with `on: false`, and its
- * server-side semantic validation remains authoritative. `wallLines:`
+ * hand-authored entry must still be removable with `on: false` — parsing
+ * preserves it losslessly rather than rejecting it on load, and today
+ * nothing downstream of this model checks it either (see
+ * `WallEdgeValidationError`'s own doc comment for why). `wallLines:`
  * deliberately does not route through this mutator — its endpoints name
  * a span, not a single edge, and are intentionally allowed to be
  * non-adjacent. */

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -37,6 +37,7 @@ import {
   YAMLSeq,
 } from 'yaml';
 import {
+  cellsAdjacent,
   cellsAreContiguous,
   cellsEqual,
   pickAttachmentEdge,
@@ -1287,13 +1288,26 @@ export function wallKindAtEdge(
   return isMap(item) ? ((item.get('kind') as WallKind) ?? 'solid') : null;
 }
 
-/** Set (add/update) or clear a wall on an arbitrary edge, with an
+/** Raised when a caller tries to create or update a `walls:` entry that
+ * does not identify one real shared hex edge. This is a model-side guard
+ * for generated edits, not a replacement for the server's validation of
+ * hand-authored YAML. */
+export class WallEdgeValidationError extends Error {}
+
+/** Set (add/update) or clear a wall on one real shared hex edge, with an
  * explicit on/off — the creation board's stroke-painting needs to force
  * a whole drag's worth of edges to the SAME state (decided by the first
  * edge touched), which a bare toggle-per-cell can't express. Setting
  * `on: true` for an edge that already has a wall updates its `kind`
  * in place (used by the door tool to flip solid↔door without going
- * through a separate lookup + toggleWallKind-style call). */
+ * through a separate lookup + toggleWallKind-style call).
+ *
+ * The adjacency guard applies only to `on: true`: an existing malformed
+ * hand-authored entry must still be removable with `on: false`, and its
+ * server-side semantic validation remains authoritative. `wallLines:`
+ * deliberately does not route through this mutator — its endpoints name
+ * a span, not a single edge, and are intentionally allowed to be
+ * non-adjacent. */
 export function setWallEdge(
   cst: Document,
   from: [number, number],
@@ -1305,6 +1319,11 @@ export function setWallEdge(
   if (!on) {
     if (idx !== -1) (cst.get('walls') as YAMLSeq).items.splice(idx, 1);
     return;
+  }
+  if (!cellsAdjacent(from, to)) {
+    throw new WallEdgeValidationError(
+      `Wall edge endpoints must be adjacent hex cells: [${from.join(',')}] -> [${to.join(',')}]`
+    );
   }
   if (idx !== -1) {
     const item = (cst.get('walls') as YAMLSeq).items[idx];

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -17,8 +17,14 @@ addition. Never conflate the two numbers.
 
 ## Changelog
 
-- **v0.3** (2026-08-03) — `+ regions: construct (proposed, rpg-project#180)`:
-  `kitchen-sink.yaml` now declares two cell-authored semantic regions
+- **v0.3** (2026-08-03) — `erratum: canonical wall adjacency`:
+  the real Kitchen Sink mutator calls now emit `[7,1]`→`[8,1]` (solid)
+  and `[7,3]`→`[8,3]` (door), replacing the non-adjacent odd-q pairs
+  ending at `[8,0]` and `[8,2]`. This corrects generated specimen data
+  only: the specimen pack remains v0.3 and every document remains
+  `version: 1`.
+  `+ regions: construct (proposed, rpg-project#180)`: `kitchen-sink.yaml`
+  now declares two cell-authored semantic regions
   (`hall-inner`, `hall-annex`) inside the `hall` room's absolute column
   range, connected via `connectRegions` — the door edge it places shows up
   as a THIRD entry in `walls:` (`{ from: [10,3], to: [11,3], kind: door }`),
@@ -186,8 +192,8 @@ connectors:
     setPlacementMount(cst, 'hall', 1, 'wall');
     setPlacementHeight(cst, 'hall', 1, 2.0);
     setPlacementRotationDegrees(cst, 'hall', 1, 12);
-    setWallEdge(cst, [7, 1], [8, 0], 'solid', true);
-    setWallEdge(cst, [7, 3], [8, 2], 'door', true);
+    setWallEdge(cst, [7, 1], [8, 1], 'solid', true);
+    setWallEdge(cst, [7, 3], [8, 3], 'door', true);
 
     // v0.3 (rpg-project#180): two cell-authored semantic regions inside
     // "hall"'s absolute column range (hall's start_column = entry's width

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
@@ -27,8 +27,8 @@ connectors:
   - { from: entry, to: hall, locked: { dc: 14, ability: dex } }
   - { from: hall, to: sanctum }
 walls:
-  - { from: [ 7, 1 ], to: [ 8, 0 ], kind: solid }
-  - { from: [ 7, 3 ], to: [ 8, 2 ], kind: door }
+  - { from: [ 7, 1 ], to: [ 8, 1 ], kind: solid }
+  - { from: [ 7, 3 ], to: [ 8, 3 ], kind: door }
   - { from: [ 10, 3 ], to: [ 11, 3 ], kind: door }
 regions:
   - id: hall-inner


### PR DESCRIPTION
## Summary

- Correct the two real Kitchen Sink `setWallEdge` calls and checked-in specimen walls to the adjacent odd-q pairs `[7,1]`→`[8,1]` and `[7,3]`→`[8,3]`.
- Keep the pack at v0.3 and document the erratum without changing YAML document `version: 1`.
- Guard `setWallEdge` additions/updates with the existing real hex adjacency model. This is a model-side guard only, not a stand-in for server validation: `walls:` is target-dialect-only, so `stripToV1Subset` strips it before every real preview/Save & Play call, and the released PutDungeon API neither accepts nor validates it today. Parsing itself stays lossless — a legacy hand-authored malformed wall round-trips through the CST unchanged and can still be removed with `on: false` — and direct, strict server-side validation of authored edges becomes authoritative only once rpg-toolkit#881 and rpg-api#768 land. `wallLines:` remains an unrestricted span model.
- Cover the original invalid pairs, corrected Kitchen Sink pairs, canvas pairs, and the region-connector pair using `cubeAtColRow` + `hexDistance`.
- Harden the creation board's `setWallEdge` call site (`DungeonBuilderConcept.handleCreationToggleWallEdge`): it now catches `WallEdgeValidationError` (and any other throw) and surfaces it through the existing `flashToast` seam instead of letting it escape uncaught. The board only ever passes real detected hex edges today, so this doesn't change any current valid interaction — it's a backstop against a future edge-detection/geometry bug reaching this call with a non-adjacent pair and crashing the whole concept.

## Validation

- `npx vitest run src/concepts/dungeon-builder/dungeonYaml.test.ts`
- `npm run ci-check`
- Regenerated the documented throwaway specimen script; the corrected Kitchen Sink mutator calls emit the requested pairs.

Closes #699

Refs KirkDiggler/rpg-project#179 and KirkDiggler/rpg-project#175.

---
— UI/UX agent, on behalf of KirkDiggler