### PR TITLE
unit: specimen pack v0.4 (ratified v0.3 cut)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4902,3 +4902,94 @@ canvas sentinel). `ci-check` clean (format/lint/typecheck/build/test).
   under Live verification — code-reviewed and its sibling branch
   live-verified, not independently live-clicked, due to automation flakiness
   in the pre-existing accordion control, not this unit's own code.
+
+## Specimen pack v0.4: regenerated at the ratified spec cut (2026-08-05)
+
+The executable half of the contract catching up to the ratified whole.
+`rpg-project`'s `ideas/dungeon-builder/spec/v0.3/spec.md` ratified
+2026-08-05 (all six pre-ratification OPEN points resolved — see that
+spec's own `README.md` Ratification record); this unit regenerates
+`specimens/` at that exact cut, via the real serializer, per the
+documented `_regen.test.ts` throwaway-script process
+(`specimens/README.md`'s "Regenerating for the next version bump").
+Full changelog is in `specimens/README.md`'s v0.4 entry — this section
+records the two structural changes and the byte-level finding, not a
+duplicate of the diff.
+
+**`rooms:`+`regions:` is now a ratified MUST-reject (spec §4.10.3.8,
+ruling 4).** `kitchen-sink.yaml` (a `rooms:`-chain doc) carried exactly
+this illegal combination as of pack v0.3 — two cell-authored regions
+(`hall-inner`/`hall-annex`) declared alongside a non-empty `rooms:`
+chain, added by the "Region-authoring unit" entry above with no
+cross-validation between the two constructs (this concept's own
+client-side validator still doesn't enforce the combination —
+`TARGET-YAML.md`'s regions "Open questions" section names this
+explicitly and remains accurate; this pack now avoids the combination by
+construction, in the generated specimen, not by a new client-side
+check). Fixed by removing the region calls from the kitchen-sink block
+of the regen script and regenerating: `kitchen-sink.yaml` now declares
+no `regions:` key. It never declared `canvas:` either (ruling 3, spec
+§4.5 point 2) — verified by inspection, not assumed.
+
+**Canvas + `regions:` is not a rejected combination — it's the
+ratified-legal home the demo moved to.** `canvas.yaml` (`rooms: []`)
+gained the identical two-region + `connectRegions` demonstration,
+relocated rather than reinvented (ids renamed `hall-inner`/`hall-annex`
+→ `canvas-inner`/`canvas-annex` only because no `hall` room exists in
+canvas mode; cell sets unchanged). `canvas.yaml`'s pre-existing top-level
+altar `facing: W` is a second, independent ratification outcome landing
+in the same file: ruling 6 settled canvas-mode top-level `facing:` as
+accepted (spec §4.6 point 3 / §4.9.2), retiring the genuinely open
+question `specimens/README.md`'s own Reconciliation-item framing
+(mirroring the spec `README.md`'s item 8) had left unresolved before
+this ratification.
+
+**A real finding, surfaced by regeneration rather than introduced by
+it**: relocating the two-region demo with identical cells did NOT
+reproduce the identical attachment-door edge. Old:
+`{from:[10,3],to:[11,3]}`. New: `{from:[10,3],to:[11,2]}`. Root cause,
+confirmed directly against `regionGeometry.ts`'s current
+`sharedBoundaryEdges`/`pickAttachmentEdge`: the region-authoring
+prototype (`d75487f`, 2026-08-03) generated the original demo under a
+4-neighbor `cellsAdjacent`, which finds only 2 shared-boundary edges
+between `hall-inner`/`hall-annex` (both same-row pairs) — `hex-true
+creation canvas` (`8793905`, same day) widened `cellsAdjacent` to real
+6-neighbor hex adjacency, which for this specific cell pair adds a THIRD
+(diagonal) shared edge; `pickAttachmentEdge`'s deterministic
+middle-of-sorted-list rule picks a different edge once the candidate
+list has 3 entries instead of 2. The later "canonical wall adjacency"
+regen pass (`ce67065`, 2026-08-04) fixed the kitchen-sink document's two
+_hand-drawn_ walls for exactly this same hex-true widening but never
+re-ran the region/`connectRegions` block, so the door byte went stale
+until this round refreshed it. Not a regression in this unit — a latent
+staleness this regeneration was the first full pass to surface.
+
+**Verification.**
+
+- All four specimen files (`kitchen-sink.yaml`, `kitchen-sink.v1-subset.yaml`,
+  `canvas.yaml`, `exploration/holes.yaml`) round-trip byte-stable through
+  `parseDungeon` → `serializeDungeon` (a dedicated throwaway
+  `_roundtrip.test.ts`, run and deleted, same discipline as the regen
+  script itself).
+- No test in this concept reads the `specimens/` directory as a fixture
+  (confirmed by search — zero references), so the byte changes above
+  required no test-reference fixes. Full `src/concepts/dungeon-builder`
+  suite: 324 tests, 16 files, unchanged and passing.
+- `exploration/holes.yaml`'s content is unchanged; regenerating it
+  through the current serializer normalized its `holes:` list-item
+  bracket spacing (`[10, 4]` → `[ 10, 4 ]`) to match the rest of the
+  pack's flow-map style, which then failed this repo's own
+  `format:check` — prettier's YAML formatter treats a bare top-level
+  `- [a, b]` list item differently from the same shape nested inside a
+  flow map. `prettier --write` reverted that one entry; no other
+  specimen file needed it.
+- A second incidental, content-neutral finding: `canvas.yaml` gained a
+  `wallLines: []` line. It had not been regenerated since pack v0.2
+  (2026-08-03); `emptyCanvasYaml` (`creation/emptyCanvasDoc.ts`) gained a
+  `wallLines:` key in `37584af` ("straight walls with visible footprint
+  (prototype)"), also 2026-08-03 but after v0.2's `canvas.yaml` was
+  generated — so the empty key was simply never picked up until this
+  full regeneration. No straight walls are authored in this specimen,
+  so this is a byte-shape change only, not a content change.
+- `ci-check` clean (format/lint/typecheck/build/test) after the prettier
+  pass.

--- a/src/concepts/dungeon-builder/specimens/README.md
+++ b/src/concepts/dungeon-builder/specimens/README.md
@@ -1,6 +1,6 @@
 # Dungeon Builder — specimen pack
 
-**Specimen pack version: v0.3** (2026-08-03). v0.1 was posted in full on
+**Specimen pack version: v0.4** (2026-08-05). v0.1 was posted in full on
 [rpg-project#175](https://github.com/KirkDiggler/rpg-project/issues/175)
 for the backend session implementing YAML processing; this and later
 versions post as short diffs on the same issue.
@@ -15,8 +15,111 @@ builder gains a new emittable construct, this pack regenerates and bumps
 (v0.2, v0.3, ...) with a one-line changelog entry below naming the
 addition. Never conflate the two numbers.
 
+**Authority, as of v0.4.** Every per-construct status claim in this file
+is checked against `rpg-project`'s ratified
+`ideas/dungeon-builder/spec/v0.3/spec.md` (RATIFIED 2026-08-05) plus its
+sibling `README.md`'s Ratification record — not against this concept's
+own proposal/probe framing alone. Where the two agree, both are cited;
+where a construct is real dialect this concept proposed before the spec
+existed, the spec section is what now settles whether the shape survived
+ratification unchanged. See "Per-construct status against the ratified
+spec," below.
+
 ## Changelog
 
+- **v0.4** (2026-08-05) — regenerated at the RATIFIED
+  `ideas/dungeon-builder/spec/v0.3/spec.md` cut (rpg-project, ratified
+  2026-08-05 — six pre-ratification OPEN points all resolved; see that
+  spec's own `README.md` Ratification record). Two structural changes,
+  both required by ratified rulings, not stylistic:
+  - `kitchen-sink.yaml` (chain doc, non-empty `rooms:`) no longer
+    declares `regions:`. Ratified ruling 4 (spec.md §4.10.3.8): a
+    document combining non-empty `rooms:` with declared `regions:` MUST
+    be rejected — the two-region demo (`hall-inner`/`hall-annex` +
+    `connectRegions`) v0.3 of this pack carried directly inside
+    `kitchen-sink.yaml` was exactly that now-illegal combination.
+    Removed; regenerating via the real serializer with the region calls
+    dropped from the throwaway `_regen.test.ts` script confirms
+    `kitchen-sink.yaml` no longer contains a `regions:` key at all.
+    (It never declared `canvas:` either — ruling 3, spec.md §4.5.2's
+    `rooms:`+`canvas:` reject — so no change was needed on that axis;
+    noted here as verified, not assumed.)
+  - `canvas.yaml` (canvas doc, `rooms: []`) gains a `regions:` block: the
+    SAME two-region + `connectRegions` demonstration relocated here
+    (ids renamed `hall-inner`/`hall-annex` → `canvas-inner`/
+    `canvas-annex` — no `hall` room exists in canvas mode to name a
+    region after; cells unchanged), since canvas+regions is not one of
+    the two ratified-rejected combinations (only `rooms:`+`canvas:` and
+    `rooms:`+`regions:` are — rulings 3 and 4) and is therefore this
+    pack's only ratified-legal home left for a `regions:` sample.
+    `canvas.yaml`'s top-level altar `facing: W` is ALSO now
+    ratified-conforming (ruling 6, spec.md §4.6 point 3 / §4.9.2:
+    canvas-mode top-level `facing:` on a non-monster, `mount: floor`
+    placement is accepted, under the same conditions a room-scoped
+    entry already gets) — before ratification this was a genuinely open
+    question (`TARGET-YAML.md`'s "canvas-mode extension" reading vs. the
+    more conservative "#178-scoped exclusion" reading, spec `README.md`
+    Reconciliation item 8), not yet settled either way; it is settled
+    now, both prior readings retired in favor of the ratified one.
+  - **A real byte-level finding from the regeneration, not a hand-edit**:
+    relocating the region demo did not reproduce the old door edge. The
+    pre-v0.4 `kitchen-sink.yaml`'s `connectRegions(hall-inner,
+hall-annex)` picked `{from:[10,3],to:[11,3]}`; the identical two
+    cell sets, run through the CURRENT `connectRegions`/
+    `pickAttachmentEdge` (`regionGeometry.ts`), pick
+    `{from:[10,3],to:[11,2]}` instead. Traced to source: `d75487f`
+    (region authoring prototype, 2026-08-03) generated the original demo
+    under the OLD 4-neighbor `cellsAdjacent`, which finds exactly 2
+    shared-boundary edges between these two regions (both same-row
+    pairs). `8793905` (hex-true creation canvas, same day) widened
+    `cellsAdjacent` to real 6-neighbor hex adjacency, which for this
+    specific pair of regions adds a THIRD (diagonal) shared edge —
+    `pickAttachmentEdge`'s deterministic "middle of the sorted list"
+    rule lands on a different edge once the candidate list has 3 entries
+    instead of 2. Verified directly against current
+    `regionGeometry.ts`: `sharedBoundaryEdges` on these two cell sets
+    returns 3 edges, not 2. The pre-v0.4 door byte was stale relative to
+    the codebase's own hex-true adjacency fix from the day it landed —
+    `ce67065`'s "canonical wall adjacency" regen pass fixed the two
+    hand-drawn walls in this same document but never re-ran the
+    region/`connectRegions` block, so this one byte went unrefreshed
+    until this round.
+  - `kitchen-sink.v1-subset.yaml` — byte-identical (regions were always
+    dropped from the v1-subset regardless of source; removing them from
+    `kitchen-sink.yaml` changes nothing this file emits).
+    `kitchen-sink.v1-subset.dropped.json` regenerated: the `"2 regions"`
+    entry is gone (nothing left to drop) and `"3 walls"` → `"2 walls"`;
+    `compiling`/`compilableBlockers` stay empty, same conservative
+    no-capabilities call every prior version of this file used.
+  - `exploration/holes.yaml` — content unchanged (still the single
+    standalone `toggleHole(10, 4)` doc). Regenerating through the
+    current serializer normalized its `holes:` entry's flow-sequence
+    bracket spacing to match the rest of the pack (`[10, 4]` →
+    `[ 10, 4 ]`); `prettier --write` then reverted that specific entry
+    back to `[10, 4]` to satisfy this repo's own `format:check` —
+    prettier's YAML formatter treats a bare top-level `- [a, b]` list
+    item differently from the same shape nested inside a flow map
+    (`{ ..., at: [ 1, 1 ] }`), which is why only this file needed a
+    prettier pass and `kitchen-sink.yaml`/`canvas.yaml` didn't.
+  - A second incidental finding, also surfaced only by a FULL
+    regeneration: `canvas.yaml` gained a `wallLines: []` line it didn't
+    carry before. `canvas.yaml` was last regenerated at v0.2
+    (2026-08-03) and this pack's own changelog has said "unchanged since
+    v0.2" through v0.3 — but `emptyCanvasYaml`
+    (`creation/emptyCanvasDoc.ts`) gained a `wallLines:` key in `37584af`
+    ("straight walls with visible footprint (prototype)"), also
+    2026-08-03 but AFTER v0.2's canvas.yaml was generated. `canvas.yaml`
+    had simply never been regenerated since, so it never picked up the
+    empty key. Content-neutral (`wallLines: []` — no straight walls are
+    authored in this specimen), but real: the pack's "unchanged since
+    v0.2" claim for `canvas.yaml` was accurate for its authored content
+    but not for its full byte shape once the base skeleton moved on.
+  - Verification: all four specimen files round-trip byte-stable through
+    `parseDungeon` → `serializeDungeon`. No test in this concept reads
+    the specimens directory as a fixture (confirmed by search — zero
+    references), so the full `src/concepts/dungeon-builder` suite (324
+    tests, 16 files) needed no reference updates and passes unchanged.
+    `ci-check` clean (format/lint/typecheck/build/test).
 - **(2026-08-04, no version bump — `stripToV1Subset` reporting shape only,
   not a new emittable construct)**: the "capability-probed graduation"
   unit made `stripToV1Subset` capability-aware (`dungeonYaml.ts`) —
@@ -79,13 +182,13 @@ of them)"` entry names both outcomes explicitly.
 
 ## Files
 
-| File                                  | What it is                                                                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kitchen-sink.yaml`                   | One document exercising every construct + field variation the builder can emit today (3-room chain, locked connector, every `place:` field combo, boss facing+targeting, both wall kinds including a region-attachment door, two cell-authored regions, start/end, lighting, count-based obstacles). No `holes:` as of v0.3 — see `exploration/holes.yaml`. |
-| `kitchen-sink.v1-subset.yaml`         | The same document run through `stripToV1Subset` — exactly what Save & Play would persist right now.                                                                                                                                                                                                                                                         |
-| `kitchen-sink.v1-subset.dropped.json` | What `stripToV1Subset` dropped from the kitchen-sink doc, and whether the result is `compilable` (≥2 rooms).                                                                                                                                                                                                                                                |
-| `canvas.yaml`                         | What creation mode ("New Dungeon," a blank canvas) emits after a few walls/doors/placements/start/end — the second real document shape (`rooms: []` + `canvas: {width,height}`, so every placement is top-level). Unchanged since v0.2.                                                                                                                     |
-| `exploration/holes.yaml`              | v0.3+. A minimal standalone specimen for the retained Hole prototype — deliberately deferred from the near-term dialect (TARGET-YAML.md), kept out of the main kitchen-sink doc so it doesn't read as carrying the same status as everything else in it.                                                                                                    |
+| File                                  | What it is                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kitchen-sink.yaml`                   | One room-chain document exercising every construct + field variation the builder can emit today for that mode (3-room chain, locked connector, every `place:` field combo, boss facing+targeting, both wall kinds, start/end, lighting, count-based obstacles). No `regions:` as of v0.4 — ratified spec §4.10.3.8 rejects `rooms:`+`regions:` in one document; the two-region demo moved to `canvas.yaml`. No `holes:` as of v0.3 — see `exploration/holes.yaml`.                                                      |
+| `kitchen-sink.v1-subset.yaml`         | The same document run through `stripToV1Subset` — exactly what Save & Play would persist right now.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `kitchen-sink.v1-subset.dropped.json` | What `stripToV1Subset` dropped from the kitchen-sink doc, and whether the result is `compilable` (≥2 rooms).                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `canvas.yaml`                         | What creation mode ("New Dungeon," a blank canvas) emits after a few walls/doors/placements/start/end/regions — the second real document shape (`rooms: []` + `canvas: {width,height}`, so every placement is top-level). As of v0.4: gains a `regions:` block (the two-region + `connectRegions` demo relocated from `kitchen-sink.yaml`, since canvas+regions is the ratified-legal combination — spec §4.5/§4.10.3.8) and its top-level altar's `facing: W` is now ratified-conforming (spec §4.6/§4.9.2, ruling 6). |
+| `exploration/holes.yaml`              | v0.3+. A minimal standalone specimen for the retained Hole prototype — deliberately deferred from the near-term dialect (TARGET-YAML.md; ratified spec §2 keeps it "deferred, not queued"), kept out of the main kitchen-sink doc so it doesn't read as carrying the same status as everything else in it.                                                                                                                                                                                                              |
 
 **Live-verified, not just claimed**: `kitchen-sink.v1-subset.yaml` was
 run through a real `PutDungeon(validate_only: true)` against an isolated
@@ -102,6 +205,33 @@ Status tags in the pack match `CONTRACT.md`/`TARGET-YAML.md` exactly:
 **[experiment: not proposed]** = a concept-local probe, not even a
 dialect candidate; **[deferred: exploration]** = deliberately not part
 of the near-term dialect.
+
+## Per-construct status against the ratified spec (v0.4)
+
+As of v0.4, every tag above additionally cites the section of
+`ideas/dungeon-builder/spec/v0.3/spec.md` (rpg-project, RATIFIED
+2026-08-05) that settles it — this replaces this file's own
+proposal/probe framing as the status authority. "Compiles today" below
+means live-verified against a real server per `TARGET-YAML.md`'s
+capability-probe table, a narrower and independently-tracked claim than
+"ratified" (a construct can be ratified spec and still not-yet-shipped
+server-side — Wave 0/#192 and Wave 1/#180 are both listed "not started"
+in spec.md §1).
+
+| Construct                                                                                    | Where in this pack                                           | Spec §                       | Status                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rooms:`/`connectors:`/room-scoped `place:`/`boss:`/`obstacles:`                             | `kitchen-sink.yaml`, `exploration/holes.yaml`                | §4.2–§4.4                    | ratified, real — compiles today (`dungeonspec.Validate`), unchanged                                                                                                                                                                                                        |
+| `walls:` (edge-native)                                                                       | `kitchen-sink.yaml`, `canvas.yaml`                           | §4.7                         | ratified — compiles today, live-verified (rpg-api#769/toolkit#881)                                                                                                                                                                                                         |
+| `start:`                                                                                     | `kitchen-sink.yaml`, `canvas.yaml`                           | §4.8                         | ratified — compiles today, overrides the generator-chosen `FloorPlan.entrance`                                                                                                                                                                                             |
+| room-scoped `place:`/`boss:` `facing:` (non-monster, floor-mount)                            | `kitchen-sink.yaml`                                          | §4.9                         | ratified — compiles today (verified live, entry-type table in `TARGET-YAML.md`)                                                                                                                                                                                            |
+| `canvas:` + top-level `place:`                                                               | `canvas.yaml`                                                | §4.5, §4.6                   | ratified (Wave 0, rpg-project#192) — **not started** server-side; decode-unknown on the current live server                                                                                                                                                                |
+| canvas-mode top-level `facing:` (`canvas.yaml`'s altar)                                      | `canvas.yaml`                                                | §4.6 point 3, §4.9.2         | **ratified-conforming as of ruling 6** (2026-08-05) — was a genuinely open ratification question before (spec `README.md` Reconciliation item 8); still not compiled server-side, same Wave 0 gate as `canvas:` itself                                                     |
+| `regions:`                                                                                   | `canvas.yaml` only (v0.4 — moved out of `kitchen-sink.yaml`) | §4.10                        | ratified shape/model (Wave 1, rpg-project#180) — **not started** server-side; decode-unknown on the current live server                                                                                                                                                    |
+| `rooms:`+`regions:` in one document                                                          | (never emitted by this pack)                                 | §4.10.3.8                    | ratified **MUST-reject** (ruling 4) — this concept's own client-side validator does not yet enforce this combination (`TARGET-YAML.md`'s regions "Open questions" section still records it as unvalidated); this pack avoids it by construction, not by client enforcement |
+| `rooms:`+`canvas:` in one document                                                           | (never emitted by this pack)                                 | §4.5 point 2                 | ratified **MUST-reject** (ruling 3)                                                                                                                                                                                                                                        |
+| `end:`, `lighting:`, `defaults:`, `height:` (any placement), `rotate_degrees:`, `targeting:` | `kitchen-sink.yaml`                                          | §2 ("Explicitly ABOVE v0.3") | above the ratified v0.3 cut — unfiled or filed-but-unimplemented per §2's table; decode-unknown server-side, target-dialect client-side                                                                                                                                    |
+| `holes:`                                                                                     | `exploration/holes.yaml`                                     | §2                           | explicitly deferred, not queued                                                                                                                                                                                                                                            |
+| `wallLines:` (straight walls)                                                                | (not emitted in this pack; client-only sugar)                | §2                           | explicitly unfiled, above v0.3                                                                                                                                                                                                                                             |
 
 ## Regenerating for the next version bump
 
@@ -207,25 +337,12 @@ connectors:
     setWallEdge(cst, [7, 1], [8, 1], 'solid', true);
     setWallEdge(cst, [7, 3], [8, 3], 'door', true);
 
-    // v0.3 (rpg-project#180): two cell-authored semantic regions inside
-    // "hall"'s absolute column range (hall's start_column = entry's width
-    // 6 + the reserved connector gap column = 7, so hall = [7,19)),
-    // connected via connectRegions -- the door edge it places lands in
-    // walls: as a THIRD entry, alongside the two hand-drawn ones above.
-    const docForRegions = toDungeonDoc(cst);
-    createRegion(cst, docForRegions, 'hall-inner', 'chamber', [
-      [9, 2],
-      [9, 3],
-      [10, 2],
-      [10, 3],
-    ]);
-    const docWithFirstRegion = toDungeonDoc(cst);
-    createRegion(cst, docWithFirstRegion, 'hall-annex', 'chamber', [
-      [11, 2],
-      [11, 3],
-    ]);
-    const docWithBothRegions = toDungeonDoc(cst);
-    connectRegions(cst, docWithBothRegions, 'hall-inner', 'hall-annex');
+    // v0.4 (ratified spec v0.3, spec.md §4.10.3.8): a room-chain document
+    // (non-empty rooms:) combining with regions: is now a RATIFIED
+    // MUST-reject combination -- the two-region demo that used to live
+    // here (hall-inner/hall-annex + connectRegions) moved to the canvas
+    // test below, the ratified-legal home for regions:. This doc stays
+    // rooms:-only, no regions: key at all.
 
     // row 4 is the reserved door row (height/2) -- avoid it.
     moveBoss(cst, 'sanctum', [4, 3]);
@@ -297,6 +414,31 @@ connectors:
     placeItem(cst, null, 'dnd5e:props:altar', [8, 8]);
     setPlacementFacing(cst, null, 1, 3); // W
 
+    // v0.4 (ratified spec v0.3, spec.md §4.10.3.8/§4.5): canvas + regions
+    // is NOT one of the two rejected combinations (rooms:+canvas: and
+    // rooms:+regions: -- rulings 3/4) -- canvas mode's rooms: [] means
+    // there is no non-empty rooms: to collide with, so canvas + regions:
+    // is the ratified-legal home for a regions: demo. This is the SAME
+    // two-region + connectRegions demonstration (identical cells,
+    // identical connectRegions call) that used to live in
+    // kitchen-sink.yaml, relocated here rather than reinvented -- only
+    // the ids changed (hall-inner/hall-annex -> canvas-inner/canvas-annex)
+    // since no "hall" room exists in canvas mode to name a region after.
+    const docForRegions = toDungeonDoc(cst);
+    createRegion(cst, docForRegions, 'canvas-inner', 'chamber', [
+      [9, 2],
+      [9, 3],
+      [10, 2],
+      [10, 3],
+    ]);
+    const docWithFirstRegion = toDungeonDoc(cst);
+    createRegion(cst, docWithFirstRegion, 'canvas-annex', 'chamber', [
+      [11, 2],
+      [11, 3],
+    ]);
+    const docWithBothRegions = toDungeonDoc(cst);
+    connectRegions(cst, docWithBothRegions, 'canvas-inner', 'canvas-annex');
+
     setStart(cst, [2, 2]);
     setEnd(cst, [12, 12]);
 
@@ -333,10 +475,13 @@ connectors:
 ```
 
 When the next version adds new fields, extend the script above with new
-mutator calls exercising them and re-run. `regions:` (rpg-project#180) now
-has a real mutator set (`createRegion`/`addCellToRegion`/
+mutator calls exercising them and re-run. `regions:` (rpg-project#180) has
+a real mutator set (`createRegion`/`addCellToRegion`/
 `removeCellFromRegion`/`renameRegion`/`setRegionArchetype`/`deleteRegion`/
-`connectRegions`) as of v0.3 — see `TARGET-YAML.md`'s "regions:" section
-for the full design; extend the kitchen-sink script's region block above,
-don't add a second one, if a future round adds more region field
-coverage.
+`connectRegions`) — see `TARGET-YAML.md`'s "regions:" section for the full
+design. As of v0.4, the region demo lives in the **canvas** test block
+(`canvas-inner`/`canvas-annex`), not kitchen-sink's — ratified spec
+§4.10.3.8 rejects `rooms:`+`regions:` in one document, and kitchen-sink is
+a `rooms:`-chain doc. Extend the canvas script's region block, don't add
+one to kitchen-sink or add a second region block, if a future round adds
+more region field coverage.

--- a/src/concepts/dungeon-builder/specimens/canvas.yaml
+++ b/src/concepts/dungeon-builder/specimens/canvas.yaml
@@ -7,8 +7,16 @@ canvas:
   height: 30
 rooms: []
 connectors: []
-walls: [ { from: [ 4, 4 ], to: [ 5, 3 ], kind: solid }, { from: [ 4, 4 ], to: [ 4, 5 ], kind: solid }, { from: [ 5, 3 ], to: [ 6, 4 ], kind: door } ]
+walls: [ { from: [ 4, 4 ], to: [ 5, 3 ], kind: solid }, { from: [ 4, 4 ], to: [ 4, 5 ], kind: solid }, { from: [ 5, 3 ], to: [ 6, 4 ], kind: door }, { from: [ 10, 3 ], to: [ 11, 2 ], kind: door } ]
+wallLines: []
 holes: []
 start: [ 2, 2 ]
 end: [ 12, 12 ]
 place: [ { ref: "dnd5e:props:pillar", at: [ 5, 5 ], blocks_movement: false, blocks_los: false }, { ref: "dnd5e:props:altar", at: [ 8, 8 ], blocks_movement: false, blocks_los: false, facing: W } ]
+regions:
+  - id: canvas-inner
+    archetype: chamber
+    cells: [ [ 9, 2 ], [ 9, 3 ], [ 10, 2 ], [ 10, 3 ] ]
+  - id: canvas-annex
+    archetype: chamber
+    cells: [ [ 11, 2 ], [ 11, 3 ] ]

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.v1-subset.dropped.json
@@ -1,8 +1,7 @@
 {
   "dropped": [
     "defaults (2 refs; blocks_movement/blocks_los materialized onto 1 placement from 1 of them)",
-    "3 walls",
-    "2 regions",
+    "2 walls",
     "start",
     "end",
     "lighting",
@@ -13,7 +12,5 @@
     "targeting (2 placements)",
     "fine-rotation experiment (2 placements)"
   ],
-  "compiling": [],
-  "compilable": true,
-  "compilableBlockers": []
+  "compilable": true
 }

--- a/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
+++ b/src/concepts/dungeon-builder/specimens/kitchen-sink.yaml
@@ -29,14 +29,6 @@ connectors:
 walls:
   - { from: [ 7, 1 ], to: [ 8, 1 ], kind: solid }
   - { from: [ 7, 3 ], to: [ 8, 3 ], kind: door }
-  - { from: [ 10, 3 ], to: [ 11, 3 ], kind: door }
-regions:
-  - id: hall-inner
-    archetype: chamber
-    cells: [ [ 9, 2 ], [ 9, 3 ], [ 10, 2 ], [ 10, 3 ] ]
-  - id: hall-annex
-    archetype: chamber
-    cells: [ [ 11, 2 ], [ 11, 3 ] ]
 place:
   - { ref: "dnd5e:props:wall-banner", at: [ 15, 3 ], blocks_movement: false, blocks_los: false, facing: E, mount: wall, height: 1.5, rotate_degrees: -8 }
   - { ref: "dnd5e:props:candles", at: [ 16, 3 ], blocks_movement: false, blocks_los: false, height: 0.4 }


### PR DESCRIPTION
## Summary

Regenerates the dungeon-builder specimen pack (`src/concepts/dungeon-builder/specimens/`) at rpg-project's ratified `ideas/dungeon-builder/spec/v0.3/spec.md` (ratified 2026-08-05) — the executable half of the contract catching up to the ratified whole.

- **`kitchen-sink.yaml`** (rooms:-chain doc) no longer declares `regions:`. Ratified ruling 4 (spec.md §4.10.3.8) rejects a document combining non-empty `rooms:` with declared `regions:` — this pack's v0.3 carried exactly that illegal combination (a two-region demo added inside the `hall` room's chain doc). Removed via a real regeneration (region mutator calls dropped from the throwaway `_regen.test.ts` script), not a hand-edit.
- **`canvas.yaml`** (`rooms: []` doc) gains the relocated two-region + `connectRegions` demo — canvas+regions is not one of the two ratified-rejected combinations (only `rooms:`+`canvas:` and `rooms:`+`regions:` are), so it's the pack's only ratified-legal home left for a `regions:` sample. Its pre-existing top-level altar `facing: W` is also now ratified-conforming (ruling 6, spec.md §4.6/§4.9.2) — previously a genuinely open ratification question.
- **Two real byte-level findings surfaced by full regeneration, documented not silently absorbed**:
  - The relocated region demo's auto-picked attachment door edge changed (`[10,3]->[11,3]` to `[10,3]->[11,2]`) — traced to the pre-v0.4 byte predating the hex-true adjacency widening (`8793905`) that added a third shared-boundary edge between the two regions; the codebase's later "canonical wall adjacency" fix (`ce67065`) only refreshed the two hand-drawn walls in the file, never the region-derived one.
  - `canvas.yaml` picked up a `wallLines: []` key it never had — it hadn't been regenerated since pack v0.2, before `wallLines:` was added to the empty-canvas skeleton.
- `kitchen-sink.v1-subset.yaml` is byte-identical (regions were always stripped regardless); `kitchen-sink.v1-subset.dropped.json` updated (`"2 regions"` entry removed, `"3 walls"` → `"2 walls"`).
- `specimens/README.md`: v0.4 changelog entry, updated Files table, and a new per-construct status table citing ratified spec §s (replacing probe-only framing as the status authority).
- `CONTRACT.md`: one new ledger section for this regeneration.

## Test plan

- [x] All four specimen files (`kitchen-sink.yaml`, `kitchen-sink.v1-subset.yaml`, `canvas.yaml`, `exploration/holes.yaml`) verified byte-stable through `parseDungeon` → `serializeDungeon` (throwaway `_roundtrip.test.ts`, run and deleted).
- [x] No test in this concept reads `specimens/` as a fixture (confirmed by search) — full `src/concepts/dungeon-builder` suite: 324 tests, 16 files, unchanged and passing.
- [x] `ci-check` clean (format/lint/typecheck/build/test).

— asset-pipeline agent, on behalf of KirkDiggler