### PR TITLE
restore: straight-wall delete button (missed the #698 squash window)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3806,3 +3806,53 @@ returned to the list. No unexpected console errors — only the established
 FIXTURES-MODE `[unimplemented] unknown service ...AuthoringService` (no
 local `rpg-api` running against this dev server), same as every prior
 round's live-verification note.
+
+**Straight-wall deletion (same-day third item).** Kirk: "gonna need a way
+to delete a wall — I dragged it again and had a small section with no way
+to remove it." The removal MUTATOR already existed
+(`dungeonYaml.ts`'s `removeWallLineAt`) and was already wired to a
+Delete/Backspace keydown effect on a selected wall (the round above) —
+what was genuinely missing was any VISIBLE affordance telling the author
+either of those existed. Added a small red "×" delete button, rendered
+offset perpendicular from the selected wall's own midpoint by 16 board
+units (`CreationBoard.tsx`'s new `straightWallDeleteButtonPoint`/
+`straightWallDeleteButtonHit`, the same render/hit-test split every other
+board overlay here already follows) so it clears the drawn stroke/
+footprint hatch instead of sitting on top of it. A caption under the
+button reads "delete" — or "delete (+N door(s))" when the wall has any,
+since `removeWallLineAt` splices the whole `wallLines:` entry (doors
+nested inside), so they're removed too, not orphaned. Clicking it calls
+the SAME `onRemoveStraightWallAt` the keyboard path already used; no new
+removal logic, only the missing UI path to it. Checked in
+`handlePointerDown` right after the endpoint-handle hit (a handle grab
+still wins if the two ever overlap) and before the redraw/reselect
+fallback.
+
+**Tests.** 1 new in `dungeonYaml.test.ts`: `removeWallLineAt` removes
+EXACTLY the targeted line (a second line survives untouched, verified by
+value not just by count) and its own door goes with it, round-tripped
+through the serialized YAML text (no stranded `doors:` fragment). 228
+dungeon-builder tests passing overall (up from 227). `ci-check` clean —
+again caught (and fixed) a pure-Prettier format diff on the touched file,
+no semantic change.
+
+**Live verification.** Own dev server (`vite --port 5183`), driven via
+`game-dev/tools/browser/_job_walldelete_verify.mjs` (kept). Same trap as
+the angle-snapping script above, hit again here and worth restating since
+it's a general one: click targets computed from the RAW cell centers a
+drag started/ended at are wrong for anything that needs the wall's own
+ACTUAL `from`/`to` — those are corner-anchored and snap to the nearest
+LATTICE CORNER, often offset from a cell's own center by up to a full hex
+radius. Fixed by reading the real committed `from`/`to` back out of the
+live YAML pane after each mutation and computing every subsequent click
+(select, delete-button) from THOSE, not the original nominal drag
+targets — the delete-button click silently landed on nothing until this
+was fixed. Confirmed: a selected wall (with a rejected off-footprint door
+click still visible as a live toast, incidentally re-confirming that
+existing reject-toast behavior too) shows both teal endpoint handles and
+the new delete button with its "delete" caption; clicking the button
+takes `wallLines:` from 1 entry to `[]` and the footprint hatch off the
+board entirely (before/after screenshots, not just the final YAML); a
+second wall drawn, selected, and removed via the Delete key confirms that
+path is still intact too. No unexpected console errors, same
+FIXTURES-MODE note as every other round.

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -125,10 +125,16 @@ interface CreationBoardProps {
    * corner-anchored (unlike `onToggleWallEdge`'s per-edge, cell-adjacent
    * painting). See `hexCorner.ts`/`straightWallGeometry.ts`. */
   onAddStraightWall: (from: CornerRef, to: CornerRef) => void;
-  /** The Delete-key affordance on a SELECTED straight wall (see this
-   * component's own selection-vs-endpoint-drag interaction model,
+  /** Removes a SELECTED straight wall (see this component's own
+   * selection-vs-endpoint-drag interaction model,
    * `selectedWallLineIndex`/`draggingEndpoint` below) — click no longer
-   * deletes on its own; it selects. */
+   * deletes on its own; it selects. Reachable two ways: the
+   * Delete/Backspace key (this component's own keydown effect) and the
+   * board's own small delete button rendered near the selected wall's
+   * midpoint (`straightWallDeleteButtonHit`/`straightWallDeleteButtonPoint`)
+   * — the keyboard path alone was undiscoverable (Kirk: "gonna need a
+   * way to delete a wall... had a small section with no way to remove
+   * it"), so this is now the primary, VISIBLE affordance. */
   onRemoveStraightWallAt: (index: number) => void;
   /** Endpoint-drag commit: fine-tune one end of an EXISTING straight wall
    * to a new corner, snapped corner-to-corner. */
@@ -234,6 +240,49 @@ function straightWallHandleHit(
   const dTo = Math.hypot(point.x - toPt.x, point.y - toPt.y);
   if (dFrom > maxDist && dTo > maxDist) return null;
   return dFrom <= dTo ? 'from' : 'to';
+}
+
+/** Where the SELECTED straight wall's own delete button renders — offset
+ * perpendicular from the line's midpoint by `OFFSET` board units, so the
+ * button sits clear of the drawn stroke/footprint hatch instead of on
+ * top of it. Shared between the render pass and `straightWallDeleteButtonHit`
+ * below so the two can never drift apart (the render/hit-test split every
+ * other overlay in this component already follows). */
+function straightWallDeleteButtonPoint(
+  from: CornerRef,
+  to: CornerRef
+): CellPos {
+  const fromPt = cornerPoint(from);
+  const toPt = cornerPoint(to);
+  const mid = { x: (fromPt.x + toPt.x) / 2, y: (fromPt.y + toPt.y) / 2 };
+  const dx = toPt.x - fromPt.x;
+  const dy = toPt.y - fromPt.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const OFFSET = 16;
+  return {
+    x: mid.x + (-dy / len) * OFFSET,
+    y: mid.y + (dx / len) * OFFSET,
+  };
+}
+
+/** Hit test for the SELECTED straight wall's own delete button (Kirk:
+ * "gonna need a way to delete a wall... had a small section with no way
+ * to remove it" — Delete/Backspace-on-selection already worked from the
+ * round above, this is the missing VISIBLE affordance). Uses the wall's
+ * own COMMITTED `from`/`to` — this button is only clickable while NOT
+ * mid-endpoint-drag (a handle hit is checked first in `handlePointerDown`
+ * and captures the gesture), so it never needs the live drag position
+ * `straightWallHandleHit`'s render counterpart accounts for. */
+function straightWallDeleteButtonHit(
+  doc: DungeonDoc,
+  lineIndex: number,
+  point: CellPos,
+  maxDist = 10
+): boolean {
+  const line = doc.wallLines[lineIndex];
+  if (!line) return false;
+  const btn = straightWallDeleteButtonPoint(line.from, line.to);
+  return Math.hypot(point.x - btn.x, point.y - btn.y) <= maxDist;
 }
 
 const CELL_SIZE = BOARD_HEX_SIZE - 1.5;
@@ -683,7 +732,11 @@ export function CreationBoard({
     if (tool === 'straightWall') {
       // A handle on the CURRENTLY SELECTED wall always wins over
       // redrawing/reselecting — it sits ON the line by construction, so
-      // this must be checked first, not as a fallback.
+      // this must be checked first, not as a fallback. The delete button
+      // is checked right after — it also sits near the selected line, so
+      // it must win over a redraw/reselect too, but never over a handle
+      // (the two are rendered offset from each other, so overlap is rare,
+      // but a handle grab is still the more specific/intentional gesture).
       if (selectedWallLineIndex !== null) {
         const handle = straightWallHandleHit(doc, selectedWallLineIndex, p);
         if (handle) {
@@ -694,6 +747,11 @@ export function CreationBoard({
             current: handle === 'from' ? line.from : line.to,
             snapped: false,
           });
+          return;
+        }
+        if (straightWallDeleteButtonHit(doc, selectedWallLineIndex, p)) {
+          onRemoveStraightWallAt(selectedWallLineIndex);
+          setSelectedWallLineIndex(null);
           return;
         }
       }
@@ -1076,6 +1134,55 @@ export function CreationBoard({
           />
         );
       }
+
+      // Delete button (Kirk: "gonna need a way to delete a wall... had a
+      // small section with no way to remove it" — Delete/Backspace on a
+      // selection already worked from the round above; nothing on the
+      // board ever told the author that, so this is the missing VISIBLE
+      // affordance, not new removal logic). Uses the wall's own
+      // COMMITTED `line.from`/`line.to` (matching `straightWallDeleteButtonHit`'s
+      // own hit-test exactly) rather than the live drag position — the
+      // button isn't clickable mid-endpoint-drag anyway (the pointer is
+      // already captured by that gesture), so it simply holds its last
+      // position until the drag ends and the wall re-renders. Doors on
+      // the wall are removed WITH it (`removeWallLineAt` splices the
+      // whole entry; `doors:` lives nested inside), called out in the
+      // caption rather than a hover tooltip — every other overlay in
+      // this component is `pointerEvents="none"`, so a native `<title>`
+      // would never actually fire.
+      const deleteBtn = straightWallDeleteButtonPoint(line.from, line.to);
+      const doorCount = line.doors.length;
+      straightWallHandleEls.push(
+        <g key="swall-delete-btn" pointerEvents="none">
+          <circle
+            cx={deleteBtn.x}
+            cy={deleteBtn.y}
+            r={9}
+            fill="#3a1c18"
+            stroke="#ff9a8a"
+            strokeWidth={2}
+          />
+          <text
+            x={deleteBtn.x}
+            y={deleteBtn.y + 4}
+            textAnchor="middle"
+            fontSize={12}
+            fontWeight={700}
+            fill="#ff9a8a"
+          >
+            ×
+          </text>
+          <text
+            x={deleteBtn.x}
+            y={deleteBtn.y + 22}
+            textAnchor="middle"
+            fontSize={9}
+            fill="#ff9a8a"
+          >
+            {`delete${doorCount > 0 ? ` (+${doorCount} door${doorCount === 1 ? '' : 's'})` : ''}`}
+          </text>
+        </g>
+      );
     }
   }
 

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -482,6 +482,33 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
       expect(toDungeonDoc(cst).wallLines).toHaveLength(1);
     });
 
+    it('removeWallLineAt removes exactly the targeted line — its own doors go with it, a second line is untouched (rpg-project#169, delete-affordance follow-up)', () => {
+      // Kirk's own ask this test exists for: "gonna need a way to delete
+      // a wall... had a small section with no way to remove it" — the
+      // UI-reachability gap was in CreationBoard.tsx (a delete button was
+      // missing); this mutator itself already removed doors correctly by
+      // construction (`doors:` lives NESTED inside the wallLine's own CST
+      // node, so splicing the whole entry out can't leave one stranded) —
+      // asserted directly here rather than just trusted.
+      const C = canonicalCorner({ cell: [0, 3], corner: 0 });
+      const D = canonicalCorner({ cell: [10, 8], corner: 3 });
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      addWallLine(cst, A, B);
+      addWallLine(cst, C, D);
+      toggleWallLineDoorAt(cst, 0, [5, 2]);
+      expect(toDungeonDoc(cst).wallLines[0].doors).toEqual([{ cell: [5, 2] }]);
+
+      removeWallLineAt(cst, 0);
+      const doc = toDungeonDoc(cst);
+      // The SECOND line (C, D) survives untouched, now at index 0 — a
+      // real "exactly the targeted line" check, not just "count went
+      // down by one."
+      expect(doc.wallLines).toEqual([{ from: C, to: D, doors: [] }]);
+      // Round-trips through the serialized YAML text too, not just the
+      // in-memory doc — no stranded `doors:` fragment left behind.
+      expect(serializeDungeon(cst)).not.toContain('doors:');
+    });
+
     it('setWallLineEndpoint overwrites one end in place, canonicalizing the new corner', () => {
       const { cst } = parseDungeon(SHOWCASE_YAML);
       addWallLine(cst, A, B);


### PR DESCRIPTION
Commit c3ae918 (straight-wall delete button affordance, door-count caption, dungeonYaml.test.ts coverage, CONTRACT.md addendum) landed on `unit/wall-corner-anchoring` after PR #698 had already been squash-merged, so it never made it to `dev`. This cherry-picks it cleanly onto current `dev`.

— asset-pipeline agent, on behalf of KirkDiggler