### PR TITLE
unit: creation-mode 3D preview (canvas-derived floor)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3997,3 +3997,223 @@ jamb/lintel breaks at the real connector positions — a visible gap in the
 wall run, not a shortened box. No unexpected console errors past the
 existing FIXTURES-MODE-adjacent ones this file already documents (the
 probe's own deliberately-invalid payload, doubled by StrictMode).
+
+## Creation-mode 3D preview unit: "can I go from new dungeon to 3D?" (2026-08-04, rpg-project#169)
+
+Kirk's ask, verbatim: "can I go from new dungeon to 3d?" — the 3D preview
+spike above was edit-mode-only from the start (its own header doc
+comment: "it needs a real compiled floor plan to exist [...] creation
+mode's proposed schema has no `FloorPlan` at all"). This unit gives
+creation mode the same 2D/3D toggle, without inventing a second compiled
+response to feed it.
+
+### The floor problem, and the settled semantic
+
+A from-scratch canvas genuinely has nothing to derive a floor from — no
+`FloorPlan`, no server round-trip at all. New module,
+`creation/canvasFloor.ts`'s `deriveCanvasFloorCells(doc)`: every
+`[col,row]` cell inside `doc.canvas`'s bounds (falling back to
+`DEFAULT_CANVAS`, matching `CreationBoard.tsx`'s own fallback), minus
+`doc.holes`. Recorded as a real dialect note, not left as an
+implementation detail — TARGET-YAML.md's `canvas:` section now says so
+explicitly, including the one deliberate non-obvious call: a
+`walls:`/`wallLines:` footprint cell is **blocked, not floorless** (Kirk's
+own rule — "any hex that is not 100% uncovered would not be
+traversable"), so it still gets a floor tile, just a flagged one — the
+exact same "flag, don't silently remove" discipline the 2D board's own
+footprint/region-overlap checks already follow.
+
+### `DungeonPreview3D`: an alternate input path, not a fork
+
+The brief's own instruction was reuse, not a copy: `DungeonPreview3D.tsx`
+grew a `floorCells?: readonly [number, number][]` prop alongside the
+existing `floorPlan?: FloorPlan` (now optional, was required).
+`buildFloorTiles` picks whichever is supplied — `floorCells` wins if both
+somehow are, though the two real callers today never combine them (edit
+mode passes `floorPlan` only; creation mode passes `floorCells` only).
+Every `floorPlan`-only feature degrades to "doesn't render" rather than
+throwing when it's absent, verified one at a time rather than assumed:
+
+- **Server-truth wall/door edges** (`hasServerEdges`/
+  `floorPlanEdgesToServerEdges`) — gated on `floorPlan` being present;
+  empty otherwise, same as the existing fixtures-mode fallback.
+- **The generator-chosen entrance marker** — has no creation-mode analog
+  at all (this file's own long-standing "Start/end: authored, in real
+  tension with the generator-chosen entrance" finding: a freeform canvas
+  has no generator to choose FOR the author) — simply doesn't render
+  without `floorPlan`, which is the CORRECT behavior, not a gap.
+- **Room-scoped `place:`/`boss:`** — the loop that resolves them via
+  `floorPlan.rooms.find(...)` is skipped entirely without `floorPlan`;
+  in practice this was ALREADY a no-op in creation mode even before this
+  unit, since a from-scratch canvas's `doc.rooms` is always `[]`
+  (`creation/emptyCanvasDoc.ts`) — the guard just keeps the function
+  honestly typed for `FloorPlan | undefined` rather than asserting
+  non-null.
+- **Click-to-place** — deliberately NOT wired for creation-mode 3D this
+  round (see "Read-only this round," below); `placeableCells` is empty
+  without `floorPlan`, so no `FloorHitCell` mounts at all — the whole
+  interaction surface is absent, not half-built.
+
+Everything doc-native — `doc.walls`, `doc.holes`, `doc.place` (top-level),
+`doc.start`/`doc.end` — needed ZERO changes; these already had no
+`floorPlan` dependency and were verified live to "just work" once
+`floorCells` supplied a floor to render them against (see "Live
+verification," below).
+
+### Two doc-native overlays, new to 3D, driven purely by `doc` (render in EITHER mode)
+
+- **Straight-wall (`doc.wallLines`) footprint, dimmed rather than
+  omitted** — the 3D sibling of the 2D board's crimson footprint hatch.
+  `buildWallLineFootprint(doc)` reuses `creation/straightWallGeometry.ts`'s
+  own `straightWallsFootprintSet` (the SAME function `CreationBoard.tsx`'s
+  2D overlay calls) rather than re-deriving the clip math a second time —
+  a flat semi-transparent crimson disc per footprint cell, cheap by
+  construction (skipped entirely when `doc.wallLines` is empty).
+- **Region (`doc.regions`) membership tint + floating label** — a
+  translucent `regionArchetypeColor`-tinted disc per member cell (same
+  archetype color the 2D board's read-only overlay already uses) plus a
+  `Billboard`+`Text` label at the region's centroid — the SAME
+  `Billboard`/`Text` primitive `AuthorGridOverlay.tsx` already uses for
+  the real game's author-grid labels, not a new one. "If cheap" from the
+  brief turned out cheap: both overlays are the identical flat-hex-mesh
+  shape `FloorHitCell`'s own click-hit layer already uses, just a
+  different Y offset/color/opacity, no new geometry primitive.
+
+**Deliberately NOT attempted this round**: full 3D geometry for a
+straight wall's own LINE (matching its corner-anchored, door-gapped
+fidelity in 2D — jambs, lintel, a real walkable opening). The brief's own
+scope was the floor treatment ("render their floor but visually distinct
+if cheap"), not a second wall-box renderer; `doc.walls` (the OTHER,
+edge-native wall representation) already renders in 3D via the existing
+`WallBox`/`DoorGap` path with zero changes needed, so creation mode is
+not wall-blind in 3D — only `wallLines:`'s own straight-line geometry
+stays 2D-only. Named here as a real follow-up, not silently deferred.
+
+### The toggle: same idiom, independent state, reused per-mode discipline
+
+Creation mode's header grows the identical `role="group" aria-label="2D
+or 3D board"` control edit mode's own header already has — not a second
+one invented for this mode. State ownership follows the EXACT precedent
+this file's "Collapsible side panels" section already set for the
+palette/YAML collapse pairs: owned by `DungeonBuilderConcept` (never
+unmounts across an edit↔create tab switch) as its own independent
+`createBoardDim` flag, not shared with edit mode's `boardDim` and not
+local `useState` inside `CreationConcept` (which DOES unmount whenever
+`mode` leaves `'create'`, so local state there would reset on every tab
+return). `CreationConcept`'s own `<main>` now mirrors edit mode's
+exact 2D/3D branch structure (an outer `overflow: hidden` flex column,
+an inner `overflow: auto` div for the SVG board vs. a padding-free
+`minHeight: 0` div for the R3F canvas) rather than inventing a second
+layout shape.
+
+### Read-only this round, by omission not by a new flag
+
+The creation-mode `<DungeonPreview3D>` call site passes only
+`floorCells`/`doc` — `selectedPlacement`/`onSelect`/`selectedPalette`/
+`onPlace`/`onReject`/`onSelectConnector` are all left unwired. Every one
+of those props was already optional, independently degrading to
+view-only per its own doc comment (written for exactly this kind of
+caller) — so "read-only" needed no new prop, no `readOnly` flag, just
+omission. Click-to-place in 3D graduating from edit mode to creation mode
+is named as a real follow-up (the brief's own framing), not attempted
+here.
+
+### Live verification
+
+Real dev server (`vite --port 5190`, never `:3001`), driven via a
+throwaway Playwright script (gitignored scratch pattern, deleted after
+the run — this repo has no blanket scratch-script gitignore rule, same
+situation the corner-anchored-walls unit's own script hit). `public/
+models/synty` rsync'd from the existing `~/game-dev/rpg-game-assets`
+checkout (same provenance the palette-thumbnail round documented) since a
+fresh worktree never has it.
+
+Built a real "New Dungeon" document by driving the ACTUAL app, not by
+hand-authoring a fixture: clicked "Play the pitch" for a zigzag `doc.walls`
+run with a door, start/end, a monster, and a facing-rotated reaper statue
+"for free" (the same real mutators a manual click calls); painted a
+3-cell region and created it via the Region tool + panel; drew a
+corner-anchored `wallLines:` straight wall via the Straight Wall tool and
+carved a door in it via the Door tool; placed a `candles` prop and set an
+explicit `height: 1.4` via the Inspector. Confirmed via the live proposed-
+YAML pane, not just the screenshots' own claim — the resulting document
+genuinely carries all of it:
+
+```yaml
+wallLines:
+  [
+    {
+      from: { cell: [0, 4], corner: 4 },
+      to: { cell: [0, 9], corner: 4 },
+      doors: [{ cell: [0, 7] }],
+    },
+  ]
+place: [..., { ref: 'dnd5e:props:candles', at: [4, 10], height: 1.4 }]
+regions:
+  - id: region-1
+    archetype: chamber
+    cells: [[2, 2], [2, 3], [3, 3]]
+```
+
+Two real scripting bugs, caught by the resulting screenshots, not
+assumed correct: (1) `document.querySelector('svg')` grabbed a small 15×15
+UI icon `<svg>` (there are several on this page) instead of the
+`CreationBoard` canvas — every computed coordinate was garbage until
+fixed to `document.querySelector('svg > polygon').closest('svg')`. (2) A
+naive `getByText('Door', {exact:false}).first()` matched the page's own
+demo-script CAPTION text ("...start/end → door → monster...") instead of
+the Door tool's palette row, since `.first()` picks DOM order and the
+caption sits above the Palette — fixed by scoping every palette
+interaction to `getByRole('button', {name: /.../})` instead of a bare
+text search. A third, geometry-specific finding: the straight wall's Door
+tool needs a click ON the wall's own rendered corner-to-corner LINE
+(`straightWallLineIndexNear`'s hit radius is a tight 8 board units), not
+near a cell CENTER — resolved by reading the wall's own rendered `<line>`
+midpoint straight out of the DOM (the longest solid-stroke line on the
+board — a single edge-wall segment is always exactly one hex-edge long,
+genuinely shorter than a multi-row straight-wall span) rather than
+re-deriving corner-anchor geometry externally.
+
+Screenshots confirm, at native resolution and cropped/upscaled for
+close-in detail: the full canvas floor rendering as real hex tiles across
+the whole 20×30 grid (not just wherever a room chain would have been);
+the demo's own zigzag `doc.walls` run with a genuine amber jamb/lintel
+door GAP (not a shortened box) next to the skeleton-captain and
+facing-rotated reaper statue; the straight wall's footprint rendering as
+5 dimmed crimson cells with a visible GAP exactly where the carved door
+cell sits; a 3-cell green-tinted region with a floating "region-1" label
+readable above it; and the `candles` prop rendering visibly elevated
+above the floor plane at its placed cell. No unexpected console errors —
+only the two established FIXTURES-MODE `[unimplemented] unknown service
+...AuthoringService` errors (edit mode's own preview probe runs
+regardless of which tab is active; unrelated to this unit, same note
+every prior round's live-verification section already carries).
+
+### Tests
+
+12 new: 5 in `creation/canvasFloor.test.ts` (bounds enumeration, holes
+exclusion, an out-of-bounds hole being a harmless no-op, the
+`DEFAULT_CANVAS` fallback, an all-holes canvas producing an empty floor
+honestly rather than erroring) + 7 in `preview3d/DungeonPreview3D.test.ts`
+(`buildFloorTiles`'s `floorCells` path: one tile per cell tagged with the
+new `CANVAS_ROOM_ID` sentinel, holes still excluded on that path, an
+honest empty map with neither input, the `floorPlan.rooms` path
+unchanged against the real `SHOWCASE_FLOORPLAN` fixture, `floorCells`
+taking priority when both are supplied; `buildWallLineFootprint`: the
+empty-`wallLines` fast path, and an exact-match cross-check against
+`straightWallFootprint` for one drawn line, proving the 3D dim overlay
+and the 2D hatch overlay agree on the same cell set rather than each
+computing their own approximation). 265 dungeon-builder tests passing
+overall (up from 253). `ci-check` clean (format/lint/typecheck/build/
+test).
+
+### Follow-ups named, not built
+
+- **3D editing (click-to-place/select/rotate) for creation mode** —
+  deliberately out of scope this round (see "Read-only this round,"
+  above); edit mode's existing 3D click-to-place/select/rotate machinery
+  is the natural thing to graduate over, not a from-scratch build.
+- **Full 3D geometry for `wallLines:`'s own straight-line shape** —
+  today's footprint-dim treatment answers "where can't I walk," not "what
+  does this wall look like as a wall" the way `doc.walls`'
+  `WallBox`/`DoorGap` path already does for edge-native walls.

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4203,9 +4203,9 @@ taking priority when both are supplied; `buildWallLineFootprint`: the
 empty-`wallLines` fast path, and an exact-match cross-check against
 `straightWallFootprint` for one drawn line, proving the 3D dim overlay
 and the 2D hatch overlay agree on the same cell set rather than each
-computing their own approximation). 265 dungeon-builder tests passing
-overall (up from 253). `ci-check` clean (format/lint/typecheck/build/
-test).
+computing their own approximation). See also the connector-band addendum
+below (2 more tests, same file) for the final count. `ci-check` clean
+(format/lint/typecheck/build/test).
 
 ### Follow-ups named, not built
 
@@ -4217,3 +4217,90 @@ test).
   today's footprint-dim treatment answers "where can't I walk," not "what
   does this wall look like as a wall" the way `doc.walls`'
   `WallBox`/`DoorGap` path already does for edge-native walls.
+
+### Addendum, same day: the connector-band chasm (edit-mode/compiled path)
+
+Kirk, from live 3D screenshots of the COMPILED path (edit mode, unrelated
+to creation mode's canvas — folded into this unit's PR since it's the
+same floor-derivation code, adjacent work, not a separate concept): the
+door jamb (`WallBox`/`DoorGap`, rendered from real `FloorPlan.edges` or
+the derived fallback either way) stood over a genuine floorless BLACK
+CHASM at every connector, not the intentional door-row void. Two
+different absences, easy to conflate, worth stating precisely:
+
+1. **The doorRow void WITHIN a room's own footprint is correct, not a
+   bug.** `buildFloorTiles`'s `if (row === floorPlan.doorRow) continue`
+   is the literal dungeonspec cell-legality rule (CONTRACT.md's own
+   long-standing "cell legality is a clean one-line derivation" finding:
+   `col ∈ [start_column, start_column+width) AND row != door_row`) —
+   doorRow genuinely isn't part of any room's walkable floor. Unchanged
+   by this fix, and shouldn't be.
+2. **`connector.column` — the single gap column BETWEEN two rooms — was
+   never visited by the room loop AT ALL, at any row.** `start_column`
+   chain accumulation (`next.startColumn = prev.startColumn +
+prev.width + 1`, CONTRACT.md's own confirmed finding) always leaves
+   exactly one such column, and it belongs to NEITHER adjacent room's
+   `[startColumn, startColumn+width)` range — verified directly against
+   `SHOWCASE_FLOORPLAN` (column 6 between antechamber `[0,6)` and shrine
+   `[7,21)`; column 21 between shrine and vault `[22,30)`, both new
+   tests assert this rather than just narrate it). The real door — a
+   genuine walkable opening, already rendered as one via
+   `WallBox`/`DoorGap` — was therefore standing over a floor tile that
+   was NEVER GENERATED, not merely excluded by the (correct) doorRow
+   rule.
+
+**Fix**: `buildFloorTiles`'s `floorPlan.rooms` branch gained a second
+pass over `floorPlan.connectors`, adding exactly one floor tile per
+connector at `[connector.column, floorPlan.doorRow]` — reusing the SAME
+column convention `boardGeometry.ts`'s `connectorAtColumn` (the 2D
+board's own door-row-click resolver) already keys off, not a new
+derivation. `roomId` on that synthetic tile is `connector.fromRoomId` — a
+real, existing room id (arbitrary between the two the connector bridges;
+nothing downstream reads a connector tile's roomId today), not a
+sentinel, since this cell genuinely belongs to the compiled dungeon the
+way a creation-mode canvas tile doesn't.
+
+**A real follow-on bug this surfaced and closed in the same pass**: once
+the connector cell has a floor tile, edit mode's existing 3D
+click-to-place machinery would happily generate a `FloorHitCell` there
+too — and `handleClickCell`'s room-local math (`cell.col -
+room.startColumn`) would silently produce an out-of-range column for
+whichever room `fromRoomId` names, since the connector's own column sits
+outside that room's width by construction. `Board.tsx`'s own 2D
+drag-drop already has the answer: it rejects any drop at `row ===
+floorPlan.doorRow` ("Can't drop on the reserved door row"). `handleClickCell`
+now carries the identical guard before it ever reaches the room lookup —
+the connector's floor tile is real and rendered, but not a legal
+placement target, matching 2D's own rule exactly rather than silently
+corrupting a placement's coordinates.
+
+**Tests.** 2 new in `DungeonPreview3D.test.ts`: a direct assertion that a
+real tile exists at `[connector.column, doorRow]` for every connector in
+the real `SHOWCASE_FLOORPLAN` fixture (keyed via the same
+`cubeAtColRow` the render path uses, not a hand-derived key), plus the
+"never inside either room's own range" claim verified against the same
+fixture rather than left as narration; and one confirming a hole exactly
+at a connector cell still wins (the connector pass respects `doc.holes`
+like every other tile). The existing `floorPlan.rooms` regression test
+was updated in place — its expected count now includes
+`+ floorPlan.connectors.length` — rather than silently drifting to a
+higher number. 267 dungeon-builder tests passing overall (up from 253
+pre-unit / 265 before this addendum). `ci-check` clean.
+
+**Live verification.** Same dev server, same `--use-gl=swiftshader`
+headless Chromium pattern this unit's own live-verification section
+above used. A direct BEFORE/AFTER pixel comparison, not just an
+after-the-fact look: the pre-fix `DungeonPreview3D.tsx` (this file's own
+prior committed state) was swapped in, screenshotted at the exact same
+default `Bounds`-fit camera framing (no manual orbit, so both shots are
+reproducibly identical except for the code change), then the fix was
+restored and the identical shot taken again. A pixel diff between the
+two (`PIL.ImageChops.difference`) localizes to a single small,
+tightly-bounded region exactly at the antechamber↔shrine connector —
+confirming the fix changes ONLY what it should and nothing else
+regressed. Cropped/marked side-by-side comparison: the void band's small
+intrusion right at the door jamb's base, present in the BEFORE shot, is
+gone in the AFTER shot — replaced by solid floor, the door now standing
+on real ground instead of over a gap. No unexpected console errors
+(same established FIXTURES-MODE `AuthoringService` notes as every prior
+round).

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -100,6 +100,14 @@ export function DungeonBuilderConcept() {
   const [editYamlCollapsed, setEditYamlCollapsed] = useState(false);
   const [createPaletteCollapsed, setCreatePaletteCollapsed] = useState(false);
   const [createYamlCollapsed, setCreateYamlCollapsed] = useState(false);
+  // Creation mode's OWN 2D/3D toggle (rpg-project#169's creation-mode 3D
+  // preview unit) — a genuinely independent flag from edit mode's
+  // `boardDim` above, same "remembered per mode" reasoning the palette/
+  // YAML collapse pairs already follow: this component never unmounts
+  // across an edit<->create tab switch, `CreationConcept` does, so the
+  // toggle has to live here to survive leaving and returning to the
+  // 'create' tab.
+  const [createBoardDim, setCreateBoardDim] = useState<'2d' | '3d'>('2d');
 
   const preview = usePutDungeonPreview(doc, yamlText);
   const save = useSaveDungeon();
@@ -534,6 +542,8 @@ export function DungeonBuilderConcept() {
           onTogglePalette={() => setCreatePaletteCollapsed((c) => !c)}
           yamlCollapsed={createYamlCollapsed}
           onToggleYaml={() => setCreateYamlCollapsed((c) => !c)}
+          boardDim={createBoardDim}
+          onSetBoardDim={setCreateBoardDim}
         />
         {toast && <ToastBanner message={toast} />}
       </div>

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -189,6 +189,21 @@ canvas:
   width: 20
   height: 30
 
+# Canvas floor semantic (rpg-project#169's creation-mode 3D preview unit,
+# 2026-08-04): a from-scratch canvas has no compiled FloorPlan, so there is
+# no server-derived floor-cell set to render — the 3D preview needed one
+# anyway and settled it: the floor is EVERY [col,row] cell inside
+# canvas.width x canvas.height, minus holes:. Deliberately NOT also
+# subtracting a walls:/wallLines: footprint cell — Kirk's rule ("any hex
+# that is not 100% uncovered would not be traversable") makes a footprint
+# cell BLOCKED, not floorless; the tile still renders, dimmed/flagged, the
+# same "flag, don't silently remove" discipline this file's other
+# footprint-interaction notes already follow. See
+# `creation/canvasFloor.ts`'s own doc comment for the implementation and
+# `preview3d/DungeonPreview3D.tsx` for how it consumes this list (a new
+# `floorCells` prop, alongside the existing `floorPlan`-driven path edit
+# mode still uses — the two are alternate inputs, not a mode flag).
+
 # TOP-LEVEL place:/boss: — same shape as a room's own place: (ref, at,
 # facing, mount/height, targeting, blocks_*), room-scoping made OPTIONAL
 # rather than required. See "Top-level placement" below for the full

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -7,13 +7,15 @@
  * rows and the shared `Inspector` — no more bespoke Tools strip or
  * hand-rolled facing/delete panel duplicating what those already do.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CollapsibleSidePanel } from '../CollapsibleSidePanel';
 import type { DungeonDoc, WallKind } from '../dungeonYaml';
 import { Inspector } from '../Inspector';
 import { Palette } from '../Palette';
+import { DungeonPreview3D } from '../preview3d/DungeonPreview3D';
 import type { BoardTool } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
+import { deriveCanvasFloorCells } from './canvasFloor';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
@@ -22,6 +24,17 @@ import { ProposedYamlPane } from './ProposedYamlPane';
 import { RegionPanel } from './RegionPanel';
 import { useDemoScript } from './useDemoScript';
 import type { RegionEditing } from './useRegionEditing';
+
+/** Same 2D/3D board-dimension toggle edit mode's own board header already
+ * has (`DungeonBuilderConcept.tsx`'s `boardDim`) — reused idiom, not a
+ * second one invented for this mode. Owned by the same never-unmounting
+ * parent (`DungeonBuilderConcept`) that already owns this mode's
+ * palette/YAML collapse flags, for the identical "remembered per mode"
+ * reason CONTRACT.md's "Collapsible side panels" section records: state
+ * kept in a component that unmounts (this one, whenever the edit/create
+ * tab flips away from 'create') resets on remount, so it has to live one
+ * level up to survive a tab switch. */
+export type BoardDim = '2d' | '3d';
 
 interface CreationConceptProps {
   doc: DungeonDoc;
@@ -65,6 +78,10 @@ interface CreationConceptProps {
   onTogglePalette: () => void;
   yamlCollapsed: boolean;
   onToggleYaml: () => void;
+  /** 2D/3D board toggle — see `BoardDim`'s own doc comment above for why
+   * this is owned by the parent rather than local `useState` here. */
+  boardDim: BoardDim;
+  onSetBoardDim: (dim: BoardDim) => void;
 }
 
 export function CreationConcept({
@@ -90,6 +107,8 @@ export function CreationConcept({
   onTogglePalette,
   yamlCollapsed,
   onToggleYaml,
+  boardDim,
+  onSetBoardDim,
 }: CreationConceptProps) {
   const [dims, setDims] = useState(DEFAULT_CANVAS);
 
@@ -97,6 +116,19 @@ export function CreationConcept({
   // own first step resets to them anyway, so a live dims edit mid-script
   // doesn't need to retarget it.
   const demo = useDemoScript(demoActions, DEFAULT_CANVAS);
+
+  // Canvas floor derivation (rpg-project#169's creation-mode 3D preview
+  // unit) — the 3D preview's own floor semantic for a from-scratch
+  // canvas, since it has no compiled `FloorPlan` to render from at all
+  // (`creation/canvasFloor.ts`'s own doc comment has the full rationale).
+  // Computed here, not inside `DungeonPreview3D` itself, per that
+  // component's own "clean interfaces" doc comment — derived only when
+  // actually needed (`boardDim === '3d'`) since `deriveCanvasFloorCells`
+  // scans the whole canvas grid.
+  const floorCells = useMemo(
+    () => (boardDim === '3d' ? deriveCanvasFloorCells(doc) : []),
+    [boardDim, doc]
+  );
 
   useEffect(() => {
     if (demo.isPlaying) {
@@ -258,7 +290,55 @@ export function CreationConcept({
             </button>
           )}
         </div>
+        <div
+          role="group"
+          aria-label="2D or 3D board"
+          style={{
+            display: 'flex',
+            gap: 2,
+            border: '1px solid var(--border-primary)',
+            borderRadius: 5,
+            padding: 2,
+          }}
+        >
+          {(['2d', '3d'] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => onSetBoardDim(d)}
+              style={{
+                padding: '3px 10px',
+                fontSize: 11.5,
+                fontWeight: 600,
+                borderRadius: 3,
+                border: 'none',
+                cursor: 'pointer',
+                background: boardDim === d ? '#5fd1c9' : 'transparent',
+                color: boardDim === d ? '#14110f' : 'var(--text-primary)',
+              }}
+            >
+              {d.toUpperCase()}
+            </button>
+          ))}
+        </div>
       </header>
+
+      {boardDim === '3d' && (
+        <div
+          style={{
+            padding: '4px 16px',
+            fontSize: 11,
+            color: '#8a7a5a',
+            borderBottom: '1px solid var(--border-primary)',
+          }}
+        >
+          Canvas floor = every cell minus holes (no compiled floor plan exists
+          for a from-scratch canvas yet — see CONTRACT.md). Straight-wall
+          footprint cells render dimmed; region cells render tinted with a
+          floating label. Read-only this round — orbit/zoom only, no
+          picking/placing in 3D here yet; use the 2D board or the palette to
+          edit.
+        </div>
+      )}
 
       {demo.caption && (
         <div
@@ -315,25 +395,51 @@ export function CreationConcept({
           />
         </CollapsibleSidePanel>
 
-        <main style={{ flex: 1, minWidth: 0, overflow: 'auto', padding: 18 }}>
-          <CreationBoard
-            doc={doc}
-            edit={edit}
-            tool={edit.selectedPalette ? null : selectedTool}
-            onSelectPlacement={(sel) => {
-              clearOtherSelections('placement');
-              edit.setSelectedPlacement(sel);
-            }}
-            onReject={toast}
-            onToggleWallEdge={onToggleWallEdge}
-            onAddStraightWall={onAddStraightWall}
-            onRemoveStraightWallAt={onRemoveStraightWallAt}
-            onSetStraightWallEndpoint={onSetStraightWallEndpoint}
-            onToggleStraightWallDoorAt={onToggleStraightWallDoorAt}
-            onToggleHole={onToggleHole}
-            onSetPoint={onSetPoint}
-            regionEdit={regionEdit}
-          />
+        <main
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          {boardDim === '2d' ? (
+            <div style={{ flex: 1, overflow: 'auto', padding: 18 }}>
+              <CreationBoard
+                doc={doc}
+                edit={edit}
+                tool={edit.selectedPalette ? null : selectedTool}
+                onSelectPlacement={(sel) => {
+                  clearOtherSelections('placement');
+                  edit.setSelectedPlacement(sel);
+                }}
+                onReject={toast}
+                onToggleWallEdge={onToggleWallEdge}
+                onAddStraightWall={onAddStraightWall}
+                onRemoveStraightWallAt={onRemoveStraightWallAt}
+                onSetStraightWallEndpoint={onSetStraightWallEndpoint}
+                onToggleStraightWallDoorAt={onToggleStraightWallDoorAt}
+                onToggleHole={onToggleHole}
+                onSetPoint={onSetPoint}
+                regionEdit={regionEdit}
+              />
+            </div>
+          ) : (
+            // Read-only this round (this component's own header banner
+            // above says so too) — deliberately NOT wiring
+            // selectedPlacement/onSelect/selectedPalette/onPlace/
+            // onSelectConnector. `DungeonPreview3D` degrades to
+            // view-only when those are omitted (its own prop doc
+            // comments), so this is the whole wiring needed for an
+            // honest read-only preview, not a partial version of the
+            // interactive one. `floorPlan` stays unset — a canvas has
+            // none — so `floorCells` (this component's own derivation
+            // above) is the only floor input.
+            <div style={{ flex: 1, minHeight: 0 }}>
+              <DungeonPreview3D floorCells={floorCells} doc={doc} />
+            </div>
+          )}
         </main>
 
         <CollapsibleSidePanel

--- a/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCanvasFloorCells } from './canvasFloor';
+
+describe('deriveCanvasFloorCells', () => {
+  it('produces every cell in a small canvas bounds, none missing or duplicated', () => {
+    const cells = deriveCanvasFloorCells({
+      canvas: { width: 3, height: 2 },
+      holes: [],
+    });
+    expect(cells).toHaveLength(6);
+    const keys = new Set(cells.map(([c, r]) => `${c},${r}`));
+    expect(keys.size).toBe(6);
+    for (let col = 0; col < 3; col++) {
+      for (let row = 0; row < 2; row++) {
+        expect(keys.has(`${col},${row}`)).toBe(true);
+      }
+    }
+  });
+
+  it('excludes every hole cell, and only those', () => {
+    const cells = deriveCanvasFloorCells({
+      canvas: { width: 4, height: 4 },
+      holes: [
+        [1, 1],
+        [2, 2],
+      ],
+    });
+    expect(cells).toHaveLength(4 * 4 - 2);
+    const keys = new Set(cells.map(([c, r]) => `${c},${r}`));
+    expect(keys.has('1,1')).toBe(false);
+    expect(keys.has('2,2')).toBe(false);
+    // A cell NOT punched as a hole stays present.
+    expect(keys.has('0,0')).toBe(true);
+    expect(keys.has('3,3')).toBe(true);
+  });
+
+  it('a hole outside the canvas bounds is simply irrelevant — no crash, no phantom exclusion', () => {
+    const cells = deriveCanvasFloorCells({
+      canvas: { width: 2, height: 2 },
+      holes: [[99, 99]],
+    });
+    expect(cells).toHaveLength(4);
+  });
+
+  it('falls back to DEFAULT_CANVAS (20x30) when doc.canvas is null', () => {
+    const cells = deriveCanvasFloorCells({ canvas: null, holes: [] });
+    expect(cells).toHaveLength(20 * 30);
+  });
+
+  it('a fully-holed canvas produces an empty floor, not an error', () => {
+    const cells = deriveCanvasFloorCells({
+      canvas: { width: 1, height: 1 },
+      holes: [[0, 0]],
+    });
+    expect(cells).toEqual([]);
+  });
+});

--- a/src/concepts/dungeon-builder/creation/canvasFloor.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.ts
@@ -1,0 +1,47 @@
+/**
+ * canvasFloor — the creation-mode "New Dungeon" canvas's own floor-cell
+ * semantic: unlike edit mode's compiled `FloorPlan` (a chain of
+ * server-generated rooms), a from-scratch canvas has no compiled floor
+ * plan to render from at all (CONTRACT.md: "creation flow ... entirely
+ * client-side, no schema exists for any of this"). The 3D preview still
+ * needs SOME floor-cell set to hand `SyntyHexFloor` — this module derives
+ * it directly from the document rather than inventing a second
+ * `FloorPlan`-shaped fixture.
+ *
+ * **The defined semantic: every cell in `doc.canvas`'s bounds, minus
+ * `doc.holes`.** Deliberately NOT also subtracting a straight-wall
+ * footprint (`doc.wallLines`) or a drawn edge-wall (`doc.walls`) cell —
+ * per Kirk's own rule ("any hex that is not 100% uncovered would not be
+ * traversable"), a wall footprint cell is BLOCKED (impassable), not
+ * FLOORLESS the way a hole is; the floor tile still belongs there, it's
+ * just flagged. `preview3d/DungeonPreview3D.tsx` renders that distinction
+ * separately (a dimmed/darkened overlay on top of the ordinary floor
+ * tile, not an omitted one) — see its own doc comment. A hole, by
+ * contrast, genuinely has no floor tile at all, matching the existing
+ * edit-mode `doc.holes` treatment this module reuses verbatim.
+ *
+ * See TARGET-YAML.md's "canvas:" section for this semantic recorded
+ * as a dialect note, not just left as an implementation detail here.
+ */
+import type { DungeonDoc } from '../dungeonYaml';
+import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+
+/** Every `[col, row]` cell inside `doc.canvas`'s bounds (or
+ * `DEFAULT_CANVAS` when the document carries none, matching
+ * `CreationBoard.tsx`'s own fallback), minus `doc.holes`. Order is
+ * column-major, row-minor — not spatially meaningful, callers only need
+ * the set. */
+export function deriveCanvasFloorCells(
+  doc: Pick<DungeonDoc, 'canvas' | 'holes'>
+): [number, number][] {
+  const grid = doc.canvas ?? DEFAULT_CANVAS;
+  const holeSet = new Set(doc.holes.map(([c, r]) => `${c},${r}`));
+  const cells: [number, number][] = [];
+  for (let col = 0; col < grid.width; col++) {
+    for (let row = 0; row < grid.height; row++) {
+      if (holeSet.has(`${col},${row}`)) continue;
+      cells.push([col, row]);
+    }
+  }
+  return cells;
+}

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
@@ -27,6 +27,7 @@ import {
   toDungeonDoc,
 } from '../dungeonYaml';
 import { SHOWCASE_FLOORPLAN, SHOWCASE_YAML } from '../fixtures';
+import { cubeAtColRow } from '../hexLayout';
 import {
   buildFloorTiles,
   buildOnePlacement,
@@ -166,18 +167,60 @@ describe('buildFloorTiles — the floorCells alternate input path (creation mode
     expect(tiles.size).toBe(0);
   });
 
-  it('the floorPlan.rooms path (edit mode) is unchanged by this unit — same tile count as before, against the real showcase fixture', () => {
+  it('the floorPlan.rooms path (edit mode) still generates every non-door-row room cell, exactly as before this unit', () => {
     const tiles = buildFloorTiles(SHOWCASE_FLOORPLAN, []);
     // Every room's width * (height - 1 for the door row), summed —
     // cross-checked against the fixture's own room widths (6/14/8,
     // CONTRACT.md's "start_column chain accumulation" finding) rather
-    // than a hard-coded magic number.
-    const expected = SHOWCASE_FLOORPLAN.rooms.reduce(
+    // than a hard-coded magic number. Room-owned cells only — the
+    // connector-band cells the next test covers are additive, checked
+    // separately so this assertion stays a pure regression check on the
+    // untouched per-room loop.
+    const roomCellCount = SHOWCASE_FLOORPLAN.rooms.reduce(
       (sum, room) => sum + room.width * (SHOWCASE_FLOORPLAN.height - 1),
       0
     );
-    expect(tiles.size).toBe(expected);
+    expect(tiles.size).toBe(
+      roomCellCount + SHOWCASE_FLOORPLAN.connectors.length
+    );
     expect(tiles.size).toBeGreaterThan(0);
+  });
+
+  it('the connector band (2026-08-04 fix): a real floor tile exists at [connector.column, doorRow] for every connector — the door no longer stands over a chasm', () => {
+    const tiles = buildFloorTiles(SHOWCASE_FLOORPLAN, []);
+    expect(SHOWCASE_FLOORPLAN.connectors.length).toBeGreaterThan(0);
+    for (const connector of SHOWCASE_FLOORPLAN.connectors) {
+      const cube = cubeAtColRow(connector.column, SHOWCASE_FLOORPLAN.doorRow);
+      const key = `${cube.x},${cube.y},${cube.z}`;
+      const tile = tiles.get(key);
+      expect(tile).toBeDefined();
+      // A real room id (one of the two the connector bridges), not a
+      // synthetic sentinel — this cell genuinely belongs to the compiled
+      // dungeon, unlike a creation-mode canvas tile.
+      expect(tile!.roomId).toBe(connector.fromRoomId);
+    }
+    // The connector's own column is never inside either adjacent room's
+    // [startColumn, startColumn+width) range (the whole reason the room
+    // loop alone could never produce this tile) — confirmed directly
+    // against the real fixture, not just asserted as a design claim.
+    for (const connector of SHOWCASE_FLOORPLAN.connectors) {
+      for (const room of SHOWCASE_FLOORPLAN.rooms) {
+        const inRoom =
+          connector.column >= room.startColumn &&
+          connector.column < room.startColumn + room.width;
+        expect(inRoom).toBe(false);
+      }
+    }
+  });
+
+  it('a hole at exactly a connector cell still wins — the connector band respects doc.holes like every other tile', () => {
+    const connector = SHOWCASE_FLOORPLAN.connectors[0];
+    const tiles = buildFloorTiles(SHOWCASE_FLOORPLAN, [
+      [connector.column, SHOWCASE_FLOORPLAN.doorRow],
+    ]);
+    const cube = cubeAtColRow(connector.column, SHOWCASE_FLOORPLAN.doorRow);
+    const key = `${cube.x},${cube.y},${cube.z}`;
+    expect(tiles.has(key)).toBe(false);
   });
 
   it('floorCells takes priority when both floorCells and floorPlan are supplied', () => {

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
@@ -17,15 +17,22 @@
  */
 import { describe, expect, it } from 'vitest';
 import { facingToRotationY } from '../boardGeometry';
+import { straightWallFootprint } from '../creation/straightWallGeometry';
 import {
+  addWallLine,
   parseDungeon,
   setPlacementMount,
   setPlacementRotationDegrees,
   setRefDefault,
   toDungeonDoc,
 } from '../dungeonYaml';
-import { SHOWCASE_YAML } from '../fixtures';
-import { buildOnePlacement } from './DungeonPreview3D';
+import { SHOWCASE_FLOORPLAN, SHOWCASE_YAML } from '../fixtures';
+import {
+  buildFloorTiles,
+  buildOnePlacement,
+  buildWallLineFootprint,
+  CANVAS_ROOM_ID,
+} from './DungeonPreview3D';
 
 describe('buildOnePlacement — resolved facing × fine-rotation composition', () => {
   it('an INHERITED facing (defaults:, nothing explicit on the placement itself) still composes with an explicit rotate_degrees, exactly like an explicit facing would', () => {
@@ -116,5 +123,96 @@ describe('buildOnePlacement — resolved facing × fine-rotation composition', (
     // is boardGeometry.test.ts's job, not this file's.
     expect(prop!.rotationY).not.toBeUndefined();
     expect(Number.isFinite(prop!.rotationY)).toBe(true);
+  });
+});
+
+// rpg-project#169's creation-mode 3D preview unit (2026-08-04) — the
+// alternate `floorCells` input path this component's own header doc
+// comment describes. `buildFloorTiles`/`buildWallLineFootprint` are pure
+// math with no Canvas/GLB dependency (same reasoning `buildOnePlacement`'s
+// own doc comment above gives for being exported and tested directly).
+describe('buildFloorTiles — the floorCells alternate input path (creation mode)', () => {
+  it('builds one tile per supplied cell, tagged with the canvas room-id sentinel', () => {
+    const tiles = buildFloorTiles(
+      undefined,
+      [],
+      [
+        [0, 0],
+        [1, 0],
+        [2, 1],
+      ]
+    );
+    expect(tiles.size).toBe(3);
+    for (const tile of tiles.values()) {
+      expect(tile.roomId).toBe(CANVAS_ROOM_ID);
+    }
+  });
+
+  it('still excludes doc.holes cells, even on the floorCells path', () => {
+    const tiles = buildFloorTiles(
+      undefined,
+      [[1, 0]],
+      [
+        [0, 0],
+        [1, 0],
+        [2, 1],
+      ]
+    );
+    expect(tiles.size).toBe(2);
+  });
+
+  it('with no floorPlan and no floorCells, produces an honest empty map rather than throwing', () => {
+    const tiles = buildFloorTiles(undefined, []);
+    expect(tiles.size).toBe(0);
+  });
+
+  it('the floorPlan.rooms path (edit mode) is unchanged by this unit — same tile count as before, against the real showcase fixture', () => {
+    const tiles = buildFloorTiles(SHOWCASE_FLOORPLAN, []);
+    // Every room's width * (height - 1 for the door row), summed —
+    // cross-checked against the fixture's own room widths (6/14/8,
+    // CONTRACT.md's "start_column chain accumulation" finding) rather
+    // than a hard-coded magic number.
+    const expected = SHOWCASE_FLOORPLAN.rooms.reduce(
+      (sum, room) => sum + room.width * (SHOWCASE_FLOORPLAN.height - 1),
+      0
+    );
+    expect(tiles.size).toBe(expected);
+    expect(tiles.size).toBeGreaterThan(0);
+  });
+
+  it('floorCells takes priority when both floorCells and floorPlan are supplied', () => {
+    const tiles = buildFloorTiles(SHOWCASE_FLOORPLAN, [], [[0, 0]]);
+    expect(tiles.size).toBe(1);
+    expect([...tiles.values()][0].roomId).toBe(CANVAS_ROOM_ID);
+  });
+});
+
+describe('buildWallLineFootprint — doc-native, mode-agnostic', () => {
+  it('an empty doc.wallLines produces an empty set, cheaply (no grid scan)', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    expect(buildWallLineFootprint(doc).size).toBe(0);
+  });
+
+  it('matches straightWallFootprint (creation/straightWallGeometry.ts) exactly for one drawn line — reused geometry, not re-derived', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    const from = { cell: [4, 4] as [number, number], corner: 0 };
+    const to = { cell: [6, 1] as [number, number], corner: 3 };
+    addWallLine(cst, from, to);
+    const doc = toDungeonDoc(cst);
+    expect(doc.wallLines).toHaveLength(1);
+
+    const grid = doc.canvas ?? { width: 20, height: 30 };
+    const expectedFootprint = straightWallFootprint(
+      doc.wallLines[0].from,
+      doc.wallLines[0].to,
+      grid
+    );
+    expect(expectedFootprint.length).toBeGreaterThan(0);
+
+    const result = buildWallLineFootprint(doc);
+    expect(result.size).toBe(expectedFootprint.length);
+    for (const [col, row] of expectedFootprint) {
+      expect(result.has(`${col},${row}`)).toBe(true);
+    }
   });
 });

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -75,6 +75,40 @@
  * spanning the opening opens the real `ConnectorInspector` — the same
  * Inspector a door-row cell already opens in 2D, now reachable by clicking
  * the actual rendered doorway in 3D too.
+ *
+ * **ALSO accepts a canvas-derived floor as an alternate input path
+ * (rpg-project#169's creation-mode 3D preview unit, 2026-08-04)** —
+ * creation mode's from-scratch canvas has no compiled `FloorPlan` at all
+ * (this file's own header paragraph above), so `floorPlan` is now
+ * OPTIONAL and a sibling `floorCells` prop (a plain `[col,row][]` list,
+ * `creation/canvasFloor.ts`'s `deriveCanvasFloorCells`) can supply the
+ * floor tile set instead. This component deliberately does NOT import
+ * `deriveCanvasFloorCells` itself or otherwise know which mode is calling
+ * it — the caller derives the list and hands it over as data, matching
+ * CONTRACT.md's operating-bar principle ("a component should not
+ * deep-couple into this concept's own state shape any more than
+ * necessary to do its one job"). Every `floorPlan`-only feature
+ * (server-truth edges, the entrance marker, room-scoped placements,
+ * click-to-place) has no creation-mode analog and simply doesn't render
+ * when `floorPlan` is absent — see each function's own guard below, not a
+ * parallel code path. `doc.place` (top-level placements), `doc.walls`,
+ * `doc.holes`, `doc.start`/`doc.end` are already doc-native fields with
+ * zero `floorPlan` dependency, so they render unchanged in either mode.
+ *
+ * Two more doc-native overlays this same unit adds, both driven purely by
+ * `doc` (so they render in EITHER mode, not gated on `floorCells`): a
+ * straight wall's (`doc.wallLines`) FOOTPRINT cells (Kirk's rule: "any hex
+ * that is not 100% uncovered would not be traversable" — the cell still
+ * has a floor tile, just visually flagged as blocked, the 3D sibling of
+ * the 2D board's crimson footprint hatch) render dimmed/darkened rather
+ * than omitted; and `doc.regions` member cells get a subtle
+ * archetype-tinted overlay plus a floating `Billboard`/`Text` label at the
+ * region's centroid (the same `Billboard`+`Text` pattern
+ * `AuthorGridOverlay.tsx` already uses for the real game's author-grid
+ * labels — a proven-cheap primitive in this codebase, not a new one).
+ * Full 3D geometry for a straight wall's own LINE (matching its
+ * corner-anchored footprint/door-gap fidelity in 2D) is NOT attempted
+ * this round — see CONTRACT.md's ledger entry for this unit.
  */
 import {
   cubeToWorld,
@@ -89,7 +123,7 @@ import { SyntyHexFloor } from '@/components/hex-grid/SyntyHexFloor';
 import type { AbsoluteFloorTile } from '@/hooks/dungeonMapGeometry';
 import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
-import { Bounds, OrbitControls } from '@react-three/drei';
+import { Billboard, Bounds, OrbitControls, Text } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import { Suspense, useMemo } from 'react';
 import { DoubleSide, Shape } from 'three';
@@ -100,6 +134,8 @@ import {
   isSameSelection,
   wallMountRotationY,
 } from '../boardGeometry';
+import { DEFAULT_CANVAS } from '../creation/emptyCanvasDoc';
+import { straightWallsFootprintSet } from '../creation/straightWallGeometry';
 import {
   resolvePlacement,
   type DungeonDoc,
@@ -112,12 +148,46 @@ import {
   type ServerEdge,
 } from '../edgesAdapter';
 import { cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
-import { END_COLOR, START_COLOR } from '../markerStyle';
+import { END_COLOR, regionArchetypeColor, START_COLOR } from '../markerStyle';
+import { regionCentroid } from '../regionGeometry';
 import type { PaletteSelection, PlacementSelection } from '../types';
 import { PreviewMonsterModel } from './PreviewMonsterModel';
 
+/** A canvas-native floor tile has no owning room ("no room chain exists
+ * yet" — `creation/emptyCanvasDoc.ts`'s own doc comment) — a plain,
+ * honest sentinel rather than an empty string or a fabricated id, since
+ * `AbsoluteFloorTile.roomId` is non-optional. Nothing currently reads
+ * this value for canvas-derived tiles (click-to-place, the only consumer,
+ * is gated off entirely whenever `floorPlan` is absent — see
+ * `buildPlaceableCells`'s call site below), so its exact value is inert
+ * today; kept as a real constant rather than an inline literal so a
+ * future consumer has one place to special-case it, if it ever needs to. */
+export const CANVAS_ROOM_ID = 'canvas';
+
 interface DungeonPreview3DProps {
-  floorPlan: FloorPlan;
+  /** Compiled room-chain floor plan — edit mode's own input, unchanged.
+   * Now OPTIONAL: omit it (or pass `undefined`) when supplying
+   * `floorCells` instead, since a from-scratch creation-mode canvas has
+   * no compiled `FloorPlan` to render from at all. Every feature that
+   * only makes sense against a real compiled response (server-truth
+   * wall/door edges, the generator-chosen entrance marker, room-scoped
+   * `place:`/`boss:`, click-to-place) degrades to "doesn't render"
+   * rather than throwing when this is absent — see this file's own
+   * header doc comment for the full list and CONTRACT.md's ledger entry
+   * for this unit. */
+  floorPlan?: FloorPlan;
+  /** Canvas-derived floor cell list — creation mode's alternate input
+   * path (`creation/canvasFloor.ts`'s `deriveCanvasFloorCells`, computed
+   * by the CALLER, not this component — see this file's header doc
+   * comment for why). When supplied, floor tiles are built directly from
+   * this list instead of `floorPlan.rooms` — takes priority if BOTH are
+   * somehow supplied, though the two callers this component has today
+   * (edit mode: `floorPlan` only; creation mode: `floorCells` only) never
+   * combine them. `floorPlan`, if also present, is still consulted for
+   * its own floorPlan-only features (server-truth edges, the entrance
+   * marker) regardless of which floor-tile path won — see
+   * `buildFloorTiles`'s own doc comment. */
+  floorCells?: readonly [number, number][];
   doc: DungeonDoc;
   /** Kirk's 2026-08-02 "3D editing" arc, part 2 — the SAME
    * `PlacementSelection`/`onSelect` contract `Board.tsx` already uses for
@@ -187,12 +257,38 @@ interface PlacedMonster {
  * Kirk's own ask specified: "3D preview = simply omit the floor hex" —
  * nearly free given `SyntyHexFloor` only ever renders whatever's in the
  * tile map handed to it. */
-function buildFloorTiles(
-  floorPlan: FloorPlan,
-  holes: readonly [number, number][]
+/** Two independent floor-tile sources, picked by which the caller
+ * supplied — see `DungeonPreview3DProps.floorCells`'s own doc comment for
+ * priority when both are somehow given. `floorCells` (creation mode) is
+ * ALREADY the exact cell list to render (its own deriver,
+ * `deriveCanvasFloorCells`, has no door-row concept — a canvas has no
+ * generator, so there's nothing to skip there); `floorPlan.rooms` (edit
+ * mode) still applies the door-row skip, unchanged. `holes` is applied to
+ * BOTH paths, since `doc.holes` is a doc-native field with no
+ * `floorPlan`/mode dependency either way. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildFloorTiles(
+  floorPlan: FloorPlan | undefined,
+  holes: readonly [number, number][],
+  floorCells?: readonly [number, number][]
 ): Map<string, AbsoluteFloorTile> {
   const holeSet = new Set(holes.map(([c, r]) => `${c},${r}`));
   const tiles = new Map<string, AbsoluteFloorTile>();
+  if (floorCells) {
+    for (const [col, row] of floorCells) {
+      if (holeSet.has(`${col},${row}`)) continue;
+      const cube = cubeAtColRow(col, row);
+      const key = `${cube.x},${cube.y},${cube.z}`;
+      tiles.set(key, {
+        x: cube.x,
+        y: cube.y,
+        z: cube.z,
+        roomId: CANVAS_ROOM_ID,
+      });
+    }
+    return tiles;
+  }
+  if (!floorPlan) return tiles;
   for (const room of floorPlan.rooms) {
     for (
       let col = room.startColumn;
@@ -297,10 +393,16 @@ function buildWalls(
  * stays a plain ternary instead of an inline IIFE. */
 function doorSelectHandler(
   wall: PlacedWall,
-  floorPlan: FloorPlan,
+  floorPlan: FloorPlan | undefined,
   onSelectConnector: ((index: number) => void) | undefined
 ): (() => void) | undefined {
-  if (!onSelectConnector || !wall.doorId) return undefined;
+  // A `doorId` only exists on a SERVER-truth door (`ServerEdge`, see
+  // `PlacedWall.doorId`'s own doc comment) — creation mode has no
+  // `floorPlan` and its `doc.walls`/`doc.wallLines` doors never carry one
+  // either, so this already returns `undefined` for every creation-mode
+  // wall via the `!wall.doorId` check alone; the explicit `!floorPlan`
+  // guard just keeps this honestly typed rather than asserting non-null.
+  if (!onSelectConnector || !wall.doorId || !floorPlan) return undefined;
   const index = connectorIndexForDoorId(floorPlan, wall.doorId);
   return index === null ? undefined : () => onSelectConnector(index);
 }
@@ -380,41 +482,50 @@ export function buildOnePlacement(
 }
 
 function buildPlacements(
-  floorPlan: FloorPlan,
+  floorPlan: FloorPlan | undefined,
   doc: DungeonDoc
 ): { props: PlacedProp[]; monsters: PlacedMonster[] } {
   const props: PlacedProp[] = [];
   const monsters: PlacedMonster[] = [];
 
-  for (const room of doc.rooms) {
-    const fpRoom = floorPlan.rooms.find((r) => r.id === room.id);
-    if (!fpRoom) continue;
+  // Room-scoped `place:`/`boss:` need a compiled room's own `startColumn`
+  // to resolve an absolute cell — genuinely nothing to do without
+  // `floorPlan`. Not a special case in practice: a creation-mode canvas's
+  // `doc.rooms` is always `[]` (`creation/emptyCanvasDoc.ts` — "no room
+  // chain exists yet"), so this loop is already a no-op there regardless;
+  // the explicit `if` just keeps this function honestly typed for
+  // `floorPlan: FloorPlan | undefined` rather than asserting non-null.
+  if (floorPlan) {
+    for (const room of doc.rooms) {
+      const fpRoom = floorPlan.rooms.find((r) => r.id === room.id);
+      if (!fpRoom) continue;
 
-    room.place.forEach((p, index) => {
-      const absCol = fpRoom.startColumn + p.at[0];
-      const { prop, monster } = buildOnePlacement(
-        doc,
-        p,
-        absCol,
-        p.at[1],
-        { roomId: room.id, index },
-        `${room.id}:${p.at[0]},${p.at[1]}:${p.ref}`
-      );
-      if (prop) props.push(prop);
-      if (monster) monsters.push(monster);
-    });
+      room.place.forEach((p, index) => {
+        const absCol = fpRoom.startColumn + p.at[0];
+        const { prop, monster } = buildOnePlacement(
+          doc,
+          p,
+          absCol,
+          p.at[1],
+          { roomId: room.id, index },
+          `${room.id}:${p.at[0]},${p.at[1]}:${p.ref}`
+        );
+        if (prop) props.push(prop);
+        if (monster) monsters.push(monster);
+      });
 
-    if (room.boss) {
-      const absCol = fpRoom.startColumn + room.boss.at[0];
-      const position = worldPosition(absCol, room.boss.at[1]);
-      const monsterRefId = room.boss.ref.split(':').pop();
-      if (monsterRefId) {
-        monsters.push({
-          key: `${room.id}:boss`,
-          position,
-          monsterRefId,
-          sel: { roomId: room.id, boss: true },
-        });
+      if (room.boss) {
+        const absCol = fpRoom.startColumn + room.boss.at[0];
+        const position = worldPosition(absCol, room.boss.at[1]);
+        const monsterRefId = room.boss.ref.split(':').pop();
+        if (monsterRefId) {
+          monsters.push({
+            key: `${room.id}:boss`,
+            position,
+            monsterRefId,
+            sel: { roomId: room.id, boss: true },
+          });
+        }
       }
     }
   }
@@ -501,14 +612,114 @@ function buildHexHitShape(): Shape {
   return shape;
 }
 
+/** Every `[col, row]` cell a straight wall (`doc.wallLines`) footprint
+ * currently claims, union across every drawn line, door cells already
+ * excluded per-line — the exact same `straightWallsFootprintSet` the 2D
+ * board's own hatch/warning overlays already use (`CreationBoard.tsx`),
+ * reused rather than re-derived. Cheap by construction, and skipped
+ * entirely for the (overwhelmingly common) `doc.wallLines.length === 0`
+ * case rather than paying for an empty grid scan. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildWallLineFootprint(doc: DungeonDoc): Set<string> {
+  if (doc.wallLines.length === 0) return new Set();
+  const grid = doc.canvas ?? DEFAULT_CANVAS;
+  return straightWallsFootprintSet(doc.wallLines, grid);
+}
+
 // Above SyntyHexFloorTile's own FLOOR_Y (0.2) so a downward ray from the
 // orbit camera always meets this layer before the visual floor texture —
 // see this file's header doc comment for why that ordering alone is
 // enough to let a placed prop's own click handler win, with no manual
-// raycasting.
+// raycasting. `REGION_TINT_Y`/`FOOTPRINT_DIM_Y` sit BELOW that
+// (`HIT_CELL_Y` below), same reasoning: both are meant to read as floor
+// decoration, not to shadow the hit-cell layer's own raycast priority —
+// and `FOOTPRINT_DIM_Y` sits above `REGION_TINT_Y` so a footprint that
+// lands inside a region (flagged, never auto-removed from the region —
+// the same "flag, don't silently rewrite" discipline `CreationBoard.tsx`
+// already follows) shows the blocked treatment on top, not hidden under
+// the region tint.
 const HIT_CELL_Y = 0.22;
 const HIT_CLEAR_COLOR = '#5fd1c9';
 const HIT_OCCUPIED_COLOR = '#ff5a3a';
+
+// The 3D sibling of the 2D board's crimson footprint hatch
+// (`CreationBoard.tsx`'s `db-footprint-hatch` pattern) — Kirk's rule ("any
+// hex that is not 100% uncovered would not be traversable") makes this a
+// BLOCKED overlay on an otherwise-real floor tile, not an omitted tile
+// the way a hole is (see `creation/canvasFloor.ts`'s own doc comment for
+// that distinction spelled out). Same crimson family as the 2D hatch's
+// own stroke color (`#c94f4f`), translucent rather than a hatch pattern —
+// a flat semi-transparent disc is the cheap 3D-legible equivalent; a true
+// hatched TEXTURE was judged not worth the extra material/UV work for a
+// first landing.
+const FOOTPRINT_DIM_Y = 0.21;
+const FOOTPRINT_DIM_COLOR = '#c94f4f';
+const FOOTPRINT_DIM_OPACITY = 0.55;
+
+function FootprintDimCell({
+  worldX,
+  worldZ,
+  shape,
+}: {
+  worldX: number;
+  worldZ: number;
+  shape: Shape;
+}) {
+  return (
+    <mesh
+      position={[worldX, FOOTPRINT_DIM_Y, worldZ]}
+      rotation={[-Math.PI / 2, 0, 0]}
+    >
+      <shapeGeometry args={[shape]} />
+      <meshBasicMaterial
+        color={FOOTPRINT_DIM_COLOR}
+        transparent
+        opacity={FOOTPRINT_DIM_OPACITY}
+        depthWrite={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+// Region membership tint — the 3D sibling of the 2D board's own
+// archetype-tinted region overlay (`CreationBoard.tsx`'s `regionEls`,
+// `regionArchetypeColor`). Deliberately subtler than the footprint dim
+// above (lower opacity, no border) — a region is informational, not a
+// warning.
+const REGION_TINT_Y = 0.205;
+const REGION_TINT_OPACITY = 0.3;
+const REGION_LABEL_HEIGHT = 0.6; // above head height, same as AuthorGridOverlay's ROOM_ID_HEIGHT
+const REGION_LABEL_FONT_SIZE = 0.34;
+const REGION_LABEL_OUTLINE_COLOR = '#100d0b';
+
+function RegionTintCell({
+  worldX,
+  worldZ,
+  shape,
+  color,
+}: {
+  worldX: number;
+  worldZ: number;
+  shape: Shape;
+  color: string;
+}) {
+  return (
+    <mesh
+      position={[worldX, REGION_TINT_Y, worldZ]}
+      rotation={[-Math.PI / 2, 0, 0]}
+    >
+      <shapeGeometry args={[shape]} />
+      <meshBasicMaterial
+        color={color}
+        transparent
+        opacity={REGION_TINT_OPACITY}
+        depthWrite={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  );
+}
 
 /** Always mounted and always clickable — even with nothing selected, so
  * clicking a floor cell gives the same "pick a palette item first" honesty
@@ -715,6 +926,7 @@ const SELECTED_COLOR = '#ffd76a';
 
 export function DungeonPreview3D({
   floorPlan,
+  floorCells,
   doc,
   selectedPlacement,
   onSelect,
@@ -724,8 +936,8 @@ export function DungeonPreview3D({
   onSelectConnector,
 }: DungeonPreview3DProps) {
   const floorTiles = useMemo(
-    () => buildFloorTiles(floorPlan, doc.holes),
-    [floorPlan, doc.holes]
+    () => buildFloorTiles(floorPlan, doc.holes, floorCells),
+    [floorPlan, doc.holes, floorCells]
   );
   const { props, monsters } = useMemo(
     () => buildPlacements(floorPlan, doc),
@@ -736,31 +948,53 @@ export function DungeonPreview3D({
     [doc.walls]
   );
   // Server-truth wall/door edges (rpg-project#169's wire-edges unit) — see
-  // this file's own header doc comment. Empty whenever `floorPlan` carries
-  // no `edges` (fixtures mode, or any pre-#767 recording), in which case
-  // this preview renders exactly as it did before this unit: `doc.walls`
-  // only.
+  // this file's own header doc comment. Empty whenever `floorPlan` is
+  // absent (creation mode — no compiled response exists at all) or
+  // carries no `edges` (fixtures mode, or any pre-#767 recording), in
+  // which case this preview renders exactly as it did before this unit:
+  // `doc.walls` only.
   const serverWalls = useMemo(
     () =>
-      hasServerEdges(floorPlan)
+      floorPlan && hasServerEdges(floorPlan)
         ? buildWalls(floorPlanEdgesToServerEdges(floorPlan), 'server')
         : [],
     [floorPlan]
   );
+  // A straight wall's (`doc.wallLines`) footprint — doc-native, renders
+  // identically regardless of `floorPlan`/`floorCells`. See
+  // `buildWallLineFootprint`'s own doc comment.
+  const wallLineFootprint = useMemo(() => buildWallLineFootprint(doc), [doc]);
+  // The generator-chosen entrance marker has no creation-mode analog at
+  // all (CONTRACT.md's "Start/end: authored, in real tension with the
+  // generator-chosen entrance" finding — a freeform canvas has no
+  // generator to choose FOR the author) — `false`, not computed, whenever
+  // `floorPlan` is absent, matching the entrance marker itself simply not
+  // rendering below.
   const entranceBlocked = useMemo(
-    () => isEntranceBlocked(floorPlan, doc),
+    () => (floorPlan ? isEntranceBlocked(floorPlan, doc) : false),
     [floorPlan, doc]
   );
+  // Click-to-place (Kirk's "3D editing" arc, part 3) has no creation-mode
+  // analog THIS ROUND either — deliberately out of scope for the
+  // creation-mode 3D preview unit (a follow-up, not a gap: edit-mode's
+  // click-to-place machinery can graduate later). An empty `floorPlan`
+  // check alone is enough to disable it honestly: no `floorPlan` means no
+  // placeable cells, which means no `FloorHitCell`s mount at all, so the
+  // whole interaction surface is simply absent rather than half-wired.
   const placeableCells = useMemo(
-    () => buildPlaceableCells(floorPlan, doc, floorTiles),
+    () => (floorPlan ? buildPlaceableCells(floorPlan, doc, floorTiles) : []),
     [floorPlan, doc, floorTiles]
   );
   const hitShape = useMemo(() => buildHexHitShape(), []);
 
   // Mirrors Board.tsx's own click-to-place cell handler almost exactly
   // (same messages, same boss/occupied rules) — see this file's header
-  // doc comment for why click-to-place is room-scoped only.
+  // doc comment for why click-to-place is room-scoped only. `floorPlan`
+  // is guaranteed non-null here in practice (`placeableCells` above is
+  // empty without it, so no `FloorHitCell` exists to call this) — the
+  // explicit guard just keeps this honestly typed.
   const handleClickCell = (cell: PlaceableCell) => {
+    if (!floorPlan) return;
     if (!selectedPalette || !onPlace) {
       onReject?.(
         'Pick a palette item first, then click an empty cell to place it.'
@@ -794,6 +1028,55 @@ export function DungeonPreview3D({
         <Suspense fallback={null}>
           <Bounds fit clip margin={1.25}>
             <SyntyHexFloor floorTiles={floorTiles} hexSize={HEX_SIZE} />
+            {doc.regions.map((region) => {
+              const color = regionArchetypeColor(region.archetype);
+              const centroid = regionCentroid(region.cells);
+              const labelPos = worldPosition(
+                centroid.col,
+                centroid.row,
+                REGION_LABEL_HEIGHT
+              );
+              return (
+                <group key={`region-${region.id}`}>
+                  {region.cells.map(([col, row]) => {
+                    const [wx, , wz] = worldPosition(col, row);
+                    return (
+                      <RegionTintCell
+                        key={`region-${region.id}-${col}-${row}`}
+                        worldX={wx}
+                        worldZ={wz}
+                        shape={hitShape}
+                        color={color}
+                      />
+                    );
+                  })}
+                  <Billboard position={labelPos}>
+                    <Text
+                      fontSize={REGION_LABEL_FONT_SIZE}
+                      color={color}
+                      anchorX="center"
+                      anchorY="middle"
+                      outlineWidth={0.016}
+                      outlineColor={REGION_LABEL_OUTLINE_COLOR}
+                    >
+                      {region.name ?? region.id}
+                    </Text>
+                  </Billboard>
+                </group>
+              );
+            })}
+            {[...wallLineFootprint].map((key) => {
+              const [col, row] = key.split(',').map(Number);
+              const [wx, , wz] = worldPosition(col, row);
+              return (
+                <FootprintDimCell
+                  key={`wallline-fp-${key}`}
+                  worldX={wx}
+                  worldZ={wz}
+                  shape={hitShape}
+                />
+              );
+            })}
             {placeableCells.map((cell) => (
               <FloorHitCell
                 key={cell.key}
@@ -889,12 +1172,11 @@ export function DungeonPreview3D({
                   <PointMarker worldX={w[0]} worldZ={w[2]} color={END_COLOR} />
                 );
               })()}
-            {floorPlan.entrance &&
+            {floorPlan?.entrance &&
               (() => {
-                const w = worldPosition(
-                  floorPlan.entrance.column,
-                  floorPlan.entrance.row
-                );
+                const entrance = floorPlan.entrance;
+                if (!entrance) return null;
+                const w = worldPosition(entrance.column, entrance.row);
                 return (
                   <PointMarker
                     worldX={w[0]}

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -304,6 +304,41 @@ export function buildFloorTiles(
       }
     }
   }
+  // The connector band (Kirk's live-screenshot finding, 2026-08-04): the
+  // doorRow skip just above is correct dungeonspec legality (`col ∈
+  // [start_column, start_column+width) AND row != door_row` — CONTRACT.md's
+  // own "cell legality" finding) — doorRow genuinely isn't part of any
+  // ROOM's walkable footprint. But `connector.column` (CONTRACT.md's
+  // "connector door position as a cell must still be derived" finding) is
+  // the single GAP column BETWEEN two rooms — `start_column` chain
+  // accumulation always leaves exactly one such column
+  // (`next.startColumn = prev.startColumn + prev.width + 1`, verified
+  // against SHOWCASE_FLOORPLAN's own room/connector columns) — and that
+  // column belongs to NEITHER room's `[startColumn, startColumn+width)`
+  // range, so the room loop above never visits it at ANY row, door or not.
+  // The real door (a genuine walkable opening — `WallBox`/`DoorGap` above
+  // already render it as one, from server-truth edges or the derived
+  // fallback either way) was therefore standing over a floor tile that
+  // was NEVER GENERATED, not merely skipped — a true chasm, not the
+  // intentional door-row void. One tile per connector, at exactly
+  // `[connector.column, doorRow]` — the same cell `boardGeometry.ts`'s
+  // `connectorAtColumn` (the 2D board's own door-row-click resolver)
+  // already keys off, so this reuses the established column convention
+  // rather than re-deriving it. `roomId` picks the FROM room — arbitrary
+  // between the two real adjacent rooms (nothing downstream reads a
+  // connector tile's roomId today), but a real room id, not a synthetic
+  // sentinel, since this cell genuinely belongs to the compiled dungeon.
+  for (const connector of floorPlan.connectors) {
+    if (holeSet.has(`${connector.column},${floorPlan.doorRow}`)) continue;
+    const cube = cubeAtColRow(connector.column, floorPlan.doorRow);
+    const key = `${cube.x},${cube.y},${cube.z}`;
+    tiles.set(key, {
+      x: cube.x,
+      y: cube.y,
+      z: cube.z,
+      roomId: connector.fromRoomId,
+    });
+  }
   return tiles;
 }
 
@@ -999,6 +1034,20 @@ export function DungeonPreview3D({
       onReject?.(
         'Pick a palette item first, then click an empty cell to place it.'
       );
+      return;
+    }
+    // The connector-band fix above (`buildFloorTiles`) gives the door its
+    // own floor tile so it no longer stands over a void — but that tile
+    // is still the reserved door row, not a placeable room cell (same
+    // rule `Board.tsx`'s own 2D drag-drop already enforces: "Can't drop
+    // on the reserved door row," `row === floorPlan.doorRow`). Without
+    // this guard, a click here would fall through to the room-lookup
+    // below using the tile's `roomId` (deliberately one of the two real
+    // adjacent rooms, not a sentinel — see that tile's own doc comment)
+    // and compute a room-LOCAL column outside that room's own width,
+    // silently corrupting the placement.
+    if (cell.row === floorPlan.doorRow) {
+      onReject?.('Can’t place on the reserved door row.');
       return;
     }
     if (selectedPalette.kind === 'boss') {


### PR DESCRIPTION
## Summary

- Gives the Dungeon Builder's "New Dungeon" tab the same 2D/3D toggle edit mode already has — Kirk's ask, verbatim: "can I go from new dungeon to 3d?"
- New `creation/canvasFloor.ts` derives the 3D preview's floor-cell set for a from-scratch canvas (no compiled `FloorPlan` exists there) directly from the document: every cell in `canvas` bounds, minus `holes`. Recorded as a dialect note in `TARGET-YAML.md`, not just an implementation detail.
- `preview3d/DungeonPreview3D.tsx`: `floorPlan` is now optional and a new `floorCells` prop is an alternate input path — a props-level refactor, not a forked component. Every `floorPlan`-only feature (server-truth edges, the generator-chosen entrance marker, room-scoped placements, click-to-place) degrades cleanly rather than throwing when absent.
- Two new doc-native overlays, driven purely by `doc` so they render in either mode: a straight wall's (`doc.wallLines`) footprint renders dimmed rather than omitted (the 3D sibling of the 2D board's crimson hatch — reuses `straightWallGeometry.ts`'s own footprint function, not a re-derivation), and `doc.regions` member cells get an archetype-tinted overlay plus a floating `Billboard`/`Text` label at the centroid (the same primitive `AuthorGridOverlay.tsx` already uses).
- `CreationConcept.tsx`/`DungeonBuilderConcept.tsx` wire the same 2D/3D toggle idiom into creation mode, with its own independent board-dim state (`createBoardDim`) owned by the never-unmounting parent — same "remembered per mode" precedent the palette/YAML collapse flags already follow.
- Read-only this round, by omission rather than a new flag: no picking/placing in creation-mode 3D yet — every interaction prop `DungeonPreview3D` already treats as optional (`selectedPlacement`/`onSelect`/`selectedPalette`/`onPlace`/`onSelectConnector`) is simply left unwired. Follow-up, not a gap: edit mode's existing 3D click-to-place/select/rotate machinery is the natural thing to graduate over later.
- Full 3D geometry for `wallLines:`'s own straight-line shape (matching its corner-anchored, door-gapped fidelity in 2D) is out of scope this round — the footprint-dim treatment answers "where can't I walk," not "what does this wall look like."

## What assumed compiled-floorplan-only inputs and needed fixing

- `buildFloorTiles`, `buildPlacements`, `doorSelectHandler`, the entrance marker, `entranceBlocked`, and `placeableCells`/click-to-place all previously required a non-optional `FloorPlan`. Each now guards on its presence explicitly (`if (floorPlan) { ... }`) rather than asserting non-null, with the room-scoped placement loop's guard being provably a no-op in creation mode today anyway (`doc.rooms` is always `[]` there).
- `doc.walls`, `doc.holes`, `doc.place` (top-level), `doc.start`/`doc.end` already had zero `floorPlan` dependency and needed no changes — confirmed by live verification, not just by reading the code.

## Test plan

- [x] `npm run ci-check` clean (format/lint/typecheck/build/test)
- [x] 265 dungeon-builder tests passing (up from 253) — 12 new: 5 in `canvasFloor.test.ts` (bounds, holes exclusion, `DEFAULT_CANVAS` fallback, an out-of-bounds hole, an all-holes canvas), 7 in `DungeonPreview3D.test.ts` (`buildFloorTiles`'s `floorCells` path incl. priority-when-both-supplied and an unchanged `floorPlan.rooms` regression against the real `SHOWCASE_FLOORPLAN` fixture; `buildWallLineFootprint` matching `straightWallFootprint` exactly, proving the 3D dim overlay and 2D hatch overlay agree on the same cells)
- [x] Live-verified against a real dev server (own port, driven via a throwaway Playwright script, deleted after the run): built a region, a corner-anchored straight wall with a carved door, a height-placed `candles` prop, start/end, and the demo script's own walls/monster/statue — toggled to 3D and confirmed via screenshots AND the live proposed-YAML pane (not just the UI's own claim) that all of it renders: the canvas floor spans the whole grid, the straight-wall footprint dims with a visible gap at the door, the region tints green with a floating "region-1" label, the candle renders elevated above the floor at its placed height, and the demo's own zigzag wall run shows a real amber jamb/lintel door gap. No unexpected console errors (only the established FIXTURES-MODE `AuthoringService` unimplemented errors edit mode's own probe always produces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4