### PR TITLE
unit: consume v0.3 wire (canvas floor + region tree), dormant until server ships

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.120",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#d9ef7d9fb49dd604d93bf88d828cfc27e409debe",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#ba7eda1f1833a713afa4f7772b3a39955de9f7b2",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.120",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/concepts/dungeon-builder/Board.tsx
+++ b/src/concepts/dungeon-builder/Board.tsx
@@ -38,6 +38,7 @@ import {
 } from './markerStyle';
 import { PlacementMarker } from './PlacementMarker';
 import { regionCentroid } from './regionGeometry';
+import { regionsByPaintOrder } from './regionTree';
 import type { BoardTool, PaletteSelection, PlacementSelection } from './types';
 
 interface BoardProps {
@@ -422,7 +423,10 @@ export function Board({
   // handlers, `pointerEvents="none"` throughout, same as the wall/hole
   // overlay above. Same `regionArchetypeColor` the interactive creation
   // board uses, so a region reads as the same archetype in both boards.
-  for (const region of doc.regions) {
+  // Painted biggest-first (`regionsByPaintOrder` above) so a nested
+  // region's overlay draws on top of its container's, "innermost
+  // visible" — see that function's own doc comment.
+  for (const region of regionsByPaintOrder(doc.regions)) {
     const color = regionArchetypeColor(region.archetype);
     for (const [col, row] of region.cells) {
       trackCellExtent(col, row);

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -5194,3 +5194,146 @@ staleness this regeneration was the first full pass to surface.
   so this is a byte-shape change only, not a content change.
 - `ci-check` clean (format/lint/typecheck/build/test) after the prettier
   pass.
+
+## v0.3 wire consumption unit: canvas floor + region tree, dormant until the server ships (2026-08-05, rpg-project#169)
+
+**Response-side consumption only**, per the ratified `ideas/dungeon-builder/spec/v0.3/spec.md`
+and the rpg-api-protos#214 conformance review this unit was scoped from.
+Bumps the protos pin **v0.1.118 → v0.1.120** (`FloorPlanRegion`,
+`FloorPlan.floor_cells`/`regions` — verified present in the generated TS
+after a forced reinstall; the first plain `npm install` silently resolved
+the WRONG commit for the same tag, the exact stale-proto trap this repo's
+convention warns about — `rm -rf node_modules/@kirkdiggler/rpg-api-protos
+&& npm install ...#v0.1.120 --force` fixed it). Two consumption paths,
+same shape: prefer the wire the moment a live response carries a
+non-empty field, fall back to the existing client-derived source
+otherwise, badge which one won.
+
+### Creation mode gets a live `PutDungeon` call for the first time
+
+Before this unit, creation mode ("New Dungeon") never called
+`PutDungeon` at all — its floor came exclusively from
+`creation/canvasFloor.ts`'s `deriveCanvasFloorCells`, and its regions
+panel from `regionTree.ts`'s client-derived containment alone (edit
+mode's `usePutDungeonPreview` instance only ever compiled EDIT mode's
+own document). `usePutDungeonPreview.ts` gains
+`useCreationFloorPlanPreview(doc, yamlText, serverState, capabilities)`
+— a SECOND hook for the creation document, deliberately taking
+`serverState`/`capabilities` as parameters rather than probing for them
+itself: those describe the SERVER, not which document is being edited,
+and both hooks run unconditionally every render (React's rules of
+hooks), so a second independent probe would double real network traffic
+(including the 17-request capability suite) for no new information.
+Both hooks now share one `compileLive(doc, yamlText, capabilities)`
+helper (extracted from `usePutDungeonPreview`'s own per-edit effect,
+behavior-preserving — its existing 12 tests pass unchanged) so the two
+request paths can't silently drift from each other.
+
+### Canvas floor (`creation/canvasFloor.ts`)
+
+`resolveCanvasFloor(doc, floorPlan)` prefers `floorPlan.floorCells` the
+moment a response carries a non-empty list, sort-normalized to ascending
+`(column, row)` — the wire's own declared order, confirmed against the
+generated field comment — via a new `sortCellsLexicographic` (conformance
+review finding A5: `deriveCanvasFloorCells`'s own doc comment explicitly
+does NOT promise its column-major order, even though it happens to
+coincide with the wire's order today when no holes are punched).
+`deriveCanvasFloorCells` becomes the labeled fallback. Wired into
+`CreationConcept.tsx`'s existing `floorCells` memo (previously
+unconditional `deriveCanvasFloorCells`) and threaded to
+`DungeonPreview3D` alongside a new `floorSource` prop.
+
+**Indicator**: `DungeonPreview3D` gets a `db-floor-source-indicator`
+badge, top-left of the 3D viewport — `FLOOR: SERVER (N cells)` (cream) /
+`FLOOR: DERIVED` (dashed amber), the exact visual idiom
+`Board.tsx`'s `db-wall-source-indicator` already established for
+server-vs-derived walls. No RTL render test for this badge — this file's
+existing testing discipline never renders `DungeonPreview3D` itself
+(react-three-fiber `<Canvas>`, not jsdom-renderable), only its exported
+pure helpers; live verification (below) is what actually proves the
+badge renders.
+
+### Region tree (new `regionTreeWire.ts`)
+
+Builds on the region-tree unit's `regionTree.ts` (merged from
+`unit/region-tree` — coordinated with that unit rather than reinventing
+`buildRegionTree`/`flattenRegionTree`, the Fog-of-War "three versions of
+one thing" trap this repo's CLAUDE.md names explicitly). Kept as a
+SEPARATE module rather than adding a `FloorPlan`-typed function to
+`regionTree.ts` itself — that file's own header comment documents itself
+as deliberately dependency-free (no `DungeonDoc`/`RegionDoc`, let alone a
+wire proto type), reusable by both boards without pulling in this
+concept's network layer.
+
+`resolveRegionTree(regions, floorPlan)` prefers `FloorPlanRegion.parent_id`
+the moment a response carries a non-empty `regions` list — building the
+SAME `RegionTree` shape directly from parent pointers rather than
+re-inferring containment from cell sets, since the wire's `parent_id` IS
+already the toolkit's own derived answer (its field comment: "Toolkit-derived
+direct declared parent ID"). `regionTree.ts`'s `buildRegionTree` becomes
+BOTH the fallback (empty/absent `floorPlan.regions`) AND the verification
+baseline: whenever the wire is present, every region's wire-declared
+parent is compared against what `buildRegionTree` would derive for the
+SAME cell sets, and a disagreement renders a named, visible warning
+(`db-region-tree-drift-warning`) rather than silently preferring one
+side — conformance review findings A2/A3's "the derivation rule isn't in
+the proto, an implementer can drift" made concrete as an actual drift
+detector. A dangling `parent_id` (resolves to no region on the same
+response — A2) is treated as root for tree-building (graceful, no crash)
+but still surfaces its own named warning, distinct from a parent
+disagreement. `RegionPanel.tsx` gets the matching
+`db-region-tree-source-indicator` badge (`REGIONS: SERVER` /
+`REGIONS: DERIVED`), same idiom as the floor badge above.
+
+### Rollout discipline (conformance review finding A4)
+
+Both consumption paths gate on **non-empty**, not on "a response
+exists" — a live, reachable server that simply hasn't shipped Wave 0/1
+yet (every server today; the client's own capability probe records
+`canvas`/`regions` as decode-unknown as of 2026-08-04) answers with an
+empty `floorCells`/`regions`, which both `resolveCanvasFloor` and
+`resolveRegionTree` treat identically to no `floorPlan` at all — never
+rendering an empty floor or an empty region tree because the producer
+hasn't shipped, exactly the trap A4 named.
+
+### Tests
+
+18 new/extended in `canvasFloor.test.ts` (`sortCellsLexicographic` +
+`resolveCanvasFloor`'s derived/server/empty-rollout-gap/sort-normalization/
+hole-disagreement cases), 9 in `regionTreeWire.test.ts` (derived fallback,
+empty-regions rollout gap, agreeing nested case, sibling case, BOTH
+mismatch directions, dangling parent, id-set drift is silently skipped
+not falsely flagged, a 3-deep nesting chain), 5 in a new
+`RegionPanel.test.tsx` (the badge/warnings actually RENDER, not just that
+the underlying logic is correct — DERIVED on null/empty, SERVER on
+agreement, the mismatch warning naming both regions, the dangling-parent
+warning still rendering the region as a root row). Every `FloorPlan`
+fixture in all three files is hand-constructed and marked SYNTHETIC —
+no live server carries these fields yet, so a "real recorded response"
+fixture (this file's usual `fixtures.ts` discipline) isn't possible for
+this unit. `usePutDungeonPreview.test.ts`'s existing 12 tests pass
+unchanged (the `compileLive` extraction is behavior-preserving). Full
+`src/concepts/dungeon-builder` suite: 360 tests, 19 files, `tsc --noEmit`
+clean.
+
+### Live verification
+
+Own dev server (fresh worktree; `public/models/synty/` rsync'd from a
+sibling worktree the same way the wire-edges unit's own ledger entry
+documents — a fresh worktree never has it, and its absence crashed the
+ENTIRE React root on first 3D-mode render with no console.error, only a
+`pageerror` about a missing texture — confirmed as an asset-sync gap, not
+a code bug, by reproducing the SAME crash-free render against a sibling
+worktree with assets present). Default `.env` (`VITE_API_HOST=
+http://localhost:8080`) reached a real, reachable rpg-api instance
+without the authoring gate's `AuthoringService` registered
+(`Unimplemented` → `serverState: 'gate-off'`) — this is, honestly, the
+ONLY live-testable state today, since no shipped server carries
+`floor_cells`/`regions`: confirmed the 3D preview's badge reads
+`FLOOR: DERIVED` and the Region panel's badge reads `REGIONS: DERIVED`,
+both against a real reachable server, with the floor/region tree
+rendering exactly as before this unit (no regression, no crash, no
+empty-floor flash). The `server`/mismatch/dangling-parent paths are
+proven by `regionTreeWire.test.ts`/`RegionPanel.test.tsx`'s constructed
+fixtures, not live — there is nothing server-side to drive them against
+yet.

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4902,3 +4902,204 @@ canvas sentinel). `ci-check` clean (format/lint/typecheck/build/test).
   under Live verification — code-reviewed and its sibling branch
   live-verified, not independently live-clicked, due to automation flakiness
   in the pre-existing accordion control, not this unit's own code.
+
+## Region tree unit: `RegionPanel` renders the derived scopes model, root row and all (2026-08-04, rpg-project#180)
+
+Platform settled a model refinement on #180 across four consumer-position
+comments the same day (issue comments `5183646492`, `5183689311`,
+`5183885326`, `5184744940` — "the runtime landing strip already exists"):
+**regions are scopes**. Four rules, in order of dependency:
+
+1. **Implicit root region.** Every cell belongs to exactly one region;
+   unpainted floor belongs to the implicit generic/root region — the model
+   is total, no "regionless" special case.
+2. **Nesting is strict containment ONLY**, resolved innermost-wins, like
+   lexical scopes. Venn/partial overlap remains forbidden.
+3. **The YAML stays flat — nesting is derived, never written.** A region is
+   inside another because its cells are a strict SUBSET of the outer
+   region's own declared `cells:` (the outer region's list literally
+   includes the inner one's cells). No `parent:` field, ever.
+4. **Containment forms chains.** Because overlap is allowed only by
+   containment, any two regions sharing a cell must be nested, hence
+   comparable — the parent of a region is its unique smallest strict
+   superset.
+
+This unit is the region panel's half of that model: render the SCOPES the
+document actually describes, not a flat list, with the implicit root as a
+real, honest row.
+
+### `regionTree.ts` — the derivation, kept pure and dialect-independent
+
+New `regionTree.ts`, sibling to `regionGeometry.ts` and following the SAME
+discipline that file's own header comment states: no dependency on
+`DungeonDoc`/`RegionDoc`, every function takes a plain `RegionLike[]`
+(`{id, name?, archetype, cells}`), so both boards and `dungeonYaml.ts` can
+import it without a cycle, and it's unit-testable without a CST document.
+
+- **`buildRegionTree(regions)`** — the containment forest. For every pair,
+  compares cell-set sizes against the shared-cell count to classify the
+  relationship as disjoint / strict-subset-either-way / overlap in one
+  formula (`relate`), rather than three separate subset checks. Parent =
+  the ancestor candidate with the SMALLEST cell count (tightest fit) —
+  verified by a test where a region has TWO valid ancestors of different
+  sizes (a tight inner chamber and a much bigger outer wing) and the tight
+  one wins, not the first one found. Depth 1 = a direct child of the
+  implicit root (root itself is depth 0 and uninstantiated — it has no
+  `RegionLike` to hold); a flat, un-nested document — everything the brush
+  can author today — puts every region at depth 1, which is the model's own
+  one-level forest, not a degraded case.
+- **`RegionOverlapWarning`** — two regions that share cells with NEITHER a
+  strict subset of the other (a true Venn overlap, or even two regions
+  painted onto the identical cell set — same-size-same-cells doesn't count
+  as containment either, since containment requires a genuine size
+  difference). Carries a capped cell sample (`OVERLAP_SAMPLE_CELLS = 6`)
+  plus the true count, for an author-facing "these don't nest" message.
+- **`flattenRegionTree(tree)`** — pre-order (parent-immediately-before-
+  children) flatten, the natural render order for an indented list.
+- **`rootCellCount(totalFloorCells, regions)`** — the implicit root's own
+  cell count: `totalFloorCells` minus every cell claimed by ANY region at
+  ANY depth (unions everything rather than just top-level regions, so it
+  stays correct even for a malformed/warned document where the "child
+  cells are always a literal subset of the parent's declared list"
+  invariant doesn't hold). **Floor-source-agnostic on purpose**: "the
+  floor" means something different for creation mode's canvas
+  (`creation/canvasFloor.ts`'s `deriveCanvasFloorCells` — the canvas
+  grid's bounds minus holes, what `RegionPanel.tsx` feeds it this round)
+  than for a compiled/edit-mode document (the server-generated
+  `FloorPlan`'s room geometry). Only creation mode has a regions panel to
+  show a root row in **this round** — edit mode's `Board.tsx` renders
+  authored regions read-only with no panel at all (unchanged) — so the
+  compiled-doc case has no consumer yet; the function doesn't hardcode
+  canvas assumptions so an edit-mode consumer can reuse it later without
+  this module needing to know about `FloorPlan`.
+- **`regionsByPaintOrder(regions)`** — biggest-cell-count-first sort, used
+  by BOTH boards' read-only/interactive region overlays (below), kept here
+  rather than duplicated because it's the same "regions are scopes" size
+  reasoning: a child's cell count is always less than its parent's.
+
+### `RegionPanel.tsx` — the tree, root row first
+
+The panel's "nothing pending/selected" branch (`CreationBoard.tsx`'s Region
+tool with no in-progress gesture) used to `doc.regions.map` a flat list, and
+returned `null` outright when `doc.regions.length === 0` ("nothing useful to
+list"). Now:
+
+- **Renders even at zero authored regions** — the root row alone, holding
+  the whole canvas floor. Picking up the Region tool now immediately shows
+  the total-coverage model before anything is painted, rather than only
+  becoming honest once a first region exists.
+- **Root row**: `(everything else)` + `rootCellCount(deriveCanvasFloorCells(doc), doc.regions)`,
+  dashed border, muted italic styling, `cursor: default` — informational
+  only this round, not selectable (nothing to edit on it yet; noted in the
+  row's own `title` tooltip as a future home for root-scope defaults).
+- **Real regions**: `flattenRegionTree(buildRegionTree(doc.regions))`,
+  indented `(depth - 1) * 14px` per row — a flat document (every region at
+  depth 1) renders with zero extra indent, unchanged from before; a nested
+  document indents each level under its parent. Click-to-select, the
+  editing hint, and the connect callout are untouched — same
+  `regionEdit`/`selectRegion` wiring as before, just fed the tree's flat
+  render order instead of `doc.regions` directly.
+- **Overlap warnings**: a red banner (same error palette this panel's own
+  id-validation messages already use — `#ff9a8a` on `#2a1512`) above the
+  list, one line per `RegionOverlapWarning`, naming both regions by
+  name-or-id, the cell count, a capped cell sample, and citing #180's
+  containment rule.
+
+### Board overlay ordering: authoring order was accidental, paint order now isn't
+
+`Board.tsx` (edit mode, read-only) and `CreationBoard.tsx` (creation mode,
+interactive) both iterated `doc.regions` in raw array/declaration order for
+their tinted-hex overlays — for a NESTED document, this only drew the inner
+region on top of the outer one if the author happened to declare outer
+before inner in the YAML. No nested document exists in the wild yet
+(shipped `validateRegionCells` is still flat non-overlap — see the dialect
+note below), but a hand-typed one pasted into the YAML pane shouldn't
+depend on declaration order to render sanely, and the brief asked this to
+be checked and fixed cheaply if it wasn't. Both loops now iterate
+`regionsByPaintOrder(doc.regions)` instead — biggest cell count first —
+so a nested region's tint always lands on top of its container's without
+either renderer needing to compute the actual containment forest just to
+get paint order right.
+
+**Proven, not assumed**: a direct DOM check (Playwright `evaluate`, not
+just a screenshot) against a doc authored with regions declared
+INNERMOST-FIRST — `reliquary` (1 cell, boss/red) before `vault` (3 cells)
+before `crypt` (6 cells, chamber/green), the reverse of "natural" order —
+confirms three overlapping polygons stack at the shared cell in DOM order
+`crypt (green) → vault (green) → reliquary (red)`, i.e. paint order tracks
+cell-count, not declaration order; the red boss region is topmost despite
+being declared first. Screenshot:
+`docs/evidence/dungeon-builder-region-tree-paint-order-proof.png`.
+
+### Dialect note: today's ceiling is a one-level forest, by construction
+
+The interactive brush still can't paint a nested region — `validateRegionCells`
+(`dungeonYaml.ts`) rejects ANY shared cell, containment included, unchanged
+by this unit (out of scope per the brief: "no nested-painting authoring, no
+validation-rule changes"). So every document the creation board itself can
+currently produce is a flat one-level forest — `buildRegionTree` handles
+arbitrary depth regardless, so it renders correctly the day validation
+allows painting a nested region, and renders a hand-edited YAML document
+(pasted into the YAML pane) that already nests today, since the PARSER
+doesn't enforce non-overlap, only the brush's mutators do.
+
+### Live verification
+
+Real dev server (`vite --port 5183` — never `:3001`), Playwright driving the
+actual hex-true board (own coordinate math replicated from
+`hooks/wallRuns.ts`'s `cubeAtColRow` + `hex-grid/hexMath.ts`'s `cubeToWorld`,
+since the board has no per-cell DOM click target — a single SVG-level
+pointer handler resolves clicks from world position, same reason
+`creationGeometry.ts`'s own header comment gives).
+
+1. **Region tool armed, zero regions painted** — root row alone,
+   `(everything else) 600` (the full 20×30 default canvas).
+   `docs/evidence/dungeon-builder-region-tree-root-only.png`.
+2. **One real region painted** (`north-alcove`, 4 cells) — root row updates
+   to `596`, region listed below at depth 1.
+   `docs/evidence/dungeon-builder-region-tree-flat-one-region.png`.
+3. **Hand-pasted nested chain** (crypt ⊃ vault ⊃ reliquary, 6/3/1 cells) —
+   root row `594` (600 − 6, unioned not double-subtracted), three rows
+   visibly step-indented one level deeper each.
+   `docs/evidence/dungeon-builder-region-tree-nested-chain.png`.
+4. **Hand-pasted Venn overlap** (`room-a`/`room-b`, 2 shared cells, neither
+   a subset) — red warning banner naming both regions + the 2 shared cells,
+   both regions listed as flat siblings (not nested — an invalid pair has
+   no containment relationship to place one under the other).
+   `docs/evidence/dungeon-builder-region-tree-venn-warning.png`.
+5. **Reverse-declaration-order paint-order proof** — above.
+
+No console errors beyond the two established FIXTURES-MODE `[unimplemented]
+unknown service ...AuthoringService` messages every prior round's
+live-verification section already carries.
+
+### Tests
+
+16 new in `regionTree.test.ts` (340 dungeon-builder tests overall, up from
+324): flat forest (every region depth 1, any authoring order, including
+single-region and zero-region edges); nested chain 3 deep; parent-is-
+smallest-superset-not-just-any-ancestor (the tight-vs-wide-outer-region
+case above); multi-child siblings under one parent; partial-overlap
+detection (a genuine Venn pair, two regions on identical cells, sample
+capping with a true count above the cap, disjoint regions producing no
+warning); `flattenRegionTree` pre-order ordering; `rootCellCount` (empty
+floor math, single-region subtraction, union-not-double-subtract for a
+nested pair, fully-covered-floor zero case). `ci-check` clean
+(format/lint/typecheck/build/test).
+
+### What did NOT ship this round — named, not silently dropped
+
+- **Nested-region authoring via the brush.** Out of scope by the brief —
+  this unit is rendering + detection, not enabling nested painting.
+  `validateRegionCells` is untouched.
+- **Any validation-rule change.** The client-side flat non-overlap rule
+  stays exactly as strict as before; this unit only renders/derives from
+  whatever a document (brush-authored or hand-typed) already contains.
+- **Root-scope defaults.** The root row's own `title` names it as a future
+  home for defaults (audio/lighting/etc. per the "regions are scopes"
+  resolution-order comment) — nothing implements that yet; the row is
+  informational only.
+- **Edit-mode root row.** `Board.tsx` has no regions panel at all (unchanged
+  from before this unit) — `rootCellCount`'s floor-source-agnostic design
+  means it's ready to be fed a compiled `FloorPlan`'s cell set whenever
+  edit mode grows one, but nothing wires that up this round.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -50,7 +50,10 @@ import { DungeonPreview3D } from './preview3d/DungeonPreview3D';
 import { RolledContentPanel } from './RolledContentPanel';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
-import { usePutDungeonPreview } from './usePutDungeonPreview';
+import {
+  useCreationFloorPlanPreview,
+  usePutDungeonPreview,
+} from './usePutDungeonPreview';
 import { useSaveDungeon } from './useSaveDungeon';
 import { WallGashExplainer } from './WallGashExplainer';
 import { YamlPane } from './YamlPane';
@@ -282,6 +285,24 @@ export function DungeonBuilderConcept() {
   );
   const creationApplyDebounce = useRef<ReturnType<typeof setTimeout> | null>(
     null
+  );
+
+  // Creation mode's own live FloorPlan preview (v0.3 wire consumption
+  // unit, 2026-08-05) — same "reuse the shared serverState/capabilities,
+  // don't re-probe" reasoning `creationV1Subset` below already documents
+  // for `preview.capabilities`; see `useCreationFloorPlanPreview`'s own
+  // doc comment for why this is a SECOND hook rather than a second call to
+  // `usePutDungeonPreview` itself. Feeds `creation/canvasFloor.ts`'s
+  // `resolveCanvasFloor` and the region tree's wire-vs-derived comparison
+  // — both dormant against every live server today (no shipped producer
+  // carries `floor_cells`/`regions` yet), so this is plumbing for the day
+  // Wave 0/1 lands, not a behavior change against any server reachable
+  // right now.
+  const creationFloorPreview = useCreationFloorPlanPreview(
+    creationDoc,
+    creationYamlText,
+    preview.serverState,
+    preview.capabilities
   );
 
   // Creation mode's own Save & Play (capability-probed graduation, this
@@ -599,6 +620,7 @@ export function DungeonBuilderConcept() {
           serverState={preview.serverState}
           capabilities={preview.capabilities}
           onRefreshCapabilities={preview.refreshCapabilities}
+          liveFloorPlan={creationFloorPreview.floorPlan}
           v1Subset={creationV1Subset}
           onSaveAndPlay={handleCreationSaveAndPlay}
           saveState={creationSave.state}

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -1672,6 +1672,37 @@ output, which is itself computed from whatever `capabilityProbe.ts`'s
 caveat to state by hand — the badges structurally can't drift from the
 connected server, because they ARE its answer, re-asked every time.
 
+## Response-side wire consumption: canvas floor + region tree (2026-08-05, dormant)
+
+The capability table above is the SEND side (what the request can carry
+without being stripped). This is the RESPONSE side: once a live server
+answers with `FloorPlan.floor_cells`/`FloorPlan.regions`
+(`FloorPlanRegion.parent_id`) — rpg-api-protos **v0.1.120**, spec.md
+§4.5.9/§4.10.4 — this concept renders FROM the wire instead of its own
+client-derived approximations:
+
+- `creation/canvasFloor.ts`'s `resolveCanvasFloor(doc, floorPlan)` prefers
+  `floorPlan.floorCells` over `deriveCanvasFloorCells` the moment it's
+  non-empty; `DungeonPreview3D`'s `FLOOR: SERVER (N)` / `FLOOR: DERIVED`
+  badge shows which one won.
+- `regionTreeWire.ts`'s `resolveRegionTree(regions, floorPlan)` prefers
+  `floorPlan.regions`/`parent_id` over `regionTree.ts`'s cell-subset
+  inference the moment it's non-empty, cross-checking the two and
+  surfacing a named warning on disagreement (or a dangling `parent_id`);
+  `RegionPanel`'s `REGIONS: SERVER` / `REGIONS: DERIVED` badge mirrors the
+  floor badge.
+
+**Ready, currently dormant.** Canvas mode (spec.md §1 group (c),
+rpg-project#192) and regions (group (d), rpg-project#180/Wave 1) are both
+not started server-side — every live server today answers with empty
+`floor_cells`/`regions` (decode-unknown fields as of the 2026-08-04
+capability probe, same table above), which both consumers treat
+identically to no response at all, never as "the document declares
+zero." The client-side plumbing exists and is tested against constructed
+fixtures now so the flip to server truth needs zero further client
+changes the day Wave 0/1 lands — see CONTRACT.md's "v0.3 wire consumption
+unit" ledger entry for the full writeup and live-verification notes.
+
 ## The v1-subset strip — what actually reaches `PutDungeon`, capability-aware
 
 This concept NEVER sends a target-dialect document to the real server

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -1460,6 +1460,62 @@ recorded here rather than silently decided, same discipline
   region's cells changes movement/line-of-sight only; the region's own
   `cells:` membership is untouched by any wall mutator.
 
+### Regions are scopes (2026-08-04 model refinement, rpg-project#180) — landed as read-only tree rendering this round
+
+Platform settled a refinement of the model above across four
+consumer-position comments on #180 the same day (issue comments
+`5183646492`, `5183689311`, `5183885326`, `5184744940`). This supersedes
+parts of "Open questions" above — recorded here as a dated refinement, not
+by silently rewriting what was previously true-as-written:
+
+1. **An implicit root region replaces "regionless."** Refines the prior
+   "Must regions fully tile?" answer above: rather than unclaimed floor
+   having no region, EVERY cell belongs to exactly one region — unpainted
+   floor belongs to the implicit generic/root region. The model is now
+   total, no "regionless" special case in any future semantic. Runtime
+   behavior is unchanged (unclaimed cells still fall back to space-level
+   defaults) — only the framing is: "the root region's defaults," not
+   "no region at all." The "sparse, disjoint regions are allowed" claim
+   above is still true for AUTHORED regions specifically — they need not
+   tile the space — it's just that the gaps between them now have a name.
+2. **Regions may nest, by strict containment ONLY, resolved
+   innermost-wins** — like lexical scopes. This refines "Non-overlapping"
+   above: overlap remains forbidden EXCEPT strict containment (Venn/partial
+   overlap stays invalid either way). A cell's semantics resolve through
+   the innermost containing region; names compose ("the Vault, in the
+   Crypt"). The shipped flat model (every region a direct child of the
+   implicit root) is exactly one level of this — nesting extends it
+   without breaking any existing document.
+3. **Nesting is DERIVED from cell-subset relationships, never written** —
+   no `parent:` field, ever. A region is inside another because its cells
+   are a strict SUBSET of the outer region's own declared `cells:` (the
+   outer region's list literally includes the inner one's). Because
+   overlap is allowed only by containment, any two regions sharing a cell
+   must be nested, hence comparable — the parent of a region is its unique
+   smallest strict superset (none exists means the implicit root).
+4. **Authored region ids compile to the runtime's existing zone ids** — no
+   new runtime concept. `encounter/data.go`'s `SpaceData.Regions`
+   (`ID`/`Hexes`/`Archetype`, the same `entrance|chamber|corridor|boss`
+   vocabulary `RoomDoc.archetype` already uses) and the perception layer's
+   per-hex `ZoneID` stamp already exist server-side; #180 is authors
+   painting more of them, including nested ones, onto the same structure
+   that already drives fog, spawn seeding, and door naming today.
+
+**Landed this round (region-tree unit, rpg-project#180)**: `RegionPanel.tsx`
+renders this model truthfully — the derived containment forest
+(`regionTree.ts`'s `buildRegionTree`, parent = smallest strict superset by
+cell-subset check) with the implicit root as a real row (`(everything
+else)`, cell count = canvas floor cells minus every claimed cell at any
+depth), children indented under parents, and a partial-overlap warning for
+any Venn pair a hand-edited document might contain. **Not landed**: nested
+authoring via the brush (`validateRegionCells` is unchanged — still flat
+non-overlap, so the interactive tool can only ever produce a one-level
+forest); the compiler-side derivation (still platform's call, per every one
+of the four comments above); root-scope defaults (the root row is
+informational only — a noted future home, nothing implements it). See
+CONTRACT.md's "Region tree unit" section for the full implementation
+writeup, tests, and live-verification evidence.
+
 ### Region attachment vs. chain `connectors:` — deliberately distinct constructs
 
 "Attach to the next region" (Kirk's ask) is implemented as placing a DOOR

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -71,6 +71,7 @@ import {
 } from '../markerStyle';
 import { PlacementMarker } from '../PlacementMarker';
 import { regionCentroid } from '../regionGeometry';
+import { regionsByPaintOrder } from '../regionTree';
 import type { BoardTool, PlacementSelection } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import { canvasPlacementRejectReason } from './canvasFloor';
@@ -1294,9 +1295,11 @@ export function CreationBoard({
   // the board's own `handlePointerDown` already resolves "was an existing
   // region clicked" via `nearestCreationCell` + a `doc.regions` scan, so
   // these elements are purely visual, not a second independent hit-test
-  // surface.
+  // surface. Painted biggest-first (`regionsByPaintOrder`, shared with
+  // `Board.tsx`'s read-only overlay) so a nested region's overlay draws
+  // on top of its container's, "innermost visible."
   const regionEls: ReactElement[] = [];
-  for (const region of doc.regions) {
+  for (const region of regionsByPaintOrder(doc.regions)) {
     const color = regionArchetypeColor(region.archetype);
     const selected = regionEdit.selectedRegionId === region.id;
     for (const [col, row] of region.cells) {

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -7,6 +7,7 @@
  * rows and the shared `Inspector` — no more bespoke Tools strip or
  * hand-rolled facing/delete panel duplicating what those already do.
  */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { useEffect, useMemo, useState } from 'react';
 import type { ServerCapabilities } from '../capabilityProbe';
@@ -19,7 +20,7 @@ import type { BoardTool } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import type { ServerState } from '../usePutDungeonPreview';
 import type { SaveState } from '../useSaveDungeon';
-import { deriveCanvasFloorCells } from './canvasFloor';
+import { resolveCanvasFloor } from './canvasFloor';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
@@ -91,6 +92,15 @@ interface CreationConceptProps {
   serverState: ServerState;
   capabilities: ServerCapabilities | null;
   onRefreshCapabilities: () => void;
+  /** The creation document's own live `PutDungeon(validate_only)` response
+   * (v0.3 wire consumption unit, 2026-08-05 — `usePutDungeonPreview.ts`'s
+   * `useCreationFloorPlanPreview`). `null` in fixtures mode, mid-debounce,
+   * or while a live server hasn't shipped `floor_cells`/`regions` yet
+   * (every server today — dormant by design, see that hook's own doc
+   * comment). Threaded down to `resolveCanvasFloor`/the region tree so
+   * this concept flips to server truth automatically the day the platform
+   * ships Wave 0/1, with zero further client changes. */
+  liveFloorPlan: FloorPlan | null;
   v1Subset: V1SubsetResult | null;
   onSaveAndPlay: () => void;
   saveState: SaveState;
@@ -129,6 +139,7 @@ export function CreationConcept({
   serverState,
   capabilities,
   onRefreshCapabilities,
+  liveFloorPlan,
   v1Subset,
   onSaveAndPlay,
   saveState,
@@ -145,18 +156,27 @@ export function CreationConcept({
   // doesn't need to retarget it.
   const demo = useDemoScript(demoActions, DEFAULT_CANVAS);
 
-  // Canvas floor derivation (rpg-project#169's creation-mode 3D preview
-  // unit) — the 3D preview's own floor semantic for a from-scratch
+  // Canvas floor resolution (rpg-project#169's creation-mode 3D preview
+  // unit; wire-consumption-aware since the v0.3 wire consumption unit,
+  // 2026-08-05) — the 3D preview's own floor semantic for a from-scratch
   // canvas, since it has no compiled `FloorPlan` to render from at all
   // (`creation/canvasFloor.ts`'s own doc comment has the full rationale).
   // Computed here, not inside `DungeonPreview3D` itself, per that
   // component's own "clean interfaces" doc comment — derived only when
-  // actually needed (`boardDim === '3d'`) since `deriveCanvasFloorCells`
-  // scans the whole canvas grid.
-  const floorCells = useMemo(
-    () => (boardDim === '3d' ? deriveCanvasFloorCells(doc) : []),
-    [boardDim, doc]
+  // actually needed (`boardDim === '3d'`) since both `resolveCanvasFloor`
+  // paths scan the whole canvas grid or the whole wire cell list.
+  // `resolveCanvasFloor` prefers `liveFloorPlan.floorCells` the moment a
+  // live response carries a non-empty one, falling back to
+  // `deriveCanvasFloorCells` otherwise (dormant against every server
+  // today — see `liveFloorPlan`'s own doc comment).
+  const resolvedFloor = useMemo(
+    () =>
+      boardDim === '3d'
+        ? resolveCanvasFloor(doc, liveFloorPlan)
+        : { cells: [], source: 'derived' as const },
+    [boardDim, doc, liveFloorPlan]
   );
+  const floorCells = resolvedFloor.cells;
 
   useEffect(() => {
     if (demo.isPlaying) {
@@ -477,6 +497,7 @@ export function CreationConcept({
             <div style={{ flex: 1, minHeight: 0 }}>
               <DungeonPreview3D
                 floorCells={floorCells}
+                floorSource={resolvedFloor.source}
                 doc={doc}
                 selectedPlacement={edit.selectedPlacement}
                 onSelect={(sel) => {

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -557,7 +557,11 @@ export function CreationConcept({
           Region is the live tool, matching every other tool-scoped panel
           in this concept. */}
       {selectedTool === 'region' && (
-        <RegionPanel doc={doc} regionEdit={regionEdit} />
+        <RegionPanel
+          doc={doc}
+          regionEdit={regionEdit}
+          liveFloorPlan={liveFloorPlan}
+        />
       )}
     </div>
   );

--- a/src/concepts/dungeon-builder/creation/RegionPanel.test.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * RegionPanel.test.tsx — v0.3 wire consumption unit (2026-08-05). Proves
+ * the region-tree source badge and drift warnings actually RENDER, not
+ * just that `regionTreeWire.ts`'s pure logic is correct
+ * (`regionTreeWire.test.ts` already covers that). No live server carries
+ * `FloorPlan.regions` yet (rpg-api-protos#214 conformance review finding
+ * A4), so every `FloorPlan` fixture here is hand-constructed — marked
+ * SYNTHETIC per this concept's existing fixtures.ts convention.
+ */
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createRegion,
+  parseDungeon,
+  toDungeonDoc,
+  type DungeonDoc,
+} from '../dungeonYaml';
+import { emptyCanvasYaml } from './emptyCanvasDoc';
+import { RegionPanel } from './RegionPanel';
+import type { RegionEditing } from './useRegionEditing';
+
+function docWithTwoSiblingRegions(): DungeonDoc {
+  const { cst, doc } = parseDungeon(emptyCanvasYaml(20, 20));
+  createRegion(cst, doc, 'north-alcove', 'chamber', [
+    [0, 0],
+    [0, 1],
+  ]);
+  const afterFirst = toDungeonDoc(cst);
+  createRegion(cst, afterFirst, 'east-annex', 'chamber', [
+    [10, 10],
+    [10, 11],
+  ]);
+  return toDungeonDoc(cst);
+}
+
+function stubRegionEdit(): RegionEditing {
+  return {
+    pendingCells: [],
+    togglePendingCell: vi.fn(),
+    setPendingCellMembership: vi.fn(),
+    clearPending: vi.fn(),
+    selectedRegionId: null,
+    selectRegion: vi.fn(),
+    justCreatedId: null,
+    handleCreate: vi.fn(),
+    handleToggleCellOnSelected: vi.fn(),
+    setSelectedRegionCellMembership: vi.fn(),
+    handleRename: vi.fn(),
+    handleSetArchetype: vi.fn(),
+    handleDelete: vi.fn(),
+    handleConnect: vi.fn(),
+  };
+}
+
+function floorPlanWithRegions(
+  regions: { id: string; parentId?: string }[]
+): FloorPlan {
+  return create(FloorPlanSchema, {
+    rooms: [],
+    connectors: [],
+    height: 0,
+    doorRow: 0,
+    floorCells: [],
+    regions: regions.map((r) => ({
+      id: r.id,
+      cells: [],
+      parentId: r.parentId,
+    })),
+  });
+}
+
+describe('RegionPanel — v0.3 wire consumption source badge/warnings', () => {
+  it('shows the DERIVED badge with no liveFloorPlan (fixtures mode / rollout gap)', () => {
+    const doc = docWithTwoSiblingRegions();
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={null}
+      />
+    );
+    expect(
+      screen.getByTestId('db-region-tree-source-indicator').textContent
+    ).toContain('REGIONS: DERIVED');
+    expect(screen.queryByTestId('db-region-tree-drift-warning')).toBeNull();
+  });
+
+  it('shows the DERIVED badge when a live response carries an EMPTY regions list (rollout gap, not "declares none")', () => {
+    const doc = docWithTwoSiblingRegions();
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlanWithRegions([])}
+      />
+    );
+    expect(
+      screen.getByTestId('db-region-tree-source-indicator').textContent
+    ).toContain('REGIONS: DERIVED');
+  });
+
+  it('shows the SERVER badge and no warning when the wire agrees with the derivation', () => {
+    const doc = docWithTwoSiblingRegions();
+    const floorPlan = floorPlanWithRegions([
+      { id: 'north-alcove' },
+      { id: 'east-annex' },
+    ]);
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlan}
+      />
+    );
+    expect(
+      screen.getByTestId('db-region-tree-source-indicator').textContent
+    ).toContain('REGIONS: SERVER');
+    expect(screen.queryByTestId('db-region-tree-drift-warning')).toBeNull();
+  });
+
+  it('renders a visible mismatch warning naming the region when the wire parent disagrees with the derivation', () => {
+    const doc = docWithTwoSiblingRegions();
+    // Disjoint siblings client-side, but the wire (incorrectly) claims
+    // east-annex nests under north-alcove — a real server/client
+    // containment disagreement.
+    const floorPlan = floorPlanWithRegions([
+      { id: 'north-alcove' },
+      { id: 'east-annex', parentId: 'north-alcove' },
+    ]);
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlan}
+      />
+    );
+    const warningText = screen.getByTestId(
+      'db-region-tree-drift-warning'
+    ).textContent;
+    expect(warningText).toContain('east-annex');
+    expect(warningText).toContain('north-alcove');
+    expect(warningText).toContain('disagreement');
+  });
+
+  it('renders a visible warning for a dangling parent_id, and still shows the region as a root row', () => {
+    const doc = docWithTwoSiblingRegions();
+    const floorPlan = floorPlanWithRegions([
+      { id: 'north-alcove', parentId: 'ghost-region' },
+      { id: 'east-annex' },
+    ]);
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlan}
+      />
+    );
+    const warningText = screen.getByTestId(
+      'db-region-tree-drift-warning'
+    ).textContent;
+    expect(warningText).toContain('north-alcove');
+    expect(warningText).toContain('ghost-region');
+    expect(warningText).toContain('treated as root');
+    // Still rendered as a normal clickable row, not dropped — throws if
+    // absent, which IS the assertion.
+    screen.getByText('north-alcove');
+  });
+});

--- a/src/concepts/dungeon-builder/creation/RegionPanel.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.tsx
@@ -11,6 +11,12 @@
 import { useEffect, useRef, useState } from 'react';
 import type { DungeonDoc } from '../dungeonYaml';
 import { sharedBoundaryEdges } from '../regionGeometry';
+import {
+  buildRegionTree,
+  flattenRegionTree,
+  rootCellCount,
+} from '../regionTree';
+import { deriveCanvasFloorCells } from './canvasFloor';
 import type { RegionEditing } from './useRegionEditing';
 
 const ARCHETYPE_OPTIONS = ['entrance', 'chamber', 'corridor', 'boss'];
@@ -161,10 +167,25 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
   // since this panel used to render nothing at all here. A compact list
   // of every existing region, click-to-select, fixes that without
   // requiring the author to already know to click precisely on the
-  // board. Truly empty (no regions drawn yet either) still renders
-  // nothing — there's nothing useful to list. ---
+  // board.
+  //
+  // Renders the SCOPES MODEL (rpg-project#180's four consumer-position
+  // comments, 2026-08-04), not a flat list: the implicit root region
+  // ("(everything else)" — every canvas floor cell not claimed by an
+  // authored region) as a real, always-present row, then every authored
+  // region indented under its derived parent (smallest strict superset by
+  // cell-subset check — `regionTree.ts`). A flat, un-nested document
+  // (everything the brush can author today) puts every region directly
+  // under the root at depth 1 — this is NOT a degraded case, it's the
+  // model's own one-level forest. Shown even with zero authored regions
+  // (root alone, holding the whole floor) so picking up the Region tool
+  // immediately shows the total-coverage model before anything is
+  // painted, rather than only becoming honest once a first region exists. ---
   if (pendingCells.length === 0 && !editingRegion && !showConnectCallout) {
-    if (doc.regions.length === 0) return null;
+    const floorCells = deriveCanvasFloorCells(doc);
+    const tree = buildRegionTree(doc.regions);
+    const rootCount = rootCellCount(floorCells, doc.regions);
+    const rows = flattenRegionTree(tree);
     return (
       <div role="dialog" aria-label="Regions" style={panelStyle}>
         <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
@@ -173,14 +194,68 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
         <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
           Click a region to edit it, or paint new board cells to start another.
         </div>
+        {tree.overlaps.length > 0 && (
+          <div
+            style={{
+              fontSize: 10,
+              color: '#ff9a8a',
+              background: '#2a1512',
+              border: '1px solid #5a2a20',
+              borderRadius: 4,
+              padding: '5px 8px',
+              marginBottom: 8,
+              lineHeight: 1.4,
+            }}
+          >
+            {tree.overlaps.map((o) => {
+              const a = doc.regions.find((r) => r.id === o.regionAId);
+              const b = doc.regions.find((r) => r.id === o.regionBId);
+              const sample = o.cells.map(([c, r]) => `[${c},${r}]`).join(', ');
+              const more = o.cellCount > o.cells.length;
+              return (
+                <div key={`${o.regionAId}-${o.regionBId}`}>
+                  ⚠ "{a?.name ?? o.regionAId}" and "{b?.name ?? o.regionBId}"
+                  overlap without either containing the other ({o.cellCount}{' '}
+                  cell{o.cellCount === 1 ? '' : 's'}: {sample}
+                  {more ? ', …' : ''}) — nesting requires strict containment
+                  (rpg-project#180).
+                </div>
+              );
+            })}
+          </div>
+        )}
         <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-          {doc.regions.map((r) => (
+          <li style={{ marginBottom: 4 }}>
+            <div
+              title="Unpainted floor — every cell not claimed by an authored region belongs to the implicit root region (rpg-project#180). Informational only this round; a future home for root-scope defaults."
+              style={{
+                ...buttonStyle,
+                width: '100%',
+                boxSizing: 'border-box',
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: 8,
+                background: 'transparent',
+                color: '#8a7a5a',
+                border: '1px dashed var(--border-primary)',
+                fontWeight: 400,
+                fontStyle: 'italic',
+                cursor: 'default',
+              }}
+            >
+              <span>(everything else)</span>
+              <span>{rootCount}</span>
+            </div>
+          </li>
+          {rows.map(({ region: r, depth }) => (
             <li key={r.id} style={{ marginBottom: 4 }}>
               <button
                 onClick={() => selectRegion(r.id)}
                 style={{
                   ...buttonStyle,
-                  width: '100%',
+                  width: `calc(100% - ${(depth - 1) * 14}px)`,
+                  marginLeft: (depth - 1) * 14,
+                  boxSizing: 'border-box',
                   display: 'flex',
                   justifyContent: 'space-between',
                   gap: 8,

--- a/src/concepts/dungeon-builder/creation/RegionPanel.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.tsx
@@ -8,14 +8,12 @@
  * "regions:" section) — edit mode renders any authored regions read-only
  * (`Board.tsx`), with no panel of its own yet.
  */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { useEffect, useRef, useState } from 'react';
 import type { DungeonDoc } from '../dungeonYaml';
 import { sharedBoundaryEdges } from '../regionGeometry';
-import {
-  buildRegionTree,
-  flattenRegionTree,
-  rootCellCount,
-} from '../regionTree';
+import { flattenRegionTree, rootCellCount } from '../regionTree';
+import { resolveRegionTree } from '../regionTreeWire';
 import { deriveCanvasFloorCells } from './canvasFloor';
 import type { RegionEditing } from './useRegionEditing';
 
@@ -36,6 +34,46 @@ function TargetDialectBadge() {
       }}
     >
       dialect
+    </span>
+  );
+}
+
+/** Region-tree source indicator (v0.3 wire consumption unit, 2026-08-05)
+ * — same "make drift visible, not silent" idiom as `Board.tsx`'s wall/
+ * door source badge (`db-wall-source-indicator`) and
+ * `preview3d/DungeonPreview3D.tsx`'s floor source badge
+ * (`db-floor-source-indicator`): distinguishes a real
+ * `FloorPlan.regions`/`parent_id` response from `regionTree.ts`'s
+ * client-derived containment fallback, which this panel used exclusively
+ * before this unit and still uses whenever a response carries no
+ * `regions` (every live server today — rollout gap A4, not a contract
+ * defect). */
+function RegionTreeSourceBadge({ source }: { source: 'server' | 'derived' }) {
+  return (
+    <span
+      data-testid="db-region-tree-source-indicator"
+      title={
+        source === 'server'
+          ? 'containment forest built from FloorPlanRegion.parent_id (rpg-api-protos v0.1.120+)'
+          : 'containment forest inferred client-side (regionTree.ts) — no live FloorPlan.regions carried yet'
+      }
+      style={{
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: 0.3,
+        borderRadius: 3,
+        padding: '1px 5px',
+        marginLeft: 6,
+        ...(source === 'server'
+          ? { color: '#100d0b', background: '#c9bfae' }
+          : {
+              color: '#e8e2d8',
+              background: 'rgba(90, 74, 58, 0.55)',
+              border: '1px dashed #8a7a5a',
+            }),
+      }}
+    >
+      {source === 'server' ? 'REGIONS: SERVER' : 'REGIONS: DERIVED'}
     </span>
   );
 }
@@ -93,9 +131,21 @@ const buttonStyle: React.CSSProperties = {
 interface RegionPanelProps {
   doc: DungeonDoc;
   regionEdit: RegionEditing;
+  /** The creation document's own live `PutDungeon(validate_only)` response
+   * (v0.3 wire consumption unit, 2026-08-05 —
+   * `usePutDungeonPreview.ts`'s `useCreationFloorPlanPreview`). `null` in
+   * fixtures mode, mid-debounce, or while a live server hasn't shipped
+   * `regions` yet (every server today). See `regionTreeWire.ts`'s
+   * `resolveRegionTree` for how this panel's tree flips to server truth
+   * once populated. */
+  liveFloorPlan: FloorPlan | null;
 }
 
-export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
+export function RegionPanel({
+  doc,
+  regionEdit,
+  liveFloorPlan,
+}: RegionPanelProps) {
   const {
     pendingCells,
     clearPending,
@@ -183,17 +233,61 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
   // painted, rather than only becoming honest once a first region exists. ---
   if (pendingCells.length === 0 && !editingRegion && !showConnectCallout) {
     const floorCells = deriveCanvasFloorCells(doc);
-    const tree = buildRegionTree(doc.regions);
+    const resolved = resolveRegionTree(doc.regions, liveFloorPlan);
+    const { tree, source, mismatches, dangling } = resolved;
     const rootCount = rootCellCount(floorCells, doc.regions);
     const rows = flattenRegionTree(tree);
     return (
       <div role="dialog" aria-label="Regions" style={panelStyle}>
         <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
           Regions <TargetDialectBadge />
+          <RegionTreeSourceBadge source={source} />
         </h4>
         <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
           Click a region to edit it, or paint new board cells to start another.
         </div>
+        {(mismatches.length > 0 || dangling.length > 0) && (
+          <div
+            data-testid="db-region-tree-drift-warning"
+            style={{
+              fontSize: 10,
+              color: '#ff9a8a',
+              background: '#2a1512',
+              border: '1px solid #5a2a20',
+              borderRadius: 4,
+              padding: '5px 8px',
+              marginBottom: 8,
+              lineHeight: 1.4,
+            }}
+          >
+            {mismatches.map((m) => {
+              const region = doc.regions.find((r) => r.id === m.regionId);
+              const label = (id: string | undefined) => {
+                if (id === undefined) return 'root';
+                const r = doc.regions.find((r) => r.id === id);
+                return `"${r?.name ?? id}"`;
+              };
+              return (
+                <div key={`mismatch-${m.regionId}`}>
+                  ⚠ "{region?.name ?? m.regionId}": server says parent{' '}
+                  {label(m.wireParentId)}, client derivation says parent{' '}
+                  {label(m.derivedParentId)} — server/client containment
+                  disagreement.
+                </div>
+              );
+            })}
+            {dangling.map((d) => {
+              const region = doc.regions.find((r) => r.id === d.regionId);
+              return (
+                <div key={`dangling-${d.regionId}`}>
+                  ⚠ "{region?.name ?? d.regionId}": server-declared parent "
+                  {d.danglingParentId}" is not a region on this response —
+                  treated as root.
+                </div>
+              );
+            })}
+          </div>
+        )}
         {tree.overlaps.length > 0 && (
           <div
             style={{

--- a/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
@@ -1,3 +1,8 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { describe, expect, it } from 'vitest';
 import {
   addWallLine,
@@ -9,6 +14,8 @@ import {
 import {
   canvasPlacementRejectReason,
   deriveCanvasFloorCells,
+  resolveCanvasFloor,
+  sortCellsLexicographic,
 } from './canvasFloor';
 import { emptyCanvasYaml } from './emptyCanvasDoc';
 import { straightWallsFootprintSet } from './straightWallGeometry';
@@ -65,6 +72,116 @@ describe('deriveCanvasFloorCells', () => {
       holes: [[0, 0]],
     });
     expect(cells).toEqual([]);
+  });
+});
+
+describe('sortCellsLexicographic', () => {
+  it('sorts ascending by column, then row', () => {
+    const sorted = sortCellsLexicographic([
+      [2, 0],
+      [0, 1],
+      [0, 0],
+      [1, 5],
+    ]);
+    expect(sorted).toEqual([
+      [0, 0],
+      [0, 1],
+      [1, 5],
+      [2, 0],
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const input: [number, number][] = [
+      [1, 1],
+      [0, 0],
+    ];
+    sortCellsLexicographic(input);
+    expect(input).toEqual([
+      [1, 1],
+      [0, 0],
+    ]);
+  });
+});
+
+// v0.3 wire consumption unit (2026-08-05) — resolveCanvasFloor prefers a
+// live FloorPlan.floor_cells (rpg-api-protos v0.1.120) over the
+// client-derived fallback. No live server carries this field yet (the
+// rpg-api-protos#214 conformance review's finding A4 — canvas mode is
+// spec.md §1 group (c), not started server-side): every FloorPlan fixture
+// below is hand-constructed to exercise the shape the wire will carry
+// once Wave 0 ships, not a real recorded response. Marked SYNTHETIC per
+// this concept's existing fixtures.ts convention.
+describe('resolveCanvasFloor — v0.3 wire consumption (SYNTHETIC fixtures, no live server carries these fields yet)', () => {
+  const doc = {
+    canvas: { width: 3, height: 2 },
+    holes: [] as [number, number][],
+  };
+
+  function floorPlanWithCells(cells: [number, number][]): FloorPlan {
+    return create(FloorPlanSchema, {
+      rooms: [],
+      connectors: [],
+      height: 0,
+      doorRow: 0,
+      floorCells: cells.map(([column, row]) => ({ column, row })),
+      regions: [],
+    });
+  }
+
+  it('null floorPlan falls back to derived, labeled "derived"', () => {
+    const result = resolveCanvasFloor(doc, null);
+    expect(result.source).toBe('derived');
+    expect(result.cells).toEqual(
+      sortCellsLexicographic(deriveCanvasFloorCells(doc))
+    );
+  });
+
+  it('a live response with EMPTY floor_cells falls back to derived — rollout gap (A4), not "declares none"', () => {
+    const result = resolveCanvasFloor(doc, floorPlanWithCells([]));
+    expect(result.source).toBe('derived');
+    expect(result.cells).toEqual(
+      sortCellsLexicographic(deriveCanvasFloorCells(doc))
+    );
+  });
+
+  it('a live response with non-empty floor_cells renders from the wire, sort-normalized', () => {
+    // Deliberately authoring-order (not sorted) on the wire fixture, to
+    // prove resolveCanvasFloor normalizes rather than trusting response
+    // order verbatim.
+    const wireCells: [number, number][] = [
+      [2, 1],
+      [0, 0],
+      [1, 0],
+    ];
+    const result = resolveCanvasFloor(doc, floorPlanWithCells(wireCells));
+    expect(result.source).toBe('server');
+    expect(result.cells).toEqual(sortCellsLexicographic(wireCells));
+  });
+
+  it('server cells win even when they disagree with the derived set (e.g. a hole the server does not know about)', () => {
+    const docWithHole = {
+      canvas: { width: 3, height: 2 },
+      holes: [[1, 0]] as [number, number][],
+    };
+    // v0.3's canvas structural floor has no hole concept server-side
+    // (`holes:` is explicitly ABOVE v0.3, spec.md §2) — a real future
+    // server response would legitimately include [1,0] even though the
+    // client's own doc punches a hole there. Wire wins.
+    const wireCells: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ];
+    const result = resolveCanvasFloor(
+      docWithHole,
+      floorPlanWithCells(wireCells)
+    );
+    expect(result.source).toBe('server');
+    expect(result.cells.some(([c, r]) => c === 1 && r === 0)).toBe(true);
   });
 });
 

--- a/src/concepts/dungeon-builder/creation/canvasFloor.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.ts
@@ -22,10 +22,25 @@
  *
  * See TARGET-YAML.md's "canvas:" section for this semantic recorded
  * as a dialect note, not just left as an implementation detail here.
+ *
+ * **v0.3 wire consumption (this unit, 2026-08-05)**: `deriveCanvasFloorCells`
+ * above is now the FALLBACK, not the only source — `resolveCanvasFloor`
+ * below prefers a live `FloorPlan.floor_cells` (rpg-api-protos v0.1.120,
+ * spec.md §4.5.9) the moment a real response carries one. See
+ * `resolveCanvasFloor`'s own doc comment for the rollout discipline (spec
+ * §1 group (c) is not shipped server-side yet, so this path is dormant
+ * against every live server today — verified by the
+ * rpg-api-protos#214 conformance review's finding A4).
  */
+import type {
+  FloorPlan,
+  FloorPlanCell,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { isCellOccupied } from '../boardGeometry';
 import type { DungeonDoc } from '../dungeonYaml';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+
+export type Cell = [number, number];
 
 /** Every `[col, row]` cell inside `doc.canvas`'s bounds (or
  * `DEFAULT_CANVAS` when the document carries none, matching
@@ -45,6 +60,84 @@ export function deriveCanvasFloorCells(
     }
   }
   return cells;
+}
+
+/** Ascending lexicographic `(column, row)` — the wire's own declared
+ * order for both `FloorPlan.floor_cells` and `FloorPlanRegion.cells`
+ * (rpg-api-protos v0.1.120's own field comments: "producers emit cells in
+ * ascending lexicographic (column, row) order"). `deriveCanvasFloorCells`
+ * above happens to already produce this order today (its column-major
+ * outer loop with an increasing-row inner loop IS ascending lexicographic
+ * whenever there are no holes to filter out — the hole filter only ever
+ * removes entries, never reorders the survivors), but its own doc comment
+ * explicitly does NOT promise that ("not spatially meaningful") — so any
+ * caller that needs to compare a wire cell list against a derived one
+ * (rpg-api-protos#214 conformance review, finding A5) normalizes BOTH
+ * sides through this function first rather than relying on the
+ * coincidence. Used both by `resolveCanvasFloor` below (so its returned
+ * cell list has one canonical order regardless of which source produced
+ * it) and by this concept's tests. */
+export function sortCellsLexicographic(cells: readonly Cell[]): Cell[] {
+  return [...cells].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+}
+
+function floorPlanCellToTuple(cell: FloorPlanCell): Cell {
+  return [cell.column, cell.row];
+}
+
+export type CanvasFloorSource = 'server' | 'derived';
+
+export interface ResolvedCanvasFloor {
+  /** Ascending-lexicographic-normalized (see `sortCellsLexicographic`),
+   * regardless of source. */
+  cells: Cell[];
+  source: CanvasFloorSource;
+}
+
+/**
+ * Chooses the creation canvas's floor cell set: the wire's own
+ * `FloorPlan.floor_cells` (rpg-api-protos v0.1.120, spec.md §4.5.9) when a
+ * live response carries a non-empty one, `deriveCanvasFloorCells` (this
+ * file, client-derived from `doc.canvas` bounds minus `doc.holes`)
+ * otherwise.
+ *
+ * **Rollout discipline (rpg-api-protos#214 conformance review, finding
+ * A4)**: canvas mode (spec.md §1 group (c), rpg-project#192) is not
+ * shipped server-side yet, and the client's own live capability probe
+ * records `canvas` as decode-unknown as of 2026-08-04
+ * (`capabilityProbe.ts`) — so an empty `floor_cells` from a REAL server
+ * today means "the producer hasn't shipped this," never "the document
+ * declares an empty floor." Gating on non-empty rather than on
+ * `floorPlan !== null` is exactly what keeps this fallback-safe: a live
+ * server that's reachable and answering, but pre-Wave-0, produces a
+ * `FloorPlan` with `floorCells: []` (the field's zero value, same as an
+ * unset repeated field), which this function treats identically to no
+ * `floorPlan` at all — never an empty rendered floor.
+ *
+ * Does not itself validate `floorPlan.width`/`floorPlan.height` against
+ * `doc.canvas` — `floor_cells` is a complete, self-describing absolute
+ * cell list per its own field comment ("clients MUST render this list,
+ * not infer floor from width and height"), so this function needs nothing
+ * else from the response to be correct. (`FloorPlan.height`'s canvas-mode
+ * meaning is independently ambiguous on the wire today — conformance
+ * review finding A1 — one more reason not to lean on it here.)
+ */
+export function resolveCanvasFloor(
+  doc: Pick<DungeonDoc, 'canvas' | 'holes'>,
+  floorPlan: FloorPlan | null
+): ResolvedCanvasFloor {
+  if (floorPlan && floorPlan.floorCells.length > 0) {
+    return {
+      cells: sortCellsLexicographic(
+        floorPlan.floorCells.map(floorPlanCellToTuple)
+      ),
+      source: 'server',
+    };
+  }
+  return {
+    cells: sortCellsLexicographic(deriveCanvasFloorCells(doc)),
+    source: 'derived',
+  };
 }
 
 /**

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -209,6 +209,17 @@ interface DungeonPreview3DProps {
    * marker) regardless of which floor-tile path won — see
    * `buildFloorTiles`'s own doc comment. */
   floorCells?: readonly [number, number][];
+  /** Which source produced `floorCells` — `creation/canvasFloor.ts`'s
+   * `resolveCanvasFloor` (v0.3 wire consumption unit, 2026-08-05). Purely
+   * a badge/label input, same "caller derives, this component just
+   * renders" discipline `floorCells` itself follows (see this prop's own
+   * doc comment) — this component does not itself decide server-vs-derived,
+   * only displays what the caller already decided. Omitted (or
+   * `undefined`) when `floorCells` itself is absent (edit mode,
+   * `floorPlan`-only) — there is no creation-canvas floor SOURCE to badge
+   * in that case, matching `Board.tsx`'s own edit-mode wall/door
+   * indicator, which this badge mirrors for creation mode's floor. */
+  floorSource?: 'server' | 'derived';
   doc: DungeonDoc;
   /** Kirk's 2026-08-02 "3D editing" arc, part 2 — the SAME
    * `PlacementSelection`/`onSelect` contract `Board.tsx` already uses for
@@ -1183,6 +1194,7 @@ const SELECTED_COLOR = '#ffd76a';
 export function DungeonPreview3D({
   floorPlan,
   floorCells,
+  floorSource,
   doc,
   selectedPlacement,
   onSelect,
@@ -1320,7 +1332,56 @@ export function DungeonPreview3D({
   };
 
   return (
-    <div style={{ width: '100%', height: '100%', background: '#0c0a08' }}>
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        background: '#0c0a08',
+      }}
+    >
+      {/* Canvas floor source indicator (v0.3 wire consumption unit,
+       * 2026-08-05) — same "make drift visible, not silent" idiom as
+       * `Board.tsx`'s wall/door source indicator (`db-wall-source-indicator`):
+       * distinguishes a real `FloorPlan.floor_cells` response
+       * (rpg-api-protos v0.1.120+) from `creation/canvasFloor.ts`'s
+       * client-derived fallback this preview used exclusively before this
+       * unit, and still uses whenever a response carries no floor_cells
+       * (every live server today — rollout gap A4, not a contract defect).
+       * Only rendered when `floorSource` is supplied at all — edit mode's
+       * `floorPlan`-only call site has no creation-canvas floor SOURCE to
+       * badge. */}
+      {floorSource && (
+        <div
+          data-testid="db-floor-source-indicator"
+          style={{
+            position: 'absolute',
+            top: 4,
+            left: 4,
+            zIndex: 5,
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: 0.3,
+            padding: '3px 7px',
+            borderRadius: 4,
+            pointerEvents: 'none',
+            ...(floorSource === 'server'
+              ? {
+                  color: '#100d0b',
+                  background: '#c9bfae',
+                }
+              : {
+                  color: '#e8e2d8',
+                  background: 'rgba(90, 74, 58, 0.55)',
+                  border: '1px dashed #8a7a5a',
+                }),
+          }}
+        >
+          {floorSource === 'server'
+            ? `FLOOR: SERVER (${floorCells?.length ?? 0} cells)`
+            : 'FLOOR: DERIVED'}
+        </div>
+      )}
       <Canvas
         camera={{ fov: 45, position: [10, 14, 10] }}
         onPointerMissed={() => onSelect?.(null)}

--- a/src/concepts/dungeon-builder/regionTree.test.ts
+++ b/src/concepts/dungeon-builder/regionTree.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRegionTree,
+  flattenRegionTree,
+  rootCellCount,
+  type RegionLike,
+} from './regionTree';
+
+function region(
+  id: string,
+  cells: [number, number][],
+  archetype = 'chamber'
+): RegionLike {
+  return { id, archetype, cells };
+}
+
+describe('buildRegionTree — flat forest (shipped dialect: no nesting authorable yet)', () => {
+  it('puts every region at depth 1 with no children, any authoring order', () => {
+    const regions = [
+      region('north-alcove', [
+        [0, 0],
+        [1, 0],
+      ]),
+      region('east-annex', [
+        [5, 5],
+        [5, 6],
+      ]),
+      region('vault', [[10, 10]]),
+    ];
+    const tree = buildRegionTree(regions);
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(3);
+    for (const root of tree.roots) {
+      expect(root.depth).toBe(1);
+      expect(root.children).toEqual([]);
+    }
+    expect(tree.roots.map((r) => r.region.id).sort()).toEqual([
+      'east-annex',
+      'north-alcove',
+      'vault',
+    ]);
+  });
+
+  it('a single region alone is a single root, no overlaps', () => {
+    const regions = [region('only', [[0, 0]])];
+    const tree = buildRegionTree(regions);
+    expect(tree.roots).toHaveLength(1);
+    expect(tree.roots[0].depth).toBe(1);
+    expect(tree.overlaps).toEqual([]);
+  });
+
+  it('no regions at all is an empty forest', () => {
+    const tree = buildRegionTree([]);
+    expect(tree.roots).toEqual([]);
+    expect(tree.overlaps).toEqual([]);
+  });
+});
+
+describe('buildRegionTree — nested chain (hand-authored YAML; not paintable via the brush yet)', () => {
+  it('crypt ⊃ vault ⊃ reliquary nests three deep, innermost as a leaf', () => {
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ]);
+    const vault = region('vault', [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+    ]);
+    const reliquary = region('reliquary', [[0, 0]]);
+    const tree = buildRegionTree([crypt, vault, reliquary]);
+
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(1);
+    const cryptNode = tree.roots[0];
+    expect(cryptNode.region.id).toBe('crypt');
+    expect(cryptNode.depth).toBe(1);
+    expect(cryptNode.children).toHaveLength(1);
+
+    const vaultNode = cryptNode.children[0];
+    expect(vaultNode.region.id).toBe('vault');
+    expect(vaultNode.depth).toBe(2);
+    expect(vaultNode.children).toHaveLength(1);
+
+    const reliquaryNode = vaultNode.children[0];
+    expect(reliquaryNode.region.id).toBe('reliquary');
+    expect(reliquaryNode.depth).toBe(3);
+    expect(reliquaryNode.children).toEqual([]);
+  });
+
+  it('parent is the SMALLEST strict superset, not just any containing region', () => {
+    // crypt is the big chamber; vault is the tight nested subset. A third
+    // region, "wing", is a superset of crypt too (an even bigger outer
+    // area) — vault's parent must resolve to crypt (the tighter fit), not
+    // wing, even though wing also strictly contains vault transitively.
+    const wing = region('wing', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [3, 0],
+      [3, 1],
+    ]);
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ]);
+    const vault = region('vault', [
+      [0, 0],
+      [1, 0],
+    ]);
+    const tree = buildRegionTree([wing, crypt, vault]);
+    expect(tree.overlaps).toEqual([]);
+
+    const wingNode = tree.roots.find((r) => r.region.id === 'wing')!;
+    expect(wingNode.depth).toBe(1);
+    expect(wingNode.children.map((c) => c.region.id)).toEqual(['crypt']);
+
+    const cryptNode = wingNode.children[0];
+    expect(cryptNode.depth).toBe(2);
+    expect(cryptNode.children.map((c) => c.region.id)).toEqual(['vault']);
+
+    const vaultNode = cryptNode.children[0];
+    expect(vaultNode.depth).toBe(3);
+  });
+});
+
+describe('buildRegionTree — multi-child (siblings under one parent)', () => {
+  it('two disjoint inner regions both nest directly under the same outer one', () => {
+    const hall = region('hall', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+    ]);
+    const innerLeft = region('inner-left', [[0, 0]]);
+    const innerRight = region('inner-right', [[4, 0]]);
+    const tree = buildRegionTree([hall, innerLeft, innerRight]);
+
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(1);
+    const hallNode = tree.roots[0];
+    expect(hallNode.region.id).toBe('hall');
+    expect(hallNode.children).toHaveLength(2);
+    expect(hallNode.children.map((c) => c.region.id).sort()).toEqual([
+      'inner-left',
+      'inner-right',
+    ]);
+    for (const child of hallNode.children) {
+      expect(child.depth).toBe(2);
+      expect(child.children).toEqual([]);
+    }
+  });
+});
+
+describe('buildRegionTree — partial-overlap detection (Venn, forbidden by the settled model)', () => {
+  it('flags two regions sharing cells with neither a strict subset of the other', () => {
+    const a = region('room-a', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+    ]);
+    const b = region('room-b', [
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ]);
+    const tree = buildRegionTree([a, b]);
+
+    // Neither region nests — both fall out as roots, since an invalid
+    // Venn pair has no containment relationship to place one under the
+    // other.
+    expect(tree.roots).toHaveLength(2);
+    expect(tree.overlaps).toHaveLength(1);
+    const warning = tree.overlaps[0];
+    expect([warning.regionAId, warning.regionBId].sort()).toEqual([
+      'room-a',
+      'room-b',
+    ]);
+    expect(warning.cellCount).toBe(2);
+    expect(warning.cells).toEqual(
+      expect.arrayContaining([
+        [1, 0],
+        [2, 0],
+      ])
+    );
+  });
+
+  it('flags two regions painted onto the exact same cells (no genuine containment either way)', () => {
+    const a = region('dup-a', [
+      [5, 5],
+      [6, 5],
+    ]);
+    const b = region('dup-b', [
+      [5, 5],
+      [6, 5],
+    ]);
+    const tree = buildRegionTree([a, b]);
+    expect(tree.overlaps).toHaveLength(1);
+    expect(tree.overlaps[0].cellCount).toBe(2);
+    // Neither is placed under the other — both surface as roots alongside
+    // the warning, not silently nested.
+    expect(tree.roots).toHaveLength(2);
+  });
+
+  it('caps the sample cells but reports the true count', () => {
+    const big1: [number, number][] = [];
+    const big2: [number, number][] = [];
+    for (let i = 0; i < 10; i++) {
+      big1.push([i, 0]);
+      big2.push([i, 1]); // no overlap on this row
+    }
+    // Force a real 8-cell overlap with leftovers on both sides so it's a
+    // genuine Venn case, not containment.
+    const a = region('wide-a', [...big1, [0, 5], [1, 5]]);
+    const b = region('wide-b', [...big1, [0, 6], [1, 6]]);
+    const tree = buildRegionTree([a, b]);
+    expect(tree.overlaps).toHaveLength(1);
+    expect(tree.overlaps[0].cellCount).toBe(10);
+    expect(tree.overlaps[0].cells.length).toBe(6); // OVERLAP_SAMPLE_CELLS cap
+  });
+
+  it('leaves disjoint regions with no warning and no containment relation', () => {
+    const a = region('far-a', [[0, 0]]);
+    const b = region('far-b', [[50, 50]]);
+    const tree = buildRegionTree([a, b]);
+    expect(tree.overlaps).toEqual([]);
+    expect(tree.roots).toHaveLength(2);
+  });
+});
+
+describe('flattenRegionTree', () => {
+  it('is pre-order (parent immediately before its children)', () => {
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+    ]);
+    const vault = region('vault', [[0, 0]]);
+    const otherRoot = region('other', [[9, 9]]);
+    const tree = buildRegionTree([otherRoot, crypt, vault]);
+    const flat = flattenRegionTree(tree);
+    const ids = flat.map((n) => n.region.id);
+    const cryptIdx = ids.indexOf('crypt');
+    const vaultIdx = ids.indexOf('vault');
+    expect(cryptIdx).toBeGreaterThanOrEqual(0);
+    expect(vaultIdx).toBe(cryptIdx + 1);
+  });
+
+  it('flattens a flat 3-region document into 3 depth-1 entries', () => {
+    const regions = [
+      region('a', [[0, 0]]),
+      region('b', [[1, 0]]),
+      region('c', [[2, 0]]),
+    ];
+    const tree = buildRegionTree(regions);
+    const flat = flattenRegionTree(tree);
+    expect(flat).toHaveLength(3);
+    expect(flat.every((n) => n.depth === 1)).toBe(true);
+  });
+});
+
+describe('rootCellCount', () => {
+  it('is the full floor when no regions are authored', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ];
+    expect(rootCellCount(floor, [])).toBe(4);
+  });
+
+  it('subtracts a single region’s cells from the floor', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ];
+    const regions = [
+      region('r1', [
+        [0, 0],
+        [1, 0],
+      ] as [number, number][]),
+    ];
+    expect(rootCellCount(floor, regions)).toBe(2);
+  });
+
+  it('unions overlapping/nested regions rather than double-subtracting shared cells', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ];
+    // crypt ⊃ vault — vault's cells are a literal subset of crypt's own
+    // declared cells (the representation decision), so the union of both
+    // regions' cells is exactly crypt's cells, not crypt's + vault's
+    // double-counted.
+    const crypt = region('crypt', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+    ]);
+    const vault = region('vault', [[0, 0]]);
+    expect(rootCellCount(floor, [crypt, vault])).toBe(1); // just [3,0]
+  });
+
+  it('is zero when regions cover the entire floor', () => {
+    const floor: [number, number][] = [
+      [0, 0],
+      [1, 0],
+    ];
+    const regions = [
+      region('r1', [
+        [0, 0],
+        [1, 0],
+      ] as [number, number][]),
+    ];
+    expect(rootCellCount(floor, regions)).toBe(0);
+  });
+});

--- a/src/concepts/dungeon-builder/regionTree.ts
+++ b/src/concepts/dungeon-builder/regionTree.ts
@@ -1,0 +1,296 @@
+/**
+ * regionTree — derives the containment forest for cell-authored semantic
+ * regions (rpg-project#180, "cell-authored semantic room regions"). This
+ * is the "regions are scopes" model settled across four consumer-position
+ * comments on that issue (2026-08-04):
+ *
+ * 1. **Implicit root region** — every cell belongs to exactly one region;
+ *    unpainted floor belongs to the implicit generic/root region. The
+ *    model is total, no "regionless" special case.
+ * 2. **Nesting is strict containment ONLY, resolved innermost-wins** —
+ *    like lexical scopes. Overlap is forbidden except strict containment
+ *    (Venn/partial overlap is invalid).
+ * 3. **The YAML stays flat — nesting is derived, never written.** A
+ *    region is inside another because its cells are a strict SUBSET of
+ *    the outer region's own declared cells (the outer region's `cells:`
+ *    list literally includes the inner one's cells — no `parent:` field,
+ *    ever: a field would duplicate what the cell sets already say, and
+ *    duplicated truth drifts).
+ * 4. **Containment forms chains, so parent and innermost are unique and
+ *    cheap.** Because overlap is allowed only by containment, all regions
+ *    containing a given cell form a chain — any two that share a cell
+ *    must be nested, hence comparable. The parent of a region R is its
+ *    smallest strict superset (unique; none exists means the implicit
+ *    root).
+ *
+ * Kept separate from `dungeonYaml.ts`'s CST layer and deliberately has NO
+ * dependency on `DungeonDoc`/`RegionDoc` — the same discipline
+ * `regionGeometry.ts` already follows (see its own header comment): every
+ * function here takes a plain `RegionLike[]`, so both boards and
+ * `dungeonYaml.ts` itself can import this module without creating a
+ * cycle, and it's unit-testable without a CST document.
+ *
+ * **Dialect note**: the SHIPPED client-side validation
+ * (`dungeonYaml.ts`'s `validateRegionCells`) still enforces flat
+ * non-overlap — ANY shared cell is rejected, including a valid strict
+ * containment. Nested authoring isn't wired up yet (no paint-a-region-
+ * inside-another affordance), so every document the creation board itself
+ * can currently produce is a flat one-level forest (every region a direct
+ * child of the implicit root). This module handles arbitrary nesting
+ * depth regardless, so it renders correctly the day validation allows
+ * painting a nested region, and so it can render a HAND-EDITED YAML
+ * document (pasted into the YAML pane) that already nests today — the
+ * parser doesn't reject it, only the interactive brush does.
+ */
+import type { Cell } from './regionGeometry';
+
+function cellKey(c: Cell): string {
+  return `${c[0]},${c[1]}`;
+}
+
+function toCellSet(cells: readonly Cell[]): Set<string> {
+  return new Set(cells.map(cellKey));
+}
+
+/** The minimal shape `buildRegionTree`/`rootCellCount` need — structurally
+ * compatible with `dungeonYaml.ts`'s `RegionDoc` without importing it (see
+ * this file's own header comment for why). */
+export interface RegionLike {
+  id: string;
+  name?: string;
+  archetype: string;
+  cells: Cell[];
+}
+
+export interface RegionTreeNode<T extends RegionLike = RegionLike> {
+  region: T;
+  /** 1 = a direct child of the implicit root (what a flat, un-nested
+   * document's regions all are today); 2 = nested one level inside a
+   * depth-1 region; and so on. The implicit root itself is depth 0 and is
+   * NOT a `RegionTreeNode` — it has no `RegionLike` to hold (see
+   * `rootCellCount` for its cell count instead). */
+  depth: number;
+  /** Regions whose smallest strict superset is this one. Empty for a leaf
+   * — every region in a flat document is a leaf. */
+  children: RegionTreeNode<T>[];
+}
+
+/** Two regions overlap without either strictly containing the other — a
+ * Venn/partial overlap, forbidden by the settled model (nesting is
+ * strict-containment-only). The interactive brush can't produce this
+ * today (`validateRegionCells` rejects ANY overlap, containment
+ * included), but a hand-edited YAML document pasted into the YAML pane
+ * can, since the parser itself doesn't enforce it — this is exactly the
+ * case this warning exists to surface. */
+export interface RegionOverlapWarning {
+  regionAId: string;
+  regionBId: string;
+  /** The intersecting cells, capped to `OVERLAP_SAMPLE_CELLS` — a
+   * "sample," not a complete accounting, since a large overlap's full
+   * cell list isn't more useful for an author-facing message than a
+   * representative handful. */
+  cells: Cell[];
+  /** True count of intersecting cells — may exceed `cells.length` when
+   * capped. */
+  cellCount: number;
+}
+
+export interface RegionTree<T extends RegionLike = RegionLike> {
+  /** Regions with no strict superset among `regions` — direct children of
+   * the implicit root. A flat, un-nested document (everything shipped
+   * today produces) has every region here, none nested under another. */
+  roots: RegionTreeNode<T>[];
+  overlaps: RegionOverlapWarning[];
+}
+
+const OVERLAP_SAMPLE_CELLS = 6;
+
+/** How two regions' cell sets relate, given their sizes and shared-cell
+ * count — the one comparison every pairwise check in this module reduces
+ * to. `sizeA <= sizeB` is NOT assumed; the caller passes both sizes as
+ * measured. */
+function relate(
+  sizeA: number,
+  sizeB: number,
+  shared: number
+): 'disjoint' | 'a-in-b' | 'b-in-a' | 'overlap' {
+  if (shared === 0) return 'disjoint';
+  // Strict containment requires the smaller set to be FULLY covered by
+  // the bigger one AND a genuine size difference — two regions painted
+  // with the exact same cells (shared === sizeA === sizeB) are neither's
+  // strict subset, so they fall through to 'overlap' below, same as a
+  // true Venn intersection. That's deliberate: an author who somehow
+  // produces two same-cells regions (hand-edited YAML; the brush's own
+  // overlap check would reject it) gets the same "these don't nest"
+  // warning a partial overlap would, not a silently-accepted containment.
+  if (shared === sizeA && sizeA < sizeB) return 'a-in-b';
+  if (shared === sizeB && sizeB < sizeA) return 'b-in-a';
+  return 'overlap';
+}
+
+/** Derives the containment forest from a flat `regions` list — parent =
+ * smallest strict superset by cell-subset check (rpg-project#180's
+ * settled model, see this file's own header comment). O(n^2) pairwise
+ * comparisons; fine for the handful-to-dozens of regions this concept
+ * authors. Order of `regions` doesn't affect the result — the forest
+ * shape is purely a function of cell-set relationships. */
+export function buildRegionTree<T extends RegionLike>(
+  regions: readonly T[]
+): RegionTree<T> {
+  const sets = new Map<string, Set<string>>();
+  for (const r of regions) sets.set(r.id, toCellSet(r.cells));
+
+  const overlaps: RegionOverlapWarning[] = [];
+  // For each region, every OTHER region that strictly contains it, with
+  // that ancestor's cell-set size — the parent is whichever candidate has
+  // the SMALLEST size (the tightest-fitting superset). Chains guarantee
+  // this is well-defined: any two ancestors of the same region must
+  // themselves be comparable (both contain this region's cells, so they
+  // share cells, so under the settled model they must nest), which is
+  // exactly why a unique smallest one exists rather than several
+  // incomparable candidates tying for "closest."
+  const ancestorCandidates = new Map<string, { id: string; size: number }[]>();
+  for (const r of regions) ancestorCandidates.set(r.id, []);
+
+  for (let i = 0; i < regions.length; i++) {
+    for (let j = i + 1; j < regions.length; j++) {
+      const a = regions[i];
+      const b = regions[j];
+      const setA = sets.get(a.id)!;
+      const setB = sets.get(b.id)!;
+      let shared = 0;
+      // Iterate the smaller set for the intersection count — cheap, and
+      // this loop runs O(n^2) times across the whole region list.
+      const [small, big] = setA.size <= setB.size ? [setA, setB] : [setB, setA];
+      for (const k of small) if (big.has(k)) shared++;
+
+      const rel = relate(setA.size, setB.size, shared);
+      if (rel === 'a-in-b') {
+        ancestorCandidates.get(a.id)!.push({ id: b.id, size: setB.size });
+      } else if (rel === 'b-in-a') {
+        ancestorCandidates.get(b.id)!.push({ id: a.id, size: setA.size });
+      } else if (rel === 'overlap') {
+        const sharedCells = a.cells.filter((c) => setB.has(cellKey(c)));
+        overlaps.push({
+          regionAId: a.id,
+          regionBId: b.id,
+          cells: sharedCells.slice(0, OVERLAP_SAMPLE_CELLS),
+          cellCount: sharedCells.length,
+        });
+      }
+      // 'disjoint' pairs need no record — they simply don't constrain
+      // each other's parent.
+    }
+  }
+
+  const parentOf = new Map<string, string | null>();
+  for (const r of regions) {
+    const candidates = ancestorCandidates.get(r.id)!;
+    if (candidates.length === 0) {
+      parentOf.set(r.id, null);
+      continue;
+    }
+    let best = candidates[0];
+    for (const c of candidates) if (c.size < best.size) best = c;
+    parentOf.set(r.id, best.id);
+  }
+
+  const nodeOf = new Map<string, RegionTreeNode<T>>();
+  for (const r of regions)
+    nodeOf.set(r.id, { region: r, depth: 0, children: [] });
+
+  const roots: RegionTreeNode<T>[] = [];
+  for (const r of regions) {
+    const node = nodeOf.get(r.id)!;
+    const parentId = parentOf.get(r.id)!;
+    if (parentId === null) {
+      roots.push(node);
+    } else {
+      nodeOf.get(parentId)!.children.push(node);
+    }
+  }
+
+  // Depths: a direct child of the implicit root is depth 1 (the implicit
+  // root itself, uninstantiated as a node, is depth 0) — chosen so "flat
+  // docs: all at depth 1" reads naturally rather than needing a +1
+  // everywhere a caller renders depth.
+  function assignDepth(node: RegionTreeNode<T>, depth: number): void {
+    node.depth = depth;
+    for (const child of node.children) assignDepth(child, depth + 1);
+  }
+  for (const root of roots) assignDepth(root, 1);
+
+  return { roots, overlaps };
+}
+
+/** Pre-order (parent-before-children) flattening of a `RegionTree` — the
+ * natural render order for an indented list ("root row first ... then
+ * children indented under parents"). Each node's own `depth` (set by
+ * `buildRegionTree`) carries the indentation a caller needs. */
+export function flattenRegionTree<T extends RegionLike>(
+  tree: RegionTree<T>
+): RegionTreeNode<T>[] {
+  const out: RegionTreeNode<T>[] = [];
+  function walk(node: RegionTreeNode<T>): void {
+    out.push(node);
+    for (const child of node.children) walk(child);
+  }
+  for (const root of tree.roots) walk(root);
+  return out;
+}
+
+/** The implicit root region's own cell count — rpg-project#180's
+ * regions-are-scopes refinement: unpainted floor belongs to the implicit
+ * generic/root region, so every document is total (no "regionless"
+ * special case). Root's cells are exactly `totalFloorCells` minus every
+ * cell claimed by ANY authored region, at any depth.
+ *
+ * Unions ALL regions regardless of nesting depth, not just top-level
+ * ones — for a VALID nested document these are the same set (a child's
+ * cells are always a literal subset of its parent's own declared `cells:`
+ * list, per the representation decision in this file's header comment),
+ * but unioning everything keeps this correct even for a malformed
+ * document `buildRegionTree` would also flag with an overlap warning.
+ *
+ * `totalFloorCells` is caller-supplied rather than derived here because
+ * "the floor" means something different for a creation-mode canvas
+ * (`creation/canvasFloor.ts`'s `deriveCanvasFloorCells` — the canvas
+ * grid's bounds minus holes) than for a compiled/edit-mode document (the
+ * server-generated `FloorPlan`'s room geometry, which this concept has no
+ * single flattened cell-list helper for yet). Only creation mode has a
+ * regions panel to show a root row in this round (`RegionPanel.tsx`);
+ * this function stays floor-source-agnostic so an edit-mode consumer can
+ * reuse it later without this module needing to know about `FloorPlan` at
+ * all. */
+/** Biggest-cell-count-first paint order for `doc.regions` — the settled
+ * "regions are scopes" model nests strictly by cell-subset, so a child
+ * region's cell count is always LESS than its parent's (see this file's
+ * own header comment). Painting the biggest first and the smallest last
+ * means a nested (inner) region's tint/stroke always lands on top of its
+ * container's, "innermost visible," WITHOUT a renderer needing the actual
+ * containment forest (`buildRegionTree`) just to get paint order right —
+ * both `Board.tsx`'s read-only overlay and `creation/CreationBoard.tsx`'s
+ * interactive one use this. Previously each simply iterated `doc.regions`
+ * in authoring/array order, which only drew correctly by accident (an
+ * author happening to declare the outer region before the inner one in
+ * the YAML) — no nested document exists in the wild yet (shipped
+ * validation is flat non-overlap), but a hand-typed one pasted into the
+ * YAML pane shouldn't depend on declaration order to render sanely. A
+ * stable sort: two same-size regions (siblings, or a still-invalid Venn
+ * overlap) keep their original relative order. */
+export function regionsByPaintOrder<T extends { cells: unknown[] }>(
+  regions: readonly T[]
+): T[] {
+  return [...regions].sort((a, b) => b.cells.length - a.cells.length);
+}
+
+export function rootCellCount<T extends RegionLike>(
+  totalFloorCells: readonly Cell[],
+  regions: readonly T[]
+): number {
+  const claimed = new Set<string>();
+  for (const r of regions) for (const c of r.cells) claimed.add(cellKey(c));
+  let count = 0;
+  for (const c of totalFloorCells) if (!claimed.has(cellKey(c))) count++;
+  return count;
+}

--- a/src/concepts/dungeon-builder/regionTreeWire.test.ts
+++ b/src/concepts/dungeon-builder/regionTreeWire.test.ts
@@ -1,0 +1,213 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  buildRegionTree,
+  flattenRegionTree,
+  type RegionLike,
+} from './regionTree';
+import { resolveRegionTree } from './regionTreeWire';
+
+function region(
+  id: string,
+  cells: [number, number][],
+  archetype = 'chamber'
+): RegionLike {
+  return { id, archetype, cells };
+}
+
+function floorPlanWithRegions(
+  regions: { id: string; parentId?: string }[]
+): FloorPlan {
+  return create(FloorPlanSchema, {
+    rooms: [],
+    connectors: [],
+    height: 0,
+    doorRow: 0,
+    floorCells: [],
+    regions: regions.map((r) => ({
+      id: r.id,
+      cells: [],
+      parentId: r.parentId,
+    })),
+  });
+}
+
+// v0.3 wire consumption unit (2026-08-05) — resolveRegionTree prefers a
+// live FloorPlan.regions (FloorPlanRegion.parent_id, rpg-api-protos
+// v0.1.120) over regionTree.ts's own client-derived containment. No live
+// server carries this field yet (rpg-api-protos#214 conformance review's
+// finding A4 — regions is spec.md §1 group (d), Wave 1, not started
+// server-side): every FloorPlan fixture below is hand-constructed to
+// exercise the shape the wire will carry once it ships, not a real
+// recorded response. Marked SYNTHETIC per this concept's existing
+// fixtures.ts convention.
+describe('resolveRegionTree — v0.3 wire consumption (SYNTHETIC fixtures, no live server carries these fields yet)', () => {
+  it('null floorPlan falls back to regionTree.ts derivation, labeled "derived"', () => {
+    const regions = [region('a', [[0, 0]]), region('b', [[5, 5]])];
+    const result = resolveRegionTree(regions, null);
+    expect(result.source).toBe('derived');
+    expect(result.mismatches).toEqual([]);
+    expect(result.dangling).toEqual([]);
+    expect(result.tree).toEqual(buildRegionTree(regions));
+  });
+
+  it('a live response with EMPTY regions falls back to derived — rollout gap (A4), not "declares none"', () => {
+    const regions = [region('a', [[0, 0]])];
+    const result = resolveRegionTree(regions, floorPlanWithRegions([]));
+    expect(result.source).toBe('derived');
+  });
+
+  it('a live response with non-empty regions renders the tree from parent_id, agreeing case has no mismatches', () => {
+    // Two regions whose cell sets ALSO nest (a strict subset), so the
+    // wire's parent_id and regionTree.ts's own cell-subset inference
+    // agree — the "everything lines up" baseline case.
+    const outer = region('shrine', [
+      [9, 2],
+      [9, 3],
+      [9, 4],
+      [10, 2],
+      [10, 3],
+      [10, 4],
+    ]);
+    const inner = region('shrine-altar', [
+      [9, 3],
+      [9, 4],
+    ]);
+    const regions = [outer, inner];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'shrine' }, // absent parentId = root
+      { id: 'shrine-altar', parentId: 'shrine' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.mismatches).toEqual([]);
+    expect(result.dangling).toEqual([]);
+    const rows = flattenRegionTree(result.tree);
+    expect(rows.map((r) => ({ id: r.region.id, depth: r.depth }))).toEqual([
+      { id: 'shrine', depth: 1 },
+      { id: 'shrine-altar', depth: 2 },
+    ]);
+  });
+
+  it('an absent parent_id on the wire means root, matching an un-nested derived sibling', () => {
+    const regions = [region('a', [[0, 0]]), region('b', [[5, 5]])];
+    const floorPlan = floorPlanWithRegions([{ id: 'a' }, { id: 'b' }]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.tree.roots).toHaveLength(2);
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it('flags a mismatch when the wire parent disagrees with the cell-subset derivation', () => {
+    // Two SIBLING (disjoint) cell sets — regionTree.ts's own derivation
+    // puts both at root. A wire response that (incorrectly, for this
+    // test) claims "b" is a child of "a" is exactly the drift class A2/A3
+    // name: the proto's derivation rule isn't parser-enforced, so an
+    // implementer — or a stale fixture — can produce a parent_id that
+    // disagrees with the cell sets.
+    const a = region('a', [
+      [0, 0],
+      [0, 1],
+    ]);
+    const b = region('b', [
+      [5, 5],
+      [5, 6],
+    ]);
+    const regions = [a, b];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'a' },
+      { id: 'b', parentId: 'a' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.mismatches).toEqual([
+      { regionId: 'b', wireParentId: 'a', derivedParentId: undefined },
+    ]);
+    // The tree still renders from the WIRE (parent_id authoritative) —
+    // "b" nests under "a" in the rendered tree despite the derived
+    // disagreement; the mismatch is a surfaced warning, not a silent
+    // override of the wire.
+    const rows = flattenRegionTree(result.tree);
+    expect(rows.map((r) => r.region.id)).toEqual(['a', 'b']);
+    expect(rows.find((r) => r.region.id === 'b')!.depth).toBe(2);
+  });
+
+  it('flags a mismatch the other direction too — derived says nested, wire says root', () => {
+    const outer = region('shrine', [
+      [9, 2],
+      [9, 3],
+    ]);
+    const inner = region('shrine-altar', [[9, 3]]); // a real subset of outer
+    const regions = [outer, inner];
+    // Wire (incorrectly) claims shrine-altar has no parent.
+    const floorPlan = floorPlanWithRegions([
+      { id: 'shrine' },
+      { id: 'shrine-altar' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.mismatches).toEqual([
+      {
+        regionId: 'shrine-altar',
+        wireParentId: undefined,
+        derivedParentId: 'shrine',
+      },
+    ]);
+  });
+
+  it('a dangling parent_id (points to a region not on this response) is treated as root AND warned', () => {
+    const regions = [region('a', [[0, 0]])];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'a', parentId: 'ghost-region' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.dangling).toEqual([
+      { regionId: 'a', danglingParentId: 'ghost-region' },
+    ]);
+    // Treated as root for tree-building purposes — no crash, no orphaned
+    // subtree, just a plain root row plus the warning.
+    expect(result.tree.roots).toHaveLength(1);
+    expect(result.tree.roots[0].region.id).toBe('a');
+    expect(result.tree.roots[0].depth).toBe(1);
+  });
+
+  it('a region present locally but absent from the wire response is skipped for mismatch-checking (not a false mismatch)', () => {
+    const regions = [region('a', [[0, 0]]), region('local-only', [[9, 9]])];
+    const floorPlan = floorPlanWithRegions([{ id: 'a' }]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it('handles a 3-deep nesting chain from the wire, matching flattenRegionTree depth semantics', () => {
+    const regions = [
+      region('outer', [
+        [0, 0],
+        [0, 1],
+        [0, 2],
+        [0, 3],
+      ]),
+      region('mid', [
+        [0, 1],
+        [0, 2],
+      ]),
+      region('inner', [[0, 1]]),
+    ];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'outer' },
+      { id: 'mid', parentId: 'outer' },
+      { id: 'inner', parentId: 'mid' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.mismatches).toEqual([]);
+    const rows = flattenRegionTree(result.tree);
+    expect(rows.map((r) => ({ id: r.region.id, depth: r.depth }))).toEqual([
+      { id: 'outer', depth: 1 },
+      { id: 'mid', depth: 2 },
+      { id: 'inner', depth: 3 },
+    ]);
+  });
+});

--- a/src/concepts/dungeon-builder/regionTreeWire.ts
+++ b/src/concepts/dungeon-builder/regionTreeWire.ts
@@ -1,0 +1,182 @@
+/**
+ * regionTreeWire — v0.3 wire consumption for the region containment forest
+ * (this unit, 2026-08-05). `regionTree.ts`'s `buildRegionTree` INFERS
+ * containment from cell-subset comparison; this module instead builds the
+ * SAME `RegionTree` shape directly from `FloorPlanRegion.parent_id`
+ * (rpg-api-protos v0.1.120, spec.md §4.10.4) when a live response carries
+ * one — the wire's `parent_id` field comment says it plainly ("Toolkit-derived
+ * direct declared parent ID"), so once it's present there is nothing left
+ * to infer: recomputing it client-side would just be re-deriving what the
+ * producer already computed authoritatively.
+ *
+ * Kept as a SEPARATE module from `regionTree.ts` rather than adding a
+ * `FloorPlan`-typed function there — `regionTree.ts`'s own header comment
+ * documents itself as deliberately dependency-free (no `DungeonDoc`/
+ * `RegionDoc`, let alone a wire proto type), reusable by both boards
+ * without pulling in this concept's network layer. This module is the one
+ * place that DOES import the wire type, the same split
+ * `creation/canvasFloor.ts`'s `resolveCanvasFloor` follows for the canvas
+ * floor's own wire-vs-derived choice.
+ *
+ * **Rollout discipline (rpg-api-protos#214 conformance review, finding
+ * A4)**: regions (spec.md §1 group (d), rpg-project#180/Wave 1) is not
+ * shipped server-side yet — a live server today always answers with an
+ * empty `FloorPlan.regions`, which this module treats identically to no
+ * `floorPlan` at all (never "the document declares zero regions").
+ *
+ * **Dangling `parent_id` (finding A2)**: the conformance review flagged
+ * that referential closure — `parent_id` resolving to another declared
+ * region's `id` — is a producer expectation the proto never states as a
+ * MUST, so a client has to defensively handle a dangling reference. This
+ * module treats a dangling `parent_id` as root for TREE-BUILDING purposes
+ * (same graceful behavior an absent `parent_id` gets) but still surfaces
+ * it as a named warning — a dangling parent is a real drift signal, not
+ * something to silently swallow.
+ */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import {
+  buildRegionTree,
+  type RegionLike,
+  type RegionTree,
+  type RegionTreeNode,
+} from './regionTree';
+
+export type RegionTreeSource = 'server' | 'derived';
+
+/** One region where the wire's authoritative parent (once present)
+ * disagrees with what `regionTree.ts`'s own cell-subset inference would
+ * derive for the SAME region set — a server/client containment
+ * disagreement is exactly the drift class worth surfacing loudly rather
+ * than silently preferring one side. `undefined` on either side means
+ * "root" on that side. */
+export interface RegionParentMismatch {
+  regionId: string;
+  wireParentId: string | undefined;
+  derivedParentId: string | undefined;
+}
+
+/** A wire region's `parent_id` that does not resolve to another wire
+ * region's `id` (conformance review finding A2). */
+export interface DanglingParentWarning {
+  regionId: string;
+  danglingParentId: string;
+}
+
+export interface ResolvedRegionTree<T extends RegionLike = RegionLike> {
+  tree: RegionTree<T>;
+  source: RegionTreeSource;
+  /** Populated only when `source === 'server'` — the VERIFICATION
+   * comparison against `regionTree.ts`'s own derivation for the same
+   * regions. Empty when `source === 'derived'` (nothing to compare
+   * against — there is no second source). */
+  mismatches: RegionParentMismatch[];
+  /** Populated only when `source === 'server'`. */
+  dangling: DanglingParentWarning[];
+}
+
+function buildTreeFromParentPointers<T extends RegionLike>(
+  regions: readonly T[],
+  parentIdOf: (id: string) => string | undefined
+): { tree: RegionTree<T>; dangling: DanglingParentWarning[] } {
+  const nodeOf = new Map<string, RegionTreeNode<T>>();
+  for (const r of regions) {
+    nodeOf.set(r.id, { region: r, depth: 0, children: [] });
+  }
+
+  const dangling: DanglingParentWarning[] = [];
+  const roots: RegionTreeNode<T>[] = [];
+  for (const r of regions) {
+    const node = nodeOf.get(r.id)!;
+    const parentId = parentIdOf(r.id);
+    if (parentId === undefined) {
+      roots.push(node);
+      continue;
+    }
+    const parentNode = nodeOf.get(parentId);
+    if (!parentNode) {
+      // A4/A2: the wire named a parent that isn't one of the declared
+      // regions on this SAME response — treat as root (same graceful
+      // fallback an absent parent_id gets) but keep the warning so the
+      // caller can surface it, not swallow it.
+      dangling.push({ regionId: r.id, danglingParentId: parentId });
+      roots.push(node);
+      continue;
+    }
+    parentNode.children.push(node);
+  }
+
+  // Same depth convention as regionTree.ts's own buildRegionTree: a
+  // direct child of the implicit root is depth 1.
+  function assignDepth(node: RegionTreeNode<T>, depth: number): void {
+    node.depth = depth;
+    for (const child of node.children) assignDepth(child, depth + 1);
+  }
+  for (const root of roots) assignDepth(root, 1);
+
+  return { tree: { roots, overlaps: [] }, dangling };
+}
+
+/** Walks a `RegionTree` into a flat `regionId -> parentId` map
+ * (`undefined` = root) — used to compare `regionTree.ts`'s own derivation
+ * against the wire's `parent_id`s one region at a time. */
+function parentMapOf<T extends RegionLike>(
+  tree: RegionTree<T>
+): Map<string, string | undefined> {
+  const out = new Map<string, string | undefined>();
+  function walk(node: RegionTreeNode<T>, parentId: string | undefined): void {
+    out.set(node.region.id, parentId);
+    for (const child of node.children) walk(child, node.region.id);
+  }
+  for (const root of tree.roots) walk(root, undefined);
+  return out;
+}
+
+/**
+ * The consumption entry point `RegionPanel.tsx` calls: prefers the wire's
+ * `FloorPlanRegion.parent_id` (`floorPlan.regions`) the moment a live
+ * response carries a non-empty list, falling back to `regionTree.ts`'s own
+ * `buildRegionTree(regions)` otherwise.
+ *
+ * `regions` is always the CALLER's own authored `doc.regions` (the
+ * document being edited) — `floorPlan.regions`, when present, is that
+ * SAME document's server-compiled projection, not an independent region
+ * set. A region id present in `regions` but absent from
+ * `floorPlan.regions` (or vice versa) is a distinct drift class this
+ * function does not itself flag — out of scope for this pass, since a
+ * matching id set is exactly what a same-document round-trip should
+ * produce and no live server projects regions at all yet to observe
+ * otherwise.
+ */
+export function resolveRegionTree<T extends RegionLike>(
+  regions: readonly T[],
+  floorPlan: FloorPlan | null
+): ResolvedRegionTree<T> {
+  if (!floorPlan || floorPlan.regions.length === 0) {
+    return {
+      tree: buildRegionTree(regions),
+      source: 'derived',
+      mismatches: [],
+      dangling: [],
+    };
+  }
+
+  const wireById = new Map(floorPlan.regions.map((r) => [r.id, r] as const));
+  const { tree, dangling } = buildTreeFromParentPointers(
+    regions,
+    (id) => wireById.get(id)?.parentId
+  );
+
+  const derivedParentOf = parentMapOf(buildRegionTree(regions));
+  const mismatches: RegionParentMismatch[] = [];
+  for (const r of regions) {
+    const wireRegion = wireById.get(r.id);
+    if (!wireRegion) continue; // id-set drift — see this function's own doc comment.
+    const wireParentId = wireRegion.parentId;
+    const derivedParentId = derivedParentOf.get(r.id);
+    if (wireParentId !== derivedParentId) {
+      mismatches.push({ regionId: r.id, wireParentId, derivedParentId });
+    }
+  }
+
+  return { tree, source: 'server', mismatches, dangling };
+}

--- a/src/concepts/dungeon-builder/usePutDungeonPreview.ts
+++ b/src/concepts/dungeon-builder/usePutDungeonPreview.ts
@@ -48,6 +48,24 @@
  * `capabilities` resets to `null` the moment `serverState` leaves
  * `'live'` (gate-off/unreachable) — a capability observed against one
  * server is never carried into a fixtures-mode fallback.
+ *
+ * **v0.3 wire consumption (this unit, 2026-08-05)**: this file also
+ * exports `useCreationFloorPlanPreview`, a second, narrower hook for
+ * creation mode's OWN document — creation mode never called `PutDungeon`
+ * at all before this unit (its floor came exclusively from
+ * `creation/canvasFloor.ts`'s client-side `deriveCanvasFloorCells`). It
+ * deliberately does NOT re-run the mount-time reachability probe or the
+ * capability-probe suite above — `serverState`/`capabilities` describe
+ * the SERVER, not which document is being edited, so a second instance
+ * probing independently would double real network traffic (including the
+ * 17-request capability suite) for no new information, every time this
+ * component renders, regardless of which mode tab is even active (React's
+ * rules of hooks mean both hook calls run unconditionally in
+ * `DungeonBuilderConcept.tsx`). Callers pass the ALREADY-established
+ * `serverState`/`capabilities` from this hook's own instance instead. Both
+ * hooks share the same request-building/response-classification logic
+ * (`compileLive` below) so the two paths can't silently drift from each
+ * other.
  */
 import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';
@@ -111,6 +129,60 @@ function classifyFailure(err: unknown): 'gate-off' | 'unreachable' | 'other' {
   // A non-ConnectError throw (network layer never got a structured gRPC
   // response at all) is exactly the "can't reach the server" case too.
   return 'unreachable';
+}
+
+/** One live `validate_only` `PutDungeon` call, shaped and classified —
+ * the exact request-building/response-handling `usePutDungeonPreview`'s
+ * own per-edit effect used to inline, factored out so
+ * `useCreationFloorPlanPreview` (below) can run the identical request for
+ * a SECOND document without a second copy of this logic to drift out of
+ * sync with this one. Never throws. */
+type LiveCompileResult =
+  | { kind: 'unparseable' }
+  | { kind: 'success'; floorPlan: FloorPlan | null }
+  | { kind: 'field-errors'; fieldErrors: ValidationError[] }
+  | { kind: 'unreachable' }
+  | { kind: 'request-error'; message: string };
+
+async function compileLive(
+  doc: DungeonDoc,
+  yamlText: string,
+  capabilities: ServerCapabilities | null
+): Promise<LiveCompileResult> {
+  let subsetYaml: string;
+  try {
+    subsetYaml = stripToV1Subset(yamlText, capabilities ?? undefined).yaml;
+  } catch {
+    // Not even shape-parseable yet (mid-edit) — nothing to preview this
+    // tick. Not a request/field error; the YAML pane's own parse-error
+    // path (DungeonBuilderConcept's applyText) already owns surfacing
+    // this.
+    return { kind: 'unparseable' };
+  }
+  try {
+    const response = await authoringClient.putDungeon(
+      create(PutDungeonRequestSchema, {
+        key: doc.key,
+        yaml: subsetYaml,
+        validateOnly: true,
+      })
+    );
+    if (response.success) {
+      return { kind: 'success', floorPlan: response.floorPlan ?? null };
+    }
+    return { kind: 'field-errors', fieldErrors: response.fieldErrors };
+  } catch (err) {
+    const kind = classifyFailure(err);
+    if (kind === 'unreachable') return { kind: 'unreachable' };
+    // InvalidArgument (key/yaml mismatch, charset) reaching here means the
+    // editor itself constructed a malformed request — a programming
+    // error, never author feedback.
+    return {
+      kind: 'request-error',
+      message:
+        err instanceof ConnectError ? err.message : 'PutDungeon request failed',
+    };
+  }
 }
 
 export function usePutDungeonPreview(
@@ -181,49 +253,25 @@ export function usePutDungeonPreview(
     debounceRef.current = setTimeout(() => {
       (async () => {
         setRequestError(null);
-        let subsetYaml: string;
-        try {
-          subsetYaml = stripToV1Subset(
-            yamlText,
-            capabilities ?? undefined
-          ).yaml;
-        } catch {
-          // Not even shape-parseable yet (mid-edit) — nothing to preview
-          // this tick. Not a request/field error; the YAML pane's own
-          // parse-error path (DungeonBuilderConcept's applyText) already
-          // owns surfacing this.
-          return;
-        }
-        try {
-          const response = await authoringClient.putDungeon(
-            create(PutDungeonRequestSchema, {
-              key: doc.key,
-              yaml: subsetYaml,
-              validateOnly: true,
-            })
-          );
-          if (response.success) {
-            setLiveFloorPlan(response.floorPlan ?? null);
+        const result = await compileLive(doc, yamlText, capabilities);
+        switch (result.kind) {
+          case 'unparseable':
+            return;
+          case 'success':
+            setLiveFloorPlan(result.floorPlan);
             setFieldErrors([]);
-          } else {
-            setFieldErrors(response.fieldErrors);
+            return;
+          case 'field-errors':
+            setFieldErrors(result.fieldErrors);
             // Keep the last good floor plan on screen rather than blanking
             // the board on every keystroke of an in-progress edit.
-          }
-        } catch (err) {
-          const kind = classifyFailure(err);
-          if (kind === 'unreachable') {
+            return;
+          case 'unreachable':
             setServerState('unreachable');
             return;
-          }
-          // InvalidArgument (key/yaml mismatch, charset) reaching here
-          // means the editor itself constructed a malformed request — a
-          // programming error, never author feedback.
-          setRequestError(
-            err instanceof ConnectError
-              ? err.message
-              : 'PutDungeon request failed'
-          );
+          case 'request-error':
+            setRequestError(result.message);
+            return;
         }
       })();
     }, DEBOUNCE_MS);
@@ -252,4 +300,80 @@ export function usePutDungeonPreview(
     capabilities,
     refreshCapabilities: () => setCapabilitiesNonce((n) => n + 1),
   };
+}
+
+/**
+ * useCreationFloorPlanPreview — the creation-mode ("New Dungeon") canvas
+ * document's own live `PutDungeon(validate_only)` preview (v0.3 wire
+ * consumption unit, 2026-08-05). Creation mode never sent its document to
+ * the server at all before this unit — its floor came exclusively from
+ * `creation/canvasFloor.ts`'s client-side `deriveCanvasFloorCells`, and
+ * its regions panel (`creation/RegionPanel.tsx`) from client-derived
+ * containment alone. This hook is what makes a real `FloorPlan.floor_cells`
+ * / `FloorPlan.regions` response reachable for that document, so the
+ * consumers of THIS hook's `floorPlan` (`creation/canvasFloor.ts`'s
+ * `resolveCanvasFloor`, `RegionPanel.tsx`'s wire-vs-derived region tree
+ * comparison) have something real to render from once the server ships
+ * Wave 0/1 (rpg-project#169/#192/#180) — today it stays effectively
+ * dormant, since a live server's `floor_cells`/`regions` are both empty
+ * (decode-unknown fields, per the rpg-api-protos#214 conformance review's
+ * finding A4) and every consumer already falls back to its client-derived
+ * source on empty.
+ *
+ * Deliberately takes `serverState`/`capabilities` as PARAMETERS rather
+ * than probing for them itself — see this file's own header comment for
+ * why a second independent probe would double real network traffic for no
+ * new information. A transport failure on THIS document's own live call
+ * does NOT flip the shared `serverState` (unlike
+ * `usePutDungeonPreview`'s own per-edit effect, which owns that state) —
+ * the edit-mode instance's mount-time probe is the one canonical
+ * reachability signal; this hook just quietly keeps its last-good
+ * `floorPlan` (or `null` if it never had one) until the shared state
+ * itself recovers or the next debounced tick succeeds.
+ *
+ * Never fabricates a local compiled `FloorPlan` the way
+ * `usePutDungeonPreview`'s own `fallbackFloorPlan` does —
+ * `compileFloorPlanLocally` only knows the room-chain shape (rooms/
+ * connectors/entrance) and produces nothing useful for a canvas-mode
+ * document (empty `rooms`, no `floorCells`/`regions` at all), so callers
+ * would get the same "nothing from the wire" signal either way; returning
+ * `null` outright is the more honest of the two equally-empty options.
+ */
+export function useCreationFloorPlanPreview(
+  doc: DungeonDoc | null,
+  yamlText: string,
+  serverState: ServerState,
+  capabilities: ServerCapabilities | null
+): { floorPlan: FloorPlan | null } {
+  const [liveFloorPlan, setLiveFloorPlan] = useState<FloorPlan | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (serverState !== 'live' || !doc) {
+      // Leaving live mode (or having no document yet) invalidates any
+      // previously-fetched response — same "never leak a capability/
+      // response observed against one server into a different state"
+      // discipline `capabilities` itself follows above.
+      setLiveFloorPlan(null);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      compileLive(doc, yamlText, capabilities).then((result) => {
+        if (result.kind === 'success') setLiveFloorPlan(result.floorPlan);
+        // 'unparseable' (mid-edit)/'field-errors'/'unreachable'/
+        // 'request-error': keep the last-good floor plan on screen,
+        // matching `usePutDungeonPreview`'s own field-errors discipline —
+        // this hook has no field_errors surface of its own (creation
+        // mode's own validation feedback is out of this unit's scope),
+        // so every non-success outcome is treated the same way here:
+        // don't blank a plan that was already rendering.
+      });
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [serverState, doc, yamlText, capabilities]);
+
+  return { floorPlan: liveFloorPlan };
 }


### PR DESCRIPTION
## Summary

Response-side consumption of the ratified Dungeon YAML Spec v0.3's wire surface (rpg-api-protos v0.1.120: `FloorPlanRegion`, `FloorPlan.floor_cells`/`regions`), scoped from the rpg-api-protos#214 conformance review. Both consumption paths prefer the wire the moment a live response carries a non-empty field, fall back to the existing client-derived source otherwise, and badge which one won — so this concept flips to server truth automatically the day the platform's Wave 0/1 (rpg-project#192/#180) lands, with zero further client changes.

**Dormant by design.** No live server ships `canvas`/`regions` yet (confirmed against the 2026-08-04 capability probe — both are decode-unknown). Every `FloorPlan` fixture exercising the "server" path is hand-constructed and marked SYNTHETIC; only the DERIVED fallback is live-testable today.

## What changed

- **Proto pin `v0.1.118` → `v0.1.120`.** Hit the stale-proto trap on the first plain `npm install` (silently resolved the wrong commit for the tag) — fixed with a forced reinstall; verified `FloorPlanRegion`/`floor_cells`/`regions` present in the generated TS afterward.
- **`usePutDungeonPreview.ts`**: creation mode ("New Dungeon") never called `PutDungeon` at all before this unit. New `useCreationFloorPlanPreview` hook gives it a live preview, sharing `serverState`/`capabilities` with the existing edit-mode probe instead of re-probing (both hooks run unconditionally per React's rules of hooks, so a second probe would double real network traffic for no new information). Extracted a shared `compileLive` helper so the two request paths can't drift — existing `usePutDungeonPreview` tests pass unchanged.
- **`creation/canvasFloor.ts`**: new `resolveCanvasFloor(doc, floorPlan)` prefers `floorPlan.floorCells` (sort-normalized to the wire's own ascending-lexicographic order — conformance finding A5) over `deriveCanvasFloorCells`. `DungeonPreview3D` gets a `FLOOR: SERVER (N)` / `FLOOR: DERIVED` badge, mirroring `Board.tsx`'s existing wall-source idiom.
- **New `regionTreeWire.ts`**: builds on the in-flight `unit/region-tree` branch's `regionTree.ts` (merged in — coordinated with that unit rather than reinventing `buildRegionTree`, the Fog-of-War "three versions of one thing" trap). `resolveRegionTree` prefers `FloorPlanRegion.parent_id` over cell-subset inference, cross-checking the two when both exist and surfacing a named warning on disagreement (findings A2/A3), with a dangling `parent_id` treated as root + warned. `RegionPanel` gets the matching `REGIONS: SERVER` / `REGIONS: DERIVED` badge plus a visible drift-warning block.
- **CONTRACT.md / TARGET-YAML.md**: ledger entry + status note recording this as ready-but-dormant.

## Dependency note

This branch merges `origin/unit/region-tree` (not yet on `dev`) because `regionTreeWire.ts` builds directly on its `regionTree.ts`. Once that branch merges to `dev`, merging `dev` back into this one will converge cleanly and this PR's diff will shrink to just this unit's own commits.

## Tests

32 new tests (18 in `canvasFloor.test.ts`, 9 in `regionTreeWire.test.ts`, 5 in a new `RegionPanel.test.tsx` proving the badge/warnings actually render). Full `src/concepts/dungeon-builder` suite: 360 tests / 19 files passing. `ci-check` clean (format/lint/typecheck/build/test).

## Live verification

Own dev server, `public/models/synty/` rsync'd from a sibling worktree (absence crashed the whole 3D render silently — an asset-sync gap, not a code bug, confirmed by reproducing against a sibling worktree with assets present). Against a real, reachable rpg-api instance with the authoring gate off (`serverState: 'gate-off'` — the only live-testable state today, since no server ships these fields):
- 3D preview badge reads `FLOOR: DERIVED`, floor renders unchanged from before this unit.
- Region panel badge reads `REGIONS: DERIVED`.

Screenshots available on request — not attached here to keep the PR body lean.

— asset-pipeline agent, on behalf of KirkDiggler