### PR TITLE
unit: region panel renders the scopes tree (root row + derived containment)

### DIFF
--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -38,6 +38,7 @@ import {
 } from './markerStyle';
 import { PlacementMarker } from './PlacementMarker';
 import { regionCentroid } from './regionGeometry';
+import { regionsByPaintOrder } from './regionTree';
 import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 
 interface BoardProps {
@@ -422,7 +423,10 @@ export function Board({
   // handlers, `pointerEvents="none"` throughout, same as the wall/hole
   // overlay above. Same `regionArchetypeColor` the interactive creation
   // board uses, so a region reads as the same archetype in both boards.
-  for (const region of doc.regions) {
+  // Painted biggest-first (`regionsByPaintOrder` above) so a nested
+  // region's overlay draws on top of its container's, "innermost
+  // visible" — see that function's own doc comment.
+  for (const region of regionsByPaintOrder(doc.regions)) {
     const color = regionArchetypeColor(region.archetype);
     for (const [col, row] of region.cells) {
       trackCellExtent(col, row);

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4902,3 +4902,204 @@ canvas sentinel). `ci-check` clean (format/lint/typecheck/build/test).
   under Live verification — code-reviewed and its sibling branch
   live-verified, not independently live-clicked, due to automation flakiness
   in the pre-existing accordion control, not this unit's own code.
+
+## Region tree unit: `RegionPanel` renders the derived scopes model, root row and all (2026-08-04, rpg-project#180)
+
+Platform settled a model refinement on #180 across four consumer-position
+comments the same day (issue comments `5183646492`, `5183689311`,
+`5183885326`, `5184744940` — "the runtime landing strip already exists"):
+**regions are scopes**. Four rules, in order of dependency:
+
+1. **Implicit root region.** Every cell belongs to exactly one region;
+   unpainted floor belongs to the implicit generic/root region — the model
+   is total, no "regionless" special case.
+2. **Nesting is strict containment ONLY**, resolved innermost-wins, like
+   lexical scopes. Venn/partial overlap remains forbidden.
+3. **The YAML stays flat — nesting is derived, never written.** A region is
+   inside another because its cells are a strict SUBSET of the outer
+   region's own declared `cells:` (the outer region's list literally
+   includes the inner one's cells). No `parent:` field, ever.
+4. **Containment forms chains.** Because overlap is allowed only by
+   containment, any two regions sharing a cell must be nested, hence
+   comparable — the parent of a region is its unique smallest strict
+   superset.
+
+This unit is the region panel's half of that model: render the SCOPES the
+document actually describes, not a flat list, with the implicit root as a
+real, honest row.
+
+### `regionTree.ts` — the derivation, kept pure and dialect-independent
+
+New `regionTree.ts`, sibling to `regionGeometry.ts` and following the SAME
+discipline that file's own header comment states: no dependency on
+`DungeonDoc`/`RegionDoc`, every function takes a plain `RegionLike[]`
+(`{id, name?, archetype, cells}`), so both boards and `dungeonYaml.ts` can
+import it without a cycle, and it's unit-testable without a CST document.
+
+- **`buildRegionTree(regions)`** — the containment forest. For every pair,
+  compares cell-set sizes against the shared-cell count to classify the
+  relationship as disjoint / strict-subset-either-way / overlap in one
+  formula (`relate`), rather than three separate subset checks. Parent =
+  the ancestor candidate with the SMALLEST cell count (tightest fit) —
+  verified by a test where a region has TWO valid ancestors of different
+  sizes (a tight inner chamber and a much bigger outer wing) and the tight
+  one wins, not the first one found. Depth 1 = a direct child of the
+  implicit root (root itself is depth 0 and uninstantiated — it has no
+  `RegionLike` to hold); a flat, un-nested document — everything the brush
+  can author today — puts every region at depth 1, which is the model's own
+  one-level forest, not a degraded case.
+- **`RegionOverlapWarning`** — two regions that share cells with NEITHER a
+  strict subset of the other (a true Venn overlap, or even two regions
+  painted onto the identical cell set — same-size-same-cells doesn't count
+  as containment either, since containment requires a genuine size
+  difference). Carries a capped cell sample (`OVERLAP_SAMPLE_CELLS = 6`)
+  plus the true count, for an author-facing "these don't nest" message.
+- **`flattenRegionTree(tree)`** — pre-order (parent-immediately-before-
+  children) flatten, the natural render order for an indented list.
+- **`rootCellCount(totalFloorCells, regions)`** — the implicit root's own
+  cell count: `totalFloorCells` minus every cell claimed by ANY region at
+  ANY depth (unions everything rather than just top-level regions, so it
+  stays correct even for a malformed/warned document where the "child
+  cells are always a literal subset of the parent's declared list"
+  invariant doesn't hold). **Floor-source-agnostic on purpose**: "the
+  floor" means something different for creation mode's canvas
+  (`creation/canvasFloor.ts`'s `deriveCanvasFloorCells` — the canvas
+  grid's bounds minus holes, what `RegionPanel.tsx` feeds it this round)
+  than for a compiled/edit-mode document (the server-generated
+  `FloorPlan`'s room geometry). Only creation mode has a regions panel to
+  show a root row in **this round** — edit mode's `Board.tsx` renders
+  authored regions read-only with no panel at all (unchanged) — so the
+  compiled-doc case has no consumer yet; the function doesn't hardcode
+  canvas assumptions so an edit-mode consumer can reuse it later without
+  this module needing to know about `FloorPlan`.
+- **`regionsByPaintOrder(regions)`** — biggest-cell-count-first sort, used
+  by BOTH boards' read-only/interactive region overlays (below), kept here
+  rather than duplicated because it's the same "regions are scopes" size
+  reasoning: a child's cell count is always less than its parent's.
+
+### `RegionPanel.tsx` — the tree, root row first
+
+The panel's "nothing pending/selected" branch (`CreationBoard.tsx`'s Region
+tool with no in-progress gesture) used to `doc.regions.map` a flat list, and
+returned `null` outright when `doc.regions.length === 0` ("nothing useful to
+list"). Now:
+
+- **Renders even at zero authored regions** — the root row alone, holding
+  the whole canvas floor. Picking up the Region tool now immediately shows
+  the total-coverage model before anything is painted, rather than only
+  becoming honest once a first region exists.
+- **Root row**: `(everything else)` + `rootCellCount(deriveCanvasFloorCells(doc), doc.regions)`,
+  dashed border, muted italic styling, `cursor: default` — informational
+  only this round, not selectable (nothing to edit on it yet; noted in the
+  row's own `title` tooltip as a future home for root-scope defaults).
+- **Real regions**: `flattenRegionTree(buildRegionTree(doc.regions))`,
+  indented `(depth - 1) * 14px` per row — a flat document (every region at
+  depth 1) renders with zero extra indent, unchanged from before; a nested
+  document indents each level under its parent. Click-to-select, the
+  editing hint, and the connect callout are untouched — same
+  `regionEdit`/`selectRegion` wiring as before, just fed the tree's flat
+  render order instead of `doc.regions` directly.
+- **Overlap warnings**: a red banner (same error palette this panel's own
+  id-validation messages already use — `#ff9a8a` on `#2a1512`) above the
+  list, one line per `RegionOverlapWarning`, naming both regions by
+  name-or-id, the cell count, a capped cell sample, and citing #180's
+  containment rule.
+
+### Board overlay ordering: authoring order was accidental, paint order now isn't
+
+`Board.tsx` (edit mode, read-only) and `CreationBoard.tsx` (creation mode,
+interactive) both iterated `doc.regions` in raw array/declaration order for
+their tinted-hex overlays — for a NESTED document, this only drew the inner
+region on top of the outer one if the author happened to declare outer
+before inner in the YAML. No nested document exists in the wild yet
+(shipped `validateRegionCells` is still flat non-overlap — see the dialect
+note below), but a hand-typed one pasted into the YAML pane shouldn't
+depend on declaration order to render sanely, and the brief asked this to
+be checked and fixed cheaply if it wasn't. Both loops now iterate
+`regionsByPaintOrder(doc.regions)` instead — biggest cell count first —
+so a nested region's tint always lands on top of its container's without
+either renderer needing to compute the actual containment forest just to
+get paint order right.
+
+**Proven, not assumed**: a direct DOM check (Playwright `evaluate`, not
+just a screenshot) against a doc authored with regions declared
+INNERMOST-FIRST — `reliquary` (1 cell, boss/red) before `vault` (3 cells)
+before `crypt` (6 cells, chamber/green), the reverse of "natural" order —
+confirms three overlapping polygons stack at the shared cell in DOM order
+`crypt (green) → vault (green) → reliquary (red)`, i.e. paint order tracks
+cell-count, not declaration order; the red boss region is topmost despite
+being declared first. Screenshot:
+`docs/evidence/dungeon-builder-region-tree-paint-order-proof.png`.
+
+### Dialect note: today's ceiling is a one-level forest, by construction
+
+The interactive brush still can't paint a nested region — `validateRegionCells`
+(`dungeonYaml.ts`) rejects ANY shared cell, containment included, unchanged
+by this unit (out of scope per the brief: "no nested-painting authoring, no
+validation-rule changes"). So every document the creation board itself can
+currently produce is a flat one-level forest — `buildRegionTree` handles
+arbitrary depth regardless, so it renders correctly the day validation
+allows painting a nested region, and renders a hand-edited YAML document
+(pasted into the YAML pane) that already nests today, since the PARSER
+doesn't enforce non-overlap, only the brush's mutators do.
+
+### Live verification
+
+Real dev server (`vite --port 5183` — never `:3001`), Playwright driving the
+actual hex-true board (own coordinate math replicated from
+`hooks/wallRuns.ts`'s `cubeAtColRow` + `hex-grid/hexMath.ts`'s `cubeToWorld`,
+since the board has no per-cell DOM click target — a single SVG-level
+pointer handler resolves clicks from world position, same reason
+`creationGeometry.ts`'s own header comment gives).
+
+1. **Region tool armed, zero regions painted** — root row alone,
+   `(everything else) 600` (the full 20×30 default canvas).
+   `docs/evidence/dungeon-builder-region-tree-root-only.png`.
+2. **One real region painted** (`north-alcove`, 4 cells) — root row updates
+   to `596`, region listed below at depth 1.
+   `docs/evidence/dungeon-builder-region-tree-flat-one-region.png`.
+3. **Hand-pasted nested chain** (crypt ⊃ vault ⊃ reliquary, 6/3/1 cells) —
+   root row `594` (600 − 6, unioned not double-subtracted), three rows
+   visibly step-indented one level deeper each.
+   `docs/evidence/dungeon-builder-region-tree-nested-chain.png`.
+4. **Hand-pasted Venn overlap** (`room-a`/`room-b`, 2 shared cells, neither
+   a subset) — red warning banner naming both regions + the 2 shared cells,
+   both regions listed as flat siblings (not nested — an invalid pair has
+   no containment relationship to place one under the other).
+   `docs/evidence/dungeon-builder-region-tree-venn-warning.png`.
+5. **Reverse-declaration-order paint-order proof** — above.
+
+No console errors beyond the two established FIXTURES-MODE `[unimplemented]
+unknown service ...AuthoringService` messages every prior round's
+live-verification section already carries.
+
+### Tests
+
+16 new in `regionTree.test.ts` (340 dungeon-builder tests overall, up from
+324): flat forest (every region depth 1, any authoring order, including
+single-region and zero-region edges); nested chain 3 deep; parent-is-
+smallest-superset-not-just-any-ancestor (the tight-vs-wide-outer-region
+case above); multi-child siblings under one parent; partial-overlap
+detection (a genuine Venn pair, two regions on identical cells, sample
+capping with a true count above the cap, disjoint regions producing no
+warning); `flattenRegionTree` pre-order ordering; `rootCellCount` (empty
+floor math, single-region subtraction, union-not-double-subtract for a
+nested pair, fully-covered-floor zero case). `ci-check` clean
+(format/lint/typecheck/build/test).
+
+### What did NOT ship this round — named, not silently dropped
+
+- **Nested-region authoring via the brush.** Out of scope by the brief —
+  this unit is rendering + detection, not enabling nested painting.
+  `validateRegionCells` is untouched.
+- **Any validation-rule change.** The client-side flat non-overlap rule
+  stays exactly as strict as before; this unit only renders/derives from
+  whatever a document (brush-authored or hand-typed) already contains.
+- **Root-scope defaults.** The root row's own `title` names it as a future
+  home for defaults (audio/lighting/etc. per the "regions are scopes"
+  resolution-order comment) — nothing implements that yet; the row is
+  informational only.
+- **Edit-mode root row.** `Board.tsx` has no regions panel at all (unchanged
+  from before this unit) — `rootCellCount`'s floor-source-agnostic design
+  means it's ready to be fed a compiled `FloorPlan`'s cell set whenever
+  edit mode grows one, but nothing wires that up this round.

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -1460,6 +1460,62 @@ recorded here rather than silently decided, same discipline
   region's cells changes movement/line-of-sight only; the region's own
   `cells:` membership is untouched by any wall mutator.
 
+### Regions are scopes (2026-08-04 model refinement, rpg-project#180) — landed as read-only tree rendering this round
+
+Platform settled a refinement of the model above across four
+consumer-position comments on #180 the same day (issue comments
+`5183646492`, `5183689311`, `5183885326`, `5184744940`). This supersedes
+parts of "Open questions" above — recorded here as a dated refinement, not
+by silently rewriting what was previously true-as-written:
+
+1. **An implicit root region replaces "regionless."** Refines the prior
+   "Must regions fully tile?" answer above: rather than unclaimed floor
+   having no region, EVERY cell belongs to exactly one region — unpainted
+   floor belongs to the implicit generic/root region. The model is now
+   total, no "regionless" special case in any future semantic. Runtime
+   behavior is unchanged (unclaimed cells still fall back to space-level
+   defaults) — only the framing is: "the root region's defaults," not
+   "no region at all." The "sparse, disjoint regions are allowed" claim
+   above is still true for AUTHORED regions specifically — they need not
+   tile the space — it's just that the gaps between them now have a name.
+2. **Regions may nest, by strict containment ONLY, resolved
+   innermost-wins** — like lexical scopes. This refines "Non-overlapping"
+   above: overlap remains forbidden EXCEPT strict containment (Venn/partial
+   overlap stays invalid either way). A cell's semantics resolve through
+   the innermost containing region; names compose ("the Vault, in the
+   Crypt"). The shipped flat model (every region a direct child of the
+   implicit root) is exactly one level of this — nesting extends it
+   without breaking any existing document.
+3. **Nesting is DERIVED from cell-subset relationships, never written** —
+   no `parent:` field, ever. A region is inside another because its cells
+   are a strict SUBSET of the outer region's own declared `cells:` (the
+   outer region's list literally includes the inner one's). Because
+   overlap is allowed only by containment, any two regions sharing a cell
+   must be nested, hence comparable — the parent of a region is its unique
+   smallest strict superset (none exists means the implicit root).
+4. **Authored region ids compile to the runtime's existing zone ids** — no
+   new runtime concept. `encounter/data.go`'s `SpaceData.Regions`
+   (`ID`/`Hexes`/`Archetype`, the same `entrance|chamber|corridor|boss`
+   vocabulary `RoomDoc.archetype` already uses) and the perception layer's
+   per-hex `ZoneID` stamp already exist server-side; #180 is authors
+   painting more of them, including nested ones, onto the same structure
+   that already drives fog, spawn seeding, and door naming today.
+
+**Landed this round (region-tree unit, rpg-project#180)**: `RegionPanel.tsx`
+renders this model truthfully — the derived containment forest
+(`regionTree.ts`'s `buildRegionTree`, parent = smallest strict superset by
+cell-subset check) with the implicit root as a real row (`(everything
+else)`, cell count = canvas floor cells minus every claimed cell at any
+depth), children indented under parents, and a partial-overlap warning for
+any Venn pair a hand-edited document might contain. **Not landed**: nested
+authoring via the brush (`validateRegionCells` is unchanged — still flat
+non-overlap, so the interactive tool can only ever produce a one-level
+forest); the compiler-side derivation (still platform's call, per every one
+of the four comments above); root-scope defaults (the root row is
+informational only — a noted future home, nothing implements it). See
+CONTRACT.md's "Region tree unit" section for the full implementation
+writeup, tests, and live-verification evidence.
+
 ### Region attachment vs. chain `connectors:` — deliberately distinct constructs
 
 "Attach to the next region" (Kirk's ask) is implemented as placing a DOOR

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -71,6 +71,7 @@ import {
 } from '../markerStyle';
 import { PlacementMarker } from '../PlacementMarker';
 import { regionCentroid } from '../regionGeometry';
+import { regionsByPaintOrder } from '../regionTree';
 import type { BoardTool, PlacementSelection } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import { canvasPlacementRejectReason } from './canvasFloor';
@@ -1294,9 +1295,11 @@ export function CreationBoard({
   // the board's own `handlePointerDown` already resolves "was an existing
   // region clicked" via `nearestCreationCell` + a `doc.regions` scan, so
   // these elements are purely visual, not a second independent hit-test
-  // surface.
+  // surface. Painted biggest-first (`regionsByPaintOrder`, shared with
+  // `Board.tsx`'s read-only overlay) so a nested region's overlay draws
+  // on top of its container's, "innermost visible."
   const regionEls: ReactElement[] = [];
-  for (const region of doc.regions) {
+  for (const region of regionsByPaintOrder(doc.regions)) {
     const color = regionArchetypeColor(region.archetype);
     const selected = regionEdit.selectedRegionId === region.id;
     for (const [col, row] of region.cells) {

--- a/src/concepts/dungeon-builder/creation/RegionPanel.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.tsx
@@ -11,6 +11,12 @@
 import { useEffect, useRef, useState } from 'react';
 import type { DungeonDoc } from '../dungeonYaml';
 import { sharedBoundaryEdges } from '../regionGeometry';
+import {
+  buildRegionTree,
+  flattenRegionTree,
+  rootCellCount,
+} from '../regionTree';
+import { deriveCanvasFloorCells } from './canvasFloor';
 import type { RegionEditing } from './useRegionEditing';
 
 const ARCHETYPE_OPTIONS = ['entrance', 'chamber', 'corridor', 'boss'];
@@ -161,10 +167,25 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
   // since this panel used to render nothing at all here. A compact list
   // of every existing region, click-to-select, fixes that without
   // requiring the author to already know to click precisely on the
-  // board. Truly empty (no regions drawn yet either) still renders
-  // nothing — there's nothing useful to list. ---
+  // board.
+  //
+  // Renders the SCOPES MODEL (rpg-project#180's four consumer-position
+  // comments, 2026-08-04), not a flat list: the implicit root region
+  // ("(everything else)" — every canvas floor cell not claimed by an
+  // authored region) as a real, always-present row, then every authored
+  // region indented under its derived parent (smallest strict superset by
+  // cell-subset check — `regionTree.ts`). A flat, un-nested document
+  // (everything the brush can author today) puts every region directly
+  // under the root at depth 1 — this is NOT a degraded case, it's the
+  // model's own one-level forest. Shown even with zero authored regions
+  // (root alone, holding the whole floor) so picking up the Region tool
+  // immediately shows the total-coverage model before anything is
+  // painted, rather than only becoming honest once a first region exists. ---
   if (pendingCells.length === 0 && !editingRegion && !showConnectCallout) {
-    if (doc.regions.length === 0) return null;
+    const floorCells = deriveCanvasFloorCells(doc);
+    const tree = buildRegionTree(doc.regions);
+    const rootCount = rootCellCount(floorCells, doc.regions);
+    const rows = flattenRegionTree(tree);
     return (
       <div role="dialog" aria-label="Regions" style={panelStyle}>
         <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
@@ -173,14 +194,68 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
         <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
           Click a region to edit it, or paint new board cells to start another.
         </div>
+        {tree.overlaps.length > 0 && (
+          <div
+            style={{
+              fontSize: 10,
+              color: '#ff9a8a',
+              background: '#2a1512',
+              border: '1px solid #5a2a20',
+              borderRadius: 4,
+              padding: '5px 8px',
+              marginBottom: 8,
+              lineHeight: 1.4,
+            }}
+          >
+            {tree.overlaps.map((o) => {
+              const a = doc.regions.find((r) => r.id === o.regionAId);
+              const b = doc.regions.find((r) => r.id === o.regionBId);
+              const sample = o.cells.map(([c, r]) => `[${c},${r}]`).join(', ');
+              const more = o.cellCount > o.cells.length;
+              return (
+                <div key={`${o.regionAId}-${o.regionBId}`}>
+                  ⚠ "{a?.name ?? o.regionAId}" and "{b?.name ?? o.regionBId}"
+                  overlap without either containing the other ({o.cellCount}{' '}
+                  cell{o.cellCount === 1 ? '' : 's'}: {sample}
+                  {more ? ', …' : ''}) — nesting requires strict containment
+                  (rpg-project#180).
+                </div>
+              );
+            })}
+          </div>
+        )}
         <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-          {doc.regions.map((r) => (
+          <li style={{ marginBottom: 4 }}>
+            <div
+              title="Unpainted floor — every cell not claimed by an authored region belongs to the implicit root region (rpg-project#180). Informational only this round; a future home for root-scope defaults."
+              style={{
+                ...buttonStyle,
+                width: '100%',
+                boxSizing: 'border-box',
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: 8,
+                background: 'transparent',
+                color: '#8a7a5a',
+                border: '1px dashed var(--border-primary)',
+                fontWeight: 400,
+                fontStyle: 'italic',
+                cursor: 'default',
+              }}
+            >
+              <span>(everything else)</span>
+              <span>{rootCount}</span>
+            </div>
+          </li>
+          {rows.map(({ region: r, depth }) => (
             <li key={r.id} style={{ marginBottom: 4 }}>
               <button
                 onClick={() => selectRegion(r.id)}
                 style={{
                   ...buttonStyle,
-                  width: '100%',
+                  width: `calc(100% - ${(depth - 1) * 14}px)`,
+                  marginLeft: (depth - 1) * 14,
+                  boxSizing: 'border-box',
                   display: 'flex',
                   justifyContent: 'space-between',
                   gap: 8,

--- a/src/concepts/dungeon-builder/regionTree.test.ts
+++ b/src/concepts/dungeon-builder/regionTree.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRegionTree,
+  flattenRegionTree,
+  rootCellCount,
+  type RegionLike,
+} from './regionTree';
+
+function region(
+  id: string,
+  cells: [number, number][],
+  archetype = 'chamber'
+): RegionLike {
+  return { id, archetype, cells };
+}
+
+describe('buildRegionTree — flat forest (shipped dialect: no nesting authorable yet)', () => {
+  it('puts every region at depth 1 with no children, any authoring order', () => {
+    const regions = [
+      region('north-alcove', [
+        [0, 0],
+        [1, 0],
+      ]),
+      region('east-annex', [
+        [5, 5],
+        [5, 6],
+      ]),
+      region('vault', [[10, 10]]),
+    ];
+    const tree = buildRegionTree(regions);
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(3);
+    for (const root of tree.roots) {
+      expect(root.depth).toBe(1);
+      expect(root.children).toEqual([]);
+    }
+    expect(tree.roots.map((r) => r.region.id).sort()).toEqual([
+      'east-annex',
+      'north-alcove',
+      'vault',
+    ]);
+  });
+
+  it('a single region alone is a single root, no overlaps', () => {
+    const regions = [region('only', [[0, 0]])];
+    const tree = buildRegionTree(regions);
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].depth).toBe(1);
+    expect(tree.overlaps).toEqual([]);
+  });
+
+  it('no regions at all is an empty forest', () => {
+    const tree = buildRegionTree([]);
+    expect(tree.roots).toEqual([]);
+    expect(tree.overlaps).toEqual([]);
+  });
+});
+
+describe('buildRegionTree — nested chain (hand-authored YAML; not paintable via the brush yet)', () => {
+  it('crypt ⊃ vault ⊃ reliquary nests three deep, innermost as a leaf', () => {
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ]);
+    const vault = region('vault', [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+    ]);
+    const reliquary = region('reliquary', [[0, 0]]);
+    const tree = buildRegionTree([crypt, vault, reliquary]);
+
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(1);
+    const cryptNode = tree.roots[0];
+    expect(cryptNode.region.id).toBe('crypt');
+    expect(cryptNode.depth).toBe(1);
+    expect(cryptNode.children).toHaveLength(1);
+
+    const vaultNode = cryptNode.children[0];
+    expect(vaultNode.region.id).toBe('vault');
+    expect(vaultNode.depth).toBe(2);
+    expect(vaultNode.children).toHaveLength(1);
+
+    const reliquaryNode = vaultNode.children[0];
+    expect(reliquaryNode.region.id).toBe('reliquary');
+    expect(reliquaryNode.depth).toBe(3);
+    expect(reliquaryNode.children).toEqual([]);
+  });
+
+  it('parent is the SMALLEST strict superset, not just any containing region', () => {
+    // crypt is the big chamber; vault is the tight nested subset. A third
+    // region, "wing", is a superset of crypt too (an even bigger outer
+    // area) — vault's parent must resolve to crypt (the tighter fit), not
+    // wing, even though wing also strictly contains vault transitively.
+    const wing = region('wing', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [3, 0],
+      [3, 1],
+    ]);
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ]);
+    const vault = region('vault', [
+      [0, 0],
+      [1, 0],
+    ]);
+    const tree = buildRegionTree([wing, crypt, vault]);
+    expect(tree.overlaps).toEqual([]);
+
+    const wingNode = tree.roots.find((r) => r.region.id === 'wing')!;
+    expect(wingNode.depth).toBe(1);
+    expect(wingNode.children.map((c) => c.region.id)).toEqual(['crypt']);
+
+    const cryptNode = wingNode.children[0];
+    expect(cryptNode.depth).toBe(2);
+    expect(cryptNode.children.map((c) => c.region.id)).toEqual(['vault']);
+
+    const vaultNode = cryptNode.children[0];
+    expect(vaultNode.depth).toBe(3);
+  });
+});
+
+describe('buildRegionTree — multi-child (siblings under one parent)', () => {
+  it('two disjoint inner regions both nest directly under the same outer one', () => {
+    const hall = region('hall', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+    ]);
+    const innerLeft = region('inner-left', [[0, 0]]);
+    const innerRight = region('inner-right', [[4, 0]]);
+    const tree = buildRegionTree([hall, innerLeft, innerRight]);
+
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(1);
+    const hallNode = tree.roots[0];
+    expect(hallNode.region.id).toBe('hall');
+    expect(hallNode.children).toHaveLength(2);
+    expect(hallNode.children.map((c) => c.region.id).sort()).toEqual([
+      'inner-left',
+      'inner-right',
+    ]);
+    for (const child of hallNode.children) {
+      expect(child.depth).toBe(2);
+      expect(child.children).toEqual([]);
+    }
+  });
+});
+
+describe('buildRegionTree — partial-overlap detection (Venn, forbidden by the settled model)', () => {
+  it('flags two regions sharing cells with neither a strict subset of the other', () => {
+    const a = region('room-a', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+    ]);
+    const b = region('room-b', [
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ]);
+    const tree = buildRegionTree([a, b]);
+
+    // Neither region nests — both fall out as roots, since an invalid
+    // Venn pair has no containment relationship to place one under the
+    // other.
+    expect(tree.roots).toHaveLength(2);
+    expect(tree.overlaps).toHaveLength(1);
+    const warning = tree.overlaps[0];
+    expect([warning.regionAId, warning.regionBId].sort()).toEqual([
+      'room-a',
+      'room-b',
+    ]);
+    expect(warning.cellCount).toBe(2);
+    expect(warning.cells).toEqual(
+      expect.arrayContaining([
+        [1, 0],
+        [2, 0],
+      ])
+    );
+  });
+
+  it('flags two regions painted onto the exact same cells (no genuine containment either way)', () => {
+    const a = region('dup-a', [
+      [5, 5],
+      [6, 5],
+    ]);
+    const b = region('dup-b', [
+      [5, 5],
+      [6, 5],
+    ]);
+    const tree = buildRegionTree([a, b]);
+    expect(tree.overlaps).toHaveLength(1);
+    expect(tree.overlaps[0].cellCount).toBe(2);
+    // Neither is placed under the other — both surface as roots alongside
+    // the warning, not silently nested.
+    expect(tree.roots).toHaveLength(2);
+  });
+
+  it('caps the sample cells but reports the true count', () => {
+    const big1: [number, number][] = [];
+    const big2: [number, number][] = [];
+    for (let i = 0; i < 10; i++) {
+      big1.push([i, 0]);
+      big2.push([i, 1]); // no overlap on this row
+    }
+    // Force a real 8-cell overlap with leftovers on both sides so it's a
+    // genuine Venn case, not containment.
+    const a = region('wide-a', [...big1, [0, 5], [1, 5]]);
+    const b = region('wide-b', [...big1, [0, 6], [1, 6]]);
+    const tree = buildRegionTree([a, b]);
+    expect(tree.overlaps).toHaveLength(1);
+    expect(tree.overlaps[0].cellCount).toBe(10);
+    expect(tree.overlaps[0].cells.length).toBe(6); // OVERLAP_SAMPLE_CELLS cap
+  });
+
+  it('leaves disjoint regions with no warning and no containment relation', () => {
+    const a = region('far-a', [[0, 0]]);
+    const b = region('far-b', [[50, 50]]);
+    const tree = buildRegionTree([a, b]);
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(2);
+  });
+});
+
+describe('flattenRegionTree', () => {
+  it('is pre-order (parent immediately before its children)', () => {
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+    ]);
+    const vault = region('vault', [[0, 0]]);
+    const otherRoot = region('other', [[9, 9]]);
+    const tree = buildRegionTree([otherRoot, crypt, vault]);
+    const flat = flattenRegionTree(tree);
+    const ids = flat.map((n) => n.region.id);
+    const cryptIdx = ids.indexOf('crypt');
+    const vaultIdx = ids.indexOf('vault');
+    expect(cryptIdx).toBeGreaterThanOrEqual(0);
+    expect(vaultIdx).toBe(cryptIdx + 1);
+  });
+
+  it('flattens a flat 3-region document into 3 depth-1 entries', () => {
+    const regions = [
+      region('a', [[0, 0]]),
+      region('b', [[1, 0]]),
+      region('c', [[2, 0]]),
+    ];
+    const tree = buildRegionTree(regions);
+    const flat = flattenRegionTree(tree);
+    expect(flat).toHaveLength(3);
+    expect(flat.every((n) => n.depth === 1)).toBe(true);
+  });
+});
+
+describe('rootCellCount', () => {
+  it('is the full floor when no regions are authored', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ];
+    expect(rootCellCount(floor, [])).toBe(4);
+  });
+
+  it('subtracts a single region’s cells from the floor', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ];
+    const regions = [
+      region('r1', [
+        [0, 0],
+        [1, 0],
+      ] as [number, number][]),
+    ];
+    expect(rootCellCount(floor, regions)).toBe(2);
+  });
+
+  it('unions overlapping/nested regions rather than double-subtracting shared cells', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ];
+    // crypt ⊃ vault — vault's cells are a literal subset of crypt's own
+    // declared cells (the representation decision), so the union of both
+    // regions' cells is exactly crypt's cells, not crypt's + vault's
+    // double-counted.
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+    ]);
+    const vault = region('vault', [[0, 0]]);
+    expect(rootCellCount(floor, [crypt, vault])).toBe(1); // just [3,0]
+  });
+
+  it('is zero when regions cover the entire floor', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+    ];
+    const regions = [
+      region('r1', [
+        [0, 0],
+        [1, 0],
+      ] as [number, number][]),
+    ];
+    expect(rootCellCount(floor, regions)).toBe(0);
+  });
+});

--- a/src/concepts/dungeon-builder/regionTree.ts
+++ b/src/concepts/dungeon-builder/regionTree.ts
@@ -1,0 +1,296 @@
+/**
+ * regionTree — derives the containment forest for cell-authored semantic
+ * regions (rpg-project#180, "cell-authored semantic room regions"). This
+ * is the "regions are scopes" model settled across four consumer-position
+ * comments on that issue (2026-08-04):
+ *
+ * 1. **Implicit root region** — every cell belongs to exactly one region;
+ *    unpainted floor belongs to the implicit generic/root region. The
+ *    model is total, no "regionless" special case.
+ * 2. **Nesting is strict containment ONLY, resolved innermost-wins** —
+ *    like lexical scopes. Overlap is forbidden except strict containment
+ *    (Venn/partial overlap is invalid).
+ * 3. **The YAML stays flat — nesting is derived, never written.** A
+ *    region is inside another because its cells are a strict SUBSET of
+ *    the outer region's own declared cells (the outer region's `cells:`
+ *    list literally includes the inner one's cells — no `parent:` field,
+ *    ever: a field would duplicate what the cell sets already say, and
+ *    duplicated truth drifts).
+ * 4. **Containment forms chains, so parent and innermost are unique and
+ *    cheap.** Because overlap is allowed only by containment, all regions
+ *    containing a given cell form a chain — any two that share a cell
+ *    must be nested, hence comparable. The parent of a region R is its
+ *    smallest strict superset (unique; none exists means the implicit
+ *    root).
+ *
+ * Kept separate from `dungeonYaml.ts`'s CST layer and deliberately has NO
+ * dependency on `DungeonDoc`/`RegionDoc` — the same discipline
+ * `regionGeometry.ts` already follows (see its own header comment): every
+ * function here takes a plain `RegionLike[]`, so both boards and
+ * `dungeonYaml.ts` itself can import this module without creating a
+ * cycle, and it's unit-testable without a CST document.
+ *
+ * **Dialect note**: the SHIPPED client-side validation
+ * (`dungeonYaml.ts`'s `validateRegionCells`) still enforces flat
+ * non-overlap — ANY shared cell is rejected, including a valid strict
+ * containment. Nested authoring isn't wired up yet (no paint-a-region-
+ * inside-another affordance), so every document the creation board itself
+ * can currently produce is a flat one-level forest (every region a direct
+ * child of the implicit root). This module handles arbitrary nesting
+ * depth regardless, so it renders correctly the day validation allows
+ * painting a nested region, and so it can render a HAND-EDITED YAML
+ * document (pasted into the YAML pane) that already nests today — the
+ * parser doesn't reject it, only the interactive brush does.
+ */
+import type { Cell } from './regionGeometry';
+
+function cellKey(c: Cell): string {
+  return `${c[0]},${c[1]}`;
+}
+
+function toCellSet(cells: readonly Cell[]): Set<string> {
+  return new Set(cells.map(cellKey));
+}
+
+/** The minimal shape `buildRegionTree`/`rootCellCount` need — structurally
+ * compatible with `dungeonYaml.ts`'s `RegionDoc` without importing it (see
+ * this file's own header comment for why). */
+export interface RegionLike {
+  id: string;
+  name?: string;
+  archetype: string;
+  cells: Cell[];
+}
+
+export interface RegionTreeNode<T extends RegionLike = RegionLike> {
+  region: T;
+  /** 1 = a direct child of the implicit root (what a flat, un-nested
+   * document's regions all are today); 2 = nested one level inside a
+   * depth-1 region; and so on. The implicit root itself is depth 0 and is
+   * NOT a `RegionTreeNode` — it has no `RegionLike` to hold (see
+   * `rootCellCount` for its cell count instead). */
+  depth: number;
+  /** Regions whose smallest strict superset is this one. Empty for a leaf
+   * — every region in a flat document is a leaf. */
+  children: RegionTreeNode<T>[];
+}
+
+/** Two regions overlap without either strictly containing the other — a
+ * Venn/partial overlap, forbidden by the settled model (nesting is
+ * strict-containment-only). The interactive brush can't produce this
+ * today (`validateRegionCells` rejects ANY overlap, containment
+ * included), but a hand-edited YAML document pasted into the YAML pane
+ * can, since the parser itself doesn't enforce it — this is exactly the
+ * case this warning exists to surface. */
+export interface RegionOverlapWarning {
+  regionAId: string;
+  regionBId: string;
+  /** The intersecting cells, capped to `OVERLAP_SAMPLE_CELLS` — a
+   * "sample," not a complete accounting, since a large overlap's full
+   * cell list isn't more useful for an author-facing message than a
+   * representative handful. */
+  cells: Cell[];
+  /** True count of intersecting cells — may exceed `cells.length` when
+   * capped. */
+  cellCount: number;
+}
+
+export interface RegionTree<T extends RegionLike = RegionLike> {
+  /** Regions with no strict superset among `regions` — direct children of
+   * the implicit root. A flat, un-nested document (everything shipped
+   * today produces) has every region here, none nested under another. */
+  roots: RegionTreeNode<T>[];
+  overlaps: RegionOverlapWarning[];
+}
+
+const OVERLAP_SAMPLE_CELLS = 6;
+
+/** How two regions' cell sets relate, given their sizes and shared-cell
+ * count — the one comparison every pairwise check in this module reduces
+ * to. `sizeA <= sizeB` is NOT assumed; the caller passes both sizes as
+ * measured. */
+function relate(
+  sizeA: number,
+  sizeB: number,
+  shared: number
+): 'disjoint' | 'a-in-b' | 'b-in-a' | 'overlap' {
+  if (shared === 0) return 'disjoint';
+  // Strict containment requires the smaller set to be FULLY covered by
+  // the bigger one AND a genuine size difference — two regions painted
+  // with the exact same cells (shared === sizeA === sizeB) are neither's
+  // strict subset, so they fall through to 'overlap' below, same as a
+  // true Venn intersection. That's deliberate: an author who somehow
+  // produces two same-cells regions (hand-edited YAML; the brush's own
+  // overlap check would reject it) gets the same "these don't nest"
+  // warning a partial overlap would, not a silently-accepted containment.
+  if (shared === sizeA && sizeA < sizeB) return 'a-in-b';
+  if (shared === sizeB && sizeB < sizeA) return 'b-in-a';
+  return 'overlap';
+}
+
+/** Derives the containment forest from a flat `regions` list — parent =
+ * smallest strict superset by cell-subset check (rpg-project#180's
+ * settled model, see this file's own header comment). O(n^2) pairwise
+ * comparisons; fine for the handful-to-dozens of regions this concept
+ * authors. Order of `regions` doesn't affect the result — the forest
+ * shape is purely a function of cell-set relationships. */
+export function buildRegionTree<T extends RegionLike>(
+  regions: readonly T[]
+): RegionTree<T> {
+  const sets = new Map<string, Set<string>>();
+  for (const r of regions) sets.set(r.id, toCellSet(r.cells));
+
+  const overlaps: RegionOverlapWarning[] = [];
+  // For each region, every OTHER region that strictly contains it, with
+  // that ancestor's cell-set size — the parent is whichever candidate has
+  // the SMALLEST size (the tightest-fitting superset). Chains guarantee
+  // this is well-defined: any two ancestors of the same region must
+  // themselves be comparable (both contain this region's cells, so they
+  // share cells, so under the settled model they must nest), which is
+  // exactly why a unique smallest one exists rather than several
+  // incomparable candidates tying for "closest."
+  const ancestorCandidates = new Map<string, { id: string; size: number }[]>();
+  for (const r of regions) ancestorCandidates.set(r.id, []);
+
+  for (let i = 0; i < regions.length; i++) {
+    for (let j = i + 1; j < regions.length; j++) {
+      const a = regions[i];
+      const b = regions[j];
+      const setA = sets.get(a.id)!;
+      const setB = sets.get(b.id)!;
+      let shared = 0;
+      // Iterate the smaller set for the intersection count — cheap, and
+      // this loop runs O(n^2) times across the whole region list.
+      const [small, big] = setA.size <= setB.size ? [setA, setB] : [setB, setA];
+      for (const k of small) if (big.has(k)) shared++;
+
+      const rel = relate(setA.size, setB.size, shared);
+      if (rel === 'a-in-b') {
+        ancestorCandidates.get(a.id)!.push({ id: b.id, size: setB.size });
+      } else if (rel === 'b-in-a') {
+        ancestorCandidates.get(b.id)!.push({ id: a.id, size: setA.size });
+      } else if (rel === 'overlap') {
+        const sharedCells = a.cells.filter((c) => setB.has(cellKey(c)));
+        overlaps.push({
+          regionAId: a.id,
+          regionBId: b.id,
+          cells: sharedCells.slice(0, OVERLAP_SAMPLE_CELLS),
+          cellCount: sharedCells.length,
+        });
+      }
+      // 'disjoint' pairs need no record — they simply don't constrain
+      // each other's parent.
+    }
+  }
+
+  const parentOf = new Map<string, string | null>();
+  for (const r of regions) {
+    const candidates = ancestorCandidates.get(r.id)!;
+    if (candidates.length === 0) {
+      parentOf.set(r.id, null);
+      continue;
+    }
+    let best = candidates[0];
+    for (const c of candidates) if (c.size < best.size) best = c;
+    parentOf.set(r.id, best.id);
+  }
+
+  const nodeOf = new Map<string, RegionTreeNode<T>>();
+  for (const r of regions)
+    nodeOf.set(r.id, { region: r, depth: 0, children: [] });
+
+  const roots: RegionTreeNode<T>[] = [];
+  for (const r of regions) {
+    const node = nodeOf.get(r.id)!;
+    const parentId = parentOf.get(r.id)!;
+    if (parentId === null) {
+      roots.push(node);
+    } else {
+      nodeOf.get(parentId)!.children.push(node);
+    }
+  }
+
+  // Depths: a direct child of the implicit root is depth 1 (the implicit
+  // root itself, uninstantiated as a node, is depth 0) — chosen so "flat
+  // docs: all at depth 1" reads naturally rather than needing a +1
+  // everywhere a caller renders depth.
+  function assignDepth(node: RegionTreeNode<T>, depth: number): void {
+    node.depth = depth;
+    for (const child of node.children) assignDepth(child, depth + 1);
+  }
+  for (const root of roots) assignDepth(root, 1);
+
+  return { roots, overlaps };
+}
+
+/** Pre-order (parent-before-children) flattening of a `RegionTree` — the
+ * natural render order for an indented list ("root row first ... then
+ * children indented under parents"). Each node's own `depth` (set by
+ * `buildRegionTree`) carries the indentation a caller needs. */
+export function flattenRegionTree<T extends RegionLike>(
+  tree: RegionTree<T>
+): RegionTreeNode<T>[] {
+  const out: RegionTreeNode<T>[] = [];
+  function walk(node: RegionTreeNode<T>): void {
+    out.push(node);
+    for (const child of node.children) walk(child);
+  }
+  for (const root of tree.roots) walk(root);
+  return out;
+}
+
+/** The implicit root region's own cell count — rpg-project#180's
+ * regions-are-scopes refinement: unpainted floor belongs to the implicit
+ * generic/root region, so every document is total (no "regionless"
+ * special case). Root's cells are exactly `totalFloorCells` minus every
+ * cell claimed by ANY authored region, at any depth.
+ *
+ * Unions ALL regions regardless of nesting depth, not just top-level
+ * ones — for a VALID nested document these are the same set (a child's
+ * cells are always a literal subset of its parent's own declared `cells:`
+ * list, per the representation decision in this file's header comment),
+ * but unioning everything keeps this correct even for a malformed
+ * document `buildRegionTree` would also flag with an overlap warning.
+ *
+ * `totalFloorCells` is caller-supplied rather than derived here because
+ * "the floor" means something different for a creation-mode canvas
+ * (`creation/canvasFloor.ts`'s `deriveCanvasFloorCells` — the canvas
+ * grid's bounds minus holes) than for a compiled/edit-mode document (the
+ * server-generated `FloorPlan`'s room geometry, which this concept has no
+ * single flattened cell-list helper for yet). Only creation mode has a
+ * regions panel to show a root row in this round (`RegionPanel.tsx`);
+ * this function stays floor-source-agnostic so an edit-mode consumer can
+ * reuse it later without this module needing to know about `FloorPlan` at
+ * all. */
+/** Biggest-cell-count-first paint order for `doc.regions` — the settled
+ * "regions are scopes" model nests strictly by cell-subset, so a child
+ * region's cell count is always LESS than its parent's (see this file's
+ * own header comment). Painting the biggest first and the smallest last
+ * means a nested (inner) region's tint/stroke always lands on top of its
+ * container's, "innermost visible," WITHOUT a renderer needing the actual
+ * containment forest (`buildRegionTree`) just to get paint order right —
+ * both `Board.tsx`'s read-only overlay and `creation/CreationBoard.tsx`'s
+ * interactive one use this. Previously each simply iterated `doc.regions`
+ * in authoring/array order, which only drew correctly by accident (an
+ * author happening to declare the outer region before the inner one in
+ * the YAML) — no nested document exists in the wild yet (shipped
+ * validation is flat non-overlap), but a hand-typed one pasted into the
+ * YAML pane shouldn't depend on declaration order to render sanely. A
+ * stable sort: two same-size regions (siblings, or a still-invalid Venn
+ * overlap) keep their original relative order. */
+export function regionsByPaintOrder<T extends { cells: unknown[] }>(
+  regions: readonly T[]
+): T[] {
+  return [...regions].sort((a, b) => b.cells.length - a.cells.length);
+}
+
+export function rootCellCount<T extends RegionLike>(
+  totalFloorCells: readonly Cell[],
+  regions: readonly T[]
+): number {
+  const claimed = new Set<string>();
+  for (const r of regions) for (const c of r.cells) claimed.add(cellKey(c));
+  let count = 0;
+  for (const c of totalFloorCells) if (!claimed.has(cellKey(c))) count++;
+  return count;
+}


### PR DESCRIPTION
## Summary

RegionPanel now renders rpg-project#180's **"regions are scopes"** model — settled across four consumer-position comments on that issue (2026-08-04) — instead of a flat list:

- **Implicit root region as a real row**: `(everything else)` with a cell count computed as canvas floor cells minus every cell claimed by any authored region, at any depth. Shown even at zero authored regions, so picking up the Region tool immediately shows the total-coverage model before anything is painted.
- **Derived containment forest, never a `parent:` field**: new `regionTree.ts` (`buildRegionTree`) computes parent = smallest strict superset by cell-subset check — the same dependency-free discipline `regionGeometry.ts` already follows, so it's unit-testable without a CST document and importable by both boards without a cycle. A flat, un-nested document (everything the interactive brush can author today) renders every region at depth 1 — the model's own one-level forest, not a degraded case; the module handles arbitrary nesting depth so it's ready the day nested authoring lands.
- **Partial-overlap ("Venn") detection**: two regions sharing cells with neither a strict subset of the other are forbidden by the settled model but reachable via hand-edited YAML pasted into the YAML pane (the parser doesn't enforce it — only the brush's `validateRegionCells` does, unchanged this round). Surfaced as a named warning with both region names and a capped cell sample.
- **Board overlay paint order fixed cheaply**: `Board.tsx` and `CreationBoard.tsx`'s region overlays previously drew in raw declaration order, which only drew a nested region on top of its container by accident of authoring order. Both now paint biggest-cell-count-first (`regionsByPaintOrder`, shared) so a nested region's tint reliably lands on top — proven with a DOM-level check against a document authored innermost-first.

## Scope

Rendering + detection only, per the unit brief — **no** nested-region authoring via the brush (`validateRegionCells` unchanged, still flat non-overlap) and **no** validation-rule changes.

## Test plan

- [x] 16 new tests in `regionTree.test.ts` (340 dungeon-builder tests overall, up from 324): flat forest, nested chain (including "parent is the smallest superset, not just any ancestor"), multi-child siblings, partial-overlap detection (Venn pair, identical-cells pair, sample capping, disjoint-no-warning), `flattenRegionTree` pre-order, `rootCellCount` math (empty floor, subtraction, union-not-double-subtract for nesting, fully-covered zero case).
- [x] `ci-check` clean (format/lint/typecheck/build/test), both locally and via the pre-push hook.
- [x] Live-verified against the real dev server (Playwright, hex-true board): Region tool armed with zero regions → root row alone; one flat region painted → root row + region at depth 1; hand-pasted 3-level nested chain → root row + step-indented tree; hand-pasted Venn-overlap doc → warning banner + both regions listed as flat siblings; a reverse-declaration-order doc → DOM-level proof that paint order (not YAML order) puts the innermost region on top.

— asset-pipeline agent, on behalf of KirkDiggler