### PR TITLE
unit: render walls/doors from wire edges (FloorPlan.edges)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.115",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#3c1dc460e77a6941fdde0ada0a65eabd5336a6b6",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#d9ef7d9fb49dd604d93bf88d828cfc27e409debe",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.115",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/concepts/dungeon-builder/Board.test.tsx
+++ b/src/concepts/dungeon-builder/Board.test.tsx
@@ -20,7 +20,11 @@ import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { Board } from './Board';
 import { parseDungeon } from './dungeonYaml';
-import { SHOWCASE_FLOORPLAN, SHOWCASE_YAML } from './fixtures';
+import {
+  S2_LOOP_FLOORPLAN,
+  SHOWCASE_FLOORPLAN,
+  SHOWCASE_YAML,
+} from './fixtures';
 
 /** showcase.yaml's shrine room already has one room-scoped altar
  * (`at: [11, 3]`) — appending a top-level one at a different, empty
@@ -145,5 +149,77 @@ describe('Board — selecting an existing room-scoped marker still works (regres
       roomId: 'shrine',
       index: expect.any(Number),
     });
+  });
+});
+
+describe('Board — wall/door source: real server edges vs the derived fallback (rpg-project#169 wire-edges unit)', () => {
+  it('shows the "server edges" badge and renders one <line> per recorded FloorPlan.edges entry when a response carries them (SHOWCASE_FLOORPLAN, re-recorded against v0.1.118)', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const { getByTestId, container } = renderBoard(doc);
+
+    const badge = getByTestId('db-wall-source-indicator');
+    expect(badge.textContent).toContain('SERVER EDGES');
+    expect(badge.textContent).toContain('196');
+
+    // Solid server edges render as plain, non-interactive <line>s in
+    // '#c9bfae' — distinct from doc.walls's own dashed authoring overlay,
+    // which showcase.yaml doesn't use at all (no walls: key), so every
+    // matching line here can only have come from the server-edges pass.
+    const solidLines = Array.from(
+      container.querySelectorAll<SVGLineElement>('line')
+    ).filter((l) => l.getAttribute('stroke') === '#c9bfae');
+    expect(solidLines).toHaveLength(194);
+  });
+
+  it('falls back to the DERIVED badge and the old door_row/connector cell rendering for a FloorPlan with no edges (pre-#767 fixture)', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const { getByTestId, container } = render(
+      <Board
+        floorPlan={S2_LOOP_FLOORPLAN}
+        doc={doc}
+        selectedPalette={null}
+        selectedPlacement={null}
+        selectedConnectorIndex={null}
+        onPlace={noop()}
+        onSelect={noop()}
+        onMove={noop()}
+        onReject={noop()}
+        onSelectConnector={noop()}
+        onWallGashClick={noop()}
+        selectedTool={null}
+        onToggleWall={noop()}
+        onToggleWallKind={noop()}
+        onToggleHole={noop()}
+        onSetPoint={noop()}
+      />
+    );
+
+    const badge = getByTestId('db-wall-source-indicator');
+    expect(badge.textContent).toContain('DERIVED');
+
+    // No server-edge <line>s at all — the connector's gap column still
+    // renders via the old cell-fill classes instead.
+    expect(container.querySelector('.db-cell-wall')).not.toBeNull();
+    expect(container.querySelectorAll('line[stroke="#c9bfae"]')).toHaveLength(
+      0
+    );
+  });
+
+  it('clicking a rendered DOOR edge whose door_id resolves to a connector opens ConnectorInspector via the same onSelectConnector callback the door-row cell already uses', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const onSelectConnector = vi.fn();
+    const { container } = renderBoard(doc, { onSelectConnector });
+
+    const doorLines = Array.from(
+      container.querySelectorAll<SVGLineElement>('line')
+    ).filter((l) => l.getAttribute('stroke') === '#ffb347');
+    // Both showcase connectors are generated doors, so both DOOR edges
+    // resolve — 2 clickable door lines, matching floorPlan.connectors.length.
+    expect(doorLines).toHaveLength(2);
+
+    fireEvent.click(doorLines[0]);
+    expect(onSelectConnector).toHaveBeenCalledWith(expect.any(Number));
+    const calledIndex = onSelectConnector.mock.calls[0][0];
+    expect([0, 1]).toContain(calledIndex);
   });
 });

--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -8,7 +8,7 @@
  * compute, the chain.
  */
 import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
