### PR TITLE
unit: straight walls stand in 3D (segment boxes + door gaps)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4547,3 +4547,117 @@ gone in the AFTER shot — replaced by solid floor, the door now standing
 on real ground instead of over a gap. No unexpected console errors
 (same established FIXTURES-MODE `AuthoringService` notes as every prior
 round).
+
+## Straight walls stand in 3D: segment boxes + door gaps (2026-08-04, rpg-project#169)
+
+Closes the "full 3D line geometry for `wallLines`" gap the creation-mode-3D-
+preview unit above named and deliberately deferred: a `doc.wallLines` entry
+was previously visible in 3D only as dimmed crimson footprint discs — the
+floor-side "where can't I walk" treatment, with nothing standing to explain
+WHY. It now also renders as real standing wall geometry, the 3D sibling of
+its corner-anchored, door-gapped fidelity in 2D.
+
+### What shipped
+
+`buildWallLineSegments` (`DungeonPreview3D.tsx`, new, exported for direct
+testing same as `buildFloorTiles`/`buildOnePlacement`): for each
+`doc.wallLines` entry, resolves `from`/`to` (`creation/hexCorner.ts`'s
+`CornerRef`s) to world-space points via `cornerWorldPos` — `cornerPoint`
+(board space, `BOARD_HEX_SIZE`) rescaled by `BOARD_TO_WORLD_SCALE`
+(`HEX_SIZE / BOARD_HEX_SIZE`), not a second corner-resolution
+implementation. **One line is one box** spanning corner to corner — never a
+piece per clipped cell — sized/positioned/rotated from the segment's own
+real geometry (length = endpoint distance, rotation = `atan2(-dz, dx)`, the
+same convention `hexEdgeBetween`/`edgeBetweenCells`/`wallBoxTransform`
+already use elsewhere in this file). A `doors:` entry splits that one box at
+its own door cell's real footprint clip interval —
+`clipSegmentToShrunkHex(aBoard, bBoard, cell...)`, the EXACT primitive
+`straightWallFootprint` already calls per candidate cell, called directly
+here for just the door's cell rather than re-derived. The resulting
+board-space `[t0, t1]` is reused UNCHANGED as a world-space lerp fraction
+between the world-space endpoints — valid because `cornerPoint`'s board
+space and this file's `hexMath.ts` world space are the exact same
+`cubeToWorld`/`hexCorners` functions, linear in their own `size` parameter
+with no additive offset, so a board-space `t` and a world-space `t` for the
+same directed segment are identical (verified via the cross-check test
+below, not just argued).
+
+**`WallBox`/`DoorGap` generalized, not duplicated.** Both previously assumed
+a fixed `HEX_SIZE`-wide edge-native piece (`wall: PlacedWall` prop). Both now
+take plain `position`/`rotationY` plus an optional `length`/`width`
+(defaulting to `HEX_SIZE`, so every existing edge-native call site is
+unchanged in behavior) — the SAME box/jamb/lintel/material family renders a
+one-hex-edge door wall and a several-hex straight-wall segment alike, so the
+two wall vocabularies read as one architecture rather than two renderers.
+`DoorGap`'s jamb width is clamped to `width / 2` so a narrow door interval
+(a shallow clip near a cell's edge) still produces two jambs meeting cleanly
+instead of overlapping; the now-unused fixed `DOOR_OPENING_WIDTH` constant
+was removed rather than left dead.
+
+**Corners need no special-case join code here either** (matching the 2D
+finding this file's own earlier "Corners: no special-case joining logic
+needed" section already established) — two `wallLines:` entries sharing a
+canonical corner resolve to the identical `cornerWorldPos` point by
+construction, so their boxes simply meet, verified live (see below), not
+just argued from the 2D case.
+
+### Tests
+
+6 new in `DungeonPreview3D.test.ts` (`buildWallLineSegments` describe
+block): a single-edge line (no doors) produces exactly one solid box, its
+length/position/rotation cross-checked against independently-computed
+`cornerPoint`-derived world geometry, not the render path's own internals;
+a door mid-line splits solid/door/solid in order, all three sharing the
+line's one rotation, with the door piece's own extent cross-checked against
+a fresh `clipSegmentToShrunkHex` call (the reuse-not-duplication proof); a
+door near one end produces a markedly asymmetric split with no
+misordering; two doors on one line produce solid/door/solid/door/solid;
+a door referencing a cell the line's geometry doesn't genuinely clip (the
+"wall ending at a corner shared with a cell does not clip that cell"
+boundary case) renders no gap — solid straight through, honestly, rather
+than guessing one; an empty `doc.wallLines` produces no segments. 17
+dungeon-builder-preview3d tests passing (up from 11), 307 dungeon-builder
+tests overall. `ci-check` clean (format/lint/typecheck/build/test).
+
+### Live verification
+
+Own dev server (`vite --port 5191`, never `:3001`), `VITE_API_HOST` pointed
+at a live envoy, driven via headless Chromium (`--use-angle=swiftshader
+--enable-unsafe-swiftshader` — the modern flag pair; the older
+`--use-gl=swiftshader` alone silently produced no WebGL context on this
+Chrome build, worth recording since the previous round's own note named a
+different flag). Authored `wallLines:` directly in the YAML pane (the
+textarea's React `onChange` only fires for a value set via the native
+`HTMLTextAreaElement` setter + a real `input` event — a plain CDP value-set
+left the controlled input's own state untouched, so a subsequent React
+re-render silently reverted the textarea to its prior content; a scripting
+gotcha worth naming for whoever automates this pane next) — one long wall
+with a door, plus a second corner-sharing pair, in EDIT mode's compiled
+board, and a third wall directly on a from-scratch canvas in CREATION
+mode's own 3D toggle.
+
+Screenshots confirm, both contexts: a straight wall standing at its real
+corner-to-corner extent (no hangover past either endpoint, matching Kirk's
+2D fix) alongside the existing pillared shrine room; the same wall's
+door carved as a genuine amber jamb-lintel gap, not a shortened box; two
+wallLines sharing a corner meeting with no visible seam, an L exactly as
+clean as the 2D case; the same scene's server-truth perimeter walls
+(edge-native, zigzag) and the new straight-wall boxes reading as one
+material/height family, not two renderers; and creation mode's own
+from-scratch canvas (no `FloorPlan` at all) rendering the identical
+wall+door geometry on its flat hex floor, confirming the component is
+genuinely mode-agnostic rather than edit-mode-only. No unexpected console
+errors (same established FIXTURES-MODE `AuthoringService` notes every prior
+round's live-verification section already carries).
+
+### What did NOT ship this round — named, not silently dropped
+
+- **Click-to-select/edit a straight wall's own box in 3D.** Out of scope by
+  the unit's own brief (rendering only) — edit-mode's existing
+  click-to-place/select machinery for props/monsters is the natural thing
+  to graduate a straight-wall pick onto later, not a from-scratch build.
+- **A stranded door's own ⚠ flag rendered in 3D.** 2D already flags a door
+  whose cell a subsequent endpoint drag un-clips; this unit's 3D geometry
+  correctly stops rendering a gap there (verified, see Tests above) but
+  does not yet surface the warning glyph itself in the 3D view — a real,
+  narrow follow-up, not a silent gap.

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
@@ -15,9 +15,15 @@
  * ref-keyed inheritance resolver) — the two features never coexisted in
  * either PR's own branch, so neither has a test proving they compose.
  */
+import { HEX_SIZE } from '@/components/hex-grid/hexMath';
+import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { describe, expect, it } from 'vitest';
 import { facingToRotationY } from '../boardGeometry';
-import { straightWallFootprint } from '../creation/straightWallGeometry';
+import { cornerPoint, type CornerRef } from '../creation/hexCorner';
+import {
+  clipSegmentToShrunkHex,
+  straightWallFootprint,
+} from '../creation/straightWallGeometry';
 import {
   addWallLine,
   parseDungeon,
@@ -25,15 +31,29 @@ import {
   setPlacementRotationDegrees,
   setRefDefault,
   toDungeonDoc,
+  toggleWallLineDoorAt,
 } from '../dungeonYaml';
 import { SHOWCASE_FLOORPLAN, SHOWCASE_YAML } from '../fixtures';
-import { cubeAtColRow } from '../hexLayout';
+import { BOARD_HEX_SIZE, cubeAtColRow } from '../hexLayout';
 import {
   buildFloorTiles,
   buildOnePlacement,
   buildWallLineFootprint,
+  buildWallLineSegments,
   CANVAS_ROOM_ID,
 } from './DungeonPreview3D';
+
+// Same board-space -> world-space ratio `DungeonPreview3D.tsx`'s own
+// `BOARD_TO_WORLD_SCALE` uses — recomputed independently here (not
+// imported) so these tests cross-check the render path's geometry against
+// a value derived fresh from first principles, not the same constant the
+// code under test already trusts.
+const WORLD_SCALE = HEX_SIZE / BOARD_HEX_SIZE;
+
+function worldOf(ref: CornerRef): { x: number; z: number } {
+  const p = cornerPoint(ref);
+  return { x: p.x * WORLD_SCALE, z: p.y * WORLD_SCALE };
+}
 
 describe('buildOnePlacement — resolved facing × fine-rotation composition', () => {
   it('an INHERITED facing (defaults:, nothing explicit on the placement itself) still composes with an explicit rotate_degrees, exactly like an explicit facing would', () => {
@@ -257,5 +277,164 @@ describe('buildWallLineFootprint — doc-native, mode-agnostic', () => {
     for (const [col, row] of expectedFootprint) {
       expect(result.has(`${col},${row}`)).toBe(true);
     }
+  });
+});
+
+// rpg-project#169's "straight walls stand in 3D" unit — the follow-up
+// this file's own header doc comment names as deliberately deferred by
+// the creation-mode-3D-preview unit above ("Full 3D geometry for a
+// straight wall's own LINE... is NOT attempted this round"). Same
+// no-Canvas testing discipline as `buildOnePlacement`/`buildFloorTiles`
+// above: `buildWallLineSegments` is pure math (no R3F/Canvas dependency),
+// so its output is asserted directly.
+describe('buildWallLineSegments — real 3D geometry for doc.wallLines', () => {
+  it('a single-edge line (no doors) becomes exactly one solid box, positioned/rotated/sized from its own corner-to-corner world geometry', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    const from: CornerRef = { cell: [5, 5], corner: 0 };
+    const to: CornerRef = { cell: [5, 5], corner: 1 };
+    addWallLine(cst, from, to);
+    const doc = toDungeonDoc(cst);
+
+    const segments = buildWallLineSegments(doc);
+    expect(segments).toHaveLength(1);
+    const [seg] = segments;
+    expect(seg.kind).toBe('solid');
+
+    // Independently derived expected geometry (fresh `cornerPoint` calls
+    // rescaled by `WORLD_SCALE`, not the render path's own internals) —
+    // proves the segment's box actually spans corner to corner rather
+    // than, say, a fixed HEX_SIZE box dropped at the midpoint.
+    const a = worldOf(from);
+    const b = worldOf(to);
+    const expectedLength = Math.hypot(b.x - a.x, b.z - a.z);
+    const expectedRotation = Math.atan2(-(b.z - a.z), b.x - a.x);
+    expect(seg.length).toBeCloseTo(expectedLength, 6);
+    expect(seg.position[0]).toBeCloseTo((a.x + b.x) / 2, 6);
+    expect(seg.position[2]).toBeCloseTo((a.z + b.z) / 2, 6);
+    expect(seg.rotationY).toBeCloseTo(expectedRotation, 6);
+    // Above the floor plane, at wall-box height — same Y every edge-native
+    // WallBox piece renders at, so the two wall vocabularies share one
+    // architecture (this file's own header doc comment).
+    expect(seg.position[1]).toBeCloseTo(WALL_HEIGHT / 2, 6);
+  });
+
+  it('a door mid-line splits one line into solid, door, solid — in that order, all sharing the line’s own rotation', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    // Same fixture straightWallGeometry.test.ts's own "door exclusion"
+    // describe block uses: footprint [[4,5],[6,5],[8,5]], door at the
+    // MIDDLE cell.
+    const from: CornerRef = { cell: [2, 5], corner: 0 };
+    const to: CornerRef = { cell: [10, 5], corner: 3 };
+    addWallLine(cst, from, to);
+    toggleWallLineDoorAt(cst, 0, [6, 5]);
+    const doc = toDungeonDoc(cst);
+    expect(doc.wallLines[0].doors).toEqual([{ cell: [6, 5] }]);
+
+    const segments = buildWallLineSegments(doc);
+    expect(segments.map((s) => s.kind)).toEqual(['solid', 'door', 'solid']);
+    // One straight line has ONE direction — every piece of it shares the
+    // exact same rotation, whether solid or door.
+    const rotations = segments.map((s) => s.rotationY);
+    expect(rotations[1]).toBeCloseTo(rotations[0], 10);
+    expect(rotations[2]).toBeCloseTo(rotations[0], 10);
+    for (const seg of segments) {
+      expect(seg.length).toBeGreaterThan(0);
+    }
+
+    // Reuse, not re-derivation: the door piece's own extent matches
+    // `clipSegmentToShrunkHex`'s real `[t0,t1]` for that cell — the SAME
+    // primitive `straightWallFootprint` already uses — lerped over
+    // independently-computed world corner points, not the render path's
+    // own internal `t`.
+    const a = cornerPoint(from);
+    const b = cornerPoint(to);
+    const interval = clipSegmentToShrunkHex(a, b, 6, 5);
+    expect(interval).not.toBeNull();
+    const [t0, t1] = interval!;
+    const aWorld = worldOf(from);
+    const bWorld = worldOf(to);
+    const lerpPoint = (t: number) => ({
+      x: aWorld.x + (bWorld.x - aWorld.x) * t,
+      z: aWorld.z + (bWorld.z - aWorld.z) * t,
+    });
+    const p0 = lerpPoint(t0);
+    const p1 = lerpPoint(t1);
+    const doorSeg = segments[1];
+    expect(doorSeg.position[0]).toBeCloseTo((p0.x + p1.x) / 2, 6);
+    expect(doorSeg.position[2]).toBeCloseTo((p0.z + p1.z) / 2, 6);
+    expect(doorSeg.length).toBeCloseTo(Math.hypot(p1.x - p0.x, p1.z - p0.z), 6);
+  });
+
+  it('a door near one end of the line produces an asymmetric split — a short leading piece, a long trailing one — with no crash or misordering', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    const from: CornerRef = { cell: [2, 5], corner: 0 };
+    const to: CornerRef = { cell: [10, 5], corner: 3 };
+    addWallLine(cst, from, to);
+    // The FIRST footprint cell along the line, not the middle one.
+    toggleWallLineDoorAt(cst, 0, [4, 5]);
+    const doc = toDungeonDoc(cst);
+
+    const segments = buildWallLineSegments(doc);
+    expect(segments.map((s) => s.kind)).toEqual(['solid', 'door', 'solid']);
+    const [leading, , trailing] = segments;
+    // The leading solid sliver (before the near-the-start door) is
+    // markedly shorter than the trailing one (which now covers the
+    // fixture's other two footprint cells' worth of line) — the split
+    // is asymmetric, not silently defaulting to some even partition.
+    expect(leading.length).toBeLessThan(trailing.length);
+  });
+
+  it('two doors on the same line produce solid/door/solid/door/solid, five pieces in line order', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    const from: CornerRef = { cell: [2, 5], corner: 0 };
+    const to: CornerRef = { cell: [10, 5], corner: 3 };
+    addWallLine(cst, from, to);
+    // The two OUTER footprint cells; [6,5] (the middle one) stays solid.
+    toggleWallLineDoorAt(cst, 0, [4, 5]);
+    toggleWallLineDoorAt(cst, 0, [8, 5]);
+    const doc = toDungeonDoc(cst);
+    expect(doc.wallLines[0].doors).toHaveLength(2);
+
+    const segments = buildWallLineSegments(doc);
+    expect(segments.map((s) => s.kind)).toEqual([
+      'solid',
+      'door',
+      'solid',
+      'door',
+      'solid',
+    ]);
+    // Every piece shares the line's one direction.
+    const rotations = segments.map((s) => s.rotationY);
+    for (const r of rotations) expect(r).toBeCloseTo(rotations[0], 10);
+  });
+
+  it('a door left stranded by geometry that no longer clips its cell renders no gap — the wall stays solid straight through, honestly, rather than guessing one', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    // corner-to-corner, exactly one cell's own edge — clips NOTHING
+    // (straightWallGeometry.test.ts's own boundary case), so [5,5] is
+    // never a valid door cell for this particular line.
+    const from: CornerRef = { cell: [5, 5], corner: 0 };
+    const to: CornerRef = { cell: [5, 5], corner: 1 };
+    addWallLine(cst, from, to);
+    const doc = toDungeonDoc(cst);
+    // Write a door directly onto the parsed doc's own wallLine (bypassing
+    // isValidDoorCell, the same way a stranded door — flagged, not
+    // deleted, per TARGET-YAML.md — can exist in a real document after an
+    // endpoint drag shrinks the footprint out from under it).
+    const strandedDoc = {
+      ...doc,
+      wallLines: [
+        { ...doc.wallLines[0], doors: [{ cell: [5, 5] as [number, number] }] },
+      ],
+    };
+
+    const segments = buildWallLineSegments(strandedDoc);
+    expect(segments).toHaveLength(1);
+    expect(segments[0].kind).toBe('solid');
+  });
+
+  it('an empty doc.wallLines produces no segments, cheaply', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    expect(buildWallLineSegments(doc)).toEqual([]);
   });
 });

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -95,7 +95,7 @@
  * `doc.holes`, `doc.start`/`doc.end` are already doc-native fields with
  * zero `floorPlan` dependency, so they render unchanged in either mode.
  *
