### PR TITLE
unit: consume v0.3 wire canvas floor (rpg-api-protos v0.1.120), dormant until server ships

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.120",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#d9ef7d9fb49dd604d93bf88d828cfc27e409debe",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#ba7eda1f1833a713afa4f7772b3a39955de9f7b2",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.120",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -50,7 +50,10 @@ import { DungeonPreview3D } from './preview3d/DungeonPreview3D';
 import { RolledContentPanel } from './RolledContentPanel';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
-import { usePutDungeonPreview } from './usePutDungeonPreview';
+import {
+  useCreationFloorPlanPreview,
+  usePutDungeonPreview,
+} from './usePutDungeonPreview';
 import { useSaveDungeon } from './useSaveDungeon';
 import { WallGashExplainer } from './WallGashExplainer';
 import { YamlPane } from './YamlPane';
@@ -282,6 +285,24 @@ export function DungeonBuilderConcept() {
   );
   const creationApplyDebounce = useRef<ReturnType<typeof setTimeout> | null>(
     null
+  );
+
+  // Creation mode's own live FloorPlan preview (v0.3 wire consumption
+  // unit, 2026-08-05) — same "reuse the shared serverState/capabilities,
+  // don't re-probe" reasoning `creationV1Subset` below already documents
+  // for `preview.capabilities`; see `useCreationFloorPlanPreview`'s own
+  // doc comment for why this is a SECOND hook rather than a second call to
+  // `usePutDungeonPreview` itself. Feeds `creation/canvasFloor.ts`'s
+  // `resolveCanvasFloor` and the region tree's wire-vs-derived comparison
+  // — both dormant against every live server today (no shipped producer
+  // carries `floor_cells`/`regions` yet), so this is plumbing for the day
+  // Wave 0/1 lands, not a behavior change against any server reachable
+  // right now.
+  const creationFloorPreview = useCreationFloorPlanPreview(
+    creationDoc,
+    creationYamlText,
+    preview.serverState,
+    preview.capabilities
   );
 
   // Creation mode's own Save & Play (capability-probed graduation, this