-import { useRef, useState, type ReactElement } from 'react';
+import { useMemo, useRef, useState, type ReactElement } from 'react';
 import {
   connectorAtColumn,
   isCellOccupied,
@@ -19,6 +19,11 @@ import {
   totalColumns,
 } from './boardGeometry';
 import type { DungeonDoc } from './dungeonYaml';
+import {
+  connectorIndexForDoorId,
+  floorPlanEdgesToServerEdges,
+  hasServerEdges,
+} from './edgesAdapter';
 import {
   BOARD_HEX_SIZE,
   cellCenter,
@@ -99,6 +104,21 @@ export function Board({
 }: BoardProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [dragging, setDragging] = useState<PlacementSelection | null>(null);
+
+  // Server-truth wall/door edges (rpg-api-protos v0.1.118+, FloorPlan.edges)
+  // — when the live/recorded response carries them, they render AS the
+  // wall/door geometry below (real per-edge truth, including room
+  // perimeter walls the old column-fill never showed at all), and the
+  // coarse connector-gap-column fill two loops down is muted rather than
+  // drawn as a confident "this is a wall" block. Falls back to the old
+  // derived-from-door_row/connectors rendering — unchanged — whenever
+  // `edges` is empty (fixtures mode, or any response recorded/compiled
+  // before #767). See edgesAdapter.ts's own doc comment.
+  const serverEdges = useMemo(
+    () =>
+      hasServerEdges(floorPlan) ? floorPlanEdgesToServerEdges(floorPlan) : null,
+    [floorPlan]
+  );
 
   const cols = totalColumns(floorPlan);
   const cells: ReactElement[] = [];
@@ -183,6 +203,15 @@ export function Board({
         const connectorIndex = floorPlan.connectors.indexOf(connector);
         const isSelectedDoor =
           isDoorRow && selectedConnectorIndex === connectorIndex;
+        // Non-door-row cells in a connector's gap column: when real
+        // `serverEdges` exist, the actual wall line for this column is
+        // drawn precisely by the overlay pass below — this cell's own fill
+        // is muted to plain background instead of the confident solid-wall
+        // block, so the board doesn't show two competing "this is a wall"
+        // signals (a whole-cell fill AND a precise line) at once. The
+        // door-row cell keeps its distinct styling either way — it's still
+        // the real, always-correct click target for the connector door,
+        // server edges or not.
         cells.push(
           <polygon
             key={`cell-${col}-${row}`}
@@ -190,7 +219,9 @@ export function Board({
             className={
               isDoorRow
                 ? `db-cell-door${isSelectedDoor ? ' db-cell-door-selected' : ''}`
-                : 'db-cell-wall'
+                : serverEdges
+                  ? 'db-cell-empty'
+                  : 'db-cell-wall'
             }
             onClick={() => {
               // The REAL connector door always wins over any active tool
@@ -246,6 +277,63 @@ export function Board({
     );
   };
   const structuralOverlay: ReactElement[] = [];
+
+  // Server-truth wall/door edges (`serverEdges`, computed above) — solid,
+  // confident stroke, unlike `doc.walls`'s own dashed/muted "PROPOSED, not
+  // compiled" language just below: these ARE compiled, real
+  // dungeonspec-generated truth, not an authoring proposal. Painted BEFORE
+  // `doc.walls` (`structuralOverlay`'s array order is paint order) so an
+  // authored target-dialect wall drawn near/over a real one still reads on
+  // top — same layering rule this pass already follows for holes/regions/
+  // start/end below. A DOOR edge whose `doorId` resolves to a real
+  // connector (`connectorIndexForDoorId` — true for every generated
+  // connector door, see `edgesAdapter.ts`) is directly clickable to open
+  // the SAME `ConnectorInspector` the door-row cell already opens: Kirk's
+  // "I clicked where a wall visibly is and found nothing behind it" ask,
+  // now answered by the wall's own rendered geometry, not just the coarse
+  // cell underneath it. A SOLID edge (or a DOOR edge with no resolvable
+  // connector — not expected for real generated content, but handled
+  // rather than assumed away) is informational only, `pointerEvents:
+  // 'none'`, same as the rest of this overlay.
+  if (serverEdges) {
+    for (const edge of serverEdges) {
+      trackCellExtent(edge.from[0], edge.from[1]);
+      trackCellExtent(edge.to[0], edge.to[1]);
+      const line = edgeBetweenCells(
+        edge.from[0],
+        edge.from[1],
+        edge.to[0],
+        edge.to[1]
+      );
+      const isDoor = edge.kind === 'door';
+      const connectorIndex = isDoor
+        ? connectorIndexForDoorId(floorPlan, edge.doorId)
+        : null;
+      structuralOverlay.push(
+        <line
+          key={`server-edge-${edge.from[0]}-${edge.from[1]}-${edge.to[0]}-${edge.to[1]}`}
+          x1={line.a.x}
+          y1={line.a.y}
+          x2={line.b.x}
+          y2={line.b.y}
+          stroke={isDoor ? '#ffb347' : '#c9bfae'}
+          strokeWidth={isDoor ? 3.5 : 2.5}
+          strokeLinecap="round"
+          style={connectorIndex !== null ? { cursor: 'pointer' } : undefined}
+          pointerEvents={connectorIndex !== null ? 'stroke' : 'none'}
+          onClick={
+            connectorIndex !== null
+              ? (e) => {
+                  e.stopPropagation();
+                  onSelectConnector(connectorIndex);
+                }
+              : undefined
+          }
+        />
+      );
+    }
+  }
+
   for (const wall of doc.walls) {
     trackCellExtent(wall.from[0], wall.from[1]);
     trackCellExtent(wall.to[0], wall.to[1]);
@@ -643,35 +731,80 @@ export function Board({
   };
 
   return (
-    <svg
-      ref={svgRef}
-      viewBox={`${vx} ${vy} ${vw} ${vh}`}
-      width={Math.max(vw, 600)}
-      height={Math.max(vh, 420)}
-      onPointerUp={handlePointerUp}
-      onClick={(e) => {
-        if (e.target === svgRef.current) onSelect(null);
-      }}
-    >
-      <defs>
-        <pattern
-          id="db-doorrow-hatch"
-          patternUnits="userSpaceOnUse"
-          width={8}
-          height={8}
-          patternTransform="rotate(45)"
-        >
-          <rect width={8} height={8} fill="#2a1e10" />
-          <line x1={0} y1={0} x2={0} y2={8} stroke="#5a4020" strokeWidth={4} />
-        </pattern>
-      </defs>
-      <g>
-        {cells}
-        {structuralOverlay}
-        {labels}
-        {markers}
-        {entranceMarker}
-      </g>
-    </svg>
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      {/* Wall/door source indicator — Kirk's "make drift visible, not
+       * silent" ask. Distinguishes real generated edge geometry
+       * (`FloorPlan.edges`, rpg-api-protos v0.1.118+) from the
+       * door_row/connector-derived fallback this board used exclusively
+       * before #767 landed server-side, and still uses whenever a
+       * response carries no edges (fixtures mode, or a pre-#767
+       * recording). */}
+      <div
+        data-testid="db-wall-source-indicator"
+        style={{
+          position: 'absolute',
+          top: 4,
+          left: 4,
+          zIndex: 5,
+          fontSize: 10,
+          fontWeight: 700,
+          letterSpacing: 0.3,
+          padding: '3px 7px',
+          borderRadius: 4,
+          pointerEvents: 'none',
+          ...(serverEdges
+            ? {
+                color: '#100d0b',
+                background: '#c9bfae',
+              }
+            : {
+                color: '#e8e2d8',
+                background: 'rgba(90, 74, 58, 0.55)',
+                border: '1px dashed #8a7a5a',
+              }),
+        }}
+      >
+        {serverEdges
+          ? `WALLS: SERVER EDGES (${serverEdges.length})`
+          : 'WALLS: DERIVED (no edge geometry on the wire)'}
+      </div>
+      <svg
+        ref={svgRef}
+        viewBox={`${vx} ${vy} ${vw} ${vh}`}
+        width={Math.max(vw, 600)}
+        height={Math.max(vh, 420)}
+        onPointerUp={handlePointerUp}
+        onClick={(e) => {
+          if (e.target === svgRef.current) onSelect(null);
+        }}
+      >
+        <defs>
+          <pattern
+            id="db-doorrow-hatch"
+            patternUnits="userSpaceOnUse"
+            width={8}
+            height={8}
+            patternTransform="rotate(45)"
+          >
+            <rect width={8} height={8} fill="#2a1e10" />
+            <line
+              x1={0}
+              y1={0}
+              x2={0}
+              y2={8}
+              stroke="#5a4020"
+              strokeWidth={4}
+            />
+          </pattern>
+        </defs>
+        <g>
+          {cells}
+          {structuralOverlay}
+          {labels}
+          {markers}
+          {entranceMarker}
+        </g>
+      </svg>
+    </div>
   );
 }

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -867,6 +867,21 @@ affordance. Four is no longer a coincidence pattern; it's the strongest
 version yet of the argument this file has been building for growing
 `FloorPlan` (or a sibling message) a real edge-native wall list.
 
+**Update, 2026-08-04 — the FIRST two of these four surfaces are now
+closed for real, response-side.** rpg-api#767 grew `FloorPlan` exactly
+the edge-native `edges` list this section argued for; the wire-edges
+rendering unit ("Wire-edges rendering unit," below, this file's most
+recent section) makes the 2D board's door-row cells and the 3D preview's
+void BOTH consume it. **Still open, unchanged by this unit**: the
+creation flow's proposed `walls:`/`wallLines:` schema is authoring — a
+from-scratch canvas has no compiled `FloorPlan` to receive edges FROM at
+all, so nothing about `FloorPlan.edges` touches it; that's rpg-project#179
+(canonical authored wall/door edges) plus toolkit#881/rpg-api#768, tracked
+separately. Four consumers named one real gap; two of the four needed a
+response field, and that field now exists and is wired — the other two
+need a request-side (authoring) contract, which is a different, still-
+open piece of work.
+
 ### What the schema actually allows for a connector — verified against the real dungeonspec Go source, not guessed
 
 Read directly from `rpg-toolkit/encounter/dungeonspec/spec.go` and
@@ -3856,3 +3871,129 @@ board entirely (before/after screenshots, not just the final YAML); a
 second wall drawn, selected, and removed via the Delete key confirms that
 path is still intact too. No unexpected console errors, same
 FIXTURES-MODE note as every other round.
+
+## Wire-edges rendering unit: 2D + 3D now draw `FloorPlan.edges` (2026-08-04, rpg-project#169)
+
+**The fourth-consumer-signal gap this file has named four times over —
+"`FloorPlan` carries no wall/door edge geometry on the wire" — is now
+closed on the response side.** rpg-api's #767 wave (merged) projects
+toolkit-canonical generated edges onto the compiled authoring `FloorPlan`:
+`repeated FloorPlanEdge edges = 6`, each `{from, to, kind, door_id}`
+(`FloorPlanCell` pairs, `FloorPlanEdgeKind` SOLID|DOOR), released in
+rpg-api-protos **v0.1.118** (bumped from v0.1.115 this unit). Both boards
+now render THAT truth when a response carries it, instead of the
+door_row/connector-derived approximations this file has documented since
+#667 — the WallGashExplainer's own former claim ("FloorPlan carries no
+wall/door edge geometry on the wire") is retired for a live response;
+fixtures mode and any pre-#767 recording still hit that path unchanged
+(a real, honest fallback, not a removed one).
+
+### One shared adapter, not two proto parses
+
+`edgesAdapter.ts` (new module) is the single place either renderer
+touches the wire shape: `floorPlanEdgesToServerEdges(floorPlan)` maps
+`FloorPlanEdge[]` to `ServerEdge[]` — `dungeonYaml.ts`'s existing
+`WallDoc` (`{from, to, kind}`, the SAME shape `doc.walls`'s own
+target-dialect authored walls already use) plus an optional `doorId`.
+Neither `Board.tsx` nor `DungeonPreview3D.tsx` imports
+`FloorPlanCell`/`FloorPlanEdgeKind` directly — this is a pure field-
+rename/enum-map, never a re-derivation: `FloorPlan.edges` is already the
+server's own canonical, deduplicated truth (one record per physical
+edge), so there's no orientation/dedup logic to reimplement client-side,
+unlike `doc.walls`'s own author-time mutators. `hasServerEdges(floorPlan)`
+(`edges.length > 0`) is the one gate both views check.
+
+### `door_id` correlates to `FloorPlanConnector` — verified against a real response, not assumed
+
+Confirmed directly (`fixtures.ts`'s re-recorded `SHOWCASE_FLOORPLAN`, not
+just the proto doc comment's promise): both DOOR edges' `doorId` match
+`SHOWCASE_FLOORPLAN.connectors[].doorId` byte-for-byte
+(`showcase-door-antechamber-shrine`, `showcase-door-shrine-vault`).
+`connectorIndexForDoorId(floorPlan, doorId)` resolves this to the same
+index `doc.connectors`/`ConnectorInspector` already key off, so a
+server-truth door is directly wired to the REAL `ConnectorInspector` —
+Kirk's "I clicked where a wall visibly is and found nothing behind it"
+ask, now answered by the wall's own rendered geometry in BOTH views, not
+just the coarse cell/gap-column underneath it.
+
+### 2D board (`Board.tsx`)
+
+A new server-edges overlay pass (`edgeBetweenCells`, the SAME geometry
+`doc.walls`'s own overlay already draws with) renders every recorded edge
+as a solid, confident line — `'#c9bfae'` for SOLID, `'#ffb347'` for DOOR
+— painted BEFORE `doc.walls`'s own dashed/muted "PROPOSED, not compiled"
+pass so an authored wall drawn over a real one still reads on top. The
+connector-gap-column cell fill (`db-cell-wall`, the old whole-column
+"this is a wall" block) is MUTED to plain background whenever real edges
+exist, rather than removed outright — the door-row cell itself (still the
+real, always-correct connector click target) is untouched either way.
+**Source indicator**: a small badge, top-left of the board —
+`WALLS: SERVER EDGES (196)` (cream) when real, `WALLS: DERIVED (no edge
+geometry on the wire)` (dashed amber) for the fallback — so drift between
+a stale-pinned client and a fresh server (or the reverse) is visible, not
+silent. A DOOR line whose `doorId` resolves is directly clickable
+(`pointerEvents: 'stroke'`) and calls the SAME `onSelectConnector` the
+door-row cell already used.
+
+### 3D preview (`DungeonPreview3D.tsx`) — the door gap is the headline
+
+**This closes the "marked door, not a walkable door" gap** the original
+3D spike named as its own next fidelity step (this file's earlier "3D
+preview: NOT a stop" section): `WallBox` now renders solid edges only
+(full height, no more per-door height-shortening hack); a new `DoorGap`
+component renders a DOOR edge (server-truth OR an authored `doc.walls`
+door — both go through the same branch now) as two solid amber jambs
+flanking a genuinely OPEN, walkable span, with a thin amber lintel piece
+reading as a door frame. Kirk's own framing for the door-row VOID finding
+elsewhere in this file: "the gash becomes a real doorway." Server-truth
+walls (`serverWalls`, gated on `hasServerEdges`) render alongside the
+existing `authoredWalls` (`doc.walls`) — additive, not a replacement,
+since 3D never had ANY server-truth wall rendering before this unit (the
+spike's own doc comment: "Deliberately NOT rendered: walls and doors").
+A server-truth door's jamb/lintel group also gets an invisible click-
+catcher spanning the opening (`onSelectConnector`, same wire-level
+`doorId` correlation as 2D) — same `ConnectorInspector`, reachable by
+clicking the actual rendered doorway in 3D now too.
+
+### Tests + fixture
+
+`SHOWCASE_FLOORPLAN.edges` (`fixtures.ts`) is a REAL recorded response,
+not synthesized: `grpcurl PutDungeon(validate_only)` against the live
+rpg-api-protos v0.1.118 server for showcase.yaml, unmodified — 196 edges
+(194 solid, 2 door), including exterior edges whose far endpoint sits
+outside the rendered bounds (negative column — `FloorPlanEdge`'s own doc
+comment: "one endpoint may be outside the rendered floor-plan bounds"),
+confirmed live, not just read in the contract text.
+`floorPlanCompile.test.ts`'s showcase case now excludes `edges` from its
+equality check with an explicit comment — `compileFloorPlanLocally` (the
+fixtures-mode fallback) never re-derives generated wall/door truth
+client-side, by design, so its own `edges` stays the proto default `[]`.
+
+12 new tests in `edgesAdapter.test.ts` (adapter correctness, doorId
+mapping, exterior-edge preservation, connector-index resolution — all
+against the real recorded fixture, not a hand-built one) + 3 new in
+`Board.test.tsx` (badge text + line count for both the real-edges and
+derived-fallback cases, and door-line-click → `onSelectConnector`
+wiring). 253 dungeon-builder tests passing overall (up from 238).
+`ci-check` clean (format/lint/typecheck/build/test).
+
+**Live verification.** Own dev server (free port, `VITE_API_HOST` pointed
+at the live envoy on `:8091`, `VITE_DEV_PLAYER_ID` set for the `Dev`
+auth scheme), driven via a throwaway Playwright script (this round's
+`public/models/synty/` was rsync'd from the existing `~/game-dev/
+rpg-game-assets` checkout the same way the palette-thumbnail round
+already documented, since a fresh worktree never has it — needed for the
+3D screenshot only, the 2D verification doesn't touch GLBs at all).
+Confirmed: the 2D board's badge reads `WALLS: SERVER EDGES (196)` against
+the live `showcase` response, with the room perimeter now visibly
+outlined (previously only the inter-room gap column read as "wall" at
+all — the perimeter was never drawn). Clicking the rendered
+antechamber↔shrine door line opened the real `ConnectorInspector`
+("Door: antechamber ↔ shrine") — the SAME panel the door-row cell already
+opens, now reachable from the wall's own geometry too. The 3D preview
+(Chromium + `--use-gl=swiftshader` for headless WebGL) shows the full
+room perimeter as solid gray wall boxes with two amber door
+jamb/lintel breaks at the real connector positions — a visible gap in the
+wall run, not a shortened box. No unexpected console errors past the
+existing FIXTURES-MODE-adjacent ones this file already documents (the
+probe's own deliberately-invalid payload, doubled by StrictMode).

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -41,6 +41,7 @@ import {
   type LockedDoc,
   type WallKind,
 } from './dungeonYaml';
+import { hasServerEdges } from './edgesAdapter';
 import { SHOWCASE_YAML } from './fixtures';
 import { Inspector } from './Inspector';
 import { Palette } from './Palette';
@@ -790,7 +791,10 @@ export function DungeonBuilderConcept() {
         )}
 
         {wallGashExplainerOpen && (
-          <WallGashExplainer onClose={() => setWallGashExplainerOpen(false)} />
+          <WallGashExplainer
+            onClose={() => setWallGashExplainerOpen(false)}
+            serverEdgesActive={hasServerEdges(preview.floorPlan)}
+          />
         )}
 
         {toast && <ToastBanner message={toast} />}

--- a/src/concepts/dungeon-builder/WallGashExplainer.tsx
+++ b/src/concepts/dungeon-builder/WallGashExplainer.tsx
@@ -11,12 +11,29 @@
  * now authorable in THIS view too, via the Structural palette category,
  * so the explainer points there instead of bouncing to a different tab.
  * See TARGET-YAML.md's "Structural palette category" section.
- */
+ *
+ * **Copy is now conditional on `serverEdgesActive`** (rpg-project#169's
+ * wire-edges unit, 2026-08-04) — the ORIGINAL "FloorPlan carries no
+ * wall/door edge geometry on the wire" claim stopped being universally
+ * true the moment rpg-api-protos v0.1.118 (rpg-api#767) shipped
+ * `FloorPlan.edges`. For a response that carries them, this cell's own
+ * REAL wall/door line is already drawn on top of it (`Board.tsx`'s
+ * server-edges overlay) — the explainer says so, instead of repeating a
+ * now-false blanket claim, while still pointing at Structural for
+ * AUTHORING an additional target-dialect wall (walls: is still not
+ * compiled server-side either way — only the "does the wire carry
+ * anything at all" half of the old copy was wrong). */
 interface WallGashExplainerProps {
   onClose: () => void;
+  /** Whether the `FloorPlan` this click landed on carries real
+   * `edges` — `edgesAdapter.ts`'s `hasServerEdges`. */
+  serverEdgesActive: boolean;
 }
 
-export function WallGashExplainer({ onClose }: WallGashExplainerProps) {
+export function WallGashExplainer({
+  onClose,
+  serverEdgesActive,
+}: WallGashExplainerProps) {
   return (
     <div
       role="dialog"
@@ -47,14 +64,26 @@ export function WallGashExplainer({ onClose }: WallGashExplainerProps) {
           lineHeight: 1.5,
         }}
       >
-        Walls here are normally DERIVED from room layout + connectors —{' '}
-        <code>FloorPlan</code> carries no wall/door edge geometry on the wire.
-        You CAN author one right here, though: open the{' '}
+        {serverEdgesActive ? (
+          <>
+            This response carries real generated wall/door geometry (
+            <code>FloorPlan.edges</code>) — the confident line drawn over this
+            cell already IS the compiled wall. Click the line itself (a door
+            line opens its connector) rather than this cell for the real thing.
+          </>
+        ) : (
+          <>
+            Walls here are normally DERIVED from room layout + connectors — this
+            response's <code>FloorPlan</code> carries no wall/door edge geometry
+            on the wire.
+          </>
+        )}{' '}
+        You CAN author your own here, though: open the{' '}
         <strong style={{ color: '#c9aeff' }}>Structural</strong> category in the
         palette and select <strong>Wall</strong> (or <strong>Door</strong>, to
         flip an existing one), then click this cell again. It's target dialect,
-        proposed — badged "not yet compiled server-side" until dungeonspec grows
-        real wall geometry. See TARGET-YAML.md.
+        proposed — badged "not yet compiled server-side" until dungeonspec
+        accepts authored wall geometry. See TARGET-YAML.md.
       </p>
       <button
         onClick={onClose}

--- a/src/concepts/dungeon-builder/edgesAdapter.test.ts
+++ b/src/concepts/dungeon-builder/edgesAdapter.test.ts
@@ -1,0 +1,105 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanEdgeKind,
+  FloorPlanSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  connectorIndexForDoorId,
+  floorPlanEdgesToServerEdges,
+  hasServerEdges,
+} from './edgesAdapter';
+import { S2_LOOP_FLOORPLAN, SHOWCASE_FLOORPLAN } from './fixtures';
+
+describe('hasServerEdges', () => {
+  it('is true for the re-recorded showcase fixture (real v0.1.118 edges)', () => {
+    expect(hasServerEdges(SHOWCASE_FLOORPLAN)).toBe(true);
+  });
+
+  it('is false for a pre-#767 fixture with no edges field populated', () => {
+    expect(hasServerEdges(S2_LOOP_FLOORPLAN)).toBe(false);
+  });
+
+  it('is false for an empty FloorPlan', () => {
+    expect(hasServerEdges(create(FloorPlanSchema, {}))).toBe(false);
+  });
+});
+
+describe('floorPlanEdgesToServerEdges', () => {
+  it('consumes the recorded edges verbatim — no re-derivation when edges are present', () => {
+    const edges = floorPlanEdgesToServerEdges(SHOWCASE_FLOORPLAN);
+    expect(edges).toHaveLength(SHOWCASE_FLOORPLAN.edges.length);
+    expect(edges).toHaveLength(196);
+
+    const solid = edges.filter((e) => e.kind === 'solid');
+    const doors = edges.filter((e) => e.kind === 'door');
+    expect(solid).toHaveLength(194);
+    expect(doors).toHaveLength(2);
+
+    // One-to-one field mapping, not a recompute: pick the first wire edge
+    // and confirm the adapted entry matches it exactly.
+    const wireFirst = SHOWCASE_FLOORPLAN.edges[0]!;
+    const adaptedFirst = edges[0]!;
+    expect(adaptedFirst.from).toEqual([
+      wireFirst.from!.column,
+      wireFirst.from!.row,
+    ]);
+    expect(adaptedFirst.to).toEqual([wireFirst.to!.column, wireFirst.to!.row]);
+  });
+
+  it('maps FLOOR_PLAN_EDGE_KIND_DOOR to kind: "door" and carries doorId through', () => {
+    const edges = floorPlanEdgesToServerEdges(SHOWCASE_FLOORPLAN);
+    const doors = edges.filter((e) => e.kind === 'door');
+    expect(doors.map((d) => d.doorId).sort()).toEqual(
+      ['showcase-door-antechamber-shrine', 'showcase-door-shrine-vault'].sort()
+    );
+  });
+
+  it('never sets doorId on a solid edge', () => {
+    const edges = floorPlanEdgesToServerEdges(SHOWCASE_FLOORPLAN);
+    for (const e of edges) {
+      if (e.kind === 'solid') expect(e.doorId).toBeUndefined();
+    }
+  });
+
+  it('preserves an exterior edge endpoint outside the rendered bounds (negative column) rather than clamping it', () => {
+    const edges = floorPlanEdgesToServerEdges(SHOWCASE_FLOORPLAN);
+    const exterior = edges.find((e) => e.from[0] === -1 || e.to[0] === -1);
+    expect(exterior).toBeDefined();
+  });
+
+  it('returns an empty array for a FloorPlan with no edges', () => {
+    expect(floorPlanEdgesToServerEdges(S2_LOOP_FLOORPLAN)).toEqual([]);
+  });
+});
+
+describe('connectorIndexForDoorId', () => {
+  it('resolves a real connector door_id to its connector index — the wire-level correlation a door click can use', () => {
+    expect(
+      connectorIndexForDoorId(
+        SHOWCASE_FLOORPLAN,
+        'showcase-door-antechamber-shrine'
+      )
+    ).toBe(0);
+    expect(
+      connectorIndexForDoorId(SHOWCASE_FLOORPLAN, 'showcase-door-shrine-vault')
+    ).toBe(1);
+  });
+
+  it('returns null for an unknown door_id', () => {
+    expect(
+      connectorIndexForDoorId(SHOWCASE_FLOORPLAN, 'not-a-real-door')
+    ).toBeNull();
+  });
+
+  it('returns null when doorId is undefined (a solid edge)', () => {
+    expect(connectorIndexForDoorId(SHOWCASE_FLOORPLAN, undefined)).toBeNull();
+  });
+});
+
+describe('FloorPlanEdgeKind sanity (guards the adapter’s own enum mapping)', () => {
+  it('SOLID and DOOR are the only non-zero values the wire uses', () => {
+    expect(FloorPlanEdgeKind.SOLID).toBe(1);
+    expect(FloorPlanEdgeKind.DOOR).toBe(2);
+  });
+});

--- a/src/concepts/dungeon-builder/edgesAdapter.ts
+++ b/src/concepts/dungeon-builder/edgesAdapter.ts
@@ -1,0 +1,89 @@
+/**
+ * edgesAdapter — turns the wire's `FloorPlan.edges` (rpg-api-protos
+ * v0.1.118+, rpg-api#767's generated-edges wave: `repeated FloorPlanEdge
+ * edges = 6`) into this concept's own edge model, the SAME `{from, to,
+ * kind}` shape `dungeonYaml.ts`'s `WallDoc` (target-dialect authored
+ * `doc.walls`) already uses — one internal edge shape, one geometry helper
+ * per view (`hexLayout.ts`'s `edgeBetweenCells` for the 2D board,
+ * `preview3d/DungeonPreview3D.tsx`'s own for the 3D preview), for BOTH
+ * `Board.tsx` and `DungeonPreview3D.tsx` to consume. Neither renderer
+ * parses the proto shape (`FloorPlanCell`/`FloorPlanEdgeKind`) directly —
+ * this module is the one place that does.
+ *
+ * This is a pure field-rename/enum-map, never a compilation step:
+ * `FloorPlan.edges` is already the server's own canonical, deduplicated
+ * truth (FloorPlanEdge's own doc comment: "FloorPlan.edges MUST emit
+ * exactly one record for each physical edge"), so there's no dedup or
+ * orientation logic to re-derive here, unlike `doc.walls`'s own author-time
+ * mutators.
+ */
+import type {
+  FloorPlan,
+  FloorPlanCell,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { FloorPlanEdgeKind } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import type { WallDoc } from './dungeonYaml';
+
+/** `WallDoc` plus the one field it has no analog for: a DOOR edge's
+ * `doorId`, carried through so a rendered door can be traced back to the
+ * `FloorPlanConnector` it belongs to. A generated connector door's
+ * `FloorPlanEdge.doorId` always equals that connector's own `doorId`
+ * (`FloorPlanEdge`'s own doc comment: "For a generated connector door it
+ * MUST equal that FloorPlanConnector.door_id") — confirmed against a real
+ * recorded response, not just the contract text: `fixtures.ts`'s
+ * `SHOWCASE_FLOORPLAN.edges` has exactly two DOOR entries, and both
+ * `doorId`s match `SHOWCASE_FLOORPLAN.connectors` verbatim. A SOLID edge
+ * never carries one (same doc comment: "MUST be absent for SOLID edges"). */
+export interface ServerEdge extends WallDoc {
+  doorId?: string;
+}
+
+/** Whether `floorPlan` carries real generated wall/door truth. False for
+ * every response compiled/recorded before v0.1.118
+ * (`compileFloorPlanLocally`'s fixtures-mode fallback, which has no
+ * `edges` field to populate at all, and the pre-#767 recorded fixtures
+ * `SMOKE_TEST_FLOORPLAN`/`S2_LOOP_FLOORPLAN`). True for a live server
+ * response from the #767 wave onward and for `SHOWCASE_FLOORPLAN`'s own
+ * re-recorded `edges`. Callers gate the server-truth rendering path on
+ * this emptiness check rather than on `serverState` alone — a
+ * stale-pinned client talking to a fresh server (or the reverse) is
+ * exactly the case this catches that a mode flag wouldn't. */
+export function hasServerEdges(floorPlan: FloorPlan): boolean {
+  return floorPlan.edges.length > 0;
+}
+
+function cellToTuple(cell: FloorPlanCell | undefined): [number, number] {
+  return cell ? [cell.column, cell.row] : [0, 0];
+}
+
+/** The adapter itself — wire shape in, this concept's own edge model out. */
+export function floorPlanEdgesToServerEdges(
+  floorPlan: FloorPlan
+): ServerEdge[] {
+  return floorPlan.edges.map((edge) => ({
+    from: cellToTuple(edge.from),
+    to: cellToTuple(edge.to),
+    kind: edge.kind === FloorPlanEdgeKind.DOOR ? 'door' : 'solid',
+    doorId: edge.doorId,
+  }));
+}
+
+/** Resolve a DOOR edge's `doorId` back to its owning connector's index in
+ * `floorPlan.connectors` — the SAME index `doc.connectors`/
+ * `ConnectorInspector`/`Board.tsx`'s existing `onSelectConnector` contract
+ * already keys off, so a click on a rendered server-truth door edge can
+ * open the real `ConnectorInspector` through the exact same prop both
+ * views already wire, no new selection channel needed. `null` when
+ * `doorId` doesn't match any connector — shouldn't happen for a real
+ * generated connector door per `FloorPlanEdge`'s own contract, but a
+ * future non-connector door (TARGET-YAML.md's proposed inner-wall doors,
+ * rpg-project#179) would fall through here rather than crash or open the
+ * wrong inspector. */
+export function connectorIndexForDoorId(
+  floorPlan: FloorPlan,
+  doorId: string | undefined
+): number | null {
+  if (!doorId) return null;
+  const index = floorPlan.connectors.findIndex((c) => c.doorId === doorId);
+  return index === -1 ? null : index;
+}

--- a/src/concepts/dungeon-builder/fixtures.ts
+++ b/src/concepts/dungeon-builder/fixtures.ts
@@ -15,10 +15,19 @@
  *     showcase-floorplan.json — this closes the standalone concept's own
  *     "unverified past 2 rooms" and "entrance cell is a guess" findings;
  *     see CONTRACT.md.
+ *
+ * `SHOWCASE_FLOORPLAN.edges` was re-captured 2026-08-04 against the live
+ * server on rpg-api-protos v0.1.118 (rpg-api#767's generated-edges wave —
+ * `repeated FloorPlanEdge edges = 6`) via `grpcurl` against the same
+ * showcase.yaml, unmodified — see that field's own doc comment for
+ * provenance. `SMOKE_TEST_FLOORPLAN`/`S2_LOOP_FLOORPLAN` predate this and
+ * carry no `edges` — they're still real v0.1.115-era responses, just from
+ * before the field existed; nothing about them needed re-recording.
  */
 import { create } from '@bufbuild/protobuf';
 import {
   type FloorPlan,
+  FloorPlanEdgeKind,
   FloorPlanSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 
@@ -115,6 +124,998 @@ export const SHOWCASE_FLOORPLAN: FloorPlan = create(FloorPlanSchema, {
   height: 8,
   doorRow: 4,
   entrance: { column: 0, row: 4 },
+  // 196 real edges (194 solid, 2 door) captured 2026-08-04 against the
+  // live rpg-api-protos v0.1.118 server via grpcurl PutDungeon(validate_only)
+  // for this exact showcase.yaml — see this file's own header doc comment.
+  // Includes exterior edges whose 'to' endpoint sits outside the rendered
+  // floor-plan bounds (negative column/row) — FloorPlanEdge's own doc
+  // comment: 'one endpoint may be outside the rendered floor-plan bounds'.
+  // Door doorId values match the connectors above exactly, confirming the
+  // wire-level correlation a door-click can use to open ConnectorInspector.
+  edges: [
+    {
+      from: { column: 0, row: 7 },
+      to: { column: -1, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 7 },
+      to: { column: -1, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 7 },
+      to: { column: 0, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 6 },
+      to: { column: -1, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 6 },
+      to: { column: -1, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 5 },
+      to: { column: -1, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 5 },
+      to: { column: -1, row: 4 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 4 },
+      to: { column: -1, row: 4 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 4 },
+      to: { column: -1, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 3 },
+      to: { column: -1, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 3 },
+      to: { column: -1, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 2 },
+      to: { column: -1, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 2 },
+      to: { column: -1, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 1 },
+      to: { column: -1, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 1 },
+      to: { column: -1, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 0 },
+      to: { column: -1, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 0 },
+      to: { column: -1, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 0 },
+      to: { column: 0, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 0, row: 0 },
+      to: { column: 1, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 1, row: 7 },
+      to: { column: 0, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 1, row: 7 },
+      to: { column: 1, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 1, row: 7 },
+      to: { column: 2, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 1, row: 0 },
+      to: { column: 1, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 2, row: 7 },
+      to: { column: 2, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 2, row: 0 },
+      to: { column: 1, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 2, row: 0 },
+      to: { column: 2, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 2, row: 0 },
+      to: { column: 3, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 3, row: 7 },
+      to: { column: 2, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 3, row: 7 },
+      to: { column: 3, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 3, row: 7 },
+      to: { column: 4, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 3, row: 0 },
+      to: { column: 3, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 4, row: 7 },
+      to: { column: 4, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 4, row: 0 },
+      to: { column: 3, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 4, row: 0 },
+      to: { column: 4, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 4, row: 0 },
+      to: { column: 5, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 7 },
+      to: { column: 4, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 7 },
+      to: { column: 5, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 7 },
+      to: { column: 6, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 7 },
+      to: { column: 6, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 6 },
+      to: { column: 6, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 6 },
+      to: { column: 6, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 5 },
+      to: { column: 6, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 5 },
+      to: { column: 6, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 4 },
+      to: { column: 6, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 3 },
+      to: { column: 6, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 2 },
+      to: { column: 6, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 2 },
+      to: { column: 6, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 1 },
+      to: { column: 6, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 1 },
+      to: { column: 6, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 0 },
+      to: { column: 5, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 0 },
+      to: { column: 6, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 5, row: 0 },
+      to: { column: 6, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 6, row: 4 },
+      to: { column: 7, row: 4 },
+      kind: FloorPlanEdgeKind.DOOR,
+      doorId: 'showcase-door-antechamber-shrine',
+    },
+    {
+      from: { column: 7, row: 7 },
+      to: { column: 6, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 7 },
+      to: { column: 6, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 7 },
+      to: { column: 7, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 7 },
+      to: { column: 8, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 6 },
+      to: { column: 6, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 6 },
+      to: { column: 6, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 5 },
+      to: { column: 6, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 5 },
+      to: { column: 6, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 4 },
+      to: { column: 6, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 3 },
+      to: { column: 6, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 2 },
+      to: { column: 6, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 2 },
+      to: { column: 6, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 1 },
+      to: { column: 6, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 1 },
+      to: { column: 6, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 0 },
+      to: { column: 6, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 0 },
+      to: { column: 6, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 7, row: 0 },
+      to: { column: 7, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 8, row: 7 },
+      to: { column: 8, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 8, row: 0 },
+      to: { column: 7, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 8, row: 0 },
+      to: { column: 8, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 8, row: 0 },
+      to: { column: 9, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 9, row: 7 },
+      to: { column: 8, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 9, row: 7 },
+      to: { column: 9, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 9, row: 7 },
+      to: { column: 10, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 9, row: 0 },
+      to: { column: 9, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 10, row: 7 },
+      to: { column: 10, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 10, row: 0 },
+      to: { column: 9, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 10, row: 0 },
+      to: { column: 10, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 10, row: 0 },
+      to: { column: 11, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 11, row: 7 },
+      to: { column: 10, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 11, row: 7 },
+      to: { column: 11, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 11, row: 7 },
+      to: { column: 12, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 11, row: 0 },
+      to: { column: 11, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 12, row: 7 },
+      to: { column: 12, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 12, row: 0 },
+      to: { column: 11, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 12, row: 0 },
+      to: { column: 12, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 12, row: 0 },
+      to: { column: 13, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 13, row: 7 },
+      to: { column: 12, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 13, row: 7 },
+      to: { column: 13, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 13, row: 7 },
+      to: { column: 14, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 13, row: 0 },
+      to: { column: 13, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 14, row: 7 },
+      to: { column: 14, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 14, row: 0 },
+      to: { column: 13, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 14, row: 0 },
+      to: { column: 14, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 14, row: 0 },
+      to: { column: 15, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 15, row: 7 },
+      to: { column: 14, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 15, row: 7 },
+      to: { column: 15, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 15, row: 7 },
+      to: { column: 16, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 15, row: 0 },
+      to: { column: 15, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 16, row: 7 },
+      to: { column: 16, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 16, row: 0 },
+      to: { column: 15, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 16, row: 0 },
+      to: { column: 16, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 16, row: 0 },
+      to: { column: 17, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 17, row: 7 },
+      to: { column: 16, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 17, row: 7 },
+      to: { column: 17, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 17, row: 7 },
+      to: { column: 18, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 17, row: 0 },
+      to: { column: 17, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 18, row: 7 },
+      to: { column: 18, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 18, row: 0 },
+      to: { column: 17, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 18, row: 0 },
+      to: { column: 18, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 18, row: 0 },
+      to: { column: 19, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 19, row: 7 },
+      to: { column: 18, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 19, row: 7 },
+      to: { column: 19, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 19, row: 7 },
+      to: { column: 20, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 19, row: 0 },
+      to: { column: 19, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 7 },
+      to: { column: 20, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 7 },
+      to: { column: 21, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 7 },
+      to: { column: 21, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 6 },
+      to: { column: 21, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 6 },
+      to: { column: 21, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 5 },
+      to: { column: 21, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 4 },
+      to: { column: 21, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 3 },
+      to: { column: 21, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 3 },
+      to: { column: 21, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 2 },
+      to: { column: 21, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 2 },
+      to: { column: 21, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 1 },
+      to: { column: 21, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 1 },
+      to: { column: 21, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 0 },
+      to: { column: 19, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 0 },
+      to: { column: 20, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 0 },
+      to: { column: 21, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 20, row: 0 },
+      to: { column: 21, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 21, row: 4 },
+      to: { column: 22, row: 5 },
+      kind: FloorPlanEdgeKind.DOOR,
+      doorId: 'showcase-door-shrine-vault',
+    },
+    {
+      from: { column: 22, row: 7 },
+      to: { column: 21, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 7 },
+      to: { column: 21, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 7 },
+      to: { column: 22, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 6 },
+      to: { column: 21, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 6 },
+      to: { column: 21, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 5 },
+      to: { column: 21, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 4 },
+      to: { column: 21, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 3 },
+      to: { column: 21, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 3 },
+      to: { column: 21, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 2 },
+      to: { column: 21, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 2 },
+      to: { column: 21, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 1 },
+      to: { column: 21, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 1 },
+      to: { column: 21, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 0 },
+      to: { column: 21, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 0 },
+      to: { column: 21, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 0 },
+      to: { column: 22, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 22, row: 0 },
+      to: { column: 23, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 23, row: 7 },
+      to: { column: 22, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 23, row: 7 },
+      to: { column: 23, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 23, row: 7 },
+      to: { column: 24, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 23, row: 0 },
+      to: { column: 23, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 24, row: 7 },
+      to: { column: 24, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 24, row: 0 },
+      to: { column: 23, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 24, row: 0 },
+      to: { column: 24, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 24, row: 0 },
+      to: { column: 25, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 25, row: 7 },
+      to: { column: 24, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 25, row: 7 },
+      to: { column: 25, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 25, row: 7 },
+      to: { column: 26, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 25, row: 0 },
+      to: { column: 25, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 26, row: 7 },
+      to: { column: 26, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 26, row: 0 },
+      to: { column: 25, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 26, row: 0 },
+      to: { column: 26, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 26, row: 0 },
+      to: { column: 27, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 27, row: 7 },
+      to: { column: 26, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 27, row: 7 },
+      to: { column: 27, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 27, row: 7 },
+      to: { column: 28, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 27, row: 0 },
+      to: { column: 27, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 28, row: 7 },
+      to: { column: 28, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 28, row: 0 },
+      to: { column: 27, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 28, row: 0 },
+      to: { column: 28, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 28, row: 0 },
+      to: { column: 29, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 7 },
+      to: { column: 28, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 7 },
+      to: { column: 29, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 7 },
+      to: { column: 30, row: 8 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 7 },
+      to: { column: 30, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 6 },
+      to: { column: 30, row: 7 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 6 },
+      to: { column: 30, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 5 },
+      to: { column: 30, row: 6 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 5 },
+      to: { column: 30, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 4 },
+      to: { column: 30, row: 5 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 4 },
+      to: { column: 30, row: 4 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 3 },
+      to: { column: 30, row: 4 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 3 },
+      to: { column: 30, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 2 },
+      to: { column: 30, row: 3 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 2 },
+      to: { column: 30, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 1 },
+      to: { column: 30, row: 2 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 1 },
+      to: { column: 30, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 0 },
+      to: { column: 29, row: -1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 0 },
+      to: { column: 30, row: 1 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+    {
+      from: { column: 29, row: 0 },
+      to: { column: 30, row: 0 },
+      kind: FloorPlanEdgeKind.SOLID,
+    },
+  ],
 });
 
 /** rpg-api PR #750's grpcurl smoke-test YAML — a synthetic 2-room

--- a/src/concepts/dungeon-builder/floorPlanCompile.test.ts
+++ b/src/concepts/dungeon-builder/floorPlanCompile.test.ts
@@ -13,7 +13,19 @@ import { compileFloorPlanLocally } from './floorPlanCompile';
 describe('compileFloorPlanLocally vs real recorded FloorPlan responses', () => {
   it('matches the real showcase.yaml response — a 3-room, non-uniform-width chain', () => {
     const { doc } = parseDungeon(SHOWCASE_YAML);
-    expect(compileFloorPlanLocally(doc)).toEqual(SHOWCASE_FLOORPLAN);
+    // `edges` excluded deliberately: SHOWCASE_FLOORPLAN's `edges` (196
+    // real recorded entries, rpg-project#169's wire-edges unit) is real
+    // generated wall/door truth dungeonspec computes server-side.
+    // `compileFloorPlanLocally` is this file's own doc comment's "grid
+    // math is server-authoritative" fixtures-mode fallback — it was never
+    // meant to (and doesn't) re-derive that generator step client-side, so
+    // its own `edges` stays the proto default `[]` by construction. See
+    // `edgesAdapter.test.ts` for the coverage that DOES assert on
+    // `SHOWCASE_FLOORPLAN.edges` itself.
+    expect(compileFloorPlanLocally(doc)).toEqual({
+      ...SHOWCASE_FLOORPLAN,
+      edges: [],
+    });
   });
 
   it("matches PR #750's real smoke-test response", () => {

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -54,13 +54,27 @@
  * gating) — reusing it would mean building the derivation step it exists
  * to avoid needing. `WallRunMesh`'s tiled-piece/corner-miter fidelity is
  * a deliberate non-goal for this first landing (see `WallBox` below).
- * Doors (`kind: 'door'`) render as a distinctly colored/shorter box, not
- * an opening — the door ROW concept in edit mode's compiled chain is a
- * different thing (a legality rule on a whole grid row) from a wall
- * segment's own `kind`, and this landing doesn't attempt to cut a real
- * gap in the box for a door frame — reads as "a marked door," not yet
- * "a walkable door," and is named honestly as the next fidelity step
- * rather than attempted here.
+ *
+ * **ALSO renders `FloorPlan.edges` (rpg-project#169's wire-edges unit,
+ * 2026-08-04, rpg-api-protos v0.1.118+)** — the same server-truth edges
+ * `Board.tsx`'s 2D overlay now draws, adapted through the SAME
+ * `edgesAdapter.ts` module (`floorPlanEdgesToServerEdges`) rather than a
+ * second parse of the proto shape. `hasServerEdges(floorPlan)` gates this:
+ * empty for fixtures mode or any pre-#767 recording, in which case this
+ * pane renders exactly as before (`doc.walls` only). **This closes the
+ * "marked door, not a walkable door" gap CONTRACT.md's "door-row void"
+ * findings name**: a DOOR edge (server-truth OR an authored
+ * `doc.walls` door — both go through the SAME `WallBox`/`DoorGap` branch
+ * now) renders as a genuine gap in the wall run — two solid jambs flanking
+ * an open, walkable span, with a thin lintel piece for door-frame
+ * styling — instead of the old shortened box that was exactly as
+ * impassable as a solid wall, just visually shorter. A server-truth door's
+ * `doorId` resolves back to its `FloorPlanConnector` (`edgesAdapter.ts`'s
+ * `connectorIndexForDoorId` — the SAME wire-level correlation the 2D board
+ * uses) and, when `onSelectConnector` is wired, an invisible click-catcher
+ * spanning the opening opens the real `ConnectorInspector` — the same
+ * Inspector a door-row cell already opens in 2D, now reachable by clicking
+ * the actual rendered doorway in 3D too.
  */
 import {
   cubeToWorld,
@@ -90,8 +104,13 @@ import {
   resolvePlacement,
   type DungeonDoc,
   type PlacementDoc,
-  type WallDoc,
 } from '../dungeonYaml';
+import {
+  connectorIndexForDoorId,
+  floorPlanEdgesToServerEdges,
+  hasServerEdges,
+  type ServerEdge,
+} from '../edgesAdapter';
 import { cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
 import { END_COLOR, START_COLOR } from '../markerStyle';
 import type { PaletteSelection, PlacementSelection } from '../types';
@@ -122,6 +141,16 @@ interface DungeonPreview3DProps {
   selectedPalette?: PaletteSelection | null;
   onPlace?: (roomId: string, at: [number, number]) => void;
   onReject?: (message: string) => void;
+  /** rpg-project#169's wire-edges unit — a server-truth DOOR edge's
+   * `doorId` resolves to a real `FloorPlanConnector` index
+   * (`edgesAdapter.ts`'s `connectorIndexForDoorId`); when wired, clicking
+   * the rendered doorway opens `ConnectorInspector` through it — the SAME
+   * `onSelectConnector` contract `Board.tsx`'s 2D door-row cell and
+   * server-edge line already use. Optional, same degrade-to-view-only
+   * pattern as every other interaction prop on this component: omitting
+   * it just means a rendered doorway isn't clickable, the gap geometry
+   * itself is unaffected either way. */
+  onSelectConnector?: (index: number) => void;
 }
 
 interface PlacedProp {
@@ -137,6 +166,11 @@ interface PlacedWall {
   position: [number, number, number];
   rotationY: number;
   isDoor: boolean;
+  /** Server-truth doors only (`ServerEdge.doorId`) — an authored
+   * `doc.walls` door has no connector to correlate to, so this stays
+   * `undefined` for those. See `DungeonPreview3DProps.onSelectConnector`'s
+   * own doc comment for what a defined value lets a click do. */
+  doorId?: string;
 }
 
 interface PlacedMonster {
@@ -215,7 +249,7 @@ function edgeBetweenCells(
   );
 }
 
-function wallBoxTransform(wall: WallDoc): {
+function wallBoxTransform(wall: ServerEdge): {
   position: [number, number, number];
   rotationY: number;
 } {
@@ -231,16 +265,44 @@ function wallBoxTransform(wall: WallDoc): {
   };
 }
 
-function buildWalls(walls: readonly WallDoc[]): PlacedWall[] {
+/** Builds render-ready wall pieces from either source — `doc.walls`
+ * (authored, `doorId` always absent) or the server-edges adapter's output
+ * (`ServerEdge[]`, `doorId` present on generated connector doors). One
+ * function for both, since both are the same `{from, to, kind}` shape —
+ * see `edgesAdapter.ts`'s own doc comment for why `ServerEdge` is a
+ * `WallDoc` superset rather than a parallel type. `keyPrefix` keeps the
+ * two sources' React keys from colliding when a document happens to
+ * author a wall on the exact same edge a server edge also covers. */
+function buildWalls(
+  walls: readonly ServerEdge[],
+  keyPrefix: string
+): PlacedWall[] {
   return walls.map((wall) => {
     const { position, rotationY } = wallBoxTransform(wall);
     return {
-      key: `${wall.from.join(',')}-${wall.to.join(',')}`,
+      key: `${keyPrefix}:${wall.from.join(',')}-${wall.to.join(',')}`,
       position,
       rotationY,
       isDoor: wall.kind === 'door',
+      doorId: wall.doorId,
     };
   });
+}
+
+/** `DoorGap`'s `onSelectDoor` for one `PlacedWall` — `undefined` unless
+ * ALL of: the caller wired `onSelectConnector` at all, this wall carries a
+ * `doorId` (server-truth only — an authored `doc.walls` door never does),
+ * and that `doorId` resolves to a real connector
+ * (`connectorIndexForDoorId`). Pulled out of the render loop so that loop
+ * stays a plain ternary instead of an inline IIFE. */
+function doorSelectHandler(
+  wall: PlacedWall,
+  floorPlan: FloorPlan,
+  onSelectConnector: ((index: number) => void) | undefined
+): (() => void) | undefined {
+  if (!onSelectConnector || !wall.doorId) return undefined;
+  const index = connectorIndexForDoorId(floorPlan, wall.doorId);
+  return index === null ? undefined : () => onSelectConnector(index);
 }
 
 /** Shared by both placement loops below (room-scoped and top-level) — the
@@ -492,30 +554,115 @@ function FloorHitCell({
 // the same distinction (Board.tsx/CreationBoard.tsx: '#e8e2d8' solid,
 // '#ffb347' door) — one visual language for "this is a drawn wall" across
 // both previews, same principle the hole rendering already established.
-// A door renders shorter (a marked threshold, not a walkable gap — see
-// this file's header doc comment for why a real opening isn't attempted
-// this round) so it reads as different from a solid run at a glance, not
-// just a different color at a distance.
 const WALL_SOLID_COLOR = '#e8e2d8';
 const WALL_DOOR_COLOR = '#ffb347';
 const WALL_THICKNESS = 0.12;
-const WALL_DOOR_HEIGHT_RATIO = 0.55;
 
 function WallBox({ wall }: { wall: PlacedWall }) {
-  const height = wall.isDoor
-    ? WALL_HEIGHT * WALL_DOOR_HEIGHT_RATIO
-    : WALL_HEIGHT;
-  const y = wall.isDoor ? (height - WALL_HEIGHT) / 2 : 0;
   return (
-    <mesh
-      position={[wall.position[0], wall.position[1] + y, wall.position[2]]}
-      rotation={[0, wall.rotationY, 0]}
-    >
-      <boxGeometry args={[HEX_SIZE, height, WALL_THICKNESS]} />
-      <meshStandardMaterial
-        color={wall.isDoor ? WALL_DOOR_COLOR : WALL_SOLID_COLOR}
-      />
+    <mesh position={wall.position} rotation={[0, wall.rotationY, 0]}>
+      <boxGeometry args={[HEX_SIZE, WALL_HEIGHT, WALL_THICKNESS]} />
+      <meshStandardMaterial color={WALL_SOLID_COLOR} />
     </mesh>
+  );
+}
+
+// A genuine gap, not a shortened box (the "marked door, not a walkable
+// door" limitation this file's header doc comment used to name as the
+// next fidelity step — closed by this unit). Two solid jambs flank an
+// OPEN, walkable span; a thin lintel piece reads as a door frame without
+// blocking the opening below it. Kirk's own framing for the door-row void
+// this same construct answers on the floor side: "the gash becomes a real
+// doorway."
+const DOOR_JAMB_WIDTH = HEX_SIZE * 0.22;
+const DOOR_OPENING_WIDTH = HEX_SIZE - DOOR_JAMB_WIDTH * 2;
+const DOOR_OPENING_HEIGHT = WALL_HEIGHT * 0.8;
+const DOOR_LINTEL_HEIGHT = WALL_HEIGHT - DOOR_OPENING_HEIGHT;
+// Wide/tall enough to comfortably catch a click near the opening without
+// competing with the floor hit-cell or an adjacent placement's own hit
+// area — invisible, `FloorHitCell`'s own "transparent but interactive"
+// pattern, not a new one.
+const DOOR_CLICK_HIT_THICKNESS = WALL_THICKNESS * 2.5;
+
+/** Local-space X offset (along the wall's OWN length, before rotation)
+ * rotated into a world-space `{dx, dz}` pair — Three.js's standard Y-axis
+ * rotation matrix (`x' = x·cos θ + z·sin θ`, `z' = -x·sin θ + z·cos θ`,
+ * evaluated at local `z = 0`). Used to place the two door jambs
+ * symmetrically about the wall's own midpoint without hand-deriving a new
+ * rotation per caller. */
+function rotateLocalXOffset(
+  rotationY: number,
+  localX: number
+): { dx: number; dz: number } {
+  return {
+    dx: localX * Math.cos(rotationY),
+    dz: -localX * Math.sin(rotationY),
+  };
+}
+
+function DoorGap({
+  wall,
+  onSelectDoor,
+}: {
+  wall: PlacedWall;
+  onSelectDoor?: () => void;
+}) {
+  const jambOffset = HEX_SIZE / 2 - DOOR_JAMB_WIDTH / 2;
+  const left = rotateLocalXOffset(wall.rotationY, jambOffset);
+  const right = rotateLocalXOffset(wall.rotationY, -jambOffset);
+  return (
+    <group>
+      <mesh
+        position={[
+          wall.position[0] + left.dx,
+          wall.position[1],
+          wall.position[2] + left.dz,
+        ]}
+        rotation={[0, wall.rotationY, 0]}
+      >
+        <boxGeometry args={[DOOR_JAMB_WIDTH, WALL_HEIGHT, WALL_THICKNESS]} />
+        <meshStandardMaterial color={WALL_DOOR_COLOR} />
+      </mesh>
+      <mesh
+        position={[
+          wall.position[0] + right.dx,
+          wall.position[1],
+          wall.position[2] + right.dz,
+        ]}
+        rotation={[0, wall.rotationY, 0]}
+      >
+        <boxGeometry args={[DOOR_JAMB_WIDTH, WALL_HEIGHT, WALL_THICKNESS]} />
+        <meshStandardMaterial color={WALL_DOOR_COLOR} />
+      </mesh>
+      <mesh
+        position={[
+          wall.position[0],
+          DOOR_OPENING_HEIGHT + DOOR_LINTEL_HEIGHT / 2,
+          wall.position[2],
+        ]}
+        rotation={[0, wall.rotationY, 0]}
+      >
+        <boxGeometry
+          args={[DOOR_OPENING_WIDTH, DOOR_LINTEL_HEIGHT, WALL_THICKNESS]}
+        />
+        <meshStandardMaterial color={WALL_DOOR_COLOR} />
+      </mesh>
+      {onSelectDoor && (
+        <mesh
+          position={wall.position}
+          rotation={[0, wall.rotationY, 0]}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelectDoor();
+          }}
+        >
+          <boxGeometry
+            args={[HEX_SIZE, WALL_HEIGHT, DOOR_CLICK_HIT_THICKNESS]}
+          />
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+        </mesh>
+      )}
+    </group>
   );
 }
 
@@ -574,6 +721,7 @@ export function DungeonPreview3D({
   selectedPalette,
   onPlace,
   onReject,
+  onSelectConnector,
 }: DungeonPreview3DProps) {
   const floorTiles = useMemo(
     () => buildFloorTiles(floorPlan, doc.holes),
@@ -583,7 +731,22 @@ export function DungeonPreview3D({
     () => buildPlacements(floorPlan, doc),
     [floorPlan, doc]
   );
-  const walls = useMemo(() => buildWalls(doc.walls), [doc.walls]);
+  const authoredWalls = useMemo(
+    () => buildWalls(doc.walls, 'authored'),
+    [doc.walls]
+  );
+  // Server-truth wall/door edges (rpg-project#169's wire-edges unit) — see
+  // this file's own header doc comment. Empty whenever `floorPlan` carries
+  // no `edges` (fixtures mode, or any pre-#767 recording), in which case
+  // this preview renders exactly as it did before this unit: `doc.walls`
+  // only.
+  const serverWalls = useMemo(
+    () =>
+      hasServerEdges(floorPlan)
+        ? buildWalls(floorPlanEdgesToServerEdges(floorPlan), 'server')
+        : [],
+    [floorPlan]
+  );
   const entranceBlocked = useMemo(
     () => isEntranceBlocked(floorPlan, doc),
     [floorPlan, doc]
@@ -640,9 +803,21 @@ export function DungeonPreview3D({
                 onClickCell={handleClickCell}
               />
             ))}
-            {walls.map((w) => (
-              <WallBox key={w.key} wall={w} />
-            ))}
+            {[...serverWalls, ...authoredWalls].map((w) =>
+              w.isDoor ? (
+                <DoorGap
+                  key={w.key}
+                  wall={w}
+                  onSelectDoor={doorSelectHandler(
+                    w,
+                    floorPlan,
+                    onSelectConnector
+                  )}
+                />
+              ) : (
+                <WallBox key={w.key} wall={w} />
+              )
+            )}
             {props.map((p) => {
               const variant = resolvePropVariant(p.variantRef);
               if (!variant) return null;


### PR DESCRIPTION
## Summary

- Bumps `@kirkdiggler/rpg-api-protos` to **v0.1.118** (rpg-api#767's generated-edges wave), verified `FloorPlanEdge`/`FloorPlanEdgeKind` are present before writing any code against them.
- New shared adapter (`edgesAdapter.ts`) turns the wire's `FloorPlan.edges` into this concept's own `WallDoc`-shaped edge model — one parse of the proto shape, consumed by both boards.
- **2D edit board**: real edge-line overlay drawn from server truth (room perimeter walls the old rendering never showed at all, not just the inter-room gap), a `WALLS: SERVER EDGES (N)` vs `WALLS: DERIVED` source badge so drift between client/server proto versions is visible, and a clickable door line wired to the real `ConnectorInspector` via `door_id` → connector correlation.
- **3D preview**: server-truth walls render at all for the first time (previously entirely absent — the original spike explicitly skipped walls). A DOOR edge now renders as a genuine gap (two jambs + a lintel piece) instead of the old shortened-but-still-impassable box — closes the "marked door, not a walkable door" limitation this concept's own doc comments named as the next fidelity step. Applies uniformly to authored `doc.walls` doors too, same component.
- `fixtures.ts`'s `SHOWCASE_FLOORPLAN.edges` is a **real recorded response** — `grpcurl PutDungeon(validate_only)` against the live v0.1.118 server for the unmodified showcase.yaml (196 edges: 194 solid, 2 door), not synthesized.
- `CONTRACT.md` gets a new ledger section plus an update to the existing "fourth consumer signal" convergence note (2D + 3D are now wire-fed for compiled chains; creation-mode authored walls are still client-side pending rpg-project#179 / toolkit#881 / rpg-api#768 — separate, still-open work).

## Test plan

- [x] `npm run ci-check` clean (format/lint/typecheck/build/test)
- [x] 253 dungeon-builder tests passing (15 new: 12 in `edgesAdapter.test.ts`, 3 in `Board.test.tsx`)
- [x] Live-verified against the real envoy service on `:8091` (own dev server, free port, `VITE_DEV_PLAYER_ID` dev auth): 2D badge reads `WALLS: SERVER EDGES (196)`, room perimeters visibly outlined, clicking the rendered door line opens the real ConnectorInspector ("Door: antechamber ↔ shrine")
- [x] 3D preview (headless Chromium + swiftshader) shows the full room perimeter as wall boxes with two amber door jamb/lintel gaps at the real connector positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4