### PR TITLE
unit: capability-probed graduation (truth-driven strip/badges/gating)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -3997,3 +3997,246 @@ jamb/lintel breaks at the real connector positions — a visible gap in the
 wall run, not a shortened box. No unexpected console errors past the
 existing FIXTURES-MODE-adjacent ones this file already documents (the
 probe's own deliberately-invalid payload, doubled by StrictMode).
+
+## Capability-probed graduation: strip/badges/Save & Play stop guessing (2026-08-04, rpg-project#169)
+
+**The trigger, verbatim:** the wire-edges unit above closed the
+RESPONSE-side wall-geometry gap this file named four times over. Days
+later, the coordinating session verified LIVE against
+`rpg-api-dungeon-builder-763` that authored `walls:` — the AUTHORING side
+— now compiles too (`success: true`), while the client still stripped it
+unconditionally and creation mode's Save & Play stayed hard-disabled with
+a blanket "the server can't compile this yet" tooltip. The strip list,
+compile badges, and Save & Play gate had been reading a hardcoded,
+comment-level snapshot of "what dungeonspec compiles" since the concept's
+earliest days — a snapshot that cannot self-correct when the server moves
+out from under it. This unit replaces the snapshot with a live probe.
+
+### The mechanism: `capabilityProbe.ts`
+
+New module. On every live connection (`usePutDungeonPreview.ts`'s own
+mount-time liveness probe finding `serverState === 'live'`), the concept
+now sends one minimal `validate_only` document per target-dialect field —
+17 fields total, each isolated against an otherwise-known-good 3-room
+base (see below for why 3, not 2) — and records exactly what THIS server
+said about THIS field, today, in `ServerCapabilities`. Concurrent
+(`Promise.all`), never blocks the board, cached until the next live
+transition or an explicit `refreshCapabilities()`.
+
+**Real finding, not assumed: dungeonspec's own decode is whole-document
+and strict**, so a naive "send everything, see what fails" probe can only
+ever answer "at least one of these isn't accepted," never which — this is
+WHY the probe is per-field, verified by actually trying the combined
+approach first and reading the batched `"field X not found"` /
+`"field Y not found"` error list `canvas-full.yaml`'s probe produced.
+
+**A real, load-bearing finding from BUILDING the probe suite, documented
+nowhere in this file before now**: the very first minimal 2-room base
+doc, otherwise pure v1, was rejected outright —
+`"dungeon must have exactly one boss room, found 0"`. Two rooms alone
+(dungeonspec's known `minRooms = 2`) is not sufficient; the chain also
+needs EXACTLY ONE boss-archetype room with a declared `boss:`, a
+CHAIN-level constraint distinct from the boss-archetype-room-needs-a-boss
+rule this file already documented. `stripToV1Subset`'s
+`compilable`/`compilableBlockers` now check both.
+
+**Verified live, 2026-08-04, against `rpg-api-dungeon-builder-763` (envoy
+`localhost:8091`)** — the transcript `capabilityProbe.ts`'s own doc
+comment carries in full:
+
+| Field                                                                                                         | Result                                                                                                |
+| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `walls:`                                                                                                      | **compiles**                                                                                          |
+| `start:`                                                                                                      | **compiles**                                                                                          |
+| `facing` (room-scoped floor prop only)                                                                        | **compiles**                                                                                          |
+| `holes:`, `end:`, `canvas:`, `lighting:`, `defaults:`, `regions:`, `height:`, `rotate_degrees:`, `targeting:` | decode-unknown (`"field X not found in type dungeonspec.Y"`)                                          |
+| `mount:` (any placement)                                                                                      | schema-known, rejected (`"unsupported capability: mounted placements are not supported"`)             |
+| `facing` (monster/boss/`mount:wall`)                                                                          | schema-known, rejected (`"unsupported capability: facing only supported on room-scoped floor props"`) |
+| top-level `place:`                                                                                            | schema-known, rejected (`"unsupported capability: top-level placement is not supported"`)             |
+
+3 of 17. Two rejection SHAPES, kept distinct rather than collapsed:
+decode-unknown (the Go struct has no field for this key at all) vs.
+schema-known-but-capability-gated (`"unsupported capability: ..."` — the
+field decodes, the constraint is deliberate and named). `wallLines:` is
+deliberately NEVER probed — client-side sugar
+(`straightWallGeometry.ts`), never sent to the real server in any form,
+per its own doc comment.
+
+### `stripToV1Subset` becomes capability-aware, not a rewrite
+
+`dungeonYaml.ts`'s `stripToV1Subset` gained an optional `capabilities`
+parameter and two new `V1SubsetResult` fields: `compiling` (the positive
+mirror of `dropped` — present AND accepted, kept verbatim) and
+`compilableBlockers` (human-readable reasons `compilable` is false, e.g.
+`"needs exactly one boss-archetype room with a declared boss (has
+none)"`, not one hardcoded message). Every existing strip DECISION now
+asks `accepted(field)` first; the mechanics (CST deletes, counting) are
+unchanged. `start`/`end` split into independent checks (verified live:
+one compiles, the other doesn't — the prior combined `"start/end"` entry
+could never have expressed that). `facing` dispatches through
+`facingCapabilityFor` — per-PLACEMENT, not per-document, since the real
+server itself distinguishes floor-prop/monster/boss/wall-mount facing.
+`defaults:`, when accepted, skips materialize-on-strip entirely (nothing
+to bake in — the server resolves inheritance itself). No `capabilities`
+argument (fixtures mode, or a probe not yet complete) reproduces the
+PRIOR static behavior exactly — verified by the existing 253-test suite
+passing unmodified bar one wording change (`'start/end'` → separate
+`'start'`/`'end'` entries, the direct consequence of the split above).
+
+`buildWalkItYaml` (Walk it) gained the same optional parameter — a real,
+pre-existing gap this unit fixed along the way: Walk it never called
+`stripToV1Subset` at ALL before this unit, so a document using any
+target-dialect field would have failed Walk it's own save outright,
+regardless of server capability. It now runs the capability-aware strip
+FIRST, monster-stripping on the result.
+
+### Badges and gating read the probe, nothing hardcoded
+
+`YamlPane.tsx` gained `CapabilitiesLine` (the "server capabilities:
+accepts N/M dialect fields" readout, with its own `refresh` affordance,
+beside the LIVE badge) and split `CompileBadgeStrip` into two halves — a
+teal "Compiles on this server: ..." confirming line and the original
+amber "Uses: ... not yet accepted" line — reading `compiling`/`dropped`
+directly, never a hardcoded field list. The Save & Play button was
+extracted into `SaveAndPlayButton` (exported) specifically so it could be
+reused verbatim, not re-implemented, by creation mode — see below. Its
+disabled tooltip now reads `v1CompilableBlockers` when non-compilable,
+naming the SPECIFIC real reason, instead of one hardcoded "declare at
+least 2 rooms" message that was already wrong the moment a boss-room
+requirement existed unstated.
+
+### Creation mode's Save & Play graduates from permanently-disabled to real
+
+`ProposedYamlPane.tsx` — previously a `disabled` button with a hardcoded
+`title`, no props to ever change it — now imports and reuses
+`SaveAndPlayButton`/`CompileBadgeStrip`/`CapabilitiesLine` from
+`YamlPane.tsx` directly (one gating implementation, not two that could
+drift) and gets a real `useSaveDungeon` instance
+(`DungeonBuilderConcept.tsx`'s new `creationSave`), wired through
+`CreationConcept.tsx`. **Reuses `preview.capabilities` from edit mode's
+existing `usePutDungeonPreview` instance** rather than probing twice —
+capabilities describe the SERVER, not which document is being viewed.
+
+**Why the button still reads disabled in practice, today, verified
+live**: creation mode has no "declare a room" UI at all
+(`emptyCanvasDoc.ts`'s `rooms: []` is the only shape it ever produces),
+and the real "at least 2 rooms, exactly one boss room" minimums are
+unconditional — so a from-scratch canvas is still genuinely unsavable.
+But the tooltip is now the REAL reason (`"needs at least 2 rooms (has
+0); needs exactly one boss-archetype room with a declared boss (has
+none)"`), not the retired blanket "proposed schema" claim — and an
+author who hand-types `rooms:` into this very pane (it's a real, editable
+CST) would see the button light up the moment the document becomes
+genuinely compilable, same as edit mode, no code change required.
+
+### Live verification — past the badges' own claim, same standard as every prior round
+
+Own dev server, free port (`5173`, never `3001`), `VITE_API_HOST` pointed
+at the live envoy (`:8091`), driven by a throwaway Playwright script
+(this file's own established pattern). Confirmed, in order:
+
+1. `● LIVE — PutDungeon reachable`, then `server capabilities: accepts
+3/17 dialect fields` — the exact live probe result above, rendered.
+2. Edited showcase.yaml's live YAML pane to add one `walls:` entry via
+   the real textarea + "Apply YAML → Board" (not a mocked test) — the
+   badge strip immediately showed `Compiles on this server: 1 wall`,
+   never the amber "not yet accepted" line.
+3. Clicked the real "Save & Play" button (enabled — `dialectDropped` was
+   EMPTY since the wall compiles, so the label correctly stayed "Save &
+   Play," not "Save the compilable subset," even though a target-dialect
+   field is present) against the SAME lab server — got
+   `Saved as "showcase".` — a real `PutDungeon(validate_only: false)`,
+   walls included, not a client-side claim.
+4. Switched to New Dungeon (creation mode) — `ProposedYamlPane` showed
+   the SAME live `server capabilities: accepts 3/17` line, the amber
+   `Uses: canvas — not yet accepted by this server` badge, and "Save the
+   compilable subset" correctly disabled with the tooltip:
+   `"Nothing compilable yet — needs at least 2 rooms (has 0); needs
+exactly one boss-archetype room with a declared boss (has none)"` —
+   the specific real reason this unit set out to deliver, not the
+   retired "proposed schema" placeholder.
+
+No unexpected console errors — only the two expected
+`[invalid_argument] key "" must match ...` entries from
+`usePutDungeonPreview`'s OWN deliberately-invalid liveness-probe payload
+(doubled by React StrictMode, same benign noise this file's every prior
+live-verification round documents).
+
+**Housekeeping**: step 3 above genuinely persisted an extra wall onto the
+SHARED `showcase` key on the lab container other in-flight units on this
+same wave also read from — restored it to the exact original
+`SHOWCASE_YAML` fixture content via a follow-up `PutDungeon(validate_only:
+false)` immediately after, verified `success: true`. The save-then-
+restore round trip is itself corroborating evidence the write path is
+real (a client-side-only claim couldn't have needed reverting).
+Screenshots: `docs/evidence/dungeon-builder-capability-probe-{edit-mode-badge,
+walls-compiling,walls-saved,creation-mode-specific-tooltip}.png`.
+
+### Tests
+
+`capabilityProbe.test.ts` (new, 6 tests) — probe/classify logic against a
+mocked `authoringClient.putDungeon`, keying responses off each probe's
+own distinct `capprobe-<field>` request key: blanket-accept, blanket-
+reject-with-verbatim-message, mixed per-field, a transport failure on one
+probe not taking down the suite, every probe declaring `validateOnly:
+true`. `dungeonYaml.test.ts` gained a
+`stripToV1Subset: capability-aware` describe block (13 tests) covering:
+an accepted field surviving verbatim vs. the no-capabilities conservative
+fallback, the independent start/end split, facing gated per PLACEMENT
+(a floor prop and a monster in the SAME document, only one keeps facing),
+wall-mount facing as its own independent capability, an accepted
+`defaults:` skipping materialize-on-strip, an accepted `topLevelPlace`
+staying un-mapped (with its own items still individually field-gated),
+canvas/holes/regions/lighting each compiling independently, and the new
+`compilableBlockers` correctness (room-count blocker, the newly-
+discovered boss-room blocker, both real fixtures with neither).
+`usePutDungeonPreview.test.ts` gained 4 tests: capabilities stay `null`
+outside live, populate once live (reflecting every probe response),
+reset to `null` the instant the server stops being live, and
+`refreshCapabilities()` re-running the suite. `YamlPane.test.tsx` (new) —
+the first render-layer test for `SaveAndPlayButton`/`CompileBadgeStrip`/
+`CapabilitiesLine`, 12 tests covering every gating state named in this
+unit's own brief: enabled+dropped-list, disabled+SPECIFIC blocker
+(asserting the old hardcoded "declare 2 rooms" text does NOT appear),
+the generic-fallback path when no blocker is supplied, mid-save, and the
+creation-mode label override. No jest-dom matchers (this repo's vitest
+config has none configured) — plain DOM properties throughout, matching
+`Board.test.tsx`'s own established convention. 287 dungeon-builder tests
+passing overall (up from 253), `ci-check` clean.
+
+### `TARGET-YAML.md` — status tracking rewritten around the probe, not hand-maintained
+
+The "Status tracking note (2026-08-03): two fields now compile on Kirk's
+branch, unreleased" section — a manually-transcribed snapshot of a
+backend-probe comment, with its own explicit "don't flip the badge based
+on this note alone" caveat — is retired. Replaced with a description of
+the MECHANISM (`capabilityProbe.ts`) and what it found on THIS unit's own
+2026-08-04 observation, framed explicitly as one observation of a live
+check, not a claim to keep in sync by hand going forward. The "place:/
+boss: facing" entry-type table is retained (still accurate) but
+re-pointed at the mechanized check. The v1-subset-strip table gained a
+second column contrasting the no-capabilities/with-capabilities
+behavior. `specimens/kitchen-sink.v1-subset.dropped.json` regenerated
+(no version bump — `kitchen-sink.yaml` itself is byte-identical; only
+`stripToV1Subset`'s report shape changed: `start`/`end` now separate
+entries, plus the new empty `compiling`/`compilableBlockers` fields) —
+`specimens/README.md`'s changelog documents why without a pack-version
+bump, since no new emittable construct was added.
+
+### What did NOT ship this round — named, not silently dropped
+
+- **Inspector.tsx's own `FacingConservativeBadge`/`TargetDialectBadge`
+  are NOT wired to `capabilityProbe.ts`.** Out of scope per this unit's
+  own brief (strip/save/badge/probe subsystem, not the Inspector) —
+  `dungeonYaml.ts`'s new `facingCapabilityFor` already encodes the
+  entry-type dispatch once; whoever picks this up next should read that
+  function first, not re-derive the split.
+- **No creation-mode "Walk it" button** — one was never asked for by
+  this unit's brief; creation mode's ONLY existing save action (Save &
+  Play) graduated. Adding Walk it to creation mode is a real scope
+  expansion, not a gap in this round.
+- **`/author` route promotion is explicitly the NEXT unit**, per this
+  unit's own brief — not attempted here.
+- **No `preview3d`/floor-derivation changes** — explicit scope boundary
+  from this unit's brief, respected; a parallel unit was in flight on
+  that surface concurrently.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -116,17 +116,26 @@ export function DungeonBuilderConcept() {
   // it without re-deriving it twice. `null` while yamlText is mid-edit
   // and not even shape-parseable yet — every consumer below treats that
   // the same as "nothing to report."
+  //
+  // `preview.capabilities` (capability-probed graduation, this unit) makes
+  // this capability-aware: a field the live server actually accepts is
+  // kept, not stripped — see `stripToV1Subset`'s own doc comment.
+  // `undefined` (fixtures mode, or the probe hasn't completed yet) falls
+  // back to the prior conservative-static behavior, same as always.
   const v1Subset = useMemo(() => {
     try {
-      return stripToV1Subset(yamlText);
+      return stripToV1Subset(yamlText, preview.capabilities ?? undefined);
     } catch {
       return null;
     }
-  }, [yamlText]);
+  }, [yamlText, preview.capabilities]);
 
   const handleWalkIt = () => {
     const walkKey = `${doc.key}-walk`;
-    walkSave.save(walkKey, buildWalkItYaml(yamlText, walkKey));
+    walkSave.save(
+      walkKey,
+      buildWalkItYaml(yamlText, walkKey, preview.capabilities ?? undefined)
+    );
   };
 
   // Clears every OTHER selection kind — called at the start of each of the
@@ -266,6 +275,30 @@ export function DungeonBuilderConcept() {
   const creationApplyDebounce = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
+
+  // Creation mode's own Save & Play (capability-probed graduation, this
+  // unit) — previously permanently disabled (`ProposedYamlPane.tsx`'s own
+  // history). Reuses `preview.capabilities`: capabilities describe the
+  // SERVER, not which document is being viewed, so probing once (on the
+  // shared `usePutDungeonPreview` instance, keyed to edit mode's doc) is
+  // correct for creation mode's own strip too — no second probe needed.
+  const creationSave = useSaveDungeon();
+  const creationV1Subset = useMemo(() => {
+    try {
+      return stripToV1Subset(
+        creationYamlText,
+        preview.capabilities ?? undefined
+      );
+    } catch {
+      return null;
+    }
+  }, [creationYamlText, preview.capabilities]);
+  const handleCreationSaveAndPlay = () => {
+    creationSave.save(
+      creationDoc.key,
+      creationV1Subset?.yaml ?? creationYamlText
+    );
+  };
 
   const syncFromCreationCst = (nextCst: typeof creationCst) => {
     setCreationCst(nextCst);
@@ -534,6 +567,15 @@ export function DungeonBuilderConcept() {
           onTogglePalette={() => setCreatePaletteCollapsed((c) => !c)}
           yamlCollapsed={createYamlCollapsed}
           onToggleYaml={() => setCreateYamlCollapsed((c) => !c)}
+          serverState={preview.serverState}
+          capabilities={preview.capabilities}
+          onRefreshCapabilities={preview.refreshCapabilities}
+          v1Subset={creationV1Subset}
+          onSaveAndPlay={handleCreationSaveAndPlay}
+          saveState={creationSave.state}
+          savedKey={creationSave.savedKey}
+          saveFieldErrors={creationSave.fieldErrors}
+          saveErrorMessage={creationSave.errorMessage}
         />
         {toast && <ToastBanner message={toast} />}
       </div>
@@ -759,7 +801,11 @@ export function DungeonBuilderConcept() {
               walkFieldErrors={walkSave.fieldErrors}
               walkErrorMessage={walkSave.errorMessage}
               dialectDropped={v1Subset?.dropped ?? []}
+              dialectCompiling={v1Subset?.compiling ?? []}
               v1Compilable={v1Subset?.compilable ?? false}
+              v1CompilableBlockers={v1Subset?.compilableBlockers ?? []}
+              capabilities={preview.capabilities}
+              onRefreshCapabilities={preview.refreshCapabilities}
             />
           </CollapsibleSidePanel>
         </div>

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -82,6 +82,16 @@ A dungeon spec is ONE YAML file. Every field in it is either:
 There is no second file, no second pane style, no "proposed schema"
 ghetto. One board, one YAML pane, some of its fields chase-badged.
 
+**This two-bucket split is no longer static, as of 2026-08-04.** A few
+target-dialect fields (`walls:`, bare `start:`, and `facing:` on a
+room-scoped floor prop) have genuinely graduated into the first bucket on
+at least one real server — see "Status tracking: capability-probed, not
+hand-recorded," further down, for the mechanism (`capabilityProbe.ts`)
+that now checks this live instead of this section claiming it by hand.
+The framing above ("v1, real today" vs. "target-dialect-only, not yet
+compiled") still describes the MAJORITY of fields correctly; treat it as
+the default, and the later section as the live exception list.
+
 ## The full annotated example
 
 ```yaml
@@ -1503,80 +1513,128 @@ overlay + centroid label, same archetype coloring
 overlay, but with zero interaction: no tool exists there to create, edit,
 or delete a region this round.
 
-## `place:`/`boss:` facing — compile status now varies by entry type (2026-08-03)
+## `place:`/`boss:` facing — compile status varies by entry type
 
-**Update, 2026-08-03, from a real backend probe (rpg-project#175's
-"Backend feedback: exercising the new authoring API" comment) — this
-supersedes the blanket "not yet compiled" framing this section's own
-badge used to give `facing` uniformly.** Reflection + `validate_only`
-calls against Kirk's authoring branch show floor-prop `facing` genuinely
-COMPILES now — but only for one specific shape: a room-scoped, non-monster,
+**Superseded, 2026-08-04, by the capability-probed graduation unit —
+status here is no longer a manually-recorded snapshot.** The finding
+below was first recorded 2026-08-03 from a one-off backend probe
+(rpg-project#175's "Backend feedback: exercising the new authoring API"
+comment, read by a human, pasted into this file by hand) — that framing
+is retired. `src/concepts/dungeon-builder/capabilityProbe.ts` now
+MECHANIZES the same kind of check: on every live connection, the concept
+sends one minimal `validate_only` doc per entry-type shape and records
+what the CURRENTLY-CONNECTED server actually says, live, in the running
+app — not a claim transcribed from an issue comment at a point in time.
+The table below documents the mechanism and what it found the last time
+this file was updated (2026-08-04, against `rpg-api-dungeon-builder-763`)
+— for what the app's OWN "server capabilities" readout (beside the LIVE
+badge, `YamlPane.tsx`) says right now, run it; that number is the live
+truth, this table is one observation of it.
+
+Reflection + `validate_only` calls show floor-prop `facing` genuinely
+COMPILES — but only for one specific shape: a room-scoped, non-monster,
 non-`mount:wall` placement. Every other entry type still decodes (the
-field is now schema-known) and is then explicitly rejected, with an
+field is schema-known) and is then explicitly rejected, with an
 author-actionable message naming the constraint: `"facing only supported
 on room-scoped floor props"`.
 
-| Entry type                                                        | Compile status                                                                                                                                                                                                                  |
+| Entry type                                                        | Compile status (verified live, 2026-08-04)                                                                                                                                                                                      |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| room-scoped floor prop (`mount` unset/`floor`, not a monster ref) | **compiles** — real, on Kirk's branch                                                                                                                                                                                           |
+| room-scoped floor prop (`mount` unset/`floor`, not a monster ref) | **compiles** — `success: true`, confirmed live                                                                                                                                                                                  |
 | monster `place:` entry                                            | decodes, rejected ("floor props" only)                                                                                                                                                                                          |
 | `boss:` entry                                                     | decodes, rejected (same message)                                                                                                                                                                                                |
 | `mount: wall` placement (any ref)                                 | decodes, rejected (same message)                                                                                                                                                                                                |
 | top-level `place:` (any ref, any mount)                           | rejected for an INDEPENDENT reason first — top-level placement itself isn't supported yet ("place[0]: unsupported capability: top-level placement is not supported") — facing's own support never gets evaluated for this shape |
 
-The Inspector now renders TWO different badges on the same `facing`
+The Inspector still renders TWO different badges on the same `facing`
 control depending on which of these applies to the currently-selected
 placement (`Inspector.tsx`'s `FacingConservativeBadge` vs.
-`TargetDialectBadge`) — a monster, a boss, or a `mount: wall` selection
-shows the more conservative "not yet supported (this entry type)" badge
-with the real validator's own rejection message in its tooltip; a plain
-room-scoped floor prop keeps the ordinary "target dialect, proposed"
-badge, which is now honestly stale in the OPPOSITE direction (see the
-tracking note immediately below) rather than overstated.
+`TargetDialectBadge`) — this unit did not touch `Inspector.tsx` (out of
+scope; the strip/save/badge/probe subsystem was). Whoever picks up
+wiring the Inspector's own badges to `capabilityProbe.ts` next should
+read THAT module first, not re-derive the entry-type split from scratch —
+`facingCapabilityFor` in `dungeonYaml.ts` already encodes it once.
 
-## Status tracking note (2026-08-03): two fields now compile on Kirk's branch, unreleased
+## Status tracking: capability-probed, not hand-recorded (rewritten 2026-08-04)
 
-Per the same rpg-project#175 backend-probe comment: **`start:`** (a bare
-`start: [c,r]`) and **floor-prop `facing`** (the one entry-type shape
-named above) now genuinely compile against Kirk's authoring branch — `start:`
-directly overrides the generator-chosen `FloorPlan.entrance`, exactly the
-"feed straight through, no generator step" resolution this file's own
-"Start/end" section left as an open question. **This branch is
-unreleased** — the shared, gate-off `rpg-api` instance this concept's own
-live-verification arc otherwise talks to does not have it yet. Every
-badge in this concept (`TargetDialectBadge` on `start:`, the facing split
-above) stays exactly as it is — "target dialect, proposed" / the new
-conservative variant — until the branch actually merges/releases; this
-note exists purely so the NEXT session that touches either field knows
-real server support already exists upstream, rather than re-discovering
-it from scratch. Do not flip either badge to "compiles" based on this
-note alone — badge state should track what the shared server this
-concept's own live-preview probe actually reaches, not what exists on an
-unmerged branch.
+**This section used to track individual fields by hand** ("two fields
+now compile on Kirk's branch, unreleased" — the prior version of this
+section, preserved in git history) **— that model is retired.** The
+"which server, which branch, is it released yet" bookkeeping a
+hand-maintained note requires is exactly what `capabilityProbe.ts` now
+does automatically, every time the concept connects to a live server, for
+every target-dialect field at once — a note that goes stale the moment
+anyone merges anything is a worse tool than a probe that can't go stale
+because it re-asks the question on every connection.
 
-## The v1-subset strip — what actually reaches `PutDungeon`
+**What capability-probed graduation actually verified live, 2026-08-04**
+(against `rpg-api-dungeon-builder-763` / its envoy sidecar — see
+`capabilityProbe.ts`'s own doc comment for the full per-field transcript
+this table summarizes):
 
-This concept NEVER sends a target-dialect document to the real server. Before any
-live `validate_only` preview call or a real `Save & Play`, the current
-document is stripped down to exactly what v1 compiles
-(`dungeonYaml.ts`'s `stripToV1Subset`):
+| Field                                                                                                         | Status                                                                                                |
+| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `walls:`                                                                                                      | **compiles** — real edges, `success: true` (rpg-api#769 / toolkit#881)                                |
+| `start:`                                                                                                      | **compiles** — overrides the generator-chosen `FloorPlan.entrance`                                    |
+| `facing` (room-scoped floor prop only)                                                                        | **compiles** — see the entry-type table above                                                         |
+| `holes:`, `end:`, `canvas:`, `lighting:`, `defaults:`, `regions:`, `height:`, `rotate_degrees:`, `targeting:` | decode-unknown — `"field X not found in type dungeonspec.Y"`                                          |
+| `mount:` (any placement)                                                                                      | schema-known, rejected — `"unsupported capability: mounted placements are not supported"`             |
+| `facing` (monster / boss / `mount:wall`)                                                                      | schema-known, rejected — `"unsupported capability: facing only supported on room-scoped floor props"` |
+| top-level `place:`                                                                                            | schema-known, rejected — `"unsupported capability: top-level placement is not supported"`             |
 
-| Field                                                            | v1 subset                                                                                                                                                                                          |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`                                                        | forced to `1` (never `2` — see the annotated example's own note)                                                                                                                                   |
-| `key`, `name`, `theme`, `height`                                 | kept as-is                                                                                                                                                                                         |
-| `rooms:`                                                         | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                                                              |
-| `connectors:`                                                    | kept as-is, including `locked:`                                                                                                                                                                    |
-| top-level `place:`                                               | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                                                           |
-| `canvas:`, `walls:`, `wallLines:`, `start:`, `end:`, `lighting:` | dropped entirely — `walls:`/`wallLines:` counted separately ("N walls" / "N straight walls"), see "Straight walls" above                                                                           |
-| `regions:`                                                       | dropped entirely — no v1 representation of any kind (dungeonspec only knows the declared `rooms:` chain); a region-attachment door edge (`walls:`) is stripped independently, see "regions:" above |
-| `defaults:`                                                      | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above                                 |
+A **real, load-bearing finding from building the probe suite, not
+previously documented anywhere in this file**: dungeonspec now rejects a
+room chain with zero boss-archetype rooms outright
+(`"dungeon must have exactly one boss room, found 0"`) — a stricter,
+CHAIN-level requirement than the boss-archetype-room-needs-a-boss
+constraint this file already documented elsewhere. `stripToV1Subset`'s
+`compilable`/`compilableBlockers` check for both `minRooms = 2` AND this
+requirement now — see "The v1-subset strip," immediately below.
 
-If, after stripping, `rooms:` has fewer than 2 entries (dungeonspec's own
-`minRooms = 2`), there IS no compilable subset — a from-scratch canvas
-with zero or one declared room can't be saved at all yet, honestly, until
-at least 2 rooms are declared. The UI says this plainly rather than
-attempting a doomed `PutDungeon` call.
+**Every badge in this concept now reads this probe's live result
+directly** — `YamlPane.tsx`'s compile-badge strip and Save & Play's
+enable/disable, and (as of this unit) creation mode's `ProposedYamlPane`
+too, all read `stripToV1Subset`'s `dropped`/`compiling`/`compilable`
+output, which is itself computed from whatever `capabilityProbe.ts`'s
+`probeAllCapabilities()` found on THIS connection. There is no more
+"badge state should track the shared server, not an unmerged branch"
+caveat to state by hand — the badges structurally can't drift from the
+connected server, because they ARE its answer, re-asked every time.
+
+## The v1-subset strip — what actually reaches `PutDungeon`, capability-aware
+
+This concept NEVER sends a target-dialect document to the real server
+verbatim. Before any live `validate_only` preview call or a real
+"Save & Play," the current document is stripped down to exactly what
+THIS server compiles (`dungeonYaml.ts`'s `stripToV1Subset`, now taking an
+optional `ServerCapabilities` — capability-probed graduation, this unit).
+A field the server accepts is kept, not dropped; a field it doesn't (or
+no `capabilities` at all — fixtures mode, or a probe still in flight) is
+dropped exactly as this table's "no capabilities" column describes, same
+as every version of this concept before capability probing existed:
+
+| Field                                                  | No capabilities (fixtures mode / probe in flight)                                                                                                                                                       | With capabilities (live, 2026-08-04 observation)                                                                                 |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `version`                                              | forced to `1` (never `2`)                                                                                                                                                                               | same                                                                                                                             |
+| `key`, `name`, `theme`, `height`                       | kept as-is                                                                                                                                                                                              | same                                                                                                                             |
+| `rooms:`                                               | kept, but every `place:`/`boss:` entry has its `facing:`/`mount:`/`height:`/`targeting:` keys dropped                                                                                                   | a room-scoped floor prop's `facing:` survives; monster/boss/`mount:wall` facing, `mount:`, `height:`, `targeting:` still dropped |
+| `connectors:`                                          | kept as-is, including `locked:`                                                                                                                                                                         | same                                                                                                                             |
+| top-level `place:`                                     | mapped down into a containing room (absolute → room-local `at`) if one exists there, otherwise dropped — see "Top-level placement" above                                                                | still mapped/dropped — not yet accepted verbatim by any server this concept has reached                                          |
+| `walls:`                                               | dropped, counted ("N walls")                                                                                                                                                                            | **kept verbatim** — real edges, this concept's own headline finding (this unit)                                                  |
+| `start:`                                               | dropped, counted ("start")                                                                                                                                                                              | **kept verbatim** — overrides the compiled `FloorPlan.entrance`                                                                  |
+| `canvas:`, `wallLines:`, `holes:`, `end:`, `lighting:` | dropped entirely — `wallLines:` is NEVER probed (client-side sugar, see `capabilityProbe.ts`'s own doc comment) and always drops regardless of capabilities                                             | still dropped — none of these decode on this server today                                                                        |
+| `regions:`                                             | dropped entirely — no v1 representation of any kind (dungeonspec only knows the declared `rooms:` chain); a region-attachment door edge (`walls:`) is stripped/kept independently, see "regions:" above | still dropped                                                                                                                    |
+| `defaults:`                                            | dropped, but not silently — every placement INHERITING a `blocks_movement`/`blocks_los` value first gets it materialized as a literal key; see "`defaults:`" above                                      | still dropped/materialized — the whole block decode-unknown on this server today                                                 |
+
+If, after stripping, the result has fewer than 2 rooms, OR does not
+contain exactly one boss-archetype room with a declared `boss:`
+(dungeonspec's own `minRooms = 2` AND the "exactly one boss room"
+requirement this unit's probing discovered — see "Status tracking,"
+above), there IS no compilable subset — a from-scratch canvas with no
+declared rooms can't be saved at all yet, honestly, until both real
+minimums are met. `stripToV1Subset`'s `compilableBlockers` names WHICH of
+the two is missing; the UI's Save & Play tooltip shows it directly rather
+than one hardcoded message that may not be the actual reason.
 
 ## Compile badges
 

--- a/src/concepts/dungeon-builder/YamlPane.test.tsx
+++ b/src/concepts/dungeon-builder/YamlPane.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * YamlPane.test.tsx — render-layer coverage for the capability-probed
+ * graduation unit's gating pieces (`SaveAndPlayButton`, `CompileBadgeStrip`,
+ * `CapabilitiesLine`), all exported from `YamlPane.tsx` so
+ * `creation/ProposedYamlPane.tsx` can reuse the exact same components
+ * rather than a second copy — see that file's own doc comment. Tests
+ * these directly against their own props (`dungeonYaml.test.ts` already
+ * covers where `dropped`/`compiling`/`v1CompilableBlockers` come from —
+ * `stripToV1Subset`), not wired through the full `DungeonBuilderConcept`
+ * composition root, per this concept's "tests that survive extraction"
+ * bar (CONTRACT.md). No jest-dom matchers — this repo's vitest config
+ * has no such setup (`vite.config.ts`'s `test` block), so assertions use
+ * plain DOM properties, matching `Board.test.tsx`'s own convention.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { DialectField, ServerCapabilities } from './capabilityProbe';
+import { DIALECT_FIELDS } from './capabilityProbe';
+import {
+  CapabilitiesLine,
+  CompileBadgeStrip,
+  SaveAndPlayButton,
+} from './YamlPane';
+
+function allCapabilities(accepted: DialectField[]): ServerCapabilities {
+  return Object.fromEntries(
+    DIALECT_FIELDS.map((f) => [f, { accepted: accepted.includes(f) }])
+  ) as ServerCapabilities;
+}
+
+describe('SaveAndPlayButton — capability-probed graduation gating', () => {
+  it('disabled with a generic reason when the server is not live', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="unreachable"
+        saveState="idle"
+        v1Compilable={true}
+        v1CompilableBlockers={[]}
+        dialectDropped={[]}
+        dialectCompiling={[]}
+        onSaveAndPlay={vi.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', {
+      name: 'Save & Play',
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toMatch(/unreachable or authoring disabled/);
+  });
+
+  it('disabled with the SPECIFIC blocker reason when nothing is compilable — not a hardcoded "declare 2 rooms" message', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="live"
+        saveState="idle"
+        v1Compilable={false}
+        v1CompilableBlockers={[
+          'needs exactly one boss-archetype room with a declared boss (has none)',
+        ]}
+        dialectDropped={['canvas']}
+        dialectCompiling={[]}
+        onSaveAndPlay={vi.fn()}
+      />
+    );
+    // dialectDropped is non-empty (canvas), so the label already reads
+    // "Save the compilable subset" — disabled state and tooltip are what
+    // this test is actually checking, not the label.
+    const btn = screen.getByRole('button', {
+      name: 'Save the compilable subset',
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toContain(
+      'needs exactly one boss-archetype room with a declared boss (has none)'
+    );
+    expect(btn.title).not.toMatch(/declare at least 2 rooms/);
+  });
+
+  it('falls back to the generic room-count message only when no specific blocker was supplied', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="live"
+        saveState="idle"
+        v1Compilable={false}
+        v1CompilableBlockers={[]}
+        dialectDropped={[]}
+        dialectCompiling={[]}
+        onSaveAndPlay={vi.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', {
+      name: 'Save & Play',
+    }) as HTMLButtonElement;
+    expect(btn.title).toMatch(/declare at least 2 rooms/);
+  });
+
+  it('enabled, plain label, when the document is already pure v1', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="live"
+        saveState="idle"
+        v1Compilable={true}
+        v1CompilableBlockers={[]}
+        dialectDropped={[]}
+        dialectCompiling={[]}
+        onSaveAndPlay={vi.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', {
+      name: 'Save & Play',
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('enabled with "Save the compilable subset" and an honest Dropped/Compiles tooltip when the doc mixes accepted and rejected dialect fields', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="live"
+        saveState="idle"
+        v1Compilable={true}
+        v1CompilableBlockers={[]}
+        dialectDropped={['1 hole']}
+        dialectCompiling={['2 walls', 'start']}
+        onSaveAndPlay={vi.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', {
+      name: 'Save the compilable subset',
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.title).toContain('Dropped: 1 hole');
+    expect(btn.title).toContain('Compiles: 2 walls, start');
+  });
+
+  it('disabled and reads "Saving…" mid-save, regardless of compilability', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="live"
+        saveState="saving"
+        v1Compilable={true}
+        v1CompilableBlockers={[]}
+        dialectDropped={[]}
+        dialectCompiling={[]}
+        onSaveAndPlay={vi.fn()}
+      />
+    );
+    const btn = screen.getByRole('button', {
+      name: 'Saving…',
+    }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('honors a caller-supplied label for the pure-v1 case (creation mode reuse)', () => {
+    render(
+      <SaveAndPlayButton
+        serverState="live"
+        saveState="idle"
+        v1Compilable={true}
+        v1CompilableBlockers={[]}
+        dialectDropped={[]}
+        dialectCompiling={[]}
+        onSaveAndPlay={vi.fn()}
+        labelWhenPure="Custom Label"
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Custom Label' })).not.toBeNull();
+  });
+});
+
+describe('CompileBadgeStrip — dual compiling/dropped halves', () => {
+  it('renders nothing for a pure-v1 document', () => {
+    const { container } = render(
+      <CompileBadgeStrip dropped={[]} compiling={[]} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows both a confirming "Compiles on this server" line and an amber "Uses: ... not yet accepted" line when the doc has both', () => {
+    const { container } = render(
+      <CompileBadgeStrip dropped={['1 hole']} compiling={['2 walls']} />
+    );
+    expect(container.textContent).toContain('Compiles on this server: 2 walls');
+    expect(container.textContent).toContain(
+      'Uses: 1 hole — not yet accepted by this server'
+    );
+  });
+});
+
+describe('CapabilitiesLine — the "server capabilities" readout', () => {
+  it('renders nothing outside live mode', () => {
+    const { container } = render(
+      <CapabilitiesLine
+        serverState="gate-off"
+        capabilities={null}
+        onRefresh={vi.fn()}
+      />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('reads "probing" while live but the probe has not completed yet', () => {
+    const { container } = render(
+      <CapabilitiesLine
+        serverState="live"
+        capabilities={null}
+        onRefresh={vi.fn()}
+      />
+    );
+    expect(container.textContent).toMatch(/probing server capabilities/);
+  });
+
+  it('shows the real accepted/total count once the probe completes', () => {
+    const { container } = render(
+      <CapabilitiesLine
+        serverState="live"
+        capabilities={allCapabilities(['walls', 'start'])}
+        onRefresh={vi.fn()}
+      />
+    );
+    expect(container.textContent).toContain(
+      `server capabilities: accepts 2/${DIALECT_FIELDS.length} dialect fields`
+    );
+  });
+});

--- a/src/concepts/dungeon-builder/YamlPane.tsx
+++ b/src/concepts/dungeon-builder/YamlPane.tsx
@@ -24,8 +24,23 @@
  * Save & Play becomes "Save the compilable subset" the moment any are —
  * both computed once in `DungeonBuilderConcept.tsx` (`stripToV1Subset`)
  * and passed down, so this component never re-derives the strip itself.
- */
+ *
+ * **Capability-probed graduation (this unit, 2026-08-04)**: the compile
+ * badges and Save & Play's enable/disable used to read a hardcoded
+ * snapshot of "what dungeonspec compiles" — stale the moment the server
+ * moved (Kirk's authoring branch started compiling authored `walls:` and
+ * bare `start:` for real). `dialectDropped`/`v1Compilable` are now
+ * TRUTH-DRIVEN: `capabilityProbe.ts` probes the real server once per live
+ * connection, `stripToV1Subset` reads the result, and everything below
+ * just renders whatever it's handed — no field name is hardcoded in this
+ * file. `dialectCompiling` is the new positive half of that same split:
+ * constructs present AND accepted, so the badge strip can say "compiles
+ * now" instead of silently omitting them. `capabilities`/
+ * `onRefreshCapabilities` drive the small "server capabilities" readout
+ * beside the LIVE badge — the same probe result, surfaced honestly rather
+ * than only acted on invisibly. */
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
+import { capabilitySummary, type ServerCapabilities } from './capabilityProbe';
 import type { ServerState } from './usePutDungeonPreview';
 import type { SaveState } from './useSaveDungeon';
 
@@ -49,14 +64,28 @@ interface YamlPaneProps {
   walkFieldErrors: ValidationError[];
   walkErrorMessage: string | null;
   /** What `stripToV1Subset` would drop from the CURRENT document — empty
-   * when it's already pure v1. Drives both the compile-badge summary and
-   * the Save & Play button's label/behavior. */
+   * when the server accepts everything present. Drives both the amber
+   * half of the compile-badge summary and the Save & Play button's
+   * label/behavior. */
   dialectDropped: string[];
-  /** False when fewer than 2 rooms remain after stripping — there is
-   * genuinely nothing compilable to save yet (dungeonspec's own
-   * minRooms=2), distinct from "some target-dialect fields would be
-   * dropped but the rest still saves fine". */
+  /** The positive mirror of `dialectDropped`: target-dialect constructs
+   * present AND accepted by the live server's own probed capabilities —
+   * kept in the saved subset, not dropped. Empty in fixtures mode or
+   * while the probe hasn't completed yet (same conservative fallback
+   * `stripToV1Subset` itself uses). */
+  dialectCompiling: string[];
+  /** False when the stripped result is genuinely unsavable — see
+   * `v1CompilableBlockers` for the SPECIFIC reason, rather than one
+   * blanket message. */
   v1Compilable: boolean;
+  /** Human-readable reasons `v1Compilable` is false ("needs at least 2
+   * rooms (has 1)", "needs exactly one boss-archetype room with a
+   * declared boss") — empty when `v1Compilable` is true. */
+  v1CompilableBlockers: string[];
+  /** `null` until the capability probe completes against a live server —
+   * drives the "server capabilities" readout beside the LIVE badge. */
+  capabilities: ServerCapabilities | null;
+  onRefreshCapabilities: () => void;
 }
 
 function ServerBadge({
@@ -117,34 +146,188 @@ function ServerBadge({
   );
 }
 
+/** The "server capabilities" readout beside the LIVE badge — the
+ * capability-probed graduation unit's own honesty surface: what did THIS
+ * server actually say yes to, today, not what this file assumes. Renders
+ * nothing outside live mode (nothing to probe) or before the probe
+ * completes at all (`capabilities === null` with `serverState === 'live'`
+ * reads as mid-probe, not "zero capabilities" — a blank readout, not a
+ * false "0/N"). Exported so `creation/ProposedYamlPane.tsx` can show the
+ * same honest readout rather than only edit mode. */
+export function CapabilitiesLine({
+  serverState,
+  capabilities,
+  onRefresh,
+}: {
+  serverState: ServerState;
+  capabilities: ServerCapabilities | null;
+  onRefresh: () => void;
+}) {
+  if (serverState !== 'live') return null;
+  if (!capabilities) {
+    return (
+      <span style={{ fontSize: 10.5, color: '#8a7a5a' }}>
+        probing server capabilities…
+      </span>
+    );
+  }
+  const { accepted, total } = capabilitySummary(capabilities);
+  return (
+    <span
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        fontSize: 10.5,
+        color: '#8a7a5a',
+      }}
+    >
+      server capabilities: accepts {accepted}/{total} dialect fields
+      <button
+        onClick={onRefresh}
+        title="Re-run the per-field capability probe against this server"
+        style={{
+          fontSize: 10,
+          background: 'none',
+          border: '1px solid var(--border-primary)',
+          color: '#8a7a5a',
+          borderRadius: 3,
+          padding: '0px 5px',
+          cursor: 'pointer',
+        }}
+      >
+        refresh
+      </button>
+    </span>
+  );
+}
+
 /** The compile-badge summary, TARGET-YAML.md's "Compile badges" section:
  * per-feature, not per-line (the `yaml` CST doesn't cheaply give real
  * line/column spans without more plumbing than this honesty is worth).
- * Renders nothing for a pure-v1 document — the badge only appears the
- * moment there's something real to say. */
-function CompileBadgeStrip({ dropped }: { dropped: string[] }) {
-  if (dropped.length === 0) return null;
+ * Renders nothing for a document using no target-dialect construct at
+ * all — the badge only appears the moment there's something real to say.
+ *
+ * Two halves, capability-probed graduation (this unit): `compiling`
+ * (present AND accepted by the live server — a confirming, teal-toned
+ * line) and `dropped` (present and NOT accepted — the original amber
+ * "not yet compiled" line). A field flips from one to the other
+ * automatically as `capabilities` changes; nothing here hardcodes which
+ * field belongs in which bucket. Exported so `creation/ProposedYamlPane.tsx`
+ * reuses the exact same badge rendering rather than a second copy. */
+export function CompileBadgeStrip({
+  dropped,
+  compiling,
+}: {
+  dropped: string[];
+  compiling: string[];
+}) {
+  if (dropped.length === 0 && compiling.length === 0) return null;
   return (
-    <div
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {compiling.length > 0 && (
+        <div
+          style={{
+            fontSize: 11,
+            color: '#8fe8b0',
+            background: '#132018',
+            border: '1px solid #2f5240',
+            borderRadius: 4,
+            padding: '5px 8px',
+            lineHeight: 1.4,
+          }}
+        >
+          Compiles on this server: {compiling.join(', ')}
+        </div>
+      )}
+      {dropped.length > 0 && (
+        <div
+          style={{
+            fontSize: 11,
+            color: '#c9aeff',
+            background: '#1c1526',
+            border: '1px solid #3a2f52',
+            borderRadius: 4,
+            padding: '5px 8px',
+            lineHeight: 1.4,
+          }}
+        >
+          Uses: {dropped.join(', ')} — not yet accepted by this server
+          (TARGET-YAML.md)
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The Save & Play button itself, capability-aware gating and all —
+ * exported so `creation/ProposedYamlPane.tsx` can grow the SAME real
+ * gating this unit gave edit mode's `YamlPane`, instead of duplicating
+ * the disabled-state logic or (worse) keeping its own hardcoded "proposed
+ * schema, can't compile" tooltip that a probed capability could make
+ * false. `labelWhenPure` lets a caller keep a mode-appropriate label for
+ * the fully-v1 case (both modes currently say "Save & Play"; kept as a
+ * parameter rather than hardcoded so a future caller isn't forced to
+ * match). */
+export function SaveAndPlayButton({
+  serverState,
+  saveState,
+  v1Compilable,
+  v1CompilableBlockers,
+  dialectDropped,
+  dialectCompiling,
+  onSaveAndPlay,
+  labelWhenPure = 'Save & Play',
+}: {
+  serverState: ServerState;
+  saveState: SaveState;
+  v1Compilable: boolean;
+  v1CompilableBlockers: string[];
+  dialectDropped: string[];
+  dialectCompiling: string[];
+  onSaveAndPlay: () => void;
+  labelWhenPure?: string;
+}) {
+  const hasDialectFields = dialectDropped.length > 0;
+  const canSave =
+    serverState === 'live' && saveState !== 'saving' && v1Compilable;
+  return (
+    <button
+      onClick={() => onSaveAndPlay()}
+      disabled={!canSave}
+      title={
+        serverState !== 'live'
+          ? 'Server unreachable or authoring disabled — nothing to save to.'
+          : !v1Compilable
+            ? `Nothing compilable yet — ${v1CompilableBlockers.join('; ') || 'declare at least 2 rooms (dungeonspec.Validate requires it).'}`
+            : hasDialectFields
+              ? `Saves the v1-expressible SUBSET (validate_only: false). Dropped: ${dialectDropped.join(', ')}.${dialectCompiling.length > 0 ? ` Compiles: ${dialectCompiling.join(', ')}.` : ''}`
+              : 'PutDungeon(validate_only: false) — persists this dungeon for real.'
+      }
       style={{
-        fontSize: 11,
-        color: '#c9aeff',
-        background: '#1c1526',
-        border: '1px solid #3a2f52',
+        background: canSave ? '#5fd1c9' : 'var(--bg-secondary)',
+        color: canSave ? '#14110f' : '#6a6255',
+        border: canSave ? 'none' : '1px solid var(--border-primary)',
         borderRadius: 4,
-        padding: '5px 8px',
-        lineHeight: 1.4,
+        padding: '5px 10px',
+        fontSize: 12,
+        fontWeight: 600,
+        cursor: canSave ? 'pointer' : 'not-allowed',
       }}
     >
-      Uses: {dropped.join(', ')} — not yet compiled server-side (TARGET-YAML.md)
-    </div>
+      {saveState === 'saving'
+        ? 'Saving…'
+        : hasDialectFields
+          ? 'Save the compilable subset'
+          : labelWhenPure}
+    </button>
   );
 }
 
 /** Shared by both Save & Play and Walk it — `honestyNote`, when given, is
  * appended to the success message (Walk it's one real caveat: the boss
  * pin survives). */
-function SaveResultPanel({
+export function SaveResultPanel({
   saveState,
   savedKey,
   saveFieldErrors,
@@ -241,11 +424,13 @@ export function YamlPane({
   walkFieldErrors,
   walkErrorMessage,
   dialectDropped,
+  dialectCompiling,
   v1Compilable,
+  v1CompilableBlockers,
+  capabilities,
+  onRefreshCapabilities,
 }: YamlPaneProps) {
   const hasDialectFields = dialectDropped.length > 0;
-  const canSave =
-    serverState === 'live' && saveState !== 'saving' && v1Compilable;
   const canWalk = serverState === 'live' && walkState !== 'saving';
   return (
     <aside
@@ -292,37 +477,25 @@ export function YamlPane({
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <ServerBadge serverState={serverState} onRetryProbe={onRetryProbe} />
         </div>
-        <CompileBadgeStrip dropped={dialectDropped} />
+        <CapabilitiesLine
+          serverState={serverState}
+          capabilities={capabilities}
+          onRefresh={onRefreshCapabilities}
+        />
+        <CompileBadgeStrip
+          dropped={dialectDropped}
+          compiling={dialectCompiling}
+        />
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <button
-            onClick={() => onSaveAndPlay()}
-            disabled={!canSave}
-            title={
-              serverState !== 'live'
-                ? 'Server unreachable or authoring disabled — nothing to save to.'
-                : !v1Compilable
-                  ? 'Nothing compilable yet — declare at least 2 rooms (dungeonspec.Validate requires it).'
-                  : hasDialectFields
-                    ? `Saves the v1-expressible SUBSET (validate_only: false). Dropped: ${dialectDropped.join(', ')}.`
-                    : 'PutDungeon(validate_only: false) — persists this dungeon for real.'
-            }
-            style={{
-              background: canSave ? '#5fd1c9' : 'var(--bg-secondary)',
-              color: canSave ? '#14110f' : '#6a6255',
-              border: canSave ? 'none' : '1px solid var(--border-primary)',
-              borderRadius: 4,
-              padding: '5px 10px',
-              fontSize: 12,
-              fontWeight: 600,
-              cursor: canSave ? 'pointer' : 'not-allowed',
-            }}
-          >
-            {saveState === 'saving'
-              ? 'Saving…'
-              : hasDialectFields
-                ? 'Save the compilable subset'
-                : 'Save & Play'}
-          </button>
+          <SaveAndPlayButton
+            serverState={serverState}
+            saveState={saveState}
+            v1Compilable={v1Compilable}
+            v1CompilableBlockers={v1CompilableBlockers}
+            dialectDropped={dialectDropped}
+            dialectCompiling={dialectCompiling}
+            onSaveAndPlay={onSaveAndPlay}
+          />
           <span style={{ fontSize: 11, color: '#8a7a5a' }}>
             {hasDialectFields
               ? 'saves the v1 subset — target-dialect fields dropped, see badge above'
@@ -433,7 +606,7 @@ export function YamlPane({
         saveErrorMessage={saveErrorMessage}
         honestyNote={
           hasDialectFields
-            ? `Saved the compilable subset — dropped: ${dialectDropped.join(', ')} (see TARGET-YAML.md).`
+            ? `Saved the compilable subset — dropped: ${dialectDropped.join(', ')}.${dialectCompiling.length > 0 ? ` Compiled for real: ${dialectCompiling.join(', ')}.` : ''} (see TARGET-YAML.md).`
             : undefined
         }
       />

--- a/src/concepts/dungeon-builder/capabilityProbe.test.ts
+++ b/src/concepts/dungeon-builder/capabilityProbe.test.ts
@@ -1,0 +1,128 @@
+import type { PutDungeonRequest } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  putDungeonFn: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  authoringClient: { putDungeon: hoisted.putDungeonFn },
+}));
+
+// Import AFTER vi.mock so the mock is applied.
+import {
+  anyCapabilityAccepted,
+  capabilitySummary,
+  DIALECT_FIELDS,
+  probeAllCapabilities,
+} from './capabilityProbe';
+
+beforeEach(() => {
+  hoisted.putDungeonFn.mockReset();
+});
+
+describe('DIALECT_FIELDS', () => {
+  it('has no duplicate entries', () => {
+    expect(new Set(DIALECT_FIELDS).size).toBe(DIALECT_FIELDS.length);
+  });
+});
+
+describe('probeAllCapabilities', () => {
+  it('marks every field accepted when the server returns success:true for every probe', async () => {
+    hoisted.putDungeonFn.mockResolvedValue({ success: true, fieldErrors: [] });
+
+    const caps = await probeAllCapabilities();
+
+    for (const field of DIALECT_FIELDS) {
+      expect(caps[field].accepted).toBe(true);
+      expect(caps[field].message).toBeUndefined();
+    }
+    expect(capabilitySummary(caps)).toEqual({
+      accepted: DIALECT_FIELDS.length,
+      total: DIALECT_FIELDS.length,
+    });
+    expect(anyCapabilityAccepted(caps)).toBe(true);
+  });
+
+  it('marks every field rejected, with the server message threaded through verbatim, when every probe fails', async () => {
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: false,
+      fieldErrors: [
+        {
+          field: '',
+          message: 'field X not found in type dungeonspec.DungeonSpec',
+        },
+      ],
+    });
+
+    const caps = await probeAllCapabilities();
+
+    for (const field of DIALECT_FIELDS) {
+      expect(caps[field].accepted).toBe(false);
+      expect(caps[field].message).toBe(
+        'field X not found in type dungeonspec.DungeonSpec'
+      );
+    }
+    expect(capabilitySummary(caps)).toEqual({
+      accepted: 0,
+      total: DIALECT_FIELDS.length,
+    });
+    expect(anyCapabilityAccepted(caps)).toBe(false);
+  });
+
+  it('distinguishes accepted vs rejected fields on a per-request basis, keyed off the probe key', async () => {
+    // Every probe uses a distinct `capprobe-<field>` key (case-lowered) —
+    // real capabilityProbe.ts contract, verified against the module's own
+    // buildProbeDoc/probeAllCapabilities. Accept only the `walls` and
+    // `start` probes, exactly like the real live server this unit
+    // verified against (2026-08-04).
+    hoisted.putDungeonFn.mockImplementation(async (req: PutDungeonRequest) => {
+      if (req.key === 'capprobe-walls' || req.key === 'capprobe-start') {
+        return { success: true, fieldErrors: [] };
+      }
+      return {
+        success: false,
+        fieldErrors: [{ field: '', message: `rejected: ${req.key}` }],
+      };
+    });
+
+    const caps = await probeAllCapabilities();
+
+    expect(caps.walls.accepted).toBe(true);
+    expect(caps.start.accepted).toBe(true);
+    expect(caps.end.accepted).toBe(false);
+    expect(caps.canvas.accepted).toBe(false);
+    expect(caps.facingFloorProp.accepted).toBe(false);
+    expect(capabilitySummary(caps)).toEqual({
+      accepted: 2,
+      total: DIALECT_FIELDS.length,
+    });
+  });
+
+  it('a transport failure on one probe is recorded as rejected with the error message, not thrown', async () => {
+    hoisted.putDungeonFn.mockImplementation(async (req: PutDungeonRequest) => {
+      if (req.key === 'capprobe-canvas') {
+        throw new Error('failed to fetch');
+      }
+      return { success: true, fieldErrors: [] };
+    });
+
+    const caps = await probeAllCapabilities();
+
+    expect(caps.canvas.accepted).toBe(false);
+    expect(caps.canvas.message).toBe('failed to fetch');
+    // Every other field's probe still resolved normally — one failing
+    // request never takes down the whole suite.
+    expect(caps.walls.accepted).toBe(true);
+  });
+
+  it('every probe request declares validateOnly: true — never a real write', async () => {
+    hoisted.putDungeonFn.mockResolvedValue({ success: true, fieldErrors: [] });
+    await probeAllCapabilities();
+    expect(hoisted.putDungeonFn).toHaveBeenCalledTimes(DIALECT_FIELDS.length);
+    for (const call of hoisted.putDungeonFn.mock.calls) {
+      const req = call[0] as PutDungeonRequest;
+      expect(req.validateOnly).toBe(true);
+    }
+  });
+});

--- a/src/concepts/dungeon-builder/capabilityProbe.ts
+++ b/src/concepts/dungeon-builder/capabilityProbe.ts
@@ -1,0 +1,400 @@
+/**
+ * capabilityProbe — per-field capability probing against the real
+ * `AuthoringService.PutDungeon` RPC (unit: "capability-probed
+ * graduation," rpg-dnd5e-web, 2026-08-04).
+ *
+ * The strip list (`dungeonYaml.ts`'s `stripToV1Subset`), the compile
+ * badges (`YamlPane.tsx`'s `CompileBadgeStrip`), and Save & Play's
+ * enable/disable gating all used to read a hardcoded, static snapshot of
+ * "what dungeonspec compiles" (a comment, not a fact checked against
+ * anything running). That snapshot went stale the moment the server
+ * moved: Kirk's authoring branch started compiling authored `walls:` and
+ * bare `start:` for real (verified live, this unit, 2026-08-04 — see
+ * `probeAllCapabilities`'s own doc comment for the transcript), while the
+ * client kept stripping both unconditionally and kept the creation-mode
+ * Save & Play button hard-disabled with a blanket "proposed schema"
+ * tooltip that was no longer honest about at least those two fields.
+ *
+ * This module replaces the snapshot with TRUTH: on live-mode connect (see
+ * `usePutDungeonPreview.ts`), send one minimal `validate_only` doc per
+ * target-dialect field, each exercising exactly ONE field against an
+ * otherwise-known-good base document, and record what THIS server said
+ * about THIS field, today. `stripToV1Subset` then takes the resulting
+ * `ServerCapabilities` map as an optional parameter — a field the server
+ * accepts is no longer stripped; a field it doesn't is stripped and
+ * counted exactly as before. No capabilities (fixtures mode, or a probe
+ * that hasn't completed/failed) falls back to the prior static,
+ * conservative behavior — never a false "accepted."
+ *
+ * **Why per-field, not one big probe.** dungeonspec's real decode is
+ * whole-document and strict: a single unrecognized field fails the ENTIRE
+ * request ("field X not found in type dungeonspec.DungeonSpec" — every
+ * unknown key on one document reports as a single batched decode error,
+ * not per-field isolation). Sending every target-dialect field at once
+ * would only ever tell you "at least one of these isn't accepted," never
+ * which. Isolating one field per request is the only way to get an
+ * honest per-field map.
+ *
+ * **Two distinct rejection shapes, both real, verified live (2026-08-04)
+ * — this module keeps them, doesn't collapse them:**
+ *
+ * 1. **Decode-unknown** — `"field X not found in type dungeonspec.Y"`.
+ *    The server's Go struct has no field for this key at all yet. Applies
+ *    today to `holes`, `end`, `canvas`, `lighting`, `defaults`,
+ *    `regions`, `height`, `rotate_degrees`, `targeting`.
+ * 2. **Schema-known, capability-gated** —
+ *    `"unsupported capability: <constraint>"`. The field DECODES (the Go
+ *    struct has it) but is explicitly, deliberately rejected for this
+ *    specific usage, with a message naming the real constraint. Applies
+ *    today to `mount` (any placement — "mounted placements are not
+ *    supported"), `facing` on a monster/boss/`mount:wall` entry ("facing
+ *    only supported on room-scoped floor props" — but facing on a plain
+ *    room-scoped floor prop is ACCEPTED, see below), and top-level
+ *    `place:` ("top-level placement is not supported").
+ *
+ * Either way the raw server message is threaded through to
+ * `CapabilityResult.message` verbatim — never paraphrased — so a UI
+ * tooltip built from it stays exactly as honest as the server's own
+ * answer, not this module's guess at wording.
+ *
+ * **`wallLines:` is deliberately NOT probed.** It's this concept's own
+ * client-side sugar (`straightWallGeometry.ts` compiles a corner-anchored
+ * line + door cells down to a footprint) — `stripToV1Subset` drops it
+ * unconditionally, on its own line, separate from `walls:`, and never
+ * projects it INTO a `walls:` entry before stripping (confirmed by
+ * reading `stripToV1Subset` itself, not assumed). The real dungeonspec
+ * server has never been sent this construct in any form, so there is
+ * nothing to probe — it stays permanently client-only until a real
+ * request-side authoring contract exists for it (rpg-project#179).
+ */
+import { authoringClient } from '@/api/client';
+import { create } from '@bufbuild/protobuf';
+import type { PutDungeonResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { PutDungeonRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+
+/** One entry per target-dialect construct `stripToV1Subset` knows how to
+ * drop. `facing` is split into 4 entry-type variants because the real
+ * server's own validator distinguishes them (see this file's doc comment,
+ * "schema-known, capability-gated") — a single `facing` boolean would
+ * have to either lie for 3 of the 4 shapes or refuse to say anything
+ * useful for any of them. */
+export type DialectField =
+  | 'walls'
+  | 'holes'
+  | 'start'
+  | 'end'
+  | 'canvas'
+  | 'lighting'
+  | 'defaults'
+  | 'regions'
+  | 'mount'
+  | 'height'
+  | 'rotationDegrees'
+  | 'targeting'
+  | 'topLevelPlace'
+  | 'facingFloorProp'
+  | 'facingMonster'
+  | 'facingBoss'
+  | 'facingWallMount';
+
+/** Every `DialectField` — order is the probe/display order. */
+export const DIALECT_FIELDS: readonly DialectField[] = [
+  'walls',
+  'start',
+  'end',
+  'holes',
+  'canvas',
+  'lighting',
+  'defaults',
+  'regions',
+  'mount',
+  'height',
+  'rotationDegrees',
+  'targeting',
+  'topLevelPlace',
+  'facingFloorProp',
+  'facingMonster',
+  'facingBoss',
+  'facingWallMount',
+];
+
+/** Short, human labels for a compact capabilities readout — not the same
+ * as the honest tooltip message (`CapabilityResult.message`), which is
+ * the real server text. */
+export const DIALECT_FIELD_LABELS: Record<DialectField, string> = {
+  walls: 'walls',
+  holes: 'holes',
+  start: 'start',
+  end: 'end',
+  canvas: 'canvas',
+  lighting: 'lighting',
+  defaults: 'defaults',
+  regions: 'regions',
+  mount: 'wall-mount',
+  height: 'height',
+  rotationDegrees: 'fine-rotation',
+  targeting: 'targeting',
+  topLevelPlace: 'top-level place',
+  facingFloorProp: 'facing (floor prop)',
+  facingMonster: 'facing (monster)',
+  facingBoss: 'facing (boss)',
+  facingWallMount: 'facing (wall-mount)',
+};
+
+export interface CapabilityResult {
+  accepted: boolean;
+  /** The real `field_errors` message(s) from the server, joined verbatim
+   * — undefined only when `accepted`. A UI tooltip should show this text
+   * directly rather than inventing its own explanation; it's already the
+   * most specific, most current answer available. */
+  message?: string;
+}
+
+export type ServerCapabilities = Record<DialectField, CapabilityResult>;
+
+/** True whenever at least one dialect-field probe came back accepted —
+ * the cheapest "has anything actually graduated" check, used to decide
+ * whether the capabilities line is worth rendering at all. */
+export function anyCapabilityAccepted(
+  caps: ServerCapabilities | null
+): boolean {
+  if (!caps) return false;
+  return DIALECT_FIELDS.some((f) => caps[f]?.accepted);
+}
+
+/** `{accepted, total}` — drives the "accepts N/M dialect fields" readout. */
+export function capabilitySummary(caps: ServerCapabilities): {
+  accepted: number;
+  total: number;
+} {
+  const accepted = DIALECT_FIELDS.filter((f) => caps[f]?.accepted).length;
+  return { accepted, total: DIALECT_FIELDS.length };
+}
+
+/**
+ * Minimal, known-good base every probe document builds on: a 3-room chain
+ * (entrance/chamber/boss) with a declared boss. Two rooms alone are NOT
+ * enough — a real, load-bearing finding from building this probe suite
+ * (verified live, 2026-08-04, not documented anywhere before this unit):
+ * `dungeonspec.Validate` now rejects a chain with zero boss-archetype
+ * rooms outright (`"dungeon must have exactly one boss room, found 0"`),
+ * where earlier writing in this concept (CONTRACT.md's "Walk it" section)
+ * only described a boss-archetype ROOM needing a boss, not the CHAIN
+ * needing a boss room at all. Every probe below inherits this base so a
+ * probe failure always means the ONE field under test was rejected, never
+ * an unrelated baseline gap.
+ *
+ * `height: 8` puts the reserved door row at row 4 (`height / 2`) — every
+ * probe places its field-under-test content on rows 0–3, matching the
+ * live probing session's own verified-safe coordinates.
+ */
+function probeBase(key: string): string {
+  return `version: 1
+key: ${key}
+name: Capability Probe
+height: 8
+rooms:
+  - id: entry
+    archetype: entrance
+    width: 6
+  - id: hall
+    archetype: chamber
+    width: 6
+  - id: vault
+    archetype: boss
+    width: 10
+    boss: { ref: "dnd5e:monsters:skeleton-captain", at: [3, 3] }
+connectors:
+  - { from: entry, to: hall }
+  - { from: hall, to: vault }
+`;
+}
+
+/** One extra snippet per `DialectField`, appended to `probeBase` (or, for
+ * boss-facing, spliced into the boss entry — see the switch below). Each
+ * exercises exactly the ONE field it's named for; every coordinate/ref is
+ * one already verified live against Kirk's authoring branch while
+ * building this probe suite (2026-08-04). */
+function buildProbeDoc(field: DialectField, key: string): string {
+  const base = probeBase(key);
+  switch (field) {
+    case 'walls':
+      return (
+        base +
+        `walls:
+  - { from: [1, 1], to: [2, 1], kind: solid }
+  - { from: [1, 2], to: [2, 2], kind: door }
+`
+      );
+    case 'holes':
+      return (
+        base +
+        `holes:
+  - [1, 1]
+`
+      );
+    case 'start':
+      return base + `start: [1, 1]\n`;
+    case 'end':
+      return base + `end: [1, 2]\n`;
+    case 'canvas':
+      return base + `canvas: { width: 20, height: 10 }\n`;
+    case 'lighting':
+      return (
+        base +
+        `lighting:
+  ambient: 0.5
+`
+      );
+    case 'defaults':
+      return (
+        base +
+        `defaults:
+  'dnd5e:monsters:skeleton-captain': { targeting: lowest-health }
+`
+      );
+    case 'regions':
+      return (
+        base +
+        `regions:
+  - { id: entry-inner, archetype: chamber, cells: [[1, 1], [1, 2]] }
+`
+      );
+    case 'mount':
+      return withEntryPlace(
+        base,
+        `{ ref: "dnd5e:props:wall-banner", at: [2, 0], mount: wall }`
+      );
+    case 'height':
+      return withEntryPlace(
+        base,
+        `{ ref: "dnd5e:props:candles", at: [2, 1], height: 1.2 }`
+      );
+    case 'rotationDegrees':
+      return withEntryPlace(
+        base,
+        `{ ref: "dnd5e:props:wall-banner", at: [2, 0], mount: wall, facing: SE, rotate_degrees: 12 }`
+      );
+    case 'targeting':
+      return withHallPlace(
+        base,
+        `{ ref: "dnd5e:monsters:skeleton-captain", at: [3, 2], targeting: lowest-health }`
+      );
+    case 'topLevelPlace':
+      return (
+        base +
+        `place:
+  - { ref: "dnd5e:props:pillar", at: [10, 2] }
+`
+      );
+    case 'facingFloorProp':
+      return withEntryPlace(
+        base,
+        `{ ref: "dnd5e:props:statue-reaper", at: [1, 1], facing: SE }`
+      );
+    case 'facingMonster':
+      return withHallPlace(
+        base,
+        `{ ref: "dnd5e:monsters:skeleton-captain", at: [3, 2], facing: NE }`
+      );
+    case 'facingBoss':
+      return base.replace(
+        'boss: { ref: "dnd5e:monsters:skeleton-captain", at: [3, 3] }',
+        'boss: { ref: "dnd5e:monsters:skeleton-captain", at: [3, 3], facing: W }'
+      );
+    case 'facingWallMount':
+      return withEntryPlace(
+        base,
+        `{ ref: "dnd5e:props:wall-banner", at: [2, 0], mount: wall, facing: SE }`
+      );
+  }
+}
+
+/** Inserts a `place:` list under the `entry` room — every probe doc that
+ * needs a room-scoped floor-prop placement uses this rather than hand-
+ * splicing YAML text repeatedly. */
+function withEntryPlace(base: string, entry: string): string {
+  return base.replace(
+    '  - id: entry\n    archetype: entrance\n    width: 6\n',
+    `  - id: entry\n    archetype: entrance\n    width: 6\n    place:\n      - ${entry}\n`
+  );
+}
+
+/** Same as `withEntryPlace`, for the `hall` room — used by probes that
+ * need a MONSTER placement (monster refs are only meaningful outside the
+ * entrance room in this base, though nothing about the base actually
+ * requires that; kept for readability, matching the verified probe
+ * documents this module's doc comment describes). */
+function withHallPlace(base: string, entry: string): string {
+  return base.replace(
+    '  - id: hall\n    archetype: chamber\n    width: 6\n',
+    `  - id: hall\n    archetype: chamber\n    width: 6\n    place:\n      - ${entry}\n`
+  );
+}
+
+function classify(response: PutDungeonResponse): CapabilityResult {
+  if (response.success) return { accepted: true };
+  const message = response.fieldErrors.map((e) => e.message).join('; ');
+  return {
+    accepted: false,
+    message: message || 'rejected — no detail returned',
+  };
+}
+
+/**
+ * Probes every `DialectField` against the real `PutDungeon` RPC,
+ * `validate_only: true`, one request per field, run concurrently. Never
+ * throws — a transport failure on an individual probe (the whole-suite
+ * caller already knows the server is reachable, since this only runs
+ * once `usePutDungeonPreview`'s own mount-time probe found `serverState
+ * === 'live'`) is recorded as `accepted: false` with the error's own
+ * message, same shape as a real rejection, so a UI reading
+ * `ServerCapabilities` never has to special-case "probe request itself
+ * failed" separately from "server said no."
+ *
+ * **Live-verified, 2026-08-04**, against `rpg-api-dungeon-builder-763` /
+ * its envoy sidecar (`localhost:8091`) — the transcript this module's own
+ * field-by-field logic is built from, not a guess:
+ *
+ * - `walls` — **accepted** (`success: true`).
+ * - `start` — **accepted** (`success: true`).
+ * - `facingFloorProp` — **accepted** (`success: true`) — a room-scoped,
+ *   non-monster, non-`mount:wall` `place:` entry's `facing:` compiles.
+ * - `holes`, `end`, `canvas`, `lighting`, `defaults`, `regions`,
+ *   `height`, `rotationDegrees`, `targeting` — decode-unknown
+ *   (`"field X not found in type dungeonspec.Y"`).
+ * - `mount` — schema-known, rejected (`"unsupported capability: mounted
+ *   placements are not supported"`).
+ * - `facingMonster`, `facingBoss`, `facingWallMount` — schema-known,
+ *   rejected (`"unsupported capability: facing only supported on
+ *   room-scoped floor props"`).
+ * - `topLevelPlace` — schema-known, rejected (`"unsupported capability:
+ *   top-level placement is not supported"`).
+ */
+export async function probeAllCapabilities(): Promise<ServerCapabilities> {
+  const entries = await Promise.all(
+    DIALECT_FIELDS.map(async (field) => {
+      const key = `capprobe-${field.toLowerCase()}`;
+      try {
+        const response = await authoringClient.putDungeon(
+          create(PutDungeonRequestSchema, {
+            key,
+            yaml: buildProbeDoc(field, key),
+            validateOnly: true,
+          })
+        );
+        return [field, classify(response)] as const;
+      } catch (err) {
+        return [
+          field,
+          {
+            accepted: false,
+            message:
+              err instanceof Error ? err.message : 'probe request failed',
+          },
+        ] as const;
+      }
+    })
+  );
+  return Object.fromEntries(entries) as ServerCapabilities;
+}

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -7,13 +7,17 @@
  * rows and the shared `Inspector` — no more bespoke Tools strip or
  * hand-rolled facing/delete panel duplicating what those already do.
  */
+import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { useEffect, useState } from 'react';
+import type { ServerCapabilities } from '../capabilityProbe';
 import { CollapsibleSidePanel } from '../CollapsibleSidePanel';
-import type { DungeonDoc, WallKind } from '../dungeonYaml';
+import type { DungeonDoc, V1SubsetResult, WallKind } from '../dungeonYaml';
 import { Inspector } from '../Inspector';
 import { Palette } from '../Palette';
 import type { BoardTool } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
+import type { ServerState } from '../usePutDungeonPreview';
+import type { SaveState } from '../useSaveDungeon';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
@@ -65,6 +69,21 @@ interface CreationConceptProps {
   onTogglePalette: () => void;
   yamlCollapsed: boolean;
   onToggleYaml: () => void;
+  /** Capability-probed graduation (this unit) — same server-capabilities
+   * truth edit mode's `YamlPane` reads, threaded down to
+   * `ProposedYamlPane` so creation mode's Save & Play gates on the real
+   * server, not a permanently-disabled placeholder. See
+   * `ProposedYamlPane.tsx`'s own doc comment for why the button still
+   * reads disabled in practice today. */
+  serverState: ServerState;
+  capabilities: ServerCapabilities | null;
+  onRefreshCapabilities: () => void;
+  v1Subset: V1SubsetResult | null;
+  onSaveAndPlay: () => void;
+  saveState: SaveState;
+  savedKey: string | null;
+  saveFieldErrors: ValidationError[];
+  saveErrorMessage: string | null;
 }
 
 export function CreationConcept({
@@ -90,6 +109,15 @@ export function CreationConcept({
   onTogglePalette,
   yamlCollapsed,
   onToggleYaml,
+  serverState,
+  capabilities,
+  onRefreshCapabilities,
+  v1Subset,
+  onSaveAndPlay,
+  saveState,
+  savedKey,
+  saveFieldErrors,
+  saveErrorMessage,
 }: CreationConceptProps) {
   const [dims, setDims] = useState(DEFAULT_CANVAS);
 
@@ -347,6 +375,15 @@ export function CreationConcept({
             yamlText={yamlText}
             onChangeText={onChangeYamlText}
             parseError={yamlParseError}
+            serverState={serverState}
+            capabilities={capabilities}
+            onRefreshCapabilities={onRefreshCapabilities}
+            v1Subset={v1Subset}
+            onSaveAndPlay={onSaveAndPlay}
+            saveState={saveState}
+            savedKey={savedKey}
+            saveFieldErrors={saveFieldErrors}
+            saveErrorMessage={saveErrorMessage}
           />
         </CollapsibleSidePanel>
       </div>

--- a/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
+++ b/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
@@ -5,24 +5,80 @@
  * today. As of the CST unification (CONTRACT.md), this is no longer a
  * hand-serialized approximation — it's the REAL `serializeDungeon(cst)`
  * text for creation mode's own document, editable and round-tripping
- * the same way edit mode's YamlPane is, just without that pane's
- * server/compile-badge/save chrome: creation mode still makes no server
- * calls (design.md defers wall/shape authoring to P4+; a real
- * PutDungeon for a freeform canvas needs a dungeonspec extension that
- * doesn't exist yet), so "Save & Play" stays disabled here rather than
- * pretending there's somewhere real for this to go.
+ * the same way edit mode's YamlPane is.
+ *
+ * **Capability-probed graduation (this unit, 2026-08-04)**: Save & Play
+ * used to be PERMANENTLY disabled here, with a blanket "the server can't
+ * compile this yet" tooltip — honest when creation mode's proposed
+ * `walls:`/`start:`/`end:`/facing schema was 100% invented, but no longer
+ * honest the moment the real server started accepting some of it for real
+ * (`walls:`, bare `start:`, room-scoped floor-prop `facing` — see
+ * `capabilityProbe.ts`). This pane now reuses the SAME
+ * `SaveAndPlayButton`/`CompileBadgeStrip`/`CapabilitiesLine` components
+ * edit mode's `YamlPane` uses, fed the SAME capability-aware
+ * `stripToV1Subset` result computed in `DungeonBuilderConcept.tsx` — one
+ * gating implementation, not two that could drift.
+ *
+ * **Why the button still reads disabled in practice, today**: creation
+ * mode has no "declare a room" UI (`emptyCanvasDoc.ts`'s own doc comment
+ * — `rooms: []` is the only shape this mode's board ever produces) and
+ * dungeonspec's real `minRooms = 2` + "exactly one boss-archetype room"
+ * requirements are unconditional, independent of which target-dialect
+ * fields the server accepts (see `stripToV1Subset`'s own
+ * `compilableBlockers`). So a from-scratch canvas is STILL genuinely
+ * unsavable today — but the button now says so with the SPECIFIC real
+ * reason ("needs at least 2 rooms (has 0)") instead of the old blanket
+ * "proposed schema" claim, and an author who hand-types `rooms:`
+ * declarations into this very pane (it's a real, editable CST — see
+ * this doc comment's own opening) would see the button light up the
+ * moment the document actually becomes compilable, same as edit mode.
  */
+import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
+import type { ServerCapabilities } from '../capabilityProbe';
+import type { V1SubsetResult } from '../dungeonYaml';
+import type { ServerState } from '../usePutDungeonPreview';
+import type { SaveState } from '../useSaveDungeon';
+import {
+  CapabilitiesLine,
+  CompileBadgeStrip,
+  SaveAndPlayButton,
+  SaveResultPanel,
+} from '../YamlPane';
+
 interface ProposedYamlPaneProps {
   yamlText: string;
   onChangeText: (text: string) => void;
   parseError: string | null;
+  serverState: ServerState;
+  capabilities: ServerCapabilities | null;
+  onRefreshCapabilities: () => void;
+  v1Subset: V1SubsetResult | null;
+  onSaveAndPlay: () => void;
+  saveState: SaveState;
+  savedKey: string | null;
+  saveFieldErrors: ValidationError[];
+  saveErrorMessage: string | null;
 }
 
 export function ProposedYamlPane({
   yamlText,
   onChangeText,
   parseError,
+  serverState,
+  capabilities,
+  onRefreshCapabilities,
+  v1Subset,
+  onSaveAndPlay,
+  saveState,
+  savedKey,
+  saveFieldErrors,
+  saveErrorMessage,
 }: ProposedYamlPaneProps) {
+  const dropped = v1Subset?.dropped ?? [];
+  const compiling = v1Subset?.compiling ?? [];
+  const compilable = v1Subset?.compilable ?? false;
+  const compilableBlockers = v1Subset?.compilableBlockers ?? [];
+  const hasDialectFields = dropped.length > 0;
   return (
     <aside
       style={{
@@ -46,33 +102,35 @@ export function ProposedYamlPane({
           textTransform: 'uppercase',
         }}
       >
-        Proposed schema — dungeonspec cannot express this today
+        Proposed schema — most of this dungeonspec cannot express yet
       </div>
       <div
         style={{
           padding: '8px 12px',
           borderBottom: '1px dashed #4a3a63',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
         }}
       >
-        <button
-          disabled
-          title="Proposed schema — the server can't compile this yet. Wall/shape authoring needs a real dungeonspec extension first (see CONTRACT.md)."
-          style={{
-            background: 'transparent',
-            color: '#5a4d70',
-            border: '1px solid #3a2f4d',
-            borderRadius: 4,
-            padding: '5px 10px',
-            fontSize: 12,
-            fontWeight: 600,
-            cursor: 'not-allowed',
-          }}
-        >
-          Save & Play
-        </button>
+        <CapabilitiesLine
+          serverState={serverState}
+          capabilities={capabilities}
+          onRefresh={onRefreshCapabilities}
+        />
+        <CompileBadgeStrip dropped={dropped} compiling={compiling} />
+        <SaveAndPlayButton
+          serverState={serverState}
+          saveState={saveState}
+          v1Compilable={compilable}
+          v1CompilableBlockers={compilableBlockers}
+          dialectDropped={dropped}
+          dialectCompiling={compiling}
+          onSaveAndPlay={onSaveAndPlay}
+        />
       </div>
       <textarea
-        aria-label="Proposed schema (invented, not real dungeonspec)"
+        aria-label="Proposed schema (mostly invented, not real dungeonspec)"
         value={yamlText}
         onChange={(e) => onChangeText(e.target.value)}
         spellCheck={false}
@@ -104,6 +162,17 @@ export function ProposedYamlPane({
           {parseError}
         </div>
       )}
+      <SaveResultPanel
+        saveState={saveState}
+        savedKey={savedKey}
+        saveFieldErrors={saveFieldErrors}
+        saveErrorMessage={saveErrorMessage}
+        honestyNote={
+          hasDialectFields
+            ? `Saved the compilable subset — dropped: ${dropped.join(', ')}.${compiling.length > 0 ? ` Compiled for real: ${compiling.join(', ')}.` : ''} (see TARGET-YAML.md).`
+            : undefined
+        }
+      />
     </aside>
   );
 }

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -2,6 +2,11 @@ import { hexDistance } from '@/components/hex-grid/hexMath';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import {
+  DIALECT_FIELDS,
+  type DialectField,
+  type ServerCapabilities,
+} from './capabilityProbe';
 import { canonicalCorner } from './creation/hexCorner';
 import {
   addCellToRegion,
@@ -983,7 +988,8 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
       expect(result.dropped).toEqual([
         '2 walls',
         '1 hole',
-        'start/end',
+        'start',
+        'end',
         'lighting',
         'facing (1 placement)',
         'wall-mount (1 placement)',
@@ -1086,6 +1092,239 @@ connectors: []
         '1 top-level placement (mapped into rooms)',
         '1 top-level placement outside any room',
       ]);
+    });
+  });
+
+  describe('stripToV1Subset: capability-aware (capability-probed graduation unit)', () => {
+    // Minimal helper: every DialectField the test doesn't explicitly list
+    // is left unaccepted, matching how a real `ServerCapabilities` reads
+    // for a server that hasn't graduated a field yet — never a silent
+    // "everything accepted" default.
+    function caps(accepted: DialectField[]): ServerCapabilities {
+      const all = Object.fromEntries(
+        DIALECT_FIELDS.map((f) => [f, { accepted: false }])
+      ) as ServerCapabilities;
+      for (const field of accepted) all[field] = { accepted: true };
+      return all;
+    }
+
+    it('keeps an accepted walls: verbatim instead of stripping it, and counts it as compiling', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      toggleWall(cst, 7, 0);
+      toggleWall(cst, 7, 4);
+
+      const result = stripToV1Subset(serializeDungeon(cst), caps(['walls']));
+
+      expect(result.dropped).toEqual([]);
+      expect(result.compiling).toEqual(['2 walls']);
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.walls).toHaveLength(2);
+    });
+
+    it('with no capabilities at all, falls back to the prior conservative-static strip (walls always dropped)', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      toggleWall(cst, 7, 0);
+
+      const result = stripToV1Subset(serializeDungeon(cst)); // no second arg
+
+      expect(result.dropped).toEqual(['1 wall']);
+      expect(result.compiling).toEqual([]);
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.walls).toEqual([]);
+    });
+
+    it('start and end are independent capabilities — one can compile while the other still drops', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setStart(cst, [0, 4]);
+      setEnd(cst, [19, 25]);
+
+      const result = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['start']) // end NOT accepted
+      );
+
+      expect(result.dropped).toEqual(['end']);
+      expect(result.compiling).toEqual(['start']);
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.start).toEqual([0, 4]);
+      expect(stripped.end).toBeNull();
+    });
+
+    it('facing is gated PER ENTRY TYPE — a floor prop keeps facing while a monster/boss/wall-mount in the same doc still loses it', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      // antechamber's own place[0] (brazier) is a plain floor prop —
+      // real fixture data, not hand-crafted.
+      setPlacementFacing(cst, 'antechamber', 0, 2);
+      placeItem(cst, 'shrine', 'dnd5e:monsters:skeleton-captain', [3, 3]);
+      setPlacementFacing(cst, 'shrine', doc.rooms[1].place.length, 4);
+      setBossFacing(cst, doc.rooms[2].id, 1);
+
+      const result = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['facingFloorProp']) // monster/boss facing NOT accepted
+      );
+
+      expect(result.dropped).toContain('facing (2 placements)');
+      expect(result.compiling).toContain('facing (1 placement)');
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.rooms[0].place[0].facing).toBe(2);
+      const monster = stripped.rooms[1].place.find((p) => p.isMonster)!;
+      expect(monster.facing).toBeNull();
+      expect(stripped.rooms[2].boss?.facing).toBeNull();
+    });
+
+    it('wall-mount facing is its own DialectField, independent of a plain floor prop facing capability', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setPlacementFacing(cst, 'antechamber', 0, 2);
+      setPlacementMount(cst, 'antechamber', 0, 'wall');
+
+      const acceptedFloorOnly = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['facingFloorProp'])
+      );
+      expect(acceptedFloorOnly.dropped).toContain('facing (1 placement)');
+
+      const acceptedWallMountToo = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['facingFloorProp', 'facingWallMount'])
+      );
+      expect(acceptedWallMountToo.compiling).toContain('facing (1 placement)');
+    });
+
+    it('an accepted defaults: block is kept verbatim — no materialize-on-strip when the server understands it directly', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setRefDefault(cst, 'dnd5e:props:statue-reaper', 'blocksMovement', true);
+
+      const result = stripToV1Subset(serializeDungeon(cst), caps(['defaults']));
+
+      expect(result.dropped).toEqual([]);
+      expect(result.compiling).toEqual(['1 default ref']);
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.defaults).toEqual({
+        'dnd5e:props:statue-reaper': { blocksMovement: true },
+      });
+      // NOT materialized onto the instance — the server resolves
+      // inheritance itself now, so baking it in here would be redundant.
+      const statue = stripped.rooms
+        .find((r) => r.id === 'shrine')!
+        .place.find((p) => p.ref === 'dnd5e:props:statue-reaper')!;
+      expect(statue.explicit.blocksMovement).toBe(false);
+    });
+
+    it('an accepted topLevelPlace keeps the top-level place: list verbatim instead of mapping it into rooms', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      placeItem(cst, null, 'dnd5e:props:pillar', [10, 3]); // would map into shrine if NOT accepted
+
+      const result = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['topLevelPlace'])
+      );
+
+      expect(result.dropped).toEqual([]);
+      expect(result.compiling).toEqual(['1 top-level placement']);
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.place).toHaveLength(1);
+      expect(stripped.place[0]).toMatchObject({
+        ref: 'dnd5e:props:pillar',
+        at: [10, 3],
+      });
+      // shrine already legitimately has 8 pillar props of its own
+      // (showcase.yaml's real "colonnade" content) — check the SPECIFIC
+      // room-local coordinate the mapped-down conversion would have used
+      // (10 - shrine's startColumn 7 = 3), not just ref presence.
+      const shrine = stripped.rooms.find((r) => r.id === 'shrine')!;
+      expect(
+        shrine.place.some(
+          (p) =>
+            p.ref === 'dnd5e:props:pillar' && p.at[0] === 3 && p.at[1] === 3
+        )
+      ).toBe(false);
+    });
+
+    it('a kept top-level placement still gets its OWN facing/mount/height/targeting stripped per-field', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      placeItem(cst, null, 'dnd5e:props:pillar', [10, 3]);
+      setPlacementFacing(cst, null, 0, 3);
+      setPlacementHeight(cst, null, 0, 2.0);
+
+      const result = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['topLevelPlace']) // facing/height NOT accepted
+      );
+
+      const { doc: stripped } = parseDungeon(result.yaml);
+      expect(stripped.place[0].facing).toBeNull();
+      expect(stripped.place[0].height).toBeNull();
+      expect(result.dropped).toEqual(
+        expect.arrayContaining(['facing (1 placement)', 'height (1 placement)'])
+      );
+    });
+
+    it('canvas/holes/regions/lighting each compile independently when their own capability is accepted', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      toggleHole(cst, 3, 6);
+      setLightingAmbient(cst, 0.8);
+      createRegion(cst, doc, 'r1', 'chamber', [[1, 1]]);
+
+      const result = stripToV1Subset(
+        serializeDungeon(cst),
+        caps(['holes', 'lighting', 'regions'])
+      );
+
+      expect(result.dropped).toEqual([]);
+      expect(result.compiling).toEqual(
+        expect.arrayContaining(['1 hole', 'lighting', '1 region'])
+      );
+    });
+
+    it('compilableBlockers names the real, unconditional server minimums — independent of any dialect capability', () => {
+      const oneRoom = `
+version: 1
+key: bare
+name: "Bare"
+height: 8
+rooms:
+  - id: only
+    archetype: entrance
+    width: 6
+connectors: []
+`;
+      const result = stripToV1Subset(oneRoom, caps(['walls', 'start']));
+      expect(result.compilable).toBe(false);
+      expect(result.compilableBlockers).toEqual(
+        expect.arrayContaining(['needs at least 2 rooms (has 1)'])
+      );
+    });
+
+    it('a real, load-bearing finding this unit uncovered: 2+ rooms alone is not enough — the chain needs exactly one boss-archetype room with a declared boss', () => {
+      const twoNonBossRooms = `
+version: 1
+key: no-boss
+name: "No Boss"
+height: 8
+rooms:
+  - id: a
+    archetype: entrance
+    width: 6
+  - id: b
+    archetype: chamber
+    width: 6
+connectors:
+  - { from: a, to: b }
+`;
+      const result = stripToV1Subset(twoNonBossRooms);
+      expect(result.compilable).toBe(false);
+      expect(result.compilableBlockers).toEqual(
+        expect.arrayContaining([
+          'needs exactly one boss-archetype room with a declared boss (has none)',
+        ])
+      );
+    });
+
+    it('a real showcase-shaped document (2 rooms + 1 boss room, boss declared) is compilable with no blockers', () => {
+      const result = stripToV1Subset(SHOWCASE_YAML);
+      expect(result.compilable).toBe(true);
+      expect(result.compilableBlockers).toEqual([]);
     });
   });
 

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -36,6 +36,7 @@ import {
   YAMLMap,
   YAMLSeq,
 } from 'yaml';