@@ -599,6 +620,7 @@ export function DungeonBuilderConcept() {
           serverState={preview.serverState}
           capabilities={preview.capabilities}
           onRefreshCapabilities={preview.refreshCapabilities}
+          liveFloorPlan={creationFloorPreview.floorPlan}
           v1Subset={creationV1Subset}
           onSaveAndPlay={handleCreationSaveAndPlay}
           saveState={creationSave.state}

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -7,6 +7,7 @@
  * rows and the shared `Inspector` — no more bespoke Tools strip or
  * hand-rolled facing/delete panel duplicating what those already do.
  */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { useEffect, useMemo, useState } from 'react';
 import type { ServerCapabilities } from '../capabilityProbe';
@@ -19,7 +20,7 @@ import type { BoardTool } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import type { ServerState } from '../usePutDungeonPreview';
 import type { SaveState } from '../useSaveDungeon';
-import { deriveCanvasFloorCells } from './canvasFloor';
+import { resolveCanvasFloor } from './canvasFloor';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
@@ -91,6 +92,15 @@ interface CreationConceptProps {
   serverState: ServerState;
   capabilities: ServerCapabilities | null;
   onRefreshCapabilities: () => void;
+  /** The creation document's own live `PutDungeon(validate_only)` response
+   * (v0.3 wire consumption unit, 2026-08-05 — `usePutDungeonPreview.ts`'s
+   * `useCreationFloorPlanPreview`). `null` in fixtures mode, mid-debounce,
+   * or while a live server hasn't shipped `floor_cells`/`regions` yet
+   * (every server today — dormant by design, see that hook's own doc
+   * comment). Threaded down to `resolveCanvasFloor`/the region tree so
+   * this concept flips to server truth automatically the day the platform
+   * ships Wave 0/1, with zero further client changes. */
+  liveFloorPlan: FloorPlan | null;
   v1Subset: V1SubsetResult | null;
   onSaveAndPlay: () => void;
   saveState: SaveState;
@@ -129,6 +139,7 @@ export function CreationConcept({
   serverState,
   capabilities,
   onRefreshCapabilities,
+  liveFloorPlan,
   v1Subset,
   onSaveAndPlay,
   saveState,
@@ -145,18 +156,27 @@ export function CreationConcept({
   // doesn't need to retarget it.
   const demo = useDemoScript(demoActions, DEFAULT_CANVAS);
 
-  // Canvas floor derivation (rpg-project#169's creation-mode 3D preview
-  // unit) — the 3D preview's own floor semantic for a from-scratch
+  // Canvas floor resolution (rpg-project#169's creation-mode 3D preview
+  // unit; wire-consumption-aware since the v0.3 wire consumption unit,
+  // 2026-08-05) — the 3D preview's own floor semantic for a from-scratch
   // canvas, since it has no compiled `FloorPlan` to render from at all
   // (`creation/canvasFloor.ts`'s own doc comment has the full rationale).
   // Computed here, not inside `DungeonPreview3D` itself, per that
   // component's own "clean interfaces" doc comment — derived only when
-  // actually needed (`boardDim === '3d'`) since `deriveCanvasFloorCells`
-  // scans the whole canvas grid.
-  const floorCells = useMemo(
-    () => (boardDim === '3d' ? deriveCanvasFloorCells(doc) : []),
-    [boardDim, doc]
+  // actually needed (`boardDim === '3d'`) since both `resolveCanvasFloor`
+  // paths scan the whole canvas grid or the whole wire cell list.
+  // `resolveCanvasFloor` prefers `liveFloorPlan.floorCells` the moment a
+  // live response carries a non-empty one, falling back to
+  // `deriveCanvasFloorCells` otherwise (dormant against every server
+  // today — see `liveFloorPlan`'s own doc comment).
+  const resolvedFloor = useMemo(
+    () =>
+      boardDim === '3d'
+        ? resolveCanvasFloor(doc, liveFloorPlan)
+        : { cells: [], source: 'derived' as const },
+    [boardDim, doc, liveFloorPlan]
   );
+  const floorCells = resolvedFloor.cells;
 
   useEffect(() => {
     if (demo.isPlaying) {
@@ -477,6 +497,7 @@ export function CreationConcept({
             <div style={{ flex: 1, minHeight: 0 }}>
               <DungeonPreview3D
                 floorCells={floorCells}
+                floorSource={resolvedFloor.source}
                 doc={doc}
                 selectedPlacement={edit.selectedPlacement}
                 onSelect={(sel) => {

--- a/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
@@ -1,3 +1,8 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { describe, expect, it } from 'vitest';
 import {
   addWallLine,
@@ -9,6 +14,8 @@ import {
 import {
   canvasPlacementRejectReason,
   deriveCanvasFloorCells,
+  resolveCanvasFloor,
+  sortCellsLexicographic,
 } from './canvasFloor';
 import { emptyCanvasYaml } from './emptyCanvasDoc';
 import { straightWallsFootprintSet } from './straightWallGeometry';
@@ -65,6 +72,116 @@ describe('deriveCanvasFloorCells', () => {
       holes: [[0, 0]],
     });
     expect(cells).toEqual([]);
+  });
+});
+
+describe('sortCellsLexicographic', () => {
+  it('sorts ascending by column, then row', () => {
+    const sorted = sortCellsLexicographic([
+      [2, 0],
+      [0, 1],
+      [0, 0],
+      [1, 5],
+    ]);
+    expect(sorted).toEqual([
+      [0, 0],
+      [0, 1],
+      [1, 5],
+      [2, 0],
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const input: [number, number][] = [
+      [1, 1],
+      [0, 0],
+    ];
+    sortCellsLexicographic(input);
+    expect(input).toEqual([
+      [1, 1],
+      [0, 0],
+    ]);
+  });
+});
+
+// v0.3 wire consumption unit (2026-08-05) — resolveCanvasFloor prefers a
+// live FloorPlan.floor_cells (rpg-api-protos v0.1.120) over the
+// client-derived fallback. No live server carries this field yet (the
+// rpg-api-protos#214 conformance review's finding A4 — canvas mode is
+// spec.md §1 group (c), not started server-side): every FloorPlan fixture
+// below is hand-constructed to exercise the shape the wire will carry
+// once Wave 0 ships, not a real recorded response. Marked SYNTHETIC per
+// this concept's existing fixtures.ts convention.
+describe('resolveCanvasFloor — v0.3 wire consumption (SYNTHETIC fixtures, no live server carries these fields yet)', () => {
+  const doc = {
+    canvas: { width: 3, height: 2 },
+    holes: [] as [number, number][],
+  };
+
+  function floorPlanWithCells(cells: [number, number][]): FloorPlan {
+    return create(FloorPlanSchema, {
+      rooms: [],
+      connectors: [],
+      height: 0,
+      doorRow: 0,
+      floorCells: cells.map(([column, row]) => ({ column, row })),
+      regions: [],
+    });
+  }
+
+  it('null floorPlan falls back to derived, labeled "derived"', () => {
+    const result = resolveCanvasFloor(doc, null);
+    expect(result.source).toBe('derived');
+    expect(result.cells).toEqual(
+      sortCellsLexicographic(deriveCanvasFloorCells(doc))
+    );
+  });
+
+  it('a live response with EMPTY floor_cells falls back to derived — rollout gap (A4), not "declares none"', () => {
+    const result = resolveCanvasFloor(doc, floorPlanWithCells([]));
+    expect(result.source).toBe('derived');
+    expect(result.cells).toEqual(
+      sortCellsLexicographic(deriveCanvasFloorCells(doc))
+    );
+  });
+
+  it('a live response with non-empty floor_cells renders from the wire, sort-normalized', () => {
+    // Deliberately authoring-order (not sorted) on the wire fixture, to
+    // prove resolveCanvasFloor normalizes rather than trusting response
+    // order verbatim.
+    const wireCells: [number, number][] = [
+      [2, 1],
+      [0, 0],
+      [1, 0],
+    ];
+    const result = resolveCanvasFloor(doc, floorPlanWithCells(wireCells));
+    expect(result.source).toBe('server');
+    expect(result.cells).toEqual(sortCellsLexicographic(wireCells));
+  });
+
+  it('server cells win even when they disagree with the derived set (e.g. a hole the server does not know about)', () => {
+    const docWithHole = {
+      canvas: { width: 3, height: 2 },
+      holes: [[1, 0]] as [number, number][],
+    };
+    // v0.3's canvas structural floor has no hole concept server-side
+    // (`holes:` is explicitly ABOVE v0.3, spec.md §2) — a real future
+    // server response would legitimately include [1,0] even though the
+    // client's own doc punches a hole there. Wire wins.
+    const wireCells: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ];
+    const result = resolveCanvasFloor(
+      docWithHole,
+      floorPlanWithCells(wireCells)
+    );
+    expect(result.source).toBe('server');
+    expect(result.cells.some(([c, r]) => c === 1 && r === 0)).toBe(true);
   });
 });
 

--- a/src/concepts/dungeon-builder/creation/canvasFloor.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.ts
@@ -22,10 +22,25 @@
  *
  * See TARGET-YAML.md's "canvas:" section for this semantic recorded
  * as a dialect note, not just left as an implementation detail here.
+ *
+ * **v0.3 wire consumption (this unit, 2026-08-05)**: `deriveCanvasFloorCells`
+ * above is now the FALLBACK, not the only source — `resolveCanvasFloor`
+ * below prefers a live `FloorPlan.floor_cells` (rpg-api-protos v0.1.120,
+ * spec.md §4.5.9) the moment a real response carries one. See
+ * `resolveCanvasFloor`'s own doc comment for the rollout discipline (spec
+ * §1 group (c) is not shipped server-side yet, so this path is dormant
+ * against every live server today — verified by the
+ * rpg-api-protos#214 conformance review's finding A4).
  */
+import type {
+  FloorPlan,
+  FloorPlanCell,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { isCellOccupied } from '../boardGeometry';
 import type { DungeonDoc } from '../dungeonYaml';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+
+export type Cell = [number, number];
 
 /** Every `[col, row]` cell inside `doc.canvas`'s bounds (or
  * `DEFAULT_CANVAS` when the document carries none, matching
@@ -45,6 +60,84 @@ export function deriveCanvasFloorCells(
     }
   }
   return cells;
+}
+
+/** Ascending lexicographic `(column, row)` — the wire's own declared
+ * order for both `FloorPlan.floor_cells` and `FloorPlanRegion.cells`
+ * (rpg-api-protos v0.1.120's own field comments: "producers emit cells in
+ * ascending lexicographic (column, row) order"). `deriveCanvasFloorCells`
+ * above happens to already produce this order today (its column-major
+ * outer loop with an increasing-row inner loop IS ascending lexicographic
+ * whenever there are no holes to filter out — the hole filter only ever
+ * removes entries, never reorders the survivors), but its own doc comment
+ * explicitly does NOT promise that ("not spatially meaningful") — so any
+ * caller that needs to compare a wire cell list against a derived one
+ * (rpg-api-protos#214 conformance review, finding A5) normalizes BOTH
+ * sides through this function first rather than relying on the
+ * coincidence. Used both by `resolveCanvasFloor` below (so its returned
+ * cell list has one canonical order regardless of which source produced
+ * it) and by this concept's tests. */
+export function sortCellsLexicographic(cells: readonly Cell[]): Cell[] {
+  return [...cells].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+}
+
+function floorPlanCellToTuple(cell: FloorPlanCell): Cell {
+  return [cell.column, cell.row];
+}
+
+export type CanvasFloorSource = 'server' | 'derived';
+
+export interface ResolvedCanvasFloor {
+  /** Ascending-lexicographic-normalized (see `sortCellsLexicographic`),
+   * regardless of source. */
+  cells: Cell[];
+  source: CanvasFloorSource;
+}
+
+/**
+ * Chooses the creation canvas's floor cell set: the wire's own
+ * `FloorPlan.floor_cells` (rpg-api-protos v0.1.120, spec.md §4.5.9) when a
+ * live response carries a non-empty one, `deriveCanvasFloorCells` (this
+ * file, client-derived from `doc.canvas` bounds minus `doc.holes`)
+ * otherwise.
+ *
+ * **Rollout discipline (rpg-api-protos#214 conformance review, finding
+ * A4)**: canvas mode (spec.md §1 group (c), rpg-project#192) is not
+ * shipped server-side yet, and the client's own live capability probe
+ * records `canvas` as decode-unknown as of 2026-08-04
+ * (`capabilityProbe.ts`) — so an empty `floor_cells` from a REAL server
+ * today means "the producer hasn't shipped this," never "the document
+ * declares an empty floor." Gating on non-empty rather than on
+ * `floorPlan !== null` is exactly what keeps this fallback-safe: a live
+ * server that's reachable and answering, but pre-Wave-0, produces a
+ * `FloorPlan` with `floorCells: []` (the field's zero value, same as an
+ * unset repeated field), which this function treats identically to no
+ * `floorPlan` at all — never an empty rendered floor.
+ *
+ * Does not itself validate `floorPlan.width`/`floorPlan.height` against
+ * `doc.canvas` — `floor_cells` is a complete, self-describing absolute
+ * cell list per its own field comment ("clients MUST render this list,
+ * not infer floor from width and height"), so this function needs nothing
+ * else from the response to be correct. (`FloorPlan.height`'s canvas-mode
+ * meaning is independently ambiguous on the wire today — conformance
+ * review finding A1 — one more reason not to lean on it here.)
+ */
+export function resolveCanvasFloor(
+  doc: Pick<DungeonDoc, 'canvas' | 'holes'>,
+  floorPlan: FloorPlan | null
+): ResolvedCanvasFloor {
+  if (floorPlan && floorPlan.floorCells.length > 0) {
+    return {
+      cells: sortCellsLexicographic(
+        floorPlan.floorCells.map(floorPlanCellToTuple)
+      ),
+      source: 'server',
+    };
+  }
+  return {
+    cells: sortCellsLexicographic(deriveCanvasFloorCells(doc)),
+    source: 'derived',
+  };
 }
 
 /**

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -209,6 +209,17 @@ interface DungeonPreview3DProps {
    * marker) regardless of which floor-tile path won — see
    * `buildFloorTiles`'s own doc comment. */
   floorCells?: readonly [number, number][];
+  /** Which source produced `floorCells` — `creation/canvasFloor.ts`'s
+   * `resolveCanvasFloor` (v0.3 wire consumption unit, 2026-08-05). Purely
+   * a badge/label input, same "caller derives, this component just
+   * renders" discipline `floorCells` itself follows (see this prop's own
+   * doc comment) — this component does not itself decide server-vs-derived,
+   * only displays what the caller already decided. Omitted (or
+   * `undefined`) when `floorCells` itself is absent (edit mode,
+   * `floorPlan`-only) — there is no creation-canvas floor SOURCE to badge
+   * in that case, matching `Board.tsx`'s own edit-mode wall/door
+   * indicator, which this badge mirrors for creation mode's floor. */
+  floorSource?: 'server' | 'derived';
   doc: DungeonDoc;
   /** Kirk's 2026-08-02 "3D editing" arc, part 2 — the SAME
    * `PlacementSelection`/`onSelect` contract `Board.tsx` already uses for
@@ -1183,6 +1194,7 @@ const SELECTED_COLOR = '#ffd76a';
 export function DungeonPreview3D({
   floorPlan,
   floorCells,
+  floorSource,
   doc,
   selectedPlacement,
   onSelect,
@@ -1320,7 +1332,56 @@ export function DungeonPreview3D({
   };
 
   return (
-    <div style={{ width: '100%', height: '100%', background: '#0c0a08' }}>
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        background: '#0c0a08',
+      }}
+    >
+      {/* Canvas floor source indicator (v0.3 wire consumption unit,
+       * 2026-08-05) — same "make drift visible, not silent" idiom as
+       * `Board.tsx`'s wall/door source indicator (`db-wall-source-indicator`):
+       * distinguishes a real `FloorPlan.floor_cells` response
+       * (rpg-api-protos v0.1.120+) from `creation/canvasFloor.ts`'s
+       * client-derived fallback this preview used exclusively before this
+       * unit, and still uses whenever a response carries no floor_cells
+       * (every live server today — rollout gap A4, not a contract defect).
+       * Only rendered when `floorSource` is supplied at all — edit mode's
+       * `floorPlan`-only call site has no creation-canvas floor SOURCE to
+       * badge. */}
+      {floorSource && (
+        <div
+          data-testid="db-floor-source-indicator"
+          style={{
+            position: 'absolute',
+            top: 4,
+            left: 4,
+            zIndex: 5,
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: 0.3,
+            padding: '3px 7px',
+            borderRadius: 4,
+            pointerEvents: 'none',
+            ...(floorSource === 'server'
+              ? {
+                  color: '#100d0b',
+                  background: '#c9bfae',
+                }
+              : {
+                  color: '#e8e2d8',
+                  background: 'rgba(90, 74, 58, 0.55)',
+                  border: '1px dashed #8a7a5a',
+                }),
+          }}
+        >
+          {floorSource === 'server'
+            ? `FLOOR: SERVER (${floorCells?.length ?? 0} cells)`
+            : 'FLOOR: DERIVED'}
+        </div>
+      )}
       <Canvas
         camera={{ fov: 45, position: [10, 14, 10] }}
         onPointerMissed={() => onSelect?.(null)}

--- a/src/concepts/dungeon-builder/usePutDungeonPreview.ts
+++ b/src/concepts/dungeon-builder/usePutDungeonPreview.ts
@@ -48,6 +48,24 @@
  * `capabilities` resets to `null` the moment `serverState` leaves
  * `'live'` (gate-off/unreachable) — a capability observed against one
  * server is never carried into a fixtures-mode fallback.
+ *
+ * **v0.3 wire consumption (this unit, 2026-08-05)**: this file also
+ * exports `useCreationFloorPlanPreview`, a second, narrower hook for
+ * creation mode's OWN document — creation mode never called `PutDungeon`
+ * at all before this unit (its floor came exclusively from
+ * `creation/canvasFloor.ts`'s client-side `deriveCanvasFloorCells`). It
+ * deliberately does NOT re-run the mount-time reachability probe or the
+ * capability-probe suite above — `serverState`/`capabilities` describe
+ * the SERVER, not which document is being edited, so a second instance
+ * probing independently would double real network traffic (including the
+ * 17-request capability suite) for no new information, every time this
+ * component renders, regardless of which mode tab is even active (React's
+ * rules of hooks mean both hook calls run unconditionally in
+ * `DungeonBuilderConcept.tsx`). Callers pass the ALREADY-established
+ * `serverState`/`capabilities` from this hook's own instance instead. Both
+ * hooks share the same request-building/response-classification logic
+ * (`compileLive` below) so the two paths can't silently drift from each
+ * other.
  */
 import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';
@@ -111,6 +129,60 @@ function classifyFailure(err: unknown): 'gate-off' | 'unreachable' | 'other' {
   // A non-ConnectError throw (network layer never got a structured gRPC
   // response at all) is exactly the "can't reach the server" case too.
   return 'unreachable';
+}
+
+/** One live `validate_only` `PutDungeon` call, shaped and classified —
+ * the exact request-building/response-handling `usePutDungeonPreview`'s
+ * own per-edit effect used to inline, factored out so
+ * `useCreationFloorPlanPreview` (below) can run the identical request for
+ * a SECOND document without a second copy of this logic to drift out of
+ * sync with this one. Never throws. */
+type LiveCompileResult =
+  | { kind: 'unparseable' }
+  | { kind: 'success'; floorPlan: FloorPlan | null }
+  | { kind: 'field-errors'; fieldErrors: ValidationError[] }
+  | { kind: 'unreachable' }
+  | { kind: 'request-error'; message: string };
+
+async function compileLive(
+  doc: DungeonDoc,
+  yamlText: string,
+  capabilities: ServerCapabilities | null
+): Promise<LiveCompileResult> {
+  let subsetYaml: string;
+  try {
+    subsetYaml = stripToV1Subset(yamlText, capabilities ?? undefined).yaml;
+  } catch {
+    // Not even shape-parseable yet (mid-edit) — nothing to preview this
+    // tick. Not a request/field error; the YAML pane's own parse-error
+    // path (DungeonBuilderConcept's applyText) already owns surfacing
+    // this.
+    return { kind: 'unparseable' };
+  }
+  try {
+    const response = await authoringClient.putDungeon(
+      create(PutDungeonRequestSchema, {
+        key: doc.key,
+        yaml: subsetYaml,
+        validateOnly: true,
+      })
+    );
+    if (response.success) {
+      return { kind: 'success', floorPlan: response.floorPlan ?? null };
+    }
+    return { kind: 'field-errors', fieldErrors: response.fieldErrors };
+  } catch (err) {
+    const kind = classifyFailure(err);
+    if (kind === 'unreachable') return { kind: 'unreachable' };
+    // InvalidArgument (key/yaml mismatch, charset) reaching here means the
+    // editor itself constructed a malformed request — a programming
+    // error, never author feedback.
+    return {
+      kind: 'request-error',
+      message:
+        err instanceof ConnectError ? err.message : 'PutDungeon request failed',
+    };
+  }
 }
 
 export function usePutDungeonPreview(
@@ -181,49 +253,25 @@ export function usePutDungeonPreview(
     debounceRef.current = setTimeout(() => {
       (async () => {
         setRequestError(null);
-        let subsetYaml: string;
-        try {
-          subsetYaml = stripToV1Subset(
-            yamlText,
-            capabilities ?? undefined
-          ).yaml;
-        } catch {
-          // Not even shape-parseable yet (mid-edit) — nothing to preview
-          // this tick. Not a request/field error; the YAML pane's own
-          // parse-error path (DungeonBuilderConcept's applyText) already
-          // owns surfacing this.
-          return;
-        }
-        try {
-          const response = await authoringClient.putDungeon(
-            create(PutDungeonRequestSchema, {
-              key: doc.key,
-              yaml: subsetYaml,
-              validateOnly: true,
-            })
-          );
-          if (response.success) {
-            setLiveFloorPlan(response.floorPlan ?? null);
+        const result = await compileLive(doc, yamlText, capabilities);
+        switch (result.kind) {
+          case 'unparseable':
+            return;
+          case 'success':
+            setLiveFloorPlan(result.floorPlan);
             setFieldErrors([]);
-          } else {
-            setFieldErrors(response.fieldErrors);
+            return;
+          case 'field-errors':
+            setFieldErrors(result.fieldErrors);
             // Keep the last good floor plan on screen rather than blanking
             // the board on every keystroke of an in-progress edit.
-          }
-        } catch (err) {
-          const kind = classifyFailure(err);
-          if (kind === 'unreachable') {
+            return;
+          case 'unreachable':
             setServerState('unreachable');
             return;
-          }
-          // InvalidArgument (key/yaml mismatch, charset) reaching here
-          // means the editor itself constructed a malformed request — a
-          // programming error, never author feedback.
-          setRequestError(
-            err instanceof ConnectError
-              ? err.message
-              : 'PutDungeon request failed'
-          );
+          case 'request-error':
+            setRequestError(result.message);
+            return;
         }
       })();
     }, DEBOUNCE_MS);
@@ -252,4 +300,80 @@ export function usePutDungeonPreview(
     capabilities,
     refreshCapabilities: () => setCapabilitiesNonce((n) => n + 1),
   };
+}
+
+/**
+ * useCreationFloorPlanPreview — the creation-mode ("New Dungeon") canvas
+ * document's own live `PutDungeon(validate_only)` preview (v0.3 wire
+ * consumption unit, 2026-08-05). Creation mode never sent its document to
+ * the server at all before this unit — its floor came exclusively from
+ * `creation/canvasFloor.ts`'s client-side `deriveCanvasFloorCells`, and
+ * its regions panel (`creation/RegionPanel.tsx`) from client-derived
+ * containment alone. This hook is what makes a real `FloorPlan.floor_cells`
+ * / `FloorPlan.regions` response reachable for that document, so the
+ * consumers of THIS hook's `floorPlan` (`creation/canvasFloor.ts`'s
+ * `resolveCanvasFloor`, `RegionPanel.tsx`'s wire-vs-derived region tree
+ * comparison) have something real to render from once the server ships
+ * Wave 0/1 (rpg-project#169/#192/#180) — today it stays effectively
+ * dormant, since a live server's `floor_cells`/`regions` are both empty
+ * (decode-unknown fields, per the rpg-api-protos#214 conformance review's
+ * finding A4) and every consumer already falls back to its client-derived
+ * source on empty.
+ *
+ * Deliberately takes `serverState`/`capabilities` as PARAMETERS rather
+ * than probing for them itself — see this file's own header comment for
+ * why a second independent probe would double real network traffic for no
+ * new information. A transport failure on THIS document's own live call
+ * does NOT flip the shared `serverState` (unlike
+ * `usePutDungeonPreview`'s own per-edit effect, which owns that state) —
+ * the edit-mode instance's mount-time probe is the one canonical
+ * reachability signal; this hook just quietly keeps its last-good
+ * `floorPlan` (or `null` if it never had one) until the shared state
+ * itself recovers or the next debounced tick succeeds.
+ *
+ * Never fabricates a local compiled `FloorPlan` the way
+ * `usePutDungeonPreview`'s own `fallbackFloorPlan` does —
+ * `compileFloorPlanLocally` only knows the room-chain shape (rooms/
+ * connectors/entrance) and produces nothing useful for a canvas-mode
+ * document (empty `rooms`, no `floorCells`/`regions` at all), so callers
+ * would get the same "nothing from the wire" signal either way; returning
+ * `null` outright is the more honest of the two equally-empty options.
+ */
+export function useCreationFloorPlanPreview(
+  doc: DungeonDoc | null,
+  yamlText: string,
+  serverState: ServerState,
+  capabilities: ServerCapabilities | null
+): { floorPlan: FloorPlan | null } {
+  const [liveFloorPlan, setLiveFloorPlan] = useState<FloorPlan | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (serverState !== 'live' || !doc) {
+      // Leaving live mode (or having no document yet) invalidates any
+      // previously-fetched response — same "never leak a capability/
+      // response observed against one server into a different state"
+      // discipline `capabilities` itself follows above.
+      setLiveFloorPlan(null);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      compileLive(doc, yamlText, capabilities).then((result) => {
+        if (result.kind === 'success') setLiveFloorPlan(result.floorPlan);
+        // 'unparseable' (mid-edit)/'field-errors'/'unreachable'/
+        // 'request-error': keep the last-good floor plan on screen,
+        // matching `usePutDungeonPreview`'s own field-errors discipline —
+        // this hook has no field_errors surface of its own (creation
+        // mode's own validation feedback is out of this unit's scope),
+        // so every non-success outcome is treated the same way here:
+        // don't blank a plan that was already rendering.
+      });
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [serverState, doc, yamlText, capabilities]);
+
+  return { floorPlan: liveFloorPlan };
 }


### PR DESCRIPTION
## Summary

Scoped down from #709 per direction: region-tree consumption depends on the in-flight `unit/region-tree` branch (#707, unmerged), so that half is paused until #707 lands on `dev`. This PR carries ONLY the canvas-floor half, which has no dependency on #707 — cherry-picked cleanly from #709's first commit onto current `dev` tip.

Response-side consumption of the ratified Dungeon YAML Spec v0.3's wire surface (rpg-api-protos v0.1.120: `FloorPlan.floor_cells`), scoped from the rpg-api-protos#214 conformance review.

**Dormant by design.** No live server ships `canvas` mode yet (confirmed against the 2026-08-04 capability probe — `canvas` is decode-unknown). The "server" path is exercised only by hand-constructed SYNTHETIC fixtures; only the DERIVED fallback is live-testable today.

## What changed

- **Proto pin `v0.1.118` → `v0.1.120`.** Hit the stale-proto trap on the first plain `npm install` (silently resolved the wrong commit for the tag) — fixed with a forced reinstall; verified `FloorPlan.floor_cells`/`FloorPlanRegion` present in the generated TS afterward (the latter isn't consumed by this PR, just confirming the pin is correct for the follow-up PR too).
- **`usePutDungeonPreview.ts`**: creation mode ("New Dungeon") never called `PutDungeon` at all before this unit. New `useCreationFloorPlanPreview` hook gives it a live preview, sharing `serverState`/`capabilities` with the existing edit-mode probe instead of re-probing (both hooks run unconditionally per React's rules of hooks, so a second probe would double real network traffic for no new information). Extracted a shared `compileLive` helper so the two request paths can't drift — existing `usePutDungeonPreview` tests pass unchanged.
- **`creation/canvasFloor.ts`**: new `resolveCanvasFloor(doc, floorPlan)` prefers `floorPlan.floorCells` (sort-normalized to the wire's own ascending-lexicographic order — conformance finding A5) over `deriveCanvasFloorCells`. `DungeonPreview3D` gets a `FLOOR: SERVER (N)` / `FLOOR: DERIVED` badge, mirroring `Board.tsx`'s existing wall-source idiom.

## Tests

18 new/extended tests in `canvasFloor.test.ts`. Full `src/concepts/dungeon-builder` suite: 330 tests / 16 files passing. `ci-check` clean (format/lint/typecheck/build/test).

## Live verification

Own dev server, `public/models/synty/` rsync'd from a sibling worktree (absence crashed the whole 3D render silently — an asset-sync gap, not a code bug). Against a real, reachable rpg-api instance with the authoring gate off (`serverState: 'gate-off'` — the only live-testable state today): 3D preview badge reads `FLOOR: DERIVED`, floor renders unchanged from before this unit, no regression.

## Follow-up

Region-tree wire consumption (`FloorPlanRegion.parent_id`) will land as a separate PR once #707 merges to `dev` — tracked, not lost; the work exists on `unit/wire-v03-consumption` (superseded PR #709, will close) pending a clean rebase onto `dev` once #707 lands.

— asset-pipeline agent, on behalf of KirkDiggler