### PR TITLE
unit: creation-mode 3D editing (place/select on the canvas)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4661,3 +4661,244 @@ round's live-verification section already carries).
   correctly stops rendering a gap there (verified, see Tests above) but
   does not yet surface the warning glyph itself in the 3D view — a real,
   narrow follow-up, not a silent gap.
+
+## Creation-mode 3D editing: place/select/rotate/delete graduate onto the canvas (2026-08-04, rpg-project#169)
+
+Closes the "Read-only this round" follow-up the creation-mode-3D-preview unit
+named: Kirk's own words framing the ask — "I cannot place in 3D but if I had a
+statue selected in 2D I can rotate it and see it in 3D." Edit mode's existing
+3D click-to-place/select machinery (Kirk's "3D editing" arc, parts 2 and 3,
+above) graduates onto creation mode's from-scratch canvas — exactly the
+"graduate, don't rebuild" framing this file's own operating bar names as the
+right shape for exactly this situation.
+
+### A real, pre-existing bug found before any 3D work: 2D creation's own click-to-place never checked legality
+
+Read `CreationBoard.tsx`'s `handlePointerDown` before touching anything: its
+`edit.selectedPalette` branch called `edit.handlePlace(null, cell)` straight
+off `nearestCreationCell`, with **no occupied check, no straight-wall-
+footprint check, and no hole check at all** — only the boss-room guard. A
+click could silently stack a second placement on an existing one, place
+inside a `wallLines:` footprint, or place directly on a hole. This predates
+this unit entirely (creation mode's click-to-place has worked this way since
+the CST-unification round) and would have stayed invisible forever, since
+nothing ever exercised the reject path to notice its absence. Verified by
+reading the code, not inferred: `useBoardEditing.ts`'s `handlePlace` and
+`dungeonYaml.ts`'s `placeItem` mutator both do zero validation of their own —
+every existing legality check in this concept (edit mode's `Board.tsx`
+`isCellOccupied` gate, the door-row reject) lives at the INTERACTION layer,
+not the mutator, and creation mode's interaction layer simply never grew one.
+
+**Fixed at the root, not just prepped for 3D** — the brief's own framing
+("build ONE shared predicate both the 2D brush and 3D click consult if they
+don't already share one") anticipated exactly this. New
+`canvasPlacementRejectReason(doc, col, row, wallLineFootprint)`
+(`creation/canvasFloor.ts`, sibling to `deriveCanvasFloorCells`) is the single
+source both now consult:
+
+1. **Real canvas floor** — in bounds, not a hole (the identical test
+   `deriveCanvasFloorCells` applies).
+2. **Not a straight-wall (`doc.wallLines`) footprint cell** — Kirk's rule
+   ("any hex that is not 100% uncovered would not be traversable") makes a
+   footprint cell BLOCKED, not floorless; the floor tile still renders
+   (dimmed, per the creation-mode-3D-preview unit's own overlay), it just
+   isn't a legal placement target. `wallLineFootprint` is caller-supplied
+   (`straightWallsFootprintSet`, the exact primitive the 2D hatch/3D dim
+   overlays already call) so a caller checking many cells computes it once,
+   not once per cell.
+3. **Not already occupied** — `boardGeometry.ts`'s `isCellOccupied`, now
+   accepting `floorPlan: FloorPlan | undefined` (a from-scratch canvas has
+   none — its room-scoped loop is a no-op for `doc.rooms === []` regardless,
+   the top-level `doc.place` loop this needs never depended on `floorPlan` in
+   the first place).
+
+`CreationBoard.tsx`'s click handler now calls this before `edit.handlePlace`,
+surfacing a reject through the same `onReject` toast seam every other tool in
+that component already uses. This is a genuine behavior change to the
+EXISTING 2D board, named honestly rather than silently bundled — matching
+this file's own precedent for a real bug found mid-unit (the connector-band
+chasm, the `movePlacementAcrossLists` field-loss fix, both above).
+
+### `DungeonPreview3D.tsx`: the same predicate, wired into the existing click-to-place machinery
+
+`buildPlaceableCells` (previously gated `floorPlan ? buildPlaceableCells(...)
+: []` at the call site, so creation mode's `placeableCells` was always empty)
+now takes `floorPlan: FloorPlan | undefined` and an explicit
+`wallLineFootprint` param, and is called unconditionally — `floorTiles`
+already unifies both mode's cell sets (`buildFloorTiles`'s own doc comment),
+so the gate was never structurally necessary once `isCellOccupied` could take
+an absent `floorPlan`. Each `PlaceableCell` gains an optional `rejectReason`:
+`undefined` for every edit-mode cell (that branch stays exactly as it was —
+silent on `occupied`, matching `Board.tsx`'s own click-to-place precedent,
+`if (occupied) return;`, no toast) and for any legally-placeable creation-mode
+cell; populated via `canvasPlacementRejectReason` for a blocked creation-mode
+one. `occupied` (drives the hit-cell's red/teal tint) is `true` whenever
+`rejectReason` is set, so the visual and the click decision can never
+disagree with each other.
+
+`handleClickCell` branches on `floorPlan` presence, the same idiom this file
+already uses everywhere else (`buildFloorTiles`, `buildPlacements`,
+`entranceBlocked`): the `floorPlan`-present branch is UNCHANGED (room lookup,
+door-row reject, room-scoped `onPlace(cell.roomId, [localCol, row])`); the
+new `!floorPlan` branch places TOP-LEVEL — `onPlace(null, [cell.col,
+cell.row])`, the exact shape `CreationBoard.tsx`'s own 2D brush already
+produces via `edit.handlePlace(null, cell)`. `onPlace`'s prop type widened
+from `(roomId: string, at) => void` to `(roomId: string | null, at) => void`
+to allow this — a pure widening, `edit.handlePlace` already accepted
+`string | null`, so edit mode's own call site needed no change.
+
+**Select/rotate/delete needed no new code at all** — this is the "graduate,
+don't rebuild" claim made concrete. `DungeonPreview3D`'s existing prop-click
+handler (`onClick={(e) => { e.stopPropagation(); onSelect(p.sel); }}`) never
+checked `floorPlan`; wiring `selectedPlacement`/`onSelect` into creation
+mode's call site (below) was the entire change needed for select. Rotate is
+the Inspector's own pre-existing facing control (`Inspector.tsx`, unchanged),
+reachable because `CreationConcept.tsx` already renders one `<Inspector>`
+outside either board (edit mode's own precedent, "one Inspector, either
+view"). Delete is the global Delete/Backspace keydown listener — see its own
+real bug, next.
+
+### A second real, pre-existing bug: the global Delete key was edit-mode only
+
+`DungeonBuilderConcept.tsx`'s keydown listener read/acted on `edit.selectedPlacement`
+alone (`edit` = the EDIT-mode `useBoardEditing` instance) — `creationEdit`
+(creation mode's own, separate instance, `useBoardEditing` called a second
+time against its own cst/doc) was never consulted. Delete/Backspace has
+therefore never removed a creation-mode placement, in EITHER view, since the
+CST-unification round — only the Inspector's own "Delete (or press Delete
+key)" button worked there (`CreationConcept.tsx`'s `onDelete={edit.handleDelete}`,
+where that `edit` prop IS `creationEdit`). Found while verifying the brief's
+own "should already be view-agnostic — verify" claim for Delete-key parity —
+it wasn't, and not for a 3D-specific reason.
+
+**Fixed at the root**: the listener now picks `mode === 'create' ? creationEdit
+: edit` as its active handle before checking `selectedPlacement`. Gating on
+`mode` (not "whichever has a selection") matters because neither `edit` nor
+`creationEdit` unmounts across a tab switch (`DungeonBuilderConcept`'s own
+"remembered per mode" precedent for `boardDim`/`createBoardDim` above) — a
+stale selection left in the INACTIVE mode must never hijack the key.
+
+### Region/wall/hole/start/end tools: 2D-only, an honest reject instead of a misleading one
+
+A new optional `selectedTool?: BoardTool | null` prop on `DungeonPreview3D`
+— purely informational, this component never acts on a tool itself (there is
+no 3D geometry-editing surface here this round). `handleClickCell`'s
+no-palette-selected branch reads it: a tool armed (region/wall/hole/etc., all
+2D-only this round) gets "That tool is 2D-only for now — switch to the 2D
+board to use it, or pick a palette item to place something here" instead of
+the generic "pick a palette item first" — which would otherwise read as a
+non-sequitur to an author who very much has SOMETHING selected, just not a
+placeable item. Edit mode's own call site doesn't pass this prop (its tools
+aren't creation-canvas-scoped the same way), so edit mode's message is
+unchanged.
+
+### Live verification
+
+Own dev server (`vite --port 5199`, never `:3001`), own throwaway Playwright
+Chromium (`--use-angle=swiftshader --enable-unsafe-swiftshader`, matching the
+straight-walls-in-3D unit's own established flag pair) rather than the shared
+chrome-devtools MCP browser at `127.0.0.1:9222` (memory: that one is Kirk's,
+collides across concurrent agents) — a fresh worktree's `public/models/synty/`
+is gitignored and absent by default; symlinked from the main checkout for the
+run, removed before committing (never part of the diff).
+
+A real end-to-end loop on a 3×3 New Dungeon canvas, driven by genuine mouse
+events at real screen coordinates (not a fiber-walk shortcut — this
+component's hit-cells are real DOM/canvas pointer targets, same as the
+existing click-to-place units' own live-verification precedent):
+
+- **Place**: palette "pillar" selected, 3D floor hex clicked — `place:`
+  gained `{ ref: "dnd5e:props:pillar", at: [0, 1], blocks_movement: false,
+blocks_los: false }`, a real top-level entry, and the pillar rendered
+  standing on the canvas. Evidence:
+  `docs/evidence/dungeon-builder-creation-3d-place-via-click.png`.
+- **Occupied-cell reject**: palette re-armed, the SAME cell clicked again —
+  toast "That cell already holds a placement.", `place:` unchanged (no
+  duplicate). Evidence:
+  `docs/evidence/dungeon-builder-creation-3d-occupied-reject-toast.png`.
+- **Select**: clicking the placed pillar's own mesh (not the floor beneath
+  it) opened the Inspector showing `dnd5e:props:pillar [0,1]` with its
+  facing/rotate/height/delete controls. Evidence:
+  `docs/evidence/dungeon-builder-creation-3d-select-opens-inspector.png`.
+- **Rotate**: two clicks on the Inspector's ↻ control while watching the
+  live 3D view — `place:` gained `facing: NW`, the pillar visibly reoriented
+  in the same screenshot. Evidence:
+  `docs/evidence/dungeon-builder-creation-3d-rotate-via-inspector.png`.
+- **Delete**: Delete key with the pillar selected — `place: []`, the pillar
+  gone from the 3D view. Evidence:
+  `docs/evidence/dungeon-builder-creation-3d-delete-via-key.png`.
+- **Banner text**: confirmed live, not just in the diff — the `boardDim ===
+'3d'` header banner no longer says "Read-only this round"; it now reads
+  the interactive copy (palette-armed vs. not) matching edit mode's own
+  banner language. Evidence:
+  `docs/evidence/dungeon-builder-creation-3d-empty-interactive-banner.png`.
+
+A real, worth-naming automation finding along the way: the empty-scene
+screen-space center of the R3F `<canvas>` element is NOT where a click lands
+on the rendered floor — `Bounds fit clip margin={1.25}` frames the CONTENT,
+not the canvas rectangle, and the side panels give the canvas asymmetric
+width, so the content's visual center sits well off the raw bounding box's
+midpoint (empirically ~30%/50% of the box for this 3×3 canvas at this
+viewport, grid-search-located, not guessed). A STANDING prop's own clickable
+mesh additionally sits well above the floor plane it stands on (~75px higher
+on screen at this camera framing for a `pillar`) — clicking the cell center
+hits the floor hit-cell underneath it, not the prop, which is exactly the
+z-ordering this file's own header doc comment describes (`HIT_CELL_Y` above
+`FLOOR_Y` so a placement click always wins over the floor — but the PROP's
+own mesh, taller still, only wins over BOTH if the ray actually intersects
+its geometry, not just its cell). Worth recording for whoever next automates
+a click against this specific 3D view.
+
+**Not independently live-clicked**: the `selectedTool`-armed reject message
+(previous section). The 2D Palette's accordion-toggle click proved
+flaky under this specific Playwright automation (`page.mouse.click` on the
+category header sometimes toggled it open, sometimes not, across otherwise
+identical runs) — an automation quirk in the PRE-EXISTING accordion, not
+something this unit touched. Confidence instead comes from: direct code
+review (a one-line ternary sibling to the branch that WAS live-verified —
+the plain "pick a palette item first" toast fired correctly and repeatedly
+in every run above whenever no tool was armed either) and `ci-check`
+(format/lint/typecheck/build/test all clean). Named honestly as a real,
+narrow gap in this round's live evidence, not silently claimed as covered.
+
+No unexpected console errors beyond the two established FIXTURES-MODE
+`[unimplemented] unknown service ...AuthoringService` messages every prior
+round's live-verification section already carries.
+
+### Tests
+
+17 new (324 dungeon-builder tests overall, up from 307): 7 in
+`creation/canvasFloor.test.ts` (`canvasPlacementRejectReason` — an ordinary
+legal cell, out-of-bounds, a hole, a straight-wall footprint cell via the
+same single-cell fixture `straightWallGeometry.test.ts` itself uses, an
+occupied top-level placement, gate-ordering, and a real `addWallLine` +
+`straightWallsFootprintSet` integration case rather than a hand-built footprint
+Set only); 4 in `boardGeometry.test.ts` (`isCellOccupied` had ZERO prior
+coverage — a top-level placement's own cell, every other cell staying clear,
+an empty canvas not crashing the now-skipped room loop, and `exclude`
+correctly index-scoped); 6 in `preview3d/DungeonPreview3D.test.ts`
+(`buildPlaceableCells`'s new creation-mode branch: one cell per floor tile,
+an occupied cell carrying `occupied`+`rejectReason`, a footprint cell doing
+the same with a DISTINCT reason, an ordinary cell carrying neither, every
+cell tagged `CANVAS_ROOM_ID`; plus one edit-mode regression-guard test
+pinning `rejectReason` always `undefined` there and `roomId` never the
+canvas sentinel). `ci-check` clean (format/lint/typecheck/build/test).
+
+### What did NOT ship this round — named, not silently dropped
+
+- **Drag-move in 3D.** Deferred, and for a reason worth stating precisely:
+  this is not a creation-mode gap, it's an EDIT-mode gap this unit had
+  nothing to graduate from. CONTRACT.md's own "New arc: 3D editing, part 3"
+  section (above) already named this: "drag-move in 3D stays the explicit
+  follow-up... The 2D board remains the only way to drag-move a placement
+  today, in either view's mode banner" — still true, unchanged by this unit.
+  Click-select + the 2D board's own drag-move is today's answer in BOTH
+  modes, not a creation-mode shortfall.
+- **Region/wall/hole/start/end 3D editing.** Out of scope by this unit's own
+  brief — placements only. A tool-armed 3D click gives the honest "switch to
+  2D" reject (above) rather than silently no-oping or misleadingly claiming
+  "pick a palette item."
+- **The `selectedTool`-armed reject message's own live click**, named above
+  under Live verification — code-reviewed and its sibling branch
+  live-verified, not independently live-clicked, due to automation flakiness
+  in the pre-existing accordion control, not this unit's own code.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -499,27 +499,48 @@ export function DungeonBuilderConcept() {
           ? 'Selected a placed piece — drag to move, Delete key to remove, toggle flags in the inspector.'
           : 'Nothing selected — pick a palette item, or click a placed piece.';
 
+  // rpg-project#169's creation-3D-editing unit found this listener was
+  // edit-mode ONLY — it read/acted on `edit.selectedPlacement` alone, so
+  // Delete/Backspace never removed a creation-mode placement in EITHER
+  // view (2D or 3D); only the Inspector's own delete button worked there
+  // (`CreationConcept.tsx`'s `onDelete={edit.handleDelete}`, where that
+  // `edit` prop is `creationEdit`, a separate `useBoardEditing` instance —
+  // see this component's own doc comment on `creationEdit` for why). A
+  // real, pre-existing gap, not 3D-specific — fixed at the root by
+  // picking whichever mode's `useBoardEditing` instance is actually live
+  // (`mode`, this component's own tab state) rather than hardcoding
+  // edit's. `edit`/`creationEdit` both persist across a tab switch
+  // (neither unmounts), so gating on `mode` — not just "whichever has a
+  // selection" — avoids a stale selection in the INACTIVE mode ever
+  // hijacking the key.
   useEffect(() => {
+    const activeEdit = mode === 'create' ? creationEdit : edit;
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.target as HTMLElement)?.tagName === 'TEXTAREA') return;
       if (
         (e.key === 'Delete' || e.key === 'Backspace') &&
-        edit.selectedPlacement
+        activeEdit.selectedPlacement
       ) {
         e.preventDefault();
-        if (edit.selectedPlacement.boss) {
+        if (activeEdit.selectedPlacement.boss) {
           flashToast(
             'Boss required — can’t delete (dungeonspec: "boss room must declare boss"). Drag it instead.'
           );
         } else {
-          edit.handleDelete();
+          activeEdit.handleDelete();
         }
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [edit.selectedPlacement, cst]);
+  }, [
+    mode,
+    edit.selectedPlacement,
+    creationEdit.selectedPlacement,
+    cst,
+    creationCst,
+  ]);
 
   const modeTabs = (
     <div style={{ display: 'flex', gap: 6, padding: '10px 16px 0' }}>

--- a/src/concepts/dungeon-builder/boardGeometry.test.ts
+++ b/src/concepts/dungeon-builder/boardGeometry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   computeFlushRotation,
   facingToRotationY,
+  isCellOccupied,
   isSameSelection,
   nearestBearingFacing,
   neighborCell,
@@ -9,7 +10,13 @@ import {
   wallBearingFacings,
   wallMountRotationY,
 } from './boardGeometry';
-import type { WallDoc } from './dungeonYaml';
+import { emptyCanvasYaml } from './creation/emptyCanvasDoc';
+import {
+  parseDungeon,
+  placeItem,
+  toDungeonDoc,
+  type WallDoc,
+} from './dungeonYaml';
 import type { PlacementSelection } from './types';
 
 const roomA0: PlacementSelection = { roomId: 'room-a', index: 0 };
@@ -254,5 +261,51 @@ describe('computeFlushRotation (Kirk\'s 2026-08-03 fine-rotation generalization:
     const walls = wallOnFacing(2);
     const result = computeFlushRotation(walls, ABS_COL, ROW, null);
     expect(result).toEqual(computeFlushRotation(walls, ABS_COL, ROW, null));
+  });
+});
+
+// `floorPlan` went from required to optional (rpg-project#169's
+// creation-3D-editing unit) — a from-scratch creation-mode canvas has no
+// compiled FloorPlan, so `creation/canvasFloor.ts`'s
+// `canvasPlacementRejectReason` calls this with `undefined`. No prior test
+// coverage existed for this function at all before this unit.
+describe('isCellOccupied — floorPlan: undefined (creation-mode canvas, rpg-project#169)', () => {
+  // A real parsed canvas doc (`parseDungeon(emptyCanvasYaml(...))`), not a
+  // hand-typed `DungeonDoc` literal — matches the fixture pattern
+  // `canvasFloor.test.ts` and `DungeonPreview3D.test.ts` already use.
+  const docWithTopLevelPlacement = () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    placeItem(cst, null, 'dnd5e:props:pillar', [3, 3]);
+    return toDungeonDoc(cst);
+  };
+
+  it('reports a top-level placement’s own cell as occupied with no floorPlan at all', () => {
+    const doc = docWithTopLevelPlacement();
+    expect(isCellOccupied(undefined, doc, 3, 3)).toBe(true);
+  });
+
+  it('leaves every other cell unoccupied', () => {
+    const doc = docWithTopLevelPlacement();
+    expect(isCellOccupied(undefined, doc, 3, 4)).toBe(false);
+    expect(isCellOccupied(undefined, doc, 4, 3)).toBe(false);
+  });
+
+  it('an empty canvas (doc.rooms === [], doc.place === []) reports nothing occupied — no crash from the skipped room loop', () => {
+    const doc = toDungeonDoc(parseDungeon(emptyCanvasYaml(20, 30)).cst);
+    expect(doc.rooms).toEqual([]);
+    expect(isCellOccupied(undefined, doc, 0, 0)).toBe(false);
+  });
+
+  it('`exclude` still lets the placement being moved/re-checked exempt its own top-level index', () => {
+    const doc = docWithTopLevelPlacement();
+    expect(
+      isCellOccupied(undefined, doc, 3, 3, { roomId: null, index: 0 })
+    ).toBe(false);
+    // A DIFFERENT index at the same cell would still be a real collision
+    // — exclude is index-specific, not a blanket "top-level never
+    // collides" escape hatch.
+    expect(
+      isCellOccupied(undefined, doc, 3, 3, { roomId: null, index: 1 })
+    ).toBe(true);
   });
 });