- * Two more doc-native overlays this same unit adds, both driven purely by
+ * Two more doc-native overlays that unit added, both driven purely by
  * `doc` (so they render in EITHER mode, not gated on `floorCells`): a
  * straight wall's (`doc.wallLines`) FOOTPRINT cells (Kirk's rule: "any hex
  * that is not 100% uncovered would not be traversable" — the cell still
@@ -106,9 +106,25 @@
  * region's centroid (the same `Billboard`+`Text` pattern
  * `AuthorGridOverlay.tsx` already uses for the real game's author-grid
  * labels — a proven-cheap primitive in this codebase, not a new one).
- * Full 3D geometry for a straight wall's own LINE (matching its
- * corner-anchored footprint/door-gap fidelity in 2D) is NOT attempted
- * this round — see CONTRACT.md's ledger entry for this unit.
+ *
+ * **Straight walls (`doc.wallLines`) now stand as real 3D geometry, not
+ * just a floor dim** (rpg-project#169 follow-up unit, 2026-08-04) — the
+ * "full 3D line geometry for wallLines" gap the creation-mode-3D-preview
+ * unit named and deliberately deferred. `buildWallLineSegments` walks
+ * each line's corner-anchored `from`/`to` (`creation/hexCorner.ts`'s
+ * `cornerPoint`, rescaled into this file's world space —
+ * `cornerWorldPos`'s own doc comment has the exact ratio) as ONE straight
+ * box (`WallBox`, now variable-length, not fixed at `HEX_SIZE`) spanning
+ * corner to corner — no per-cell pieces, matching Kirk's own mental model
+ * of a straight wall as a single run. A `doors:` entry splits that run at
+ * its own footprint clip interval (`clipSegmentToShrunkHex`, the SAME
+ * primitive `straightWallFootprint` already uses for the 2D/footprint-dim
+ * math — reused, not re-derived) into solid pieces flanking a `DoorGap`
+ * (now variable-width too) at the gap's own real extent — the identical
+ * amber jamb+lintel visual language edge-native `doc.walls` doors already
+ * use, one door language for both wall vocabularies. See this file's own
+ * `buildWallLineSegments` doc comment for the full geometry writeup and
+ * CONTRACT.md's ledger entry for this unit's live verification.
  */
 import {
   cubeToWorld,
@@ -135,7 +151,11 @@ import {
   wallMountRotationY,
 } from '../boardGeometry';
 import { DEFAULT_CANVAS } from '../creation/emptyCanvasDoc';
-import { straightWallsFootprintSet } from '../creation/straightWallGeometry';
+import { cornerPoint, type CornerRef } from '../creation/hexCorner';
+import {
+  clipSegmentToShrunkHex,
+  straightWallsFootprintSet,
+} from '../creation/straightWallGeometry';
 import {
   resolvePlacement,
   type DungeonDoc,
@@ -147,7 +167,7 @@ import {
   hasServerEdges,
   type ServerEdge,
 } from '../edgesAdapter';
-import { cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
+import { BOARD_HEX_SIZE, cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
 import { END_COLOR, regionArchetypeColor, START_COLOR } from '../markerStyle';
 import { regionCentroid } from '../regionGeometry';
 import type { PaletteSelection, PlacementSelection } from '../types';
@@ -661,6 +681,135 @@ export function buildWallLineFootprint(doc: DungeonDoc): Set<string> {
   return straightWallsFootprintSet(doc.wallLines, grid);
 }
 
+/** The uniform scale between this concept's 2D board-space corner math
+ * (`hexLayout.ts`'s `BOARD_HEX_SIZE`, `creation/hexCorner.ts`'s
+ * `cornerPoint`) and this file's own 3D world space (`hexMath.ts`'s
+ * `HEX_SIZE`). Both are the exact same `cubeToWorld`/`hexCorners`
+ * functions (`hexLayout.ts`'s own header doc comment: "Same odd-q
+ * pointy-top math the real 3D floor renders with"), each linear in its
+ * own `size` parameter with no additive offset —
+ * `cubeToWorld(cube, size) = size * SQRT_3 * (...)`/`size * 1.5 * cube.z`,
+ * and `hexCorners(center, size)` adds `size * cos/sin` to a center that's
+ * already scaled the same way. A board-space point therefore scales
+ * EXACTLY into world space by this one ratio; no re-derivation needed. */
+const BOARD_TO_WORLD_SCALE = HEX_SIZE / BOARD_HEX_SIZE;
+
+/** A `CornerRef`'s world-space `{x, z}` point — `cornerPoint` (board
+ * space) rescaled by `BOARD_TO_WORLD_SCALE`, not a second corner-
+ * resolution implementation. Reusing `cornerPoint` (rather than
+ * re-deriving via `hexCorners`/`cubeAtColRow` at `HEX_SIZE` directly)
+ * keeps corner-index normalization and cell/world math in exactly ONE
+ * place — any future fix to `cornerPoint` itself propagates to this 3D
+ * render path automatically instead of needing a parallel fix here. */
+function cornerWorldPos(ref: CornerRef): { x: number; z: number } {
+  const p = cornerPoint(ref);
+  return { x: p.x * BOARD_TO_WORLD_SCALE, z: p.y * BOARD_TO_WORLD_SCALE };
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/** One render-ready piece of a `wallLines:` entry — either a solid run or
+ * a door's own gap span. `position`/`rotationY` are ready to hand
+ * straight to `WallBox`/`DoorGap` unchanged; `length` doubles as
+ * `WallBox`'s box width and `DoorGap`'s gap `width`. */
+export interface WallLineSegment {
+  key: string;
+  kind: 'solid' | 'door';
+  position: [number, number, number];
+  rotationY: number;
+  length: number;
+}
+
+/**
+ * Render-ready pieces for every `doc.wallLines` entry — real 3D wall
+ * geometry, not just the footprint dim `buildWallLineFootprint` already
+ * builds (the two are siblings: this renders WHAT the wall looks like,
+ * that flags WHERE it blocks movement). One `wallLines:` entry becomes
+ * ONE straight box spanning corner to corner (`cornerWorldPos`) — never a
+ * piece per clipped cell, matching Kirk's own mental model of a straight
+ * wall as a single run, not a chain of edge segments — UNLESS it carries
+ * `doors:`, in which case the run splits at each door's own footprint
+ * clip interval into alternating solid/door pieces.
+ *
+ * **Door intervals are reused, not re-derived**: `clipSegmentToShrunkHex`
+ * is the exact primitive `straightWallFootprint` already calls per
+ * candidate cell to build the 2D/footprint-dim door exclusion — calling
+ * it directly here for just the door's own cell gives the identical
+ * `[t0, t1]` clip interval TARGET-YAML.md's "Doors" section describes,
+ * with no second footprint derivation. A door whose cell the line no
+ * longer genuinely clips (stranded by an endpoint drag — 2D flags this
+ * with a ⚠ marker, TARGET-YAML.md's "flag, never silently repair"
+ * discipline) simply produces no interval here, so the wall renders solid
+ * straight through it rather than guessing a gap — this component owns
+ * geometry, not the flag.
+ *
+ * **`t` is computed once, in board space, and reused for world space
+ * unchanged.** `clipSegmentToShrunkHex` takes board-space `CellPos`
+ * points (`cornerPoint`'s own output) because its epsilon
+ * (`FOOTPRINT_EPSILON`) is tuned relative to `BOARD_HEX_SIZE` — but the
+ * resulting `t` is a pure fraction along the SAME directed segment
+ * `cornerWorldPos`'s world points also lie on (both are the same line,
+ * uniformly rescaled by `BOARD_TO_WORLD_SCALE` — see that constant's own
+ * doc comment), so lerping the WORLD endpoints by a board-computed `t`
+ * lands exactly on the point `cornerWorldPos` would give that fraction of
+ * the way along the line. No world-space clip math needed.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildWallLineSegments(doc: DungeonDoc): WallLineSegment[] {
+  const segments: WallLineSegment[] = [];
+  doc.wallLines.forEach((line, lineIndex) => {
+    const aBoard = cornerPoint(line.from);
+    const bBoard = cornerPoint(line.to);
+    const aWorld = cornerWorldPos(line.from);
+    const bWorld = cornerWorldPos(line.to);
+    const dx = bWorld.x - aWorld.x;
+    const dz = bWorld.z - aWorld.z;
+    const totalLength = Math.hypot(dx, dz);
+    if (totalLength < 1e-9) return; // degenerate (from === to) — nothing to draw
+    const rotationY = Math.atan2(-dz, dx); // hexEdgeBetween's own atan2 convention
+
+    const doorTs = (line.doors ?? [])
+      .map((d) => clipSegmentToShrunkHex(aBoard, bBoard, d.cell[0], d.cell[1]))
+      .filter((interval): interval is [number, number] => interval !== null)
+      .sort((a, b) => a[0] - b[0]);
+
+    const pointAt = (t: number): [number, number] => [
+      lerp(aWorld.x, bWorld.x, t),
+      lerp(aWorld.z, bWorld.z, t),
+    ];
+    const pushPiece = (
+      kind: 'solid' | 'door',
+      t0: number,
+      t1: number,
+      idx: number
+    ) => {
+      // A door landing exactly at a segment's own endpoint leaves nothing
+      // before/after it to draw — an empty piece, not a zero-length box.
+      if (t1 - t0 < 1e-6) return;
+      const [x0, z0] = pointAt(t0);
+      const [x1, z1] = pointAt(t1);
+      segments.push({
+        key: `wallline-${lineIndex}-${kind}-${idx}`,
+        kind,
+        position: [(x0 + x1) / 2, WALL_HEIGHT / 2, (z0 + z1) / 2],
+        rotationY,
+        length: Math.hypot(x1 - x0, z1 - z0),
+      });
+    };
+
+    let cursor = 0;
+    doorTs.forEach(([t0, t1], idx) => {
+      pushPiece('solid', cursor, t0, idx);
+      pushPiece('door', t0, t1, idx);
+      cursor = t1;
+    });
+    pushPiece('solid', cursor, 1, doorTs.length);
+  });
+  return segments;
+}
+
 // Above SyntyHexFloorTile's own FLOOR_Y (0.2) so a downward ray from the
 // orbit camera always meets this layer before the visual floor texture —
 // see this file's header doc comment for why that ordering alone is
@@ -804,10 +953,24 @@ const WALL_SOLID_COLOR = '#e8e2d8';
 const WALL_DOOR_COLOR = '#ffb347';
 const WALL_THICKNESS = 0.12;
 
-function WallBox({ wall }: { wall: PlacedWall }) {
+/** `length` defaults to `HEX_SIZE` — a single edge-native `doc.walls`/
+ * server-truth wall piece is always exactly one hex-edge long. A straight
+ * `wallLines:` segment (`buildWallLineSegments`) is typically several
+ * hexes long and passes its own real `length` instead — same box, same
+ * material, genuinely variable length, so the two wall vocabularies read
+ * as one architecture rather than two renderers. */
+function WallBox({
+  position,
+  rotationY,
+  length = HEX_SIZE,
+}: {
+  position: [number, number, number];
+  rotationY: number;
+  length?: number;
+}) {
   return (
-    <mesh position={wall.position} rotation={[0, wall.rotationY, 0]}>
-      <boxGeometry args={[HEX_SIZE, WALL_HEIGHT, WALL_THICKNESS]} />
+    <mesh position={position} rotation={[0, rotationY, 0]}>
+      <boxGeometry args={[length, WALL_HEIGHT, WALL_THICKNESS]} />
       <meshStandardMaterial color={WALL_SOLID_COLOR} />
     </mesh>
   );
@@ -821,7 +984,6 @@ function WallBox({ wall }: { wall: PlacedWall }) {
 // this same construct answers on the floor side: "the gash becomes a real
 // doorway."
 const DOOR_JAMB_WIDTH = HEX_SIZE * 0.22;
-const DOOR_OPENING_WIDTH = HEX_SIZE - DOOR_JAMB_WIDTH * 2;
 const DOOR_OPENING_HEIGHT = WALL_HEIGHT * 0.8;
 const DOOR_LINTEL_HEIGHT = WALL_HEIGHT - DOOR_OPENING_HEIGHT;
 // Wide/tall enough to comfortably catch a click near the opening without
@@ -846,65 +1008,71 @@ function rotateLocalXOffset(
   };
 }
 
+/** `width` defaults to `HEX_SIZE` (an edge-native door's own fixed gap
+ * span) — a straight `wallLines:` door's gap (`buildWallLineSegments`)
+ * passes its own real interval width instead, since a corner-anchored
+ * line's clip interval through its door cell isn't necessarily a full hex
+ * width. Jamb width is clamped to `width / 2` so a genuinely narrow gap
+ * (a shallow clip near a cell's edge) still produces two jambs meeting in
+ * the middle rather than overlapping/inverting; the opening (and its
+ * lintel) shrinks to fill whatever's left, never negative. */
 function DoorGap({
-  wall,
+  position,
+  rotationY,
+  width = HEX_SIZE,
   onSelectDoor,
 }: {
-  wall: PlacedWall;
+  position: [number, number, number];
+  rotationY: number;
+  width?: number;
   onSelectDoor?: () => void;
 }) {
-  const jambOffset = HEX_SIZE / 2 - DOOR_JAMB_WIDTH / 2;
-  const left = rotateLocalXOffset(wall.rotationY, jambOffset);
-  const right = rotateLocalXOffset(wall.rotationY, -jambOffset);
+  const jambWidth = Math.min(DOOR_JAMB_WIDTH, width / 2);
+  const openingWidth = Math.max(width - jambWidth * 2, 0);
+  const jambOffset = width / 2 - jambWidth / 2;
+  const left = rotateLocalXOffset(rotationY, jambOffset);
+  const right = rotateLocalXOffset(rotationY, -jambOffset);
   return (
     <group>
       <mesh
-        position={[
-          wall.position[0] + left.dx,
-          wall.position[1],
-          wall.position[2] + left.dz,
-        ]}
-        rotation={[0, wall.rotationY, 0]}
+        position={[position[0] + left.dx, position[1], position[2] + left.dz]}
+        rotation={[0, rotationY, 0]}
       >
-        <boxGeometry args={[DOOR_JAMB_WIDTH, WALL_HEIGHT, WALL_THICKNESS]} />
+        <boxGeometry args={[jambWidth, WALL_HEIGHT, WALL_THICKNESS]} />
         <meshStandardMaterial color={WALL_DOOR_COLOR} />
       </mesh>
       <mesh
-        position={[
-          wall.position[0] + right.dx,
-          wall.position[1],
-          wall.position[2] + right.dz,
-        ]}
-        rotation={[0, wall.rotationY, 0]}
+        position={[position[0] + right.dx, position[1], position[2] + right.dz]}
+        rotation={[0, rotationY, 0]}
       >
-        <boxGeometry args={[DOOR_JAMB_WIDTH, WALL_HEIGHT, WALL_THICKNESS]} />
+        <boxGeometry args={[jambWidth, WALL_HEIGHT, WALL_THICKNESS]} />
         <meshStandardMaterial color={WALL_DOOR_COLOR} />
       </mesh>
-      <mesh
-        position={[
-          wall.position[0],
-          DOOR_OPENING_HEIGHT + DOOR_LINTEL_HEIGHT / 2,
-          wall.position[2],
-        ]}
-        rotation={[0, wall.rotationY, 0]}
-      >
-        <boxGeometry
-          args={[DOOR_OPENING_WIDTH, DOOR_LINTEL_HEIGHT, WALL_THICKNESS]}
-        />
-        <meshStandardMaterial color={WALL_DOOR_COLOR} />
-      </mesh>
+      {openingWidth > 0 && (
+        <mesh
+          position={[
+            position[0],
+            DOOR_OPENING_HEIGHT + DOOR_LINTEL_HEIGHT / 2,
+            position[2],
+          ]}
+          rotation={[0, rotationY, 0]}
+        >
+          <boxGeometry
+            args={[openingWidth, DOOR_LINTEL_HEIGHT, WALL_THICKNESS]}
+          />
+          <meshStandardMaterial color={WALL_DOOR_COLOR} />
+        </mesh>
+      )}
       {onSelectDoor && (
         <mesh
-          position={wall.position}
-          rotation={[0, wall.rotationY, 0]}
+          position={position}
+          rotation={[0, rotationY, 0]}
           onClick={(e) => {
             e.stopPropagation();
             onSelectDoor();
           }}
         >
-          <boxGeometry
-            args={[HEX_SIZE, WALL_HEIGHT, DOOR_CLICK_HIT_THICKNESS]}
-          />
+          <boxGeometry args={[width, WALL_HEIGHT, DOOR_CLICK_HIT_THICKNESS]} />
           <meshBasicMaterial transparent opacity={0} depthWrite={false} />
         </mesh>
       )}
@@ -999,6 +1167,10 @@ export function DungeonPreview3D({
   // identically regardless of `floorPlan`/`floorCells`. See
   // `buildWallLineFootprint`'s own doc comment.
   const wallLineFootprint = useMemo(() => buildWallLineFootprint(doc), [doc]);
+  // The straight wall's own real geometry (this unit) — doc-native too,
+  // same reasoning as the footprint above. See `buildWallLineSegments`'s
+  // own doc comment.
+  const wallLineSegments = useMemo(() => buildWallLineSegments(doc), [doc]);
   // The generator-chosen entrance marker has no creation-mode analog at
   // all (CONTRACT.md's "Start/end: authored, in real tension with the
   // generator-chosen entrance" finding — a freeform canvas has no
@@ -1139,7 +1311,8 @@ export function DungeonPreview3D({
               w.isDoor ? (
                 <DoorGap
                   key={w.key}
-                  wall={w}
+                  position={w.position}
+                  rotationY={w.rotationY}
                   onSelectDoor={doorSelectHandler(
                     w,
                     floorPlan,
@@ -1147,7 +1320,28 @@ export function DungeonPreview3D({
                   )}
                 />
               ) : (
-                <WallBox key={w.key} wall={w} />
+                <WallBox
+                  key={w.key}
+                  position={w.position}
+                  rotationY={w.rotationY}
+                />
+              )
+            )}
+            {wallLineSegments.map((seg) =>
+              seg.kind === 'door' ? (
+                <DoorGap
+                  key={seg.key}
+                  position={seg.position}
+                  rotationY={seg.rotationY}
+                  width={seg.length}
+                />
+              ) : (
+                <WallBox
+                  key={seg.key}
+                  position={seg.position}
+                  rotationY={seg.rotationY}
+                  length={seg.length}
+                />
               )
             )}
             {props.map((p) => {


### PR DESCRIPTION
## Summary

`doc.wallLines` straight walls previously rendered in the 3D preview only as dimmed crimson footprint discs (the "where can't I walk" floor treatment) — nothing stood up to explain *why*. This unit closes the "full 3D line geometry for wallLines" follow-up named in CONTRACT.md's creation-mode-3D-preview section.

- **`buildWallLineSegments`** (new, exported for direct testing): resolves each `wallLines:` entry's corner-anchored endpoints to world space and renders it as **one box spanning corner to corner** (never per-cell pieces) — length/position/rotation derived from the segment's own real geometry, using the same `atan2` convention `hexEdgeBetween`/`wallBoxTransform` already use elsewhere in this file.
- **Doors carve real gaps**: a `doors:[{cell}]` entry splits the box at that cell's real footprint clip interval — reusing `clipSegmentToShrunkHex`, the exact primitive `straightWallFootprint` already calls, not a re-derivation.
- **`WallBox`/`DoorGap` generalized, not duplicated**: both now take `position`/`rotationY` plus an optional `length`/`width` (default `HEX_SIZE`, so existing edge-native call sites are unchanged) — one box/jamb/lintel/material family for both wall vocabularies.
- Works in **both** 3D contexts (edit mode's compiled-`FloorPlan` preview and creation mode's from-scratch-canvas toggle) with zero mode-specific code, since the component is doc-native either way.

## How door intervals were computed

Board-space `t0`/`t1` from `clipSegmentToShrunkHex` (tuned for `BOARD_HEX_SIZE`'s epsilon) is reused **unchanged** as a world-space lerp fraction between the world-space corner endpoints — valid because `cornerPoint`'s board-space math and this file's `hexMath.ts` world-space math are the exact same `cubeToWorld`/`hexCorners` functions, linear in their own `size` parameter with no additive offset. Verified by a cross-check test, not just argued.

## Test plan

- [x] 6 new tests in `DungeonPreview3D.test.ts`: single-edge line → one solid box (cross-checked against independently-computed corner geometry); door mid-line → solid/door/solid with the door piece's extent cross-checked against a fresh `clipSegmentToShrunkHex` call; door near one end → asymmetric split, no misordering; two doors → 5 alternating pieces; a door on a cell the line doesn't genuinely clip → renders solid, no guessed gap; empty `wallLines` → no segments.
- [x] 307 dungeon-builder tests passing, `ci-check` clean (format/lint/typecheck/build/test).
- [x] Live-verified, both 3D contexts (own dev server, headless Chromium with `--use-angle=swiftshader --enable-unsafe-swiftshader`): a straight wall standing at its real corner-to-corner extent (no hangover); a genuine amber jamb-lintel door gap; two wallLines sharing a corner meeting with no visible seam (L-corner); the existing edge-native perimeter walls and the new straight-wall boxes reading as one architecture; creation mode's from-scratch canvas rendering the identical wall+door geometry. No unexpected console errors.
- [x] CONTRACT.md ledger entry added documenting the unit.

Screenshots (door gap close-up, L-corner, coexistence overview, creation-mode 3D) captured during live verification.

— asset-pipeline agent, on behalf of KirkDiggler

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4