+import type { DialectField, ServerCapabilities } from './capabilityProbe';
 import {
   canonicalCorner,
   cornerPoint,
@@ -1127,9 +1128,28 @@ export function stripMonsterPlacements(cst: Document): void {
  * CST, so building a walk variant never disturbs the board being edited.
  * `boss:` is left untouched (see `stripMonsterPlacements`'s doc comment)
  * — the walk variant is NOT monster-free, only place:-monster-free, and
- * the UI must say so rather than implying a true no-encounter walkthrough. */
-export function buildWalkItYaml(yamlText: string, walkKey: string): string {
-  const { cst } = parseDungeon(yamlText);
+ * the UI must say so rather than implying a true no-encounter walkthrough.
+ *
+ * **Capability-probed graduation (this unit, 2026-08-04).** Before this
+ * unit, Walk it sent `yamlText` STRAIGHT to `parseDungeon` — unlike Save &
+ * Play, it never ran `stripToV1Subset` at all, so a document using any
+ * target-dialect construct (walls, start, ...) would fail Walk it's own
+ * save outright the moment that construct was present, regardless of
+ * whether the server actually accepted it. `capabilities` (optional, same
+ * `ServerCapabilities` Save & Play's own strip reads) fixes this: the v1-
+ * expressible/capability-accepted subset is computed FIRST, monster
+ * stripping happens on THAT, so Walk it and Save & Play now agree on what
+ * "compilable" means, and an accepted field (Kirk's `walls:` survives
+ * both saves, not just one. `undefined` (fixtures mode, or a
+ * pre-capability-probe caller/test) falls back to the prior conservative-
+ * static strip, same as `stripToV1Subset` itself. */
+export function buildWalkItYaml(
+  yamlText: string,
+  walkKey: string,
+  capabilities?: ServerCapabilities
+): string {
+  const subsetYaml = stripToV1Subset(yamlText, capabilities).yaml;
+  const { cst } = parseDungeon(subsetYaml);
   stripMonsterPlacements(cst);
   cst.set('key', walkKey);
   return serializeDungeon(cst);
@@ -2230,261 +2250,463 @@ function materializeRefDefaults(
 
 export interface V1SubsetResult {
   /** The stripped, v1-only YAML text — always `version: 1`, never any
-   * target-dialect-only field. */
+   * target-dialect-only field the server doesn't currently accept (an
+   * ACCEPTED field, per `capabilities`, survives verbatim — see this
+   * function's own doc comment). */
   yaml: string;
   /** Human-readable list of what got dropped ("3 walls", "1 hole",
-   * "start/end", "facing (2 placements)", "lighting") — empty when the
-   * input was already pure v1. Drives the "Save the compilable subset"
-   * diff summary (TARGET-YAML.md). */
+   * "start", "facing (2 placements)", "lighting") — empty when the input
+   * uses no target-dialect construct the server currently rejects. Drives
+   * the "Save the compilable subset" diff summary (TARGET-YAML.md) and
+   * the amber half of the compile-badge strip. */
   dropped: string[];
-  /** False when fewer than 2 rooms remain after stripping — dungeonspec's
-   * own `minRooms = 2` (validate.go) makes the result genuinely
-   * unsavable, not merely unenriched. A from-scratch target-dialect
-   * canvas with 0-1 declared rooms has NO compilable subset yet. */
+  /** The mirror of `dropped`: target-dialect constructs present in the
+   * input that `capabilities` says THIS server currently accepts, and
+   * that therefore survived into `yaml` unstripped — "2 walls", "start".
+   * Always empty when `capabilities` is omitted (the conservative static
+   * fallback strips everything target-dialect, same as before this
+   * field existed) — never a guess. Drives the confirming half of the
+   * compile-badge strip, so a badge flips from "Dropped" to "Uses
+   * (compiles)" automatically the moment a server capability changes,
+   * with no static list to hand-edit. */
+  compiling: string[];
+  /** False when the stripped result is genuinely unsavable — dungeonspec's
+   * own real server-side minimums, not a target-dialect concern:
+   * `minRooms = 2` (validate.go), and (verified live, this unit,
+   * 2026-08-04 — not previously documented anywhere in this concept) the
+   * chain must contain EXACTLY ONE boss-archetype room with a declared
+   * `boss:` ("dungeon must have exactly one boss room, found 0" is a
+   * real, current rejection, not a guess). See `compilableBlockers` for
+   * which of these is the actual reason, when false. */
   compilable: boolean;
+  /** Human-readable reasons `compilable` is false ("needs at least 2
+   * rooms (has 1)", "needs exactly one boss-archetype room with a
+   * declared boss") — empty when `compilable` is true. Lets the Save &
+   * Play tooltip name the SPECIFIC blocking constraint instead of one
+   * hardcoded message that may not be the actual reason (a from-scratch
+   * canvas with 2 plain rooms and no boss room fails the real server for
+   * a different reason than "fewer than 2 rooms," and deserves a
+   * different tooltip). */
+  compilableBlockers: string[];
+}
+
+function pluralCount(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`;
+}
+
+/** Which `DialectField` governs a placement's own `facing:` — the real
+ * server distinguishes by entry type (verified live, this unit,
+ * 2026-08-04: a room-scoped, non-monster, non-`mount:wall` floor prop's
+ * facing compiles; every other shape decodes but is explicitly rejected,
+ * `"unsupported capability: facing only supported on room-scoped floor
+ * props"`), so a single blanket `facing` capability can't answer "is
+ * THIS placement's facing accepted" correctly for anything but the one
+ * shape that currently works. `BossDoc` entries never call this — they
+ * always use `facingBoss` directly (see `stripToV1Subset` below), since
+ * `BossDoc` carries no `isMonster`/`mount` to dispatch on. */
+function facingCapabilityFor(placement: {
+  isMonster: boolean;
+  mount: Mount;
+}): DialectField {
+  if (placement.isMonster) return 'facingMonster';
+  if (placement.mount === 'wall') return 'facingWallMount';
+  return 'facingFloorProp';
 }
 
 /** Strip a target-dialect document down to exactly what dungeonspec
- * compiles today (the v1-expressible subset) — TARGET-YAML.md's "The
- * v1-subset strip" table, in code. Parses a FRESH CST from `yamlText`
- * (never mutates a caller's live board CST), so this is safe to call on
- * every live-preview debounce tick and every Save & Play click without
- * disturbing what the author is editing.
+ * compiles TODAY, ON THIS SERVER — TARGET-YAML.md's "The v1-subset
+ * strip" table, generalized from a static snapshot to a live one.
+ * Parses a FRESH CST from `yamlText` (never mutates a caller's live board
+ * CST), so this is safe to call on every live-preview debounce tick and
+ * every Save & Play click without disturbing what the author is editing.
  *
- * `defaults:` (target dialect, proposed — see `DungeonDoc.defaults`'s own
- * doc comment) is the one dropped construct that isn't simply discarded:
- * `materializeRefDefaults` bakes every inherited `blocks_movement`/
- * `blocks_los` onto its placement FIRST, so the returned subset preserves
- * the authored behavior a default was standing in for. `targeting`/
- * `height`/`facing` defaults have no v1 representation regardless and are
- * lost the same way an explicit one would be — only counted via the
- * `defaults (...)` entry below, not double-counted in the per-field
- * facing/height/targeting tallies further down (those only ever count a
- * literal key actually present on the instance). */
-export function stripToV1Subset(yamlText: string): V1SubsetResult {
+ * `capabilities` (optional, `capabilityProbe.ts`'s `ServerCapabilities`)
+ * is the truth this function now checks before stripping ANY
+ * target-dialect field: present AND accepted → kept verbatim, counted in
+ * `compiling`; present and not accepted (or `capabilities` omitted
+ * entirely — fixtures mode, or a probe that hasn't completed yet) →
+ * stripped exactly as before this unit, counted in `dropped`. This is
+ * the ONLY behavior change from the prior static version: every stripping
+ * DECISION below now asks `accepted(field)` first; the actual strip
+ * mechanics (CST deletes, `dropped`/`compiling` bookkeeping) are
+ * unchanged.
+ *
+ * `defaults:` is the one construct that isn't a plain keep-or-strip
+ * toggle even when NOT accepted: `materializeRefDefaults` bakes every
+ * inherited `blocks_movement`/`blocks_los` onto its placement FIRST, so
+ * the returned subset preserves the authored behavior a default was
+ * standing in for. `targeting`/`height`/`facing` defaults have no v1
+ * representation regardless of inheritance and are lost the same way an
+ * explicit one would be — only counted via the `defaults (...)` entry,
+ * never double-counted in the per-field facing/height/targeting tallies
+ * further down (those only ever count a literal key actually present on
+ * the instance). If `defaults` IS accepted, none of this runs — the whole
+ * `defaults:` block is kept exactly as authored, materialization
+ * skipped entirely (nothing to bake onto anything; the server now
+ * resolves the inheritance itself). */
+export function stripToV1Subset(
+  yamlText: string,
+  capabilities?: ServerCapabilities
+): V1SubsetResult {
   const { cst, doc } = parseDungeon(yamlText);
   const dropped: string[] = [];
+  const compiling: string[] = [];
+  const accepted = (field: DialectField): boolean =>
+    capabilities?.[field]?.accepted === true;
 
   cst.set('version', 1);
-  cst.delete('canvas');
 
-  // Materialize-on-strip (see `materializeRefDefaults`'s own doc
-  // comment): bake every INHERITED blocks_movement/blocks_los onto its
-  // placement BEFORE defaults: is dropped below, so the compilable
-  // subset preserves the authored behavior a ref-level default was
-  // standing in for — a `blocks_movement: true` default silently
-  // vanishing on strip would be exactly the kind of gap CONTRACT.md's
-  // "entrance-blocked" UX learning exists to catch, just moved from the
-  // live board to the saved subset.
-  const { usedRefs: defaultRefsUsed, placementsMaterialized } =
-    materializeRefDefaults(cst, doc);
-  const defaultRefCount = Object.keys(doc.defaults).length;
-  if (defaultRefCount > 0) {
-    dropped.push(
-      placementsMaterialized > 0
-        ? `defaults (${defaultRefCount} ref${defaultRefCount === 1 ? '' : 's'}; blocks_movement/blocks_los materialized onto ${placementsMaterialized} placement${placementsMaterialized === 1 ? '' : 's'} from ${defaultRefsUsed.size} of them)`
-        : `defaults (${defaultRefCount} ref${defaultRefCount === 1 ? '' : 's'})`
-    );
+  if (doc.canvas) {
+    if (accepted('canvas')) {
+      compiling.push('canvas');
+    } else {
+      dropped.push('canvas');
+      cst.delete('canvas');
+    }
   }
-  cst.delete('defaults');
+
+  if (Object.keys(doc.defaults).length > 0 && accepted('defaults')) {
+    compiling.push(
+      pluralCount(Object.keys(doc.defaults).length, 'default ref')
+    );
+  } else {
+    // Materialize-on-strip (see `materializeRefDefaults`'s own doc
+    // comment): bake every INHERITED blocks_movement/blocks_los onto its
+    // placement BEFORE defaults: is dropped below, so the compilable
+    // subset preserves the authored behavior a ref-level default was
+    // standing in for — a `blocks_movement: true` default silently
+    // vanishing on strip would be exactly the kind of gap CONTRACT.md's
+    // "entrance-blocked" UX learning exists to catch, just moved from the
+    // live board to the saved subset.
+    const { usedRefs: defaultRefsUsed, placementsMaterialized } =
+      materializeRefDefaults(cst, doc);
+    const defaultRefCount = Object.keys(doc.defaults).length;
+    if (defaultRefCount > 0) {
+      dropped.push(
+        placementsMaterialized > 0
+          ? `defaults (${defaultRefCount} ref${defaultRefCount === 1 ? '' : 's'}; blocks_movement/blocks_los materialized onto ${placementsMaterialized} placement${placementsMaterialized === 1 ? '' : 's'} from ${defaultRefsUsed.size} of them)`
+          : `defaults (${defaultRefCount} ref${defaultRefCount === 1 ? '' : 's'})`
+      );
+    }
+    cst.delete('defaults');
+  }
 
   if (doc.walls.length > 0) {
-    dropped.push(
-      `${doc.walls.length} wall${doc.walls.length === 1 ? '' : 's'}`
-    );
+    if (accepted('walls')) {
+      compiling.push(pluralCount(doc.walls.length, 'wall'));
+    } else {
+      dropped.push(pluralCount(doc.walls.length, 'wall'));
+      cst.delete('walls');
+    }
   }
-  cst.delete('walls');
 
-  // Straight walls (this unit) — a sibling target-dialect-only construct
-  // to `walls:` above, dropped the same honest way, counted separately
-  // ("N straight walls", not folded into the edge-wall tally) since the
-  // two are genuinely different authoring constructs (see
-  // `WallLineDoc`'s own doc comment).
+  // Straight walls — a sibling target-dialect-only construct to `walls:`
+  // above, NOT probed (see capabilityProbe.ts's own doc comment: it's
+  // this concept's own client-side sugar, never sent to the real server
+  // in any form) — always dropped, counted separately from the edge-wall
+  // tally since the two are genuinely different authoring constructs
+  // (see `WallLineDoc`'s own doc comment).
   if (doc.wallLines.length > 0) {
-    dropped.push(
-      `${doc.wallLines.length} straight wall${doc.wallLines.length === 1 ? '' : 's'}`
-    );
+    dropped.push(pluralCount(doc.wallLines.length, 'straight wall'));
   }
   cst.delete('wallLines');
 
   if (doc.holes.length > 0) {
-    dropped.push(
-      `${doc.holes.length} hole${doc.holes.length === 1 ? '' : 's'}`
-    );
+    if (accepted('holes')) {
+      compiling.push(pluralCount(doc.holes.length, 'hole'));
+    } else {
+      dropped.push(pluralCount(doc.holes.length, 'hole'));
+      cst.delete('holes');
+    }
   }
-  cst.delete('holes');
 
-  // Cell-authored semantic regions (rpg-project#180) have no v1
-  // representation at all — dungeonspec only knows the declared `rooms:`
-  // chain. Dropped entirely, counted honestly like every other
-  // target-dialect construct here. A door edge a `connectRegions` call
-  // placed on a region's boundary is a SEPARATE `walls:` entry (see
-  // `connectRegions`'s own doc comment) and is stripped independently by
-  // the `walls:` handling above — deleting `regions:` here never touches it.
+  // Cell-authored semantic regions (rpg-project#180). A door edge a
+  // `connectRegions` call placed on a region's boundary is a SEPARATE
+  // `walls:` entry (see `connectRegions`'s own doc comment) and is
+  // handled independently by the `walls:` block above — this block never
+  // touches it either way.
   if (doc.regions.length > 0) {
-    dropped.push(
-      `${doc.regions.length} region${doc.regions.length === 1 ? '' : 's'}`
-    );
+    if (accepted('regions')) {
+      compiling.push(pluralCount(doc.regions.length, 'region'));
+    } else {
+      dropped.push(pluralCount(doc.regions.length, 'region'));
+      cst.delete('regions');
+    }
   }
-  cst.delete('regions');
 
-  if (doc.start || doc.end) dropped.push('start/end');
-  cst.delete('start');
-  cst.delete('end');
+  // start/end are INDEPENDENT capabilities, not one combined toggle —
+  // verified live, this unit, 2026-08-04: a bare `start: [c,r]` compiles
+  // today, `end:` does not (no schema representation of any kind, per
+  // this file's own `DungeonDoc.end` doc comment) — collapsing them into
+  // one "start/end" check (the prior behavior) would either wrongly keep
+  // `end:` or wrongly strip a compiling `start:`.
+  if (doc.start) {
+    if (accepted('start')) {
+      compiling.push('start');
+    } else {
+      dropped.push('start');
+      cst.delete('start');
+    }
+  }
+  if (doc.end) {
+    if (accepted('end')) {
+      compiling.push('end');
+    } else {
+      dropped.push('end');
+      cst.delete('end');
+    }
+  }
 
-  if (doc.lighting) dropped.push('lighting');
-  cst.delete('lighting');
+  if (doc.lighting) {
+    if (accepted('lighting')) {
+      compiling.push('lighting');
+    } else {
+      dropped.push('lighting');
+      cst.delete('lighting');
+    }
+  }
 
-  // Top-level place: (target dialect, proposed — TARGET-YAML.md's "top-level
-  // placement" section) has no v1 analog at all; dungeonspec only knows
-  // room-scoped place:. A top-level entry whose absolute column falls
-  // inside a declared room's own column range MAPS DOWN into that
-  // room's place: list (absolute -> room-local `at`) rather than being
-  // lost — v1's room-scoped place: is a real subset of what the entry
-  // meant, not a different claim. One outside every room's range has no
-  // v1 home and is dropped, counted honestly like every other
-  // target-dialect field here. Room bounds use the SAME startColumn accumulation rule
-  // floorPlanCompile.ts uses server-side (`next.startColumn =
-  // prev.startColumn + prev.width + 1`) — pure client math, only ever
-  // used here to decide "does this column fall in this room," never to
-  // author a gameplay position.
+  // Top-level place: (TARGET-YAML.md's "top-level placement" section) has
+  // no v1 analog at all when NOT accepted; dungeonspec only knows
+  // room-scoped place:. Not accepted (today's server): a top-level entry
+  // whose absolute column falls inside a declared room's own column range
+  // MAPS DOWN into that room's place: list (absolute -> room-local `at`)
+  // rather than being lost; one outside every room's range has no v1 home
+  // and is dropped. Room bounds use the SAME startColumn accumulation
+  // rule floorPlanCompile.ts uses server-side. Accepted: the whole
+  // top-level `place:` list is kept exactly as authored — no mapping, no
+  // room-scoping — and each of ITS items still gets the same per-field
+  // (facing/mount/height/targeting/rotate_degrees) stripping every
+  // room-scoped placement gets, via the pass below.
   let mappedPlacementCount = 0;
   let outOfRoomPlacementCount = 0;
+  const topLevelPlaceAccepted = accepted('topLevelPlace');
   const topPlace = cst.get('place');
-  if (isSeq(topPlace)) {
-    const roomBounds = doc.rooms.reduce<
-      { id: string; startColumn: number; width: number }[]
-    >((acc, r) => {
-      const prev = acc[acc.length - 1];
-      const startColumn = prev ? prev.startColumn + prev.width + 1 : 0;
-      acc.push({ id: r.id, startColumn, width: r.width });
-      return acc;
-    }, []);
-    for (const item of [...topPlace.items]) {
-      if (!isMap(item)) continue;
-      const atNode = item.get('at');
-      if (!isSeq(atNode)) continue;
-      const col = atNode.get(0) as number;
-      const row = atNode.get(1) as number;
-      const room = roomBounds.find(
-        (r) => col >= r.startColumn && col < r.startColumn + r.width
-      );
-      if (!room) {
-        outOfRoomPlacementCount++;
-        continue;
+  if (isSeq(topPlace) && topPlace.items.length > 0) {
+    if (topLevelPlaceAccepted) {
+      compiling.push(pluralCount(topPlace.items.length, 'top-level placement'));
+    } else {
+      const roomBounds = doc.rooms.reduce<
+        { id: string; startColumn: number; width: number }[]
+      >((acc, r) => {
+        const prev = acc[acc.length - 1];
+        const startColumn = prev ? prev.startColumn + prev.width + 1 : 0;
+        acc.push({ id: r.id, startColumn, width: r.width });
+        return acc;
+      }, []);
+      for (const item of [...topPlace.items]) {
+        if (!isMap(item)) continue;
+        const atNode = item.get('at');
+        if (!isSeq(atNode)) continue;
+        const col = atNode.get(0) as number;
+        const row = atNode.get(1) as number;
+        const room = roomBounds.find(
+          (r) => col >= r.startColumn && col < r.startColumn + r.width
+        );
+        if (!room) {
+          outOfRoomPlacementCount++;
+          continue;
+        }
+        const localAtNode = new YAMLSeq(cst.schema);
+        localAtNode.flow = true;
+        localAtNode.items = [col - room.startColumn, row];
+        item.set('at', localAtNode);
+        placeSeq(cst, room.id).items.push(item);
+        mappedPlacementCount++;
       }
-      const localAtNode = new YAMLSeq(cst.schema);
-      localAtNode.flow = true;
-      localAtNode.items = [col - room.startColumn, row];
-      item.set('at', localAtNode);
-      placeSeq(cst, room.id).items.push(item);
-      mappedPlacementCount++;
+      cst.delete('place');
+      if (mappedPlacementCount > 0) {
+        dropped.push(
+          `${mappedPlacementCount} top-level placement${mappedPlacementCount === 1 ? '' : 's'} (mapped into rooms)`
+        );
+      }
+      if (outOfRoomPlacementCount > 0) {
+        dropped.push(
+          `${outOfRoomPlacementCount} top-level placement${outOfRoomPlacementCount === 1 ? '' : 's'} outside any room`
+        );
+      }
     }
-  }
-  cst.delete('place');
-  // `dropped` drives BOTH the "Uses: ..." compile badge (what
-  // target-dialect content is currently present) and the post-save
-  // "Dropped: ..." honesty note (YamlPane.tsx) — the same array, doing
-  // double duty for every other target-dialect field, because for every
-  // other field "in use" and "genuinely lost" are the same set. Top-level
-  // placement is the first case where
-  // they diverge: a mapped one survives (relocated, not erased), an
-  // out-of-room one doesn't. Both still need to show up in "Uses:" (the
-  // construct IS present), so both get an entry — worded to stay honest
-  // in the "Dropped:" reading too ("mapped into rooms" is not "lost").
-  if (mappedPlacementCount > 0) {
-    dropped.push(
-      `${mappedPlacementCount} top-level placement${mappedPlacementCount === 1 ? '' : 's'} (mapped into rooms)`
-    );
-  }
-  if (outOfRoomPlacementCount > 0) {
-    dropped.push(
-      `${outOfRoomPlacementCount} top-level placement${outOfRoomPlacementCount === 1 ? '' : 's'} outside any room`
-    );
   }
 
-  let facingCount = 0;
-  let mountCount = 0;
-  let heightCount = 0;
-  let targetingCount = 0;
-  let rotationDegreesCount = 0;
-  const stripPlacementFields = (item: YAMLMap) => {
+  let facingDroppedCount = 0;
+  let facingCompilingCount = 0;
+  let mountDroppedCount = 0;
+  let mountCompilingCount = 0;
+  let heightDroppedCount = 0;
+  let heightCompilingCount = 0;
+  let targetingDroppedCount = 0;
+  let targetingCompilingCount = 0;
+  let rotationDroppedCount = 0;
+  let rotationCompilingCount = 0;
+
+  // Shared by every room-scoped place:/boss: entry AND (when
+  // topLevelPlaceAccepted) every kept top-level place: entry — one place
+  // this per-field stripping logic lives, rather than duplicated per
+  // caller. `facingCap` is resolved by the CALLER (facingCapabilityFor
+  // for a PlacementDoc, or the literal 'facingBoss' for a BossDoc) since
+  // only the caller knows which doc/index it's looking at.
+  const stripPlacementFields = (item: YAMLMap, facingCap: DialectField) => {
     if (item.has('facing')) {
-      item.delete('facing');
-      facingCount++;
+      if (accepted(facingCap)) {
+        facingCompilingCount++;
+      } else {
+        item.delete('facing');
+        facingDroppedCount++;
+      }
     }
-    // mount/height are DECOUPLED (Kirk-batch, 2026-08-02 — see
-    // setPlacementMount's/setPlacementHeight's own doc comments): a
-    // placement can carry either, both, or neither, so each is counted
-    // and stripped independently, matching rotate_degrees's own
-    // already-independent shape just below.
+    // mount/height are DECOUPLED (Kirk-batch, 2026-08-02): a placement
+    // can carry either, both, or neither, so each is counted and
+    // stripped independently, matching rotate_degrees's own already-
+    // independent shape below.
     if (item.has('mount')) {
-      item.delete('mount');
-      mountCount++;
+      if (accepted('mount')) {
+        mountCompilingCount++;
+      } else {
+        item.delete('mount');
+        mountDroppedCount++;
+      }
     }
     if (item.has('height')) {
-      item.delete('height');
-      heightCount++;
+      if (accepted('height')) {
+        heightCompilingCount++;
+      } else {
+        item.delete('height');
+        heightDroppedCount++;
+      }
     }
     if (item.has('targeting')) {
-      item.delete('targeting');
-      targetingCount++;
+      if (accepted('targeting')) {
+        targetingCompilingCount++;
+      } else {
+        item.delete('targeting');
+        targetingDroppedCount++;
+      }
     }
-    // EXPERIMENT, not even a target-dialect proposal (see
-    // PlacementDoc.rotationDegrees's own doc comment) — counted and
-    // stripped separately from mount/height rather than folded into
-    // that count, so the "Uses:"/"Dropped:" summary can name it
-    // honestly as the fine-rotation probe it is, not as part of the
-    // real wall-mount proposal.
+    // EXPERIMENT, not even a target-dialect proposal — never probed,
+    // never accepted; kept as its own always-strip counter so a future
+    // probe result can slot in the same `accepted('rotationDegrees')`
+    // shape as every other field without a second code path.
     if (item.has('rotate_degrees')) {
-      item.delete('rotate_degrees');
-      rotationDegreesCount++;
+      if (accepted('rotationDegrees')) {
+        rotationCompilingCount++;
+      } else {
+        item.delete('rotate_degrees');
+        rotationDroppedCount++;
+      }
     }
   };
+
   const rooms = cst.get('rooms');
   if (isSeq(rooms)) {
-    for (const room of rooms.items) {
-      if (!isMap(room)) continue;
+    rooms.items.forEach((room, ri) => {
+      if (!isMap(room)) return;
       const place = room.get('place', true);
-      if (isSeq(place)) {
-        for (const item of place.items) {
-          if (isMap(item)) stripPlacementFields(item);
-        }
+      const docPlacements = doc.rooms[ri]?.place;
+      if (isSeq(place) && docPlacements) {
+        place.items.forEach((item, pi) => {
+          if (!isMap(item)) return;
+          const placement = docPlacements[pi];
+          const facingCap = placement
+            ? facingCapabilityFor(placement)
+            : 'facingFloorProp';
+          stripPlacementFields(item, facingCap);
+        });
       }
       const boss = room.get('boss', true);
-      if (isMap(boss)) stripPlacementFields(boss);
+      if (isMap(boss)) stripPlacementFields(boss, 'facingBoss');
+    });
+  }
+  // Kept top-level placements (topLevelPlaceAccepted) never went through
+  // the rooms loop above — their own facing/mount/height/etc. still need
+  // stripping per-field, same as any room-scoped placement.
+  if (topLevelPlaceAccepted) {
+    const keptTopPlace = cst.get('place');
+    if (isSeq(keptTopPlace)) {
+      keptTopPlace.items.forEach((item, pi) => {
+        if (!isMap(item)) return;
+        const placement = doc.place[pi];
+        const facingCap = placement
+          ? facingCapabilityFor(placement)
+          : 'facingFloorProp';
+        stripPlacementFields(item, facingCap);
+      });
     }
   }
-  if (facingCount > 0) {
+
+  if (facingDroppedCount > 0) {
     dropped.push(
-      `facing (${facingCount} placement${facingCount === 1 ? '' : 's'})`
+      `facing (${facingDroppedCount} placement${facingDroppedCount === 1 ? '' : 's'})`
     );
   }
-  if (mountCount > 0) {
-    dropped.push(
-      `wall-mount (${mountCount} placement${mountCount === 1 ? '' : 's'})`
+  if (facingCompilingCount > 0) {
+    compiling.push(
+      `facing (${facingCompilingCount} placement${facingCompilingCount === 1 ? '' : 's'})`
     );
   }
-  if (heightCount > 0) {
+  if (mountDroppedCount > 0) {
     dropped.push(
-      `height (${heightCount} placement${heightCount === 1 ? '' : 's'})`
+      `wall-mount (${mountDroppedCount} placement${mountDroppedCount === 1 ? '' : 's'})`
     );
   }
-  if (targetingCount > 0) {
-    dropped.push(
-      `targeting (${targetingCount} placement${targetingCount === 1 ? '' : 's'})`
+  if (mountCompilingCount > 0) {
+    compiling.push(
+      `wall-mount (${mountCompilingCount} placement${mountCompilingCount === 1 ? '' : 's'})`
     );
   }
-  if (rotationDegreesCount > 0) {
+  if (heightDroppedCount > 0) {
     dropped.push(
-      `fine-rotation experiment (${rotationDegreesCount} placement${rotationDegreesCount === 1 ? '' : 's'})`
+      `height (${heightDroppedCount} placement${heightDroppedCount === 1 ? '' : 's'})`
+    );
+  }
+  if (heightCompilingCount > 0) {
+    compiling.push(
+      `height (${heightCompilingCount} placement${heightCompilingCount === 1 ? '' : 's'})`
+    );
+  }
+  if (targetingDroppedCount > 0) {
+    dropped.push(
+      `targeting (${targetingDroppedCount} placement${targetingDroppedCount === 1 ? '' : 's'})`
+    );
+  }
+  if (targetingCompilingCount > 0) {
+    compiling.push(
+      `targeting (${targetingCompilingCount} placement${targetingCompilingCount === 1 ? '' : 's'})`
+    );
+  }
+  if (rotationDroppedCount > 0) {
+    dropped.push(
+      `fine-rotation experiment (${rotationDroppedCount} placement${rotationDroppedCount === 1 ? '' : 's'})`
+    );
+  }
+  if (rotationCompilingCount > 0) {
+    compiling.push(
+      `fine-rotation experiment (${rotationCompilingCount} placement${rotationCompilingCount === 1 ? '' : 's'})`
     );
   }
 
   const strippedDoc = toDungeonDoc(cst);
+  const compilableBlockers: string[] = [];
+  if (strippedDoc.rooms.length < 2) {
+    compilableBlockers.push(
+      `needs at least 2 rooms (has ${strippedDoc.rooms.length})`
+    );
+  }
+  const bossRooms = strippedDoc.rooms.filter((r) => r.archetype === 'boss');
+  if (bossRooms.length !== 1 || !bossRooms[0]?.boss) {
+    compilableBlockers.push(
+      bossRooms.length === 0
+        ? 'needs exactly one boss-archetype room with a declared boss (has none)'
+        : bossRooms.length > 1
+          ? `needs exactly one boss-archetype room (has ${bossRooms.length})`
+          : 'the boss-archetype room needs a declared boss'
+    );
+  }
+
   return {
     yaml: serializeDungeon(cst),
     dropped,
-    compilable: strippedDoc.rooms.length >= 2,
+    compiling,
+    compilable: compilableBlockers.length === 0,
+    compilableBlockers,
   };
 }

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -17,6 +17,18 @@ addition. Never conflate the two numbers.
 
 ## Changelog
 
+- **(2026-08-04, no version bump — `stripToV1Subset` reporting shape only,
+  not a new emittable construct)**: the "capability-probed graduation"
+  unit made `stripToV1Subset` capability-aware (`dungeonYaml.ts`) —
+  `kitchen-sink.v1-subset.dropped.json` regenerated to match its new
+  shape: the old combined `"start/end"` entry is now two independent
+  entries, `"start"` and `"end"` (the real server accepts one but not the
+  other — see `capabilityProbe.ts`), and the file gained `compiling`
+  (empty here — this regen calls `stripToV1Subset` with no capabilities,
+  same conservative-static call every prior version of this file used)
+  and `compilableBlockers` (empty — the doc is compilable) alongside the
+  existing `dropped`/`compilable`. `kitchen-sink.yaml` itself is
+  byte-identical; only the report format changed.
 - **v0.3** (2026-08-03) — `erratum: canonical wall adjacency`:
   the real Kitchen Sink mutator calls now emit `[7,1]`→`[8,1]` (solid)
   and `[7,3]`→`[8,3]` (door), replacing the non-adjacent odd-q pairs

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
@@ -3,7 +3,8 @@
     "defaults (2 refs; blocks_movement/blocks_los materialized onto 1 placement from 1 of them)",
     "3 walls",
     "2 regions",
-    "start/end",
+    "start",
+    "end",
     "lighting",
     "2 top-level placements (mapped into rooms)",
     "facing (4 placements)",
@@ -12,5 +13,7 @@
     "targeting (2 placements)",
     "fine-rotation experiment (2 placements)"
   ],
-  "compilable": true
+  "compiling": [],
+  "compilable": true,
+  "compilableBlockers": []
 }

--- a/src/concepts/dungeon-builder/usePutDungeonPreview.test.ts
+++ b/src/concepts/dungeon-builder/usePutDungeonPreview.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/api/client', () => ({
 }));
 
 // Import AFTER vi.mock so the mock is applied.
+import { capabilitySummary, DIALECT_FIELDS } from './capabilityProbe';
 import { parseDungeon } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
 import { usePutDungeonPreview } from './usePutDungeonPreview';
@@ -178,5 +179,103 @@ describe('usePutDungeonPreview — live mode per-edit preview', () => {
       timeout: 2000,
     });
     expect(result.current.fieldErrors).toEqual([]);
+  });
+});
+
+describe('usePutDungeonPreview — capability probe (capability-probed graduation unit)', () => {
+  it('capabilities stay null while probing/gate-off/unreachable — never populated outside live', async () => {
+    hoisted.putDungeonFn.mockRejectedValue(
+      new ConnectError('unknown service', Code.Unimplemented)
+    );
+    const { result } = renderHook(() =>
+      usePutDungeonPreview(doc, SHOWCASE_YAML)
+    );
+    await waitFor(() => expect(result.current.serverState).toBe('gate-off'));
+    expect(result.current.capabilities).toBeNull();
+  });
+
+  it('populates capabilities once serverState becomes live, reflecting every probe response', async () => {
+    hoisted.putDungeonFn.mockRejectedValueOnce(
+      new ConnectError('bad key', Code.InvalidArgument) // liveness probe
+    );
+    // Every subsequent call (the 17-field capability probe suite) hits
+    // this default — a blanket "accepts everything" server, the simplest
+    // case to assert against without keying off individual request keys.
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+
+    const { result } = renderHook(() =>
+      usePutDungeonPreview(doc, SHOWCASE_YAML)
+    );
+    await waitFor(() => expect(result.current.serverState).toBe('live'));
+    await waitFor(() => expect(result.current.capabilities).not.toBeNull());
+
+    expect(capabilitySummary(result.current.capabilities!)).toEqual({
+      accepted: DIALECT_FIELDS.length,
+      total: DIALECT_FIELDS.length,
+    });
+  });
+
+  it('resets capabilities to null the moment the server stops being live', async () => {
+    hoisted.putDungeonFn.mockRejectedValueOnce(
+      new ConnectError('bad key', Code.InvalidArgument) // liveness probe
+    );
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+
+    const { result } = renderHook(() =>
+      usePutDungeonPreview(doc, SHOWCASE_YAML)
+    );
+    await waitFor(() => expect(result.current.serverState).toBe('live'));
+    await waitFor(() => expect(result.current.capabilities).not.toBeNull());
+
+    // Force the next (retried) liveness probe to find the server gone —
+    // a fresh mockRejectedValueOnce takes priority over the blanket
+    // mockResolvedValue default queued above.
+    hoisted.putDungeonFn.mockRejectedValueOnce(
+      new ConnectError('failed to fetch', Code.Unavailable)
+    );
+    result.current.retryProbe();
+
+    await waitFor(() => expect(result.current.serverState).toBe('unreachable'));
+    expect(result.current.capabilities).toBeNull();
+  });
+
+  it('refreshCapabilities re-runs the full probe suite against the current live server', async () => {
+    hoisted.putDungeonFn.mockRejectedValueOnce(
+      new ConnectError('bad key', Code.InvalidArgument) // liveness probe
+    );
+    // First pass: the server accepts nothing.
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: false,
+      fieldErrors: [{ field: '', message: 'field X not found' }],
+    } as unknown as PutDungeonResponse);
+
+    const { result } = renderHook(() =>
+      usePutDungeonPreview(doc, SHOWCASE_YAML)
+    );
+    await waitFor(() => expect(result.current.serverState).toBe('live'));
+    await waitFor(() =>
+      expect(capabilitySummary(result.current.capabilities!).accepted).toBe(0)
+    );
+
+    // Server now accepts everything — refresh should pick that up without
+    // any other state (serverState, doc, yamlText) changing.
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+    result.current.refreshCapabilities();
+
+    await waitFor(() =>
+      expect(capabilitySummary(result.current.capabilities!).accepted).toBe(
+        DIALECT_FIELDS.length
+      )
+    );
+    expect(result.current.serverState).toBe('live');
   });
 });

--- a/src/concepts/dungeon-builder/usePutDungeonPreview.ts
+++ b/src/concepts/dungeon-builder/usePutDungeonPreview.ts
@@ -34,6 +34,20 @@
  * actually persist if clicked right now. A document that isn't even
  * shape-parseable yet (mid-edit) skips this tick silently — the YAML
  * pane's own parse-error path already owns surfacing that.
+ *
+ * **Capability-probed graduation (this unit, 2026-08-04)**: the strip
+ * above used to be a hardcoded snapshot of "what dungeonspec compiles" —
+ * it went stale the moment the server moved (Kirk's authoring branch
+ * started compiling authored `walls:` and bare `start:` for real while
+ * the client kept stripping both unconditionally). This hook now probes
+ * `ServerCapabilities` (`capabilityProbe.ts`) once per live connection —
+ * on the SAME transition that flips `serverState` to `'live'`, and again
+ * on `refreshCapabilities()` — and feeds the result into every
+ * `stripToV1Subset` call this hook makes, so the live per-edit preview
+ * reflects the true accepted subset, not a stale static one.
+ * `capabilities` resets to `null` the moment `serverState` leaves
+ * `'live'` (gate-off/unreachable) — a capability observed against one
+ * server is never carried into a fixtures-mode fallback.
  */
 import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';
@@ -44,6 +58,10 @@ import {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { useEffect, useRef, useState } from 'react';
+import {
+  probeAllCapabilities,
+  type ServerCapabilities,
+} from './capabilityProbe';
 import { stripToV1Subset, type DungeonDoc } from './dungeonYaml';
 import { SHOWCASE_FLOORPLAN } from './fixtures';
 import { compileFloorPlanLocally } from './floorPlanCompile';
@@ -68,6 +86,18 @@ export interface UsePutDungeonPreviewResult {
    * field_errors-shaped message. */
   requestError: string | null;
   retryProbe: () => void;
+  /** `null` until the capability probe suite completes against a live
+   * server — every caller that reads this (the "server capabilities"
+   * readout, `stripToV1Subset`, Save & Play gating) already treats `null`
+   * as "no capabilities," the same conservative-static fallback as
+   * before capability probing existed. Never populated outside
+   * `serverState === 'live'`. */
+  capabilities: ServerCapabilities | null;
+  /** Re-runs the full probe suite against the current live server —
+   * the capabilities readout's own refresh affordance, independent of
+   * `retryProbe` (which re-checks basic reachability, not per-field
+   * acceptance). */
+  refreshCapabilities: () => void;
 }
 
 const DEBOUNCE_MS = 500;
@@ -92,6 +122,10 @@ export function usePutDungeonPreview(
   const [fieldErrors, setFieldErrors] = useState<ValidationError[]>([]);
   const [requestError, setRequestError] = useState<string | null>(null);
   const [probeNonce, setProbeNonce] = useState(0);
+  const [capabilities, setCapabilities] = useState<ServerCapabilities | null>(
+    null
+  );
+  const [capabilitiesNonce, setCapabilitiesNonce] = useState(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Mount-time (and manual retry) probe.
@@ -119,6 +153,27 @@ export function usePutDungeonPreview(
     };
   }, [probeNonce]);
 
+  // Capability probe: runs once per live connection (this effect's own
+  // `serverState` dependency covers both the initial live transition and
+  // a `retryProbe`-driven recovery from unreachable/gate-off), and again
+  // on `refreshCapabilities()` (via `capabilitiesNonce`). Reset to `null`
+  // the instant the server stops being live — a capability observed
+  // against one server must never leak into a fixtures-mode fallback or
+  // a DIFFERENT server reached after a retry.
+  useEffect(() => {
+    if (serverState !== 'live') {
+      setCapabilities(null);
+      return;
+    }
+    let cancelled = false;
+    probeAllCapabilities().then((caps) => {
+      if (!cancelled) setCapabilities(caps);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [serverState, capabilitiesNonce]);
+
   // Live per-edit preview, debounced, only while the probe found the gate on.
   useEffect(() => {
     if (serverState !== 'live' || !doc) return;
@@ -128,7 +183,10 @@ export function usePutDungeonPreview(
         setRequestError(null);
         let subsetYaml: string;
         try {
-          subsetYaml = stripToV1Subset(yamlText).yaml;
+          subsetYaml = stripToV1Subset(
+            yamlText,
+            capabilities ?? undefined
+          ).yaml;
         } catch {
           // Not even shape-parseable yet (mid-edit) — nothing to preview
           // this tick. Not a request/field error; the YAML pane's own
@@ -172,7 +230,7 @@ export function usePutDungeonPreview(
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [serverState, doc, yamlText]);
+  }, [serverState, doc, yamlText, capabilities]);
 
   const fallbackFloorPlan = doc
     ? doc.key === 'showcase'
@@ -191,5 +249,7 @@ export function usePutDungeonPreview(
     fieldErrors: serverState === 'live' ? fieldErrors : [],
     requestError,
     retryProbe: () => setProbeNonce((n) => n + 1),
+    capabilities,
+    refreshCapabilities: () => setCapabilitiesNonce((n) => n + 1),
   };
 }


### PR DESCRIPTION
## Summary

The Dungeon Builder's strip list, compile badges, and Save & Play gating read a hardcoded, comment-level snapshot of "what dungeonspec compiles" since the concept's earliest days. That snapshot went stale the moment the server moved: Kirk's authoring branch now compiles authored `walls:`, bare `start:`, and room-scoped floor-prop `facing:` for real — verified live against `rpg-api-dungeon-builder-763` — while the client kept stripping all of it unconditionally, and creation mode's Save & Play stayed permanently disabled with a blanket "the server can't compile this yet" tooltip that was no longer honest.

This unit replaces the hardcoded snapshot with a live probe:

- **New `capabilityProbe.ts`**: on every live connection, sends one minimal `validate_only` document per target-dialect field (17 total, isolated against an otherwise-known-good base) and records what the connected server actually said, today — not a claim transcribed from an issue comment at a point in time.
- **`stripToV1Subset` becomes capability-aware**: gained an optional `capabilities` parameter. A field the server accepts is kept, not stripped, and counted in a new `compiling` list (the positive mirror of `dropped`). No capabilities (fixtures mode, or a probe still in flight) falls back to the exact prior conservative-static behavior — verified by the existing test suite passing unmodified bar one wording split (`start`/`end` are independent capabilities now, not one combined check).
- **Compile badges and Save & Play (both modes) read the live result directly** — a teal "Compiles on this server: ..." line alongside the existing amber "not yet accepted" one, and a disabled-Save tooltip that names the SPECIFIC blocking constraint (`v1CompilableBlockers`) instead of one hardcoded "declare 2 rooms" message.
- **Creation mode's Save & Play graduates from permanently-disabled to real**, reusing the exact same `SaveAndPlayButton`/`CompileBadgeStrip`/`CapabilitiesLine` components edit mode uses (extracted and exported from `YamlPane.tsx`) rather than a second, driftable implementation.
- **Fixes a real pre-existing gap**: Walk it never called `stripToV1Subset` at all, so any target-dialect field would break its save regardless of server support — now runs the capability-aware strip first.
- **A load-bearing finding from building the probe suite**: dungeonspec now requires exactly one boss-archetype room with a declared boss per chain, not just `minRooms = 2` — `stripToV1Subset`'s new `compilableBlockers` names this explicitly rather than the UI showing a misleading "just add rooms" message.

Full writeup, the live probe transcript, and the "why per-field, not one big probe" rationale are in `CONTRACT.md`'s new "Capability-probed graduation" section. `TARGET-YAML.md`'s status-tracking section is rewritten around the mechanism instead of a hand-maintained "on Kirk's branch, unreleased" note.

## Live capability map (verified 2026-08-04, `rpg-api-dungeon-builder-763`)

3 of 17 dialect fields currently compile: `walls:`, `start:`, and `facing` on a room-scoped floor prop. Everything else is either decode-unknown (`"field X not found"`) or schema-known-but-explicitly-gated (`"unsupported capability: ..."`) — both kept distinct in the probe result, not collapsed.

## Test plan

- [x] `ci-check` clean (format/lint/typecheck/build/test)
- [x] 287 dungeon-builder tests passing (up from 253) — new `capabilityProbe.test.ts`, a capability-aware `stripToV1Subset` describe block in `dungeonYaml.test.ts`, capability-lifecycle tests in `usePutDungeonPreview.test.ts`, and a new `YamlPane.test.tsx` covering every gating state (enabled+dropped-list, disabled+specific-blocker, generic fallback, mid-save, creation-mode label override)
- [x] Live-verified against the real server, own dev server on a free port (`5173`), `VITE_API_HOST` pointed at the live envoy: capabilities line renders the real 3/17, an authored `walls:` entry showed the "Compiles on this server" badge and saved for real (`Saved as "showcase"`), creation mode's tooltip named the specific real blockers instead of the retired blanket claim — screenshots in `docs/evidence/` (gitignored, local only)
- [x] The `showcase` key on the shared lab server was restored to its original fixture content after the live save test (verified `success: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— asset-pipeline agent, on behalf of KirkDiggler