--- a/src/concepts/dungeon-builder/boardGeometry.ts
+++ b/src/concepts/dungeon-builder/boardGeometry.ts
@@ -77,35 +77,50 @@ export interface OccupiedCheck {
  * optionally excluding one specific placement (the one being dragged).
  * Checks room-scoped placements (room-local `at` + the room's compiled
  * `startColumn`) AND top-level placements (`doc.place`, already absolute
- * — no room offset to add). */
+ * — no room offset to add).
+ *
+ * `floorPlan` is OPTIONAL (rpg-project#169's creation-3D-editing unit) — a
+ * from-scratch creation-mode canvas has no compiled `FloorPlan` to resolve
+ * a room-scoped placement's `startColumn` against, but its `doc.rooms` is
+ * always `[]` (`creation/emptyCanvasDoc.ts`'s own "no room chain exists
+ * yet" doc comment), so the room-scoped loop is already a no-op there
+ * regardless — the `if (floorPlan)` guard just keeps this honestly typed
+ * for `FloorPlan | undefined` rather than asserting non-null, matching
+ * this file's neighbors (`buildPlacements` in `DungeonPreview3D.tsx`
+ * already does the identical thing for the same reason). The top-level
+ * `doc.place` loop below never depended on `floorPlan` in the first
+ * place — it's the one this optionality exists to keep working for a
+ * canvas's own top-level placements. */
 export function isCellOccupied(
-  floorPlan: FloorPlan,
+  floorPlan: FloorPlan | undefined,
   doc: DungeonDoc,
   absCol: number,
   row: number,
   exclude?: OccupiedCheck
 ): boolean {
-  for (const room of doc.rooms) {
-    const fpRoom = floorPlan.rooms.find((r) => r.id === room.id);
-    if (!fpRoom) continue;
-    if (room.boss) {
-      const bc = fpRoom.startColumn + room.boss.at[0];
-      const br = room.boss.at[1];
-      if (bc === absCol && br === row) {
-        if (
-          !(exclude && exclude.roomId === room.id && exclude.index === 'boss')
-        ) {
-          return true;
+  if (floorPlan) {
+    for (const room of doc.rooms) {
+      const fpRoom = floorPlan.rooms.find((r) => r.id === room.id);
+      if (!fpRoom) continue;
+      if (room.boss) {
+        const bc = fpRoom.startColumn + room.boss.at[0];
+        const br = room.boss.at[1];
+        if (bc === absCol && br === row) {
+          if (
+            !(exclude && exclude.roomId === room.id && exclude.index === 'boss')
+          ) {
+            return true;
+          }
         }
       }
-    }
-    for (let i = 0; i < room.place.length; i++) {
-      if (exclude && exclude.roomId === room.id && exclude.index === i)
-        continue;
-      const p = room.place[i];
-      const pc = fpRoom.startColumn + p.at[0];
-      const pr = p.at[1];
-      if (pc === absCol && pr === row) return true;
+      for (let i = 0; i < room.place.length; i++) {
+        if (exclude && exclude.roomId === room.id && exclude.index === i)
+          continue;
+        const p = room.place[i];
+        const pc = fpRoom.startColumn + p.at[0];
+        const pr = p.at[1];
+        if (pc === absCol && pr === row) return true;
+      }
     }
   }
   for (let i = 0; i < doc.place.length; i++) {

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -73,6 +73,7 @@ import { PlacementMarker } from '../PlacementMarker';
 import { regionCentroid } from '../regionGeometry';
 import type { BoardTool, PlacementSelection } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
+import { canvasPlacementRejectReason } from './canvasFloor';
 import {
   creationCellCenter,
   creationCellPolygon,
@@ -647,6 +648,26 @@ export function CreationBoard({
         onReject(
           'Boss stays room-scoped — this canvas has no rooms yet to hold one (see TARGET-YAML.md).'
         );
+        return;
+      }
+      // rpg-project#169's creation-3D-editing unit: this click used to
+      // reach `edit.handlePlace` unconditionally — no occupied/footprint/
+      // hole check at all, a real gap (a click could silently stack a
+      // second placement on an existing one, or place inside a straight
+      // wall's own footprint or a hole). `canvasPlacementRejectReason` is
+      // the SAME predicate the 3D click-to-place layer now consults
+      // (`DungeonPreview3D.tsx`), so the two views can never disagree
+      // about where a click is legal — see that function's own doc
+      // comment (`canvasFloor.ts`) for the exact three gates.
+      const footprint = straightWallsFootprintSet(doc.wallLines, grid);
+      const reject = canvasPlacementRejectReason(
+        doc,
+        cell[0],
+        cell[1],
+        footprint
+      );
+      if (reject) {
+        onReject(reject);
         return;
       }
       edit.handlePlace(null, cell);

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -362,9 +362,10 @@ export function CreationConcept({
           Canvas floor = every cell minus holes (no compiled floor plan exists
           for a from-scratch canvas yet — see CONTRACT.md). Straight-wall
           footprint cells render dimmed; region cells render tinted with a
-          floating label. Read-only this round — orbit/zoom only, no
-          picking/placing in 3D here yet; use the 2D board or the palette to
-          edit.
+          floating label.{' '}
+          {edit.selectedPalette
+            ? `Palette: ${edit.selectedPalette.ref.split(':').pop()} selected — click an empty floor hex to place it (highlighted teal); orbit/zoom with the mouse.`
+            : 'Click a placed prop/monster to select it (opens the Inspector — rotate/delete there), or pick a palette item to place one here too. Region/wall/hole/start/end tools stay 2D-only this round — switch to the 2D board for those.'}
         </div>
       )}
 
@@ -454,18 +455,39 @@ export function CreationConcept({
               />
             </div>
           ) : (
-            // Read-only this round (this component's own header banner
-            // above says so too) — deliberately NOT wiring
-            // selectedPlacement/onSelect/selectedPalette/onPlace/
-            // onSelectConnector. `DungeonPreview3D` degrades to
-            // view-only when those are omitted (its own prop doc
-            // comments), so this is the whole wiring needed for an
-            // honest read-only preview, not a partial version of the
-            // interactive one. `floorPlan` stays unset — a canvas has
-            // none — so `floorCells` (this component's own derivation
-            // above) is the only floor input.
+            // Creation-mode 3D editing parity (rpg-project#169's
+            // creation-3D-editing unit) — graduates edit-mode's existing
+            // 3D click-to-place/select/rotate machinery onto the canvas,
+            // closing the "read-only this round" follow-up the
+            // creation-mode-3D-preview unit named. Wiring mirrors
+            // `DungeonBuilderConcept.tsx`'s own edit-mode call site
+            // exactly (`selectedPlacement`/`onSelect`/`selectedPalette`/
+            // `onPlace`/`onReject`), plus `selectedTool` so a 2D-only
+            // tool (region/wall/hole/start/end) armed while the author
+            // clicks in 3D gets an honest "switch to 2D" message instead
+            // of the generic "pick a palette item" one.
+            // `floorPlan` stays unset — a canvas has none — so
+            // `floorCells` (this component's own derivation above) is
+            // the only floor input; `onPlace`'s `roomId` argument is
+            // always `null` on this path (`DungeonPreview3D.tsx`'s own
+            // `handleClickCell` doc comment) — the same top-level shape
+            // `CreationBoard.tsx`'s 2D brush already produces via
+            // `edit.handlePlace(null, cell)`. Region/wall 3D editing
+            // itself stays out of scope this round — see CONTRACT.md.
             <div style={{ flex: 1, minHeight: 0 }}>
-              <DungeonPreview3D floorCells={floorCells} doc={doc} />
+              <DungeonPreview3D
+                floorCells={floorCells}
+                doc={doc}
+                selectedPlacement={edit.selectedPlacement}
+                onSelect={(sel) => {
+                  clearOtherSelections('placement');
+                  edit.setSelectedPlacement(sel);
+                }}
+                selectedPalette={edit.selectedPalette}
+                onPlace={edit.handlePlace}
+                onReject={toast}
+                selectedTool={selectedTool}
+              />
             </div>
           )}
         </main>

--- a/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { deriveCanvasFloorCells } from './canvasFloor';
+import {
+  addWallLine,
+  parseDungeon,
+  placeItem,
+  toDungeonDoc,
+  toggleHole,
+} from '../dungeonYaml';
+import {
+  canvasPlacementRejectReason,
+  deriveCanvasFloorCells,
+} from './canvasFloor';
+import { emptyCanvasYaml } from './emptyCanvasDoc';
+import { straightWallsFootprintSet } from './straightWallGeometry';
 
 describe('deriveCanvasFloorCells', () => {
   it('produces every cell in a small canvas bounds, none missing or duplicated', () => {
@@ -53,5 +65,79 @@ describe('deriveCanvasFloorCells', () => {
       holes: [[0, 0]],
     });
     expect(cells).toEqual([]);
+  });
+});
+
+// rpg-project#169's creation-3D-editing unit — the ONE placement-legality
+// predicate both the 2D brush (`CreationBoard.tsx`) and the 3D
+// click-to-place layer (`preview3d/DungeonPreview3D.tsx`) now consult.
+// Built off a real parsed canvas doc (`parseDungeon(emptyCanvasYaml(...))`),
+// not a hand-typed `DungeonDoc` literal — `isCellOccupied` (this
+// function's own third gate) takes the full `DungeonDoc` shape, and a real
+// parse is the same fixture pattern `DungeonPreview3D.test.ts` already
+// uses rather than a second, parallel one.
+describe('canvasPlacementRejectReason', () => {
+  const emptyDoc = () =>
+    toDungeonDoc(parseDungeon(emptyCanvasYaml(20, 30)).cst);
+
+  it('an ordinary empty floor cell is legal — null, no reason', () => {
+    const doc = emptyDoc();
+    expect(canvasPlacementRejectReason(doc, 5, 5, new Set())).toBeNull();
+  });
+
+  it('rejects a cell outside the canvas bounds, same as a hole would', () => {
+    const doc = emptyDoc();
+    expect(canvasPlacementRejectReason(doc, -1, 5, new Set())).not.toBeNull();
+    expect(canvasPlacementRejectReason(doc, 20, 5, new Set())).not.toBeNull();
+    expect(canvasPlacementRejectReason(doc, 5, 30, new Set())).not.toBeNull();
+  });
+
+  it('rejects a hole cell', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    toggleHole(cst, 5, 5);
+    const doc = toDungeonDoc(cst);
+    expect(canvasPlacementRejectReason(doc, 5, 5, new Set())).not.toBeNull();
+    // A neighboring, non-hole cell stays legal — the reject is cell-
+    // specific, not a whole-canvas panic.
+    expect(canvasPlacementRejectReason(doc, 6, 5, new Set())).toBeNull();
+  });
+
+  it('rejects a cell inside a straight wall’s footprint, and only that cell', () => {
+    const doc = emptyDoc();
+    // Same known single-cell footprint fixture straightWallGeometry.test.ts
+    // itself uses ("a wall ENDING at a corner shared with a cell does not
+    // clip that cell"): this line's footprint is exactly [[5, 4]].
+    const footprint = new Set(['5,4']);
+    expect(canvasPlacementRejectReason(doc, 5, 4, footprint)).not.toBeNull();
+    // A neighboring cell the footprint doesn't cover stays legal — the
+    // rule is footprint MEMBERSHIP, not proximity to a drawn wall.
+    expect(canvasPlacementRejectReason(doc, 5, 5, footprint)).toBeNull();
+    expect(canvasPlacementRejectReason(doc, 6, 5, footprint)).toBeNull();
+  });
+
+  it('rejects an already-occupied cell (top-level doc.place)', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    placeItem(cst, null, 'dnd5e:props:pillar', [3, 3]);
+    const doc = toDungeonDoc(cst);
+    expect(canvasPlacementRejectReason(doc, 3, 3, new Set())).not.toBeNull();
+    // The occupied placement's own cell is the only one affected.
+    expect(canvasPlacementRejectReason(doc, 4, 3, new Set())).toBeNull();
+  });
+
+  it('checks gates in order: an out-of-bounds cell is rejected for that reason even if it would also be "occupied" by coincidence', () => {
+    const doc = emptyDoc();
+    // No real placement can exist out of bounds, but this proves the
+    // bounds/hole gate runs FIRST regardless — a caller never needs a
+    // real occupied placement out of bounds to trust this ordering.
+    const reason = canvasPlacementRejectReason(doc, -5, -5, new Set());
+    expect(reason).toMatch(/floor/i);
+  });
+
+  it('addWallLine + straightWallsFootprintSet integration: a real authored wall line rejects its own footprint cell', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    addWallLine(cst, { cell: [5, 4], corner: 2 }, { cell: [5, 4], corner: 5 });
+    const doc = toDungeonDoc(cst);
+    const footprint = straightWallsFootprintSet(doc.wallLines, doc.canvas!);
+    expect(canvasPlacementRejectReason(doc, 5, 4, footprint)).not.toBeNull();
   });
 });

--- a/src/concepts/dungeon-builder/creation/canvasFloor.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.ts
@@ -23,6 +23,7 @@
  * See TARGET-YAML.md's "canvas:" section for this semantic recorded
  * as a dialect note, not just left as an implementation detail here.
  */
+import { isCellOccupied } from '../boardGeometry';
 import type { DungeonDoc } from '../dungeonYaml';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
 
@@ -44,4 +45,65 @@ export function deriveCanvasFloorCells(
     }
   }
   return cells;
+}
+
+/**
+ * The ONE placement-legality rule for a top-level (`doc.place`,
+ * `roomId: null`) placement on the creation canvas — rpg-project#169's
+ * creation-3D-editing unit. Returns a human-readable reject reason, or
+ * `null` when `(col, row)` is a legal target.
+ *
+ * **Written to be the single source both the 2D brush
+ * (`CreationBoard.tsx`'s click-to-place) and the 3D click-to-place layer
+ * (`preview3d/DungeonPreview3D.tsx`, once wired) consult** — the two views
+ * must never disagree about where a click is legal. Before this unit,
+ * NEITHER actually enforced this: `CreationBoard.tsx`'s own
+ * `handlePointerDown` called `edit.handlePlace(null, cell)` straight off
+ * `nearestCreationCell` with no occupied/footprint/hole check at all (a
+ * real, verified gap this unit closes at the root, not just in 3D — see
+ * CONTRACT.md's ledger entry for this unit).
+ *
+ * Three gates, checked in order:
+ * 1. **Real canvas floor** — in `doc.canvas`'s bounds (or
+ *    `DEFAULT_CANVAS`) and not a hole, the exact same test
+ *    `deriveCanvasFloorCells` applies (not re-derived as a Set lookup
+ *    here, since callers building many cells at once already have that
+ *    set cheaply from `deriveCanvasFloorCells` itself — this per-cell
+ *    check exists for the 2D brush's single-click case, where building
+ *    the whole floor set just to check one cell would be wasted work).
+ * 2. **Not a straight-wall (`doc.wallLines`) footprint cell** — Kirk's
+ *    rule ("any hex that is not 100% uncovered would not be traversable")
+ *    makes a footprint cell BLOCKED, not floorless: the floor tile still
+ *    renders (`deriveCanvasFloorCells` doesn't exclude it), but it isn't a
+ *    legal placement target. `wallLineFootprint` is a caller-supplied set
+ *    (`creation/straightWallGeometry.ts`'s `straightWallsFootprintSet`)
+ *    rather than recomputed here, so a caller checking many cells (the 3D
+ *    click layer, once wired) computes it once, not once per cell.
+ * 3. **Not already occupied** — `boardGeometry.ts`'s `isCellOccupied`,
+ *    called with no `floorPlan` (a from-scratch canvas has none — see
+ *    `isCellOccupied`'s own doc comment for why that's safe: its
+ *    room-scoped loop is a no-op for `doc.rooms === []` regardless, and
+ *    the top-level `doc.place` loop this actually needs never depended on
+ *    `floorPlan` in the first place).
+ */
+export function canvasPlacementRejectReason(
+  doc: DungeonDoc,
+  col: number,
+  row: number,
+  wallLineFootprint: ReadonlySet<string>
+): string | null {
+  const grid = doc.canvas ?? DEFAULT_CANVAS;
+  const inBounds =
+    col >= 0 && col < grid.width && row >= 0 && row < grid.height;
+  const isHole = doc.holes.some(([c, r]) => c === col && r === row);
+  if (!inBounds || isHole) {
+    return 'No floor there — off the canvas, or a hole.';
+  }
+  if (wallLineFootprint.has(`${col},${row}`)) {
+    return "That cell is blocked by a straight wall's footprint — pick an uncovered cell.";
+  }
+  if (isCellOccupied(undefined, doc, col, row)) {
+    return 'That cell already holds a placement.';
+  }
+  return null;
 }

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
@@ -19,6 +19,8 @@ import { HEX_SIZE } from '@/components/hex-grid/hexMath';
 import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { describe, expect, it } from 'vitest';
 import { facingToRotationY } from '../boardGeometry';
+import { deriveCanvasFloorCells } from '../creation/canvasFloor';
+import { emptyCanvasYaml } from '../creation/emptyCanvasDoc';
 import { cornerPoint, type CornerRef } from '../creation/hexCorner';
 import {
   clipSegmentToShrunkHex,
@@ -27,6 +29,7 @@ import {
 import {
   addWallLine,
   parseDungeon,
+  placeItem,
   setPlacementMount,
   setPlacementRotationDegrees,
   setRefDefault,
@@ -38,6 +41,7 @@ import { BOARD_HEX_SIZE, cubeAtColRow } from '../hexLayout';
 import {
   buildFloorTiles,
   buildOnePlacement,
+  buildPlaceableCells,
   buildWallLineFootprint,
   buildWallLineSegments,
   CANVAS_ROOM_ID,
@@ -436,5 +440,84 @@ describe('buildWallLineSegments — real 3D geometry for doc.wallLines', () => {
   it('an empty doc.wallLines produces no segments, cheaply', () => {
     const { doc } = parseDungeon(SHOWCASE_YAML);
     expect(buildWallLineSegments(doc)).toEqual([]);
+  });
+});
+
+// rpg-project#169's creation-3D-editing unit — graduates click-to-place
+// onto creation mode's canvas. `buildPlaceableCells` now branches per-cell
+// on `floorPlan` presence instead of the caller gating the whole array to
+// `[]` without one; these tests cover the NEW creation-mode branch
+// (`floorPlan: undefined`) and pin the existing edit-mode branch's
+// behavior as an explicit regression guard.
+describe('buildPlaceableCells — creation mode (floorPlan: undefined, rpg-project#169)', () => {
+  function creationSetup() {
+    const { cst } = parseDungeon(emptyCanvasYaml(6, 6));
+    // Occupied cell.
+    placeItem(cst, null, 'dnd5e:props:pillar', [2, 2]);
+    // Footprint-blocked cell: the same single-cell fixture
+    // straightWallGeometry.test.ts/canvasFloor.test.ts both use.
+    addWallLine(cst, { cell: [4, 4], corner: 2 }, { cell: [4, 4], corner: 5 });
+    const doc = toDungeonDoc(cst);
+    const floorCells = deriveCanvasFloorCells(doc);
+    const floorTiles = buildFloorTiles(undefined, doc.holes, floorCells);
+    const wallLineFootprint = buildWallLineFootprint(doc);
+    const cells = buildPlaceableCells(
+      undefined,
+      doc,
+      floorTiles,
+      wallLineFootprint
+    );
+    const at = (col: number, row: number) =>
+      cells.find((c) => c.col === col && c.row === row);
+    return { doc, cells, at };
+  }
+
+  it('one PlaceableCell per canvas floor cell (no room-loop gate to skip them)', () => {
+    const { cells } = creationSetup();
+    expect(cells).toHaveLength(6 * 6);
+  });
+
+  it('an occupied cell is occupied + carries a rejectReason', () => {
+    const { at } = creationSetup();
+    const cell = at(2, 2);
+    expect(cell?.occupied).toBe(true);
+    expect(cell?.rejectReason).toBeTruthy();
+  });
+
+  it('a straight-wall-footprint cell is occupied + carries a rejectReason, distinct from an ordinary occupied one', () => {
+    const { at } = creationSetup();
+    const cell = at(4, 4);
+    expect(cell?.occupied).toBe(true);
+    expect(cell?.rejectReason).toBeTruthy();
+    expect(cell?.rejectReason).not.toBe(at(2, 2)?.rejectReason);
+  });
+
+  it('an ordinary empty cell is not occupied and carries no rejectReason', () => {
+    const { at } = creationSetup();
+    const cell = at(0, 0);
+    expect(cell?.occupied).toBe(false);
+    expect(cell?.rejectReason).toBeUndefined();
+  });
+
+  it('every creation-mode cell carries the CANVAS_ROOM_ID sentinel roomId', () => {
+    const { cells } = creationSetup();
+    for (const cell of cells) expect(cell.roomId).toBe(CANVAS_ROOM_ID);
+  });
+});
+
+describe('buildPlaceableCells — edit mode (floorPlan present) stays unchanged', () => {
+  it('occupied is still the plain isCellOccupied result, and rejectReason is always undefined', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const floorTiles = buildFloorTiles(SHOWCASE_FLOORPLAN, doc.holes);
+    const cells = buildPlaceableCells(
+      SHOWCASE_FLOORPLAN,
+      doc,
+      floorTiles,
+      new Set()
+    );
+    expect(cells.length).toBeGreaterThan(0);
+    for (const cell of cells) expect(cell.rejectReason).toBeUndefined();
+    // Real room ids, never the creation-mode sentinel.
+    for (const cell of cells) expect(cell.roomId).not.toBe(CANVAS_ROOM_ID);
   });
 });

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -150,6 +150,7 @@ import {
   isSameSelection,
   wallMountRotationY,
 } from '../boardGeometry';
+import { canvasPlacementRejectReason } from '../creation/canvasFloor';
 import { DEFAULT_CANVAS } from '../creation/emptyCanvasDoc';
 import { cornerPoint, type CornerRef } from '../creation/hexCorner';
 import {
@@ -170,7 +171,7 @@ import {
 import { BOARD_HEX_SIZE, cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
 import { END_COLOR, regionArchetypeColor, START_COLOR } from '../markerStyle';
 import { regionCentroid } from '../regionGeometry';
-import type { PaletteSelection, PlacementSelection } from '../types';
+import type { BoardTool, PaletteSelection, PlacementSelection } from '../types';
 import { PreviewMonsterModel } from './PreviewMonsterModel';
 
 /** A canvas-native floor tile has no owning room ("no room chain exists
@@ -223,13 +224,19 @@ interface DungeonPreview3DProps {
   /** Kirk's 2026-08-02 "3D editing" arc, part 3 — click-to-place. The
    * SAME `PaletteSelection`/`onPlace` contract `Board.tsx` already uses:
    * a palette item selected + a floor hex clicked places it via the
-   * identical `handlePlace` mutator, room-scoped only (Board.tsx's own
-   * click-to-place never produces a top-level placement either). All
-   * three optional together — omitting them (no caller does today, but
-   * nothing structurally requires wiring this) degrades to the
-   * select-and-rotate-only behavior part 2 shipped, unchanged. */
+   * identical `handlePlace` mutator. Room-scoped when `floorPlan` is
+   * present (Board.tsx's own click-to-place never produces a top-level
+   * placement either) — but when `floorPlan` is ABSENT (creation mode's
+   * canvas, rpg-project#169's creation-3D-editing unit), a legal click
+   * calls `onPlace(null, [col, row])` instead: the exact top-level shape
+   * `CreationBoard.tsx`'s own 2D brush already produces via
+   * `edit.handlePlace(null, cell)`. `roomId` is therefore `string | null`,
+   * not just `string` — see `handleClickCell`'s own doc comment for the
+   * full floorPlan-present-vs-absent branch. All three optional
+   * together — omitting them degrades to the select-and-rotate-only
+   * behavior part 2 shipped, unchanged. */
   selectedPalette?: PaletteSelection | null;
-  onPlace?: (roomId: string, at: [number, number]) => void;
+  onPlace?: (roomId: string | null, at: [number, number]) => void;
   onReject?: (message: string) => void;
   /** rpg-project#169's wire-edges unit — a server-truth DOOR edge's
    * `doorId` resolves to a real `FloorPlanConnector` index
@@ -241,6 +248,18 @@ interface DungeonPreview3DProps {
    * it just means a rendered doorway isn't clickable, the gap geometry
    * itself is unaffected either way. */
   onSelectConnector?: (index: number) => void;
+  /** Which 2D-only `BoardTool` (if any) is currently armed — region/wall/
+   * hole/start/end editing stays 2D-only this round
+   * (rpg-project#169's creation-3D-editing unit; see CONTRACT.md).
+   * Purely informational: this component never acts on a tool itself
+   * (there is no 3D geometry-editing surface here), it only uses this to
+   * give an honest reject message — "switch to 2D" — instead of the
+   * generic "pick a palette item first" when a tool (not a palette item)
+   * is the reason nothing is armed for a click. Optional; omitting it
+   * (edit mode's own call site does, since edit mode's tools aren't
+   * creation-canvas-scoped the same way) just falls back to the
+   * pre-existing generic message. */
+  selectedTool?: BoardTool | null;
 }
 
 interface PlacedProp {
@@ -608,7 +627,7 @@ function buildPlacements(
   return { props, monsters };
 }
 
-interface PlaceableCell {
+export interface PlaceableCell {
   key: string;
   col: number;
   row: number;
@@ -616,20 +635,47 @@ interface PlaceableCell {
   worldX: number;
   worldZ: number;
   occupied: boolean;
+  /** Creation-mode only (`floorPlan` absent) — WHY this cell isn't a
+   * legal placement target (`creation/canvasFloor.ts`'s
+   * `canvasPlacementRejectReason`), for `handleClickCell`'s reject toast.
+   * `undefined` for every edit-mode cell (that branch stays SILENT on
+   * `occupied`, matching `Board.tsx`'s own click-to-place precedent
+   * exactly — see `handleClickCell`'s own doc comment) and for any
+   * legally-placeable creation-mode cell. */
+  rejectReason?: string;
 }
 
-/** Click-to-place targets (Kirk's "3D editing" arc, part 3) — one entry
- * per floor tile `buildFloorTiles` already generated, resolved back to
- * (col, row) via `hexColumn`/`hexRow` — the exact inverse of
+/** Click-to-place targets (Kirk's "3D editing" arc, part 3; extended to
+ * creation mode by rpg-project#169's creation-3D-editing unit) — one
+ * entry per floor tile `buildFloorTiles` already generated, resolved back
+ * to (col, row) via `hexColumn`/`hexRow` — the exact inverse of
  * `cubeAtColRow`, so this never re-derives placement math independently
- * of the rest of the concept. Every floor tile already belongs to a real
- * room (`buildFloorTiles` only ever iterates `floorPlan.rooms`), so
- * `roomId` here is always non-null — matches `Board.tsx`'s own click-to-
- * place, which is room-scoped only. */
-function buildPlaceableCells(
-  floorPlan: FloorPlan,
+ * of the rest of the concept.
+ *
+ * `floorPlan` is now OPTIONAL, matching this file's own established
+ * "alternate input path" shape (`buildFloorTiles`'s own doc comment):
+ * every edit-mode floor tile already belongs to a real room
+ * (`buildFloorTiles` only ever iterates `floorPlan.rooms` on that path),
+ * so `roomId` there is a real room id, unchanged; every creation-mode
+ * floor tile carries the `CANVAS_ROOM_ID` sentinel instead (`floorCells`
+ * path) — this function doesn't need to special-case that, it's just
+ * along for the ride in `PlaceableCell.roomId`, unused by the
+ * creation-mode branch of `handleClickCell` below (which places
+ * top-level, `roomId: null`, not room-scoped).
+ *
+ * `occupied`/`rejectReason` are computed differently per mode: edit mode
+ * keeps its original single `isCellOccupied` check (silent on the
+ * click side, see `handleClickCell`); creation mode runs the full shared
+ * `canvasPlacementRejectReason` (footprint AND occupied, with a real
+ * message) since that's the SAME predicate the 2D brush
+ * (`CreationBoard.tsx`) now consults — the two views must never disagree
+ * about where a click is legal. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildPlaceableCells(
+  floorPlan: FloorPlan | undefined,
   doc: DungeonDoc,
-  floorTiles: Map<string, AbsoluteFloorTile>
+  floorTiles: Map<string, AbsoluteFloorTile>,
+  wallLineFootprint: ReadonlySet<string>
 ): PlaceableCell[] {
   const cells: PlaceableCell[] = [];
   for (const tile of floorTiles.values()) {
@@ -637,6 +683,10 @@ function buildPlaceableCells(
     const col = hexColumn(cube);
     const row = hexRow(cube);
     const world = cubeToWorld(cube, HEX_SIZE);
+    const rejectReason = floorPlan
+      ? undefined
+      : (canvasPlacementRejectReason(doc, col, row, wallLineFootprint) ??
+        undefined);
     cells.push({
       key: `${tile.x},${tile.y},${tile.z}`,
       col,
@@ -644,7 +694,10 @@ function buildPlaceableCells(
       roomId: tile.roomId,
       worldX: world.x,
       worldZ: world.z,
-      occupied: isCellOccupied(floorPlan, doc, col, row),
+      occupied: floorPlan
+        ? isCellOccupied(floorPlan, doc, col, row)
+        : rejectReason !== undefined,
+      rejectReason,
     });
   }
   return cells;
@@ -1137,6 +1190,7 @@ export function DungeonPreview3D({
   onPlace,
   onReject,
   onSelectConnector,
+  selectedTool,
 }: DungeonPreview3DProps) {
   const floorTiles = useMemo(
     () => buildFloorTiles(floorPlan, doc.holes, floorCells),
@@ -1181,31 +1235,59 @@ export function DungeonPreview3D({
     () => (floorPlan ? isEntranceBlocked(floorPlan, doc) : false),
     [floorPlan, doc]
   );
-  // Click-to-place (Kirk's "3D editing" arc, part 3) has no creation-mode
-  // analog THIS ROUND either — deliberately out of scope for the
-  // creation-mode 3D preview unit (a follow-up, not a gap: edit-mode's
-  // click-to-place machinery can graduate later). An empty `floorPlan`
-  // check alone is enough to disable it honestly: no `floorPlan` means no
-  // placeable cells, which means no `FloorHitCell`s mount at all, so the
-  // whole interaction surface is simply absent rather than half-wired.
+  // Click-to-place (Kirk's "3D editing" arc, part 3) now covers creation
+  // mode too (rpg-project#169's creation-3D-editing unit) — `floorPlan`
+  // presence still decides WHICH legality rule applies (room-scoped vs.
+  // top-level canvas), but `placeableCells` is no longer gated to "empty
+  // without floorPlan": `floorTiles` already carries the right cell set
+  // for either mode (`buildFloorTiles`'s own doc comment), and
+  // `buildPlaceableCells` now branches internally per-cell instead of the
+  // caller branching on the whole set.
   const placeableCells = useMemo(
-    () => (floorPlan ? buildPlaceableCells(floorPlan, doc, floorTiles) : []),
-    [floorPlan, doc, floorTiles]
+    () => buildPlaceableCells(floorPlan, doc, floorTiles, wallLineFootprint),
+    [floorPlan, doc, floorTiles, wallLineFootprint]
   );
   const hitShape = useMemo(() => buildHexHitShape(), []);
 
-  // Mirrors Board.tsx's own click-to-place cell handler almost exactly
-  // (same messages, same boss/occupied rules) — see this file's header
-  // doc comment for why click-to-place is room-scoped only. `floorPlan`
-  // is guaranteed non-null here in practice (`placeableCells` above is
-  // empty without it, so no `FloorHitCell` exists to call this) — the
-  // explicit guard just keeps this honestly typed.
+  // Mirrors Board.tsx's own click-to-place cell handler for the edit-mode
+  // (floorPlan present) branch — same messages, same boss/occupied rules,
+  // still silent on `occupied` there (no toast, matching Board.tsx's own
+  // click-to-place precedent exactly — `if (occupied) return;`).
+  //
+  // The `!floorPlan` branch (creation mode's from-scratch canvas, this
+  // unit) is a genuinely different placement shape: TOP-LEVEL
+  // (`roomId: null`, absolute `[col, row]`, no room to resolve a
+  // room-local column against) — the exact shape `CreationBoard.tsx`'s
+  // own 2D brush already produces via `edit.handlePlace(null, cell)`.
+  // Legality is `cell.rejectReason` (already resolved by
+  // `buildPlaceableCells` via the SAME `canvasPlacementRejectReason` the
+  // 2D brush now consults), not a fresh room/door-row lookup — there is
+  // no room chain or door row on a canvas to check against.
   const handleClickCell = (cell: PlaceableCell) => {
-    if (!floorPlan) return;
     if (!selectedPalette || !onPlace) {
       onReject?.(
-        'Pick a palette item first, then click an empty cell to place it.'
+        selectedTool
+          ? 'That tool is 2D-only for now — switch to the 2D board to use it, or pick a palette item to place something here.'
+          : 'Pick a palette item first, then click an empty cell to place it.'
       );
+      return;
+    }
+    if (!floorPlan) {
+      // Boss stays room-scoped even in the target dialect (dungeonspec's
+      // validateBossCardinality needs an owning archetype:boss room) — a
+      // from-scratch canvas has zero rooms, same guard
+      // `CreationBoard.tsx`'s own 2D click handler makes.
+      if (selectedPalette.kind === 'boss') {
+        onReject?.(
+          'Boss stays room-scoped — this canvas has no rooms yet to hold one (see TARGET-YAML.md).'
+        );
+        return;
+      }
+      if (cell.rejectReason) {
+        onReject?.(cell.rejectReason);
+        return;
+      }
+      onPlace(null, [cell.col, cell.row]);
       return;
     }
     // The connector-band fix above (`buildFloorTiles`) gives the door its


### PR DESCRIPTION
## Summary

Graduates edit-mode's existing 3D click-to-place/select machinery onto creation mode's from-scratch canvas, closing the "read-only this round" follow-up the creation-mode-3D-preview unit named. Kirk's own framing: "I cannot place in 3D but if I had a statue selected in 2D I can rotate it and see it in 3D."

- **Place** via a 3D click on a canvas floor hex (top-level, `roomId: null`, absolute coords) — the same shape the 2D brush already produces.
- **Select** a placed prop/monster by clicking its own mesh in 3D — opens the shared Inspector (same selection state as 2D).
- **Rotate** via the Inspector's existing facing control while watching the live 3D view.
- **Delete** with the Delete key.
- **Region/wall/hole/start/end tools stay 2D-only** this round — an armed tool clicked in 3D now gets an honest "switch to 2D" reject instead of the generic "pick a palette item" message.
- **Drag-move in 3D stays deferred** — edit mode itself has no 3D drag-move machinery yet to graduate from (unchanged from the prior unit's own framing).

## Two real, pre-existing bugs found and fixed at the root

1. **2D creation's own click-to-place had zero legality checking.** Reading `CreationBoard.tsx` before touching anything: its palette-click branch called `edit.handlePlace(null, cell)` with no occupied/footprint/hole check at all — a click could silently stack a placement on an existing one, inside a straight wall's footprint, or on a hole. New `canvasPlacementRejectReason` (`creation/canvasFloor.ts`) is the ONE predicate both the 2D brush and the 3D click-to-place layer now consult, so the two views can never disagree about where a click is legal.
2. **The global Delete-key listener was edit-mode only.** `DungeonBuilderConcept.tsx`'s keydown handler only ever read edit mode's own `useBoardEditing` instance — creation mode's separate instance (`creationEdit`) was never wired in, so Delete/Backspace never removed a creation-mode placement in either view (only the Inspector's own delete button worked). Found while verifying the brief's own "should already be view-agnostic" claim for Delete-key parity. Fixed by gating the listener on which mode's tab is active.

## Tests

17 new (324 dungeon-builder tests overall, up from 307):
- 7 in `creation/canvasFloor.test.ts` — `canvasPlacementRejectReason`'s three gates (bounds/hole, footprint, occupied), gate ordering, and a real `addWallLine` integration case.
- 4 in `boardGeometry.test.ts` — `isCellOccupied` had zero prior test coverage; now covers the `floorPlan: undefined` path this unit adds.
- 6 in `preview3d/DungeonPreview3D.test.ts` — `buildPlaceableCells`'s new creation-mode branch, plus an edit-mode regression guard pinning the existing behavior unchanged.

## Live verification

Own dev server (`vite --port 5199`, never `:3001`), own throwaway Playwright Chromium (not the shared chrome-devtools MCP browser, which collides across concurrent agents). Real end-to-end loop on a 3×3 New Dungeon canvas, driven by genuine mouse events at real screen coordinates:

- **Place**: palette "pillar" selected, 3D floor hex clicked — `place:` gained a real top-level entry, pillar rendered standing on the canvas.
- **Occupied-cell reject**: the same cell clicked again — toast "That cell already holds a placement.", no duplicate.
- **Select**: clicking the placed pillar's own mesh opened the Inspector showing `dnd5e:props:pillar [0,1]` with its full control set.
- **Rotate**: two Inspector ↻ clicks while watching 3D — `place:` gained `facing: NW`, pillar visibly reoriented.
- **Delete**: Delete key — `place: []`, pillar gone from 3D.
- **Banner text**: confirmed live — no longer says "Read-only this round."

Screenshots: `docs/evidence/dungeon-builder-creation-3d-*.png` (gitignored, not part of this diff — referenced from CONTRACT.md same as every prior round).

**Named honestly, not silently claimed as covered**: the `selectedTool`-armed reject message's own live click hit Playwright-specific accordion-toggle flakiness unrelated to this unit's code (the pre-existing Palette accordion, not something this PR touches). Confidence instead comes from direct code review (a one-line ternary sibling to the branch that WAS live-verified) plus `ci-check` green.

`ci-check` clean (format/lint/typecheck/build/test) — confirmed again by the pre-push hook.

— asset-pipeline agent, on behalf of KirkDiggler