### PR TITLE
unit: consume v0.3 region wire (parent_id tree + drift warnings)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.120",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#d9ef7d9fb49dd604d93bf88d828cfc27e409debe",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#ba7eda1f1833a713afa4f7772b3a39955de9f7b2",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.118",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.120",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -5194,3 +5194,146 @@ staleness this regeneration was the first full pass to surface.
   so this is a byte-shape change only, not a content change.
 - `ci-check` clean (format/lint/typecheck/build/test) after the prettier
   pass.
+
+## v0.3 wire consumption unit: canvas floor + region tree, dormant until the server ships (2026-08-05, rpg-project#169)
+
+**Response-side consumption only**, per the ratified `ideas/dungeon-builder/spec/v0.3/spec.md`
+and the rpg-api-protos#214 conformance review this unit was scoped from.
+Bumps the protos pin **v0.1.118 → v0.1.120** (`FloorPlanRegion`,
+`FloorPlan.floor_cells`/`regions` — verified present in the generated TS
+after a forced reinstall; the first plain `npm install` silently resolved
+the WRONG commit for the same tag, the exact stale-proto trap this repo's
+convention warns about — `rm -rf node_modules/@kirkdiggler/rpg-api-protos
+&& npm install ...#v0.1.120 --force` fixed it). Two consumption paths,
+same shape: prefer the wire the moment a live response carries a
+non-empty field, fall back to the existing client-derived source
+otherwise, badge which one won.
+
+### Creation mode gets a live `PutDungeon` call for the first time
+
+Before this unit, creation mode ("New Dungeon") never called
+`PutDungeon` at all — its floor came exclusively from
+`creation/canvasFloor.ts`'s `deriveCanvasFloorCells`, and its regions
+panel from `regionTree.ts`'s client-derived containment alone (edit
+mode's `usePutDungeonPreview` instance only ever compiled EDIT mode's
+own document). `usePutDungeonPreview.ts` gains
+`useCreationFloorPlanPreview(doc, yamlText, serverState, capabilities)`
+— a SECOND hook for the creation document, deliberately taking
+`serverState`/`capabilities` as parameters rather than probing for them
+itself: those describe the SERVER, not which document is being edited,
+and both hooks run unconditionally every render (React's rules of
+hooks), so a second independent probe would double real network traffic
+(including the 17-request capability suite) for no new information.
+Both hooks now share one `compileLive(doc, yamlText, capabilities)`
+helper (extracted from `usePutDungeonPreview`'s own per-edit effect,
+behavior-preserving — its existing 12 tests pass unchanged) so the two
+request paths can't silently drift from each other.
+
+### Canvas floor (`creation/canvasFloor.ts`)
+
+`resolveCanvasFloor(doc, floorPlan)` prefers `floorPlan.floorCells` the
+moment a response carries a non-empty list, sort-normalized to ascending
+`(column, row)` — the wire's own declared order, confirmed against the
+generated field comment — via a new `sortCellsLexicographic` (conformance
+review finding A5: `deriveCanvasFloorCells`'s own doc comment explicitly
+does NOT promise its column-major order, even though it happens to
+coincide with the wire's order today when no holes are punched).
+`deriveCanvasFloorCells` becomes the labeled fallback. Wired into
+`CreationConcept.tsx`'s existing `floorCells` memo (previously
+unconditional `deriveCanvasFloorCells`) and threaded to
+`DungeonPreview3D` alongside a new `floorSource` prop.
+
+**Indicator**: `DungeonPreview3D` gets a `db-floor-source-indicator`
+badge, top-left of the 3D viewport — `FLOOR: SERVER (N cells)` (cream) /
+`FLOOR: DERIVED` (dashed amber), the exact visual idiom
+`Board.tsx`'s `db-wall-source-indicator` already established for
+server-vs-derived walls. No RTL render test for this badge — this file's
+existing testing discipline never renders `DungeonPreview3D` itself
+(react-three-fiber `<Canvas>`, not jsdom-renderable), only its exported
+pure helpers; live verification (below) is what actually proves the
+badge renders.
+
+### Region tree (new `regionTreeWire.ts`)
+
+Builds on the region-tree unit's `regionTree.ts` (merged from
+`unit/region-tree` — coordinated with that unit rather than reinventing
+`buildRegionTree`/`flattenRegionTree`, the Fog-of-War "three versions of
+one thing" trap this repo's CLAUDE.md names explicitly). Kept as a
+SEPARATE module rather than adding a `FloorPlan`-typed function to
+`regionTree.ts` itself — that file's own header comment documents itself
+as deliberately dependency-free (no `DungeonDoc`/`RegionDoc`, let alone a
+wire proto type), reusable by both boards without pulling in this
+concept's network layer.
+
+`resolveRegionTree(regions, floorPlan)` prefers `FloorPlanRegion.parent_id`
+the moment a response carries a non-empty `regions` list — building the
+SAME `RegionTree` shape directly from parent pointers rather than
+re-inferring containment from cell sets, since the wire's `parent_id` IS
+already the toolkit's own derived answer (its field comment: "Toolkit-derived
+direct declared parent ID"). `regionTree.ts`'s `buildRegionTree` becomes
+BOTH the fallback (empty/absent `floorPlan.regions`) AND the verification
+baseline: whenever the wire is present, every region's wire-declared
+parent is compared against what `buildRegionTree` would derive for the
+SAME cell sets, and a disagreement renders a named, visible warning
+(`db-region-tree-drift-warning`) rather than silently preferring one
+side — conformance review findings A2/A3's "the derivation rule isn't in
+the proto, an implementer can drift" made concrete as an actual drift
+detector. A dangling `parent_id` (resolves to no region on the same
+response — A2) is treated as root for tree-building (graceful, no crash)
+but still surfaces its own named warning, distinct from a parent
+disagreement. `RegionPanel.tsx` gets the matching
+`db-region-tree-source-indicator` badge (`REGIONS: SERVER` /
+`REGIONS: DERIVED`), same idiom as the floor badge above.
+
+### Rollout discipline (conformance review finding A4)
+
+Both consumption paths gate on **non-empty**, not on "a response
+exists" — a live, reachable server that simply hasn't shipped Wave 0/1
+yet (every server today; the client's own capability probe records
+`canvas`/`regions` as decode-unknown as of 2026-08-04) answers with an
+empty `floorCells`/`regions`, which both `resolveCanvasFloor` and
+`resolveRegionTree` treat identically to no `floorPlan` at all — never
+rendering an empty floor or an empty region tree because the producer
+hasn't shipped, exactly the trap A4 named.
+
+### Tests
+
+18 new/extended in `canvasFloor.test.ts` (`sortCellsLexicographic` +
+`resolveCanvasFloor`'s derived/server/empty-rollout-gap/sort-normalization/
+hole-disagreement cases), 9 in `regionTreeWire.test.ts` (derived fallback,
+empty-regions rollout gap, agreeing nested case, sibling case, BOTH
+mismatch directions, dangling parent, id-set drift is silently skipped
+not falsely flagged, a 3-deep nesting chain), 5 in a new
+`RegionPanel.test.tsx` (the badge/warnings actually RENDER, not just that
+the underlying logic is correct — DERIVED on null/empty, SERVER on
+agreement, the mismatch warning naming both regions, the dangling-parent
+warning still rendering the region as a root row). Every `FloorPlan`
+fixture in all three files is hand-constructed and marked SYNTHETIC —
+no live server carries these fields yet, so a "real recorded response"
+fixture (this file's usual `fixtures.ts` discipline) isn't possible for
+this unit. `usePutDungeonPreview.test.ts`'s existing 12 tests pass
+unchanged (the `compileLive` extraction is behavior-preserving). Full
+`src/concepts/dungeon-builder` suite: 360 tests, 19 files, `tsc --noEmit`
+clean.
+
+### Live verification
+
+Own dev server (fresh worktree; `public/models/synty/` rsync'd from a
+sibling worktree the same way the wire-edges unit's own ledger entry
+documents — a fresh worktree never has it, and its absence crashed the
+ENTIRE React root on first 3D-mode render with no console.error, only a
+`pageerror` about a missing texture — confirmed as an asset-sync gap, not
+a code bug, by reproducing the SAME crash-free render against a sibling
+worktree with assets present). Default `.env` (`VITE_API_HOST=
+http://localhost:8080`) reached a real, reachable rpg-api instance
+without the authoring gate's `AuthoringService` registered
+(`Unimplemented` → `serverState: 'gate-off'`) — this is, honestly, the
+ONLY live-testable state today, since no shipped server carries
+`floor_cells`/`regions`: confirmed the 3D preview's badge reads
+`FLOOR: DERIVED` and the Region panel's badge reads `REGIONS: DERIVED`,
+both against a real reachable server, with the floor/region tree
+rendering exactly as before this unit (no regression, no crash, no
+empty-floor flash). The `server`/mismatch/dangling-parent paths are
+proven by `regionTreeWire.test.ts`/`RegionPanel.test.tsx`'s constructed
+fixtures, not live — there is nothing server-side to drive them against
+yet.

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -50,7 +50,10 @@ import { DungeonPreview3D } from './preview3d/DungeonPreview3D';
 import { RolledContentPanel } from './RolledContentPanel';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
-import { usePutDungeonPreview } from './usePutDungeonPreview';
+import {
+  useCreationFloorPlanPreview,
+  usePutDungeonPreview,
+} from './usePutDungeonPreview';
 import { useSaveDungeon } from './useSaveDungeon';
 import { WallGashExplainer } from './WallGashExplainer';
 import { YamlPane } from './YamlPane';
@@ -282,6 +285,24 @@ export function DungeonBuilderConcept() {
   );
   const creationApplyDebounce = useRef<ReturnType<typeof setTimeout> | null>(
     null
+  );
+
+  // Creation mode's own live FloorPlan preview (v0.3 wire consumption
+  // unit, 2026-08-05) — same "reuse the shared serverState/capabilities,
+  // don't re-probe" reasoning `creationV1Subset` below already documents
+  // for `preview.capabilities`; see `useCreationFloorPlanPreview`'s own
+  // doc comment for why this is a SECOND hook rather than a second call to
+  // `usePutDungeonPreview` itself. Feeds `creation/canvasFloor.ts`'s
+  // `resolveCanvasFloor` and the region tree's wire-vs-derived comparison
+  // — both dormant against every live server today (no shipped producer
+  // carries `floor_cells`/`regions` yet), so this is plumbing for the day
+  // Wave 0/1 lands, not a behavior change against any server reachable
+  // right now.
+  const creationFloorPreview = useCreationFloorPlanPreview(
+    creationDoc,
+    creationYamlText,
+    preview.serverState,
+    preview.capabilities
   );
 
   // Creation mode's own Save & Play (capability-probed graduation, this
@@ -599,6 +620,7 @@ export function DungeonBuilderConcept() {
           serverState={preview.serverState}
           capabilities={preview.capabilities}
           onRefreshCapabilities={preview.refreshCapabilities}
+          liveFloorPlan={creationFloorPreview.floorPlan}
           v1Subset={creationV1Subset}
           onSaveAndPlay={handleCreationSaveAndPlay}
           saveState={creationSave.state}

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -1672,6 +1672,37 @@ output, which is itself computed from whatever `capabilityProbe.ts`'s
 caveat to state by hand — the badges structurally can't drift from the
 connected server, because they ARE its answer, re-asked every time.
 
+## Response-side wire consumption: canvas floor + region tree (2026-08-05, dormant)
+
+The capability table above is the SEND side (what the request can carry
+without being stripped). This is the RESPONSE side: once a live server
+answers with `FloorPlan.floor_cells`/`FloorPlan.regions`
+(`FloorPlanRegion.parent_id`) — rpg-api-protos **v0.1.120**, spec.md
+§4.5.9/§4.10.4 — this concept renders FROM the wire instead of its own
+client-derived approximations:
+
+- `creation/canvasFloor.ts`'s `resolveCanvasFloor(doc, floorPlan)` prefers
+  `floorPlan.floorCells` over `deriveCanvasFloorCells` the moment it's
+  non-empty; `DungeonPreview3D`'s `FLOOR: SERVER (N)` / `FLOOR: DERIVED`
+  badge shows which one won.
+- `regionTreeWire.ts`'s `resolveRegionTree(regions, floorPlan)` prefers
+  `floorPlan.regions`/`parent_id` over `regionTree.ts`'s cell-subset
+  inference the moment it's non-empty, cross-checking the two and
+  surfacing a named warning on disagreement (or a dangling `parent_id`);
+  `RegionPanel`'s `REGIONS: SERVER` / `REGIONS: DERIVED` badge mirrors the
+  floor badge.
+
+**Ready, currently dormant.** Canvas mode (spec.md §1 group (c),
+rpg-project#192) and regions (group (d), rpg-project#180/Wave 1) are both
+not started server-side — every live server today answers with empty
+`floor_cells`/`regions` (decode-unknown fields as of the 2026-08-04
+capability probe, same table above), which both consumers treat
+identically to no response at all, never as "the document declares
+zero." The client-side plumbing exists and is tested against constructed
+fixtures now so the flip to server truth needs zero further client
+changes the day Wave 0/1 lands — see CONTRACT.md's "v0.3 wire consumption
+unit" ledger entry for the full writeup and live-verification notes.
+
 ## The v1-subset strip — what actually reaches `PutDungeon`, capability-aware
 
 This concept NEVER sends a target-dialect document to the real server

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -7,6 +7,7 @@
  * rows and the shared `Inspector` — no more bespoke Tools strip or
  * hand-rolled facing/delete panel duplicating what those already do.
  */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { useEffect, useMemo, useState } from 'react';
 import type { ServerCapabilities } from '../capabilityProbe';
@@ -19,7 +20,7 @@ import type { BoardTool } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import type { ServerState } from '../usePutDungeonPreview';
 import type { SaveState } from '../useSaveDungeon';
-import { deriveCanvasFloorCells } from './canvasFloor';
+import { resolveCanvasFloor } from './canvasFloor';
 import { CreationBoard } from './CreationBoard';
 import type { DemoActions } from './demoScript';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
@@ -91,6 +92,15 @@ interface CreationConceptProps {
   serverState: ServerState;
   capabilities: ServerCapabilities | null;
   onRefreshCapabilities: () => void;
+  /** The creation document's own live `PutDungeon(validate_only)` response
+   * (v0.3 wire consumption unit, 2026-08-05 — `usePutDungeonPreview.ts`'s
+   * `useCreationFloorPlanPreview`). `null` in fixtures mode, mid-debounce,
+   * or while a live server hasn't shipped `floor_cells`/`regions` yet
+   * (every server today — dormant by design, see that hook's own doc
+   * comment). Threaded down to `resolveCanvasFloor`/the region tree so
+   * this concept flips to server truth automatically the day the platform
+   * ships Wave 0/1, with zero further client changes. */
+  liveFloorPlan: FloorPlan | null;
   v1Subset: V1SubsetResult | null;
   onSaveAndPlay: () => void;
   saveState: SaveState;
@@ -129,6 +139,7 @@ export function CreationConcept({
   serverState,
   capabilities,
   onRefreshCapabilities,
+  liveFloorPlan,
   v1Subset,
   onSaveAndPlay,
   saveState,
@@ -145,18 +156,27 @@ export function CreationConcept({
   // doesn't need to retarget it.
   const demo = useDemoScript(demoActions, DEFAULT_CANVAS);
 
-  // Canvas floor derivation (rpg-project#169's creation-mode 3D preview
-  // unit) — the 3D preview's own floor semantic for a from-scratch
+  // Canvas floor resolution (rpg-project#169's creation-mode 3D preview
+  // unit; wire-consumption-aware since the v0.3 wire consumption unit,
+  // 2026-08-05) — the 3D preview's own floor semantic for a from-scratch
   // canvas, since it has no compiled `FloorPlan` to render from at all
   // (`creation/canvasFloor.ts`'s own doc comment has the full rationale).
   // Computed here, not inside `DungeonPreview3D` itself, per that
   // component's own "clean interfaces" doc comment — derived only when
-  // actually needed (`boardDim === '3d'`) since `deriveCanvasFloorCells`
-  // scans the whole canvas grid.
-  const floorCells = useMemo(
-    () => (boardDim === '3d' ? deriveCanvasFloorCells(doc) : []),
-    [boardDim, doc]
+  // actually needed (`boardDim === '3d'`) since both `resolveCanvasFloor`
+  // paths scan the whole canvas grid or the whole wire cell list.
+  // `resolveCanvasFloor` prefers `liveFloorPlan.floorCells` the moment a
+  // live response carries a non-empty one, falling back to
+  // `deriveCanvasFloorCells` otherwise (dormant against every server
+  // today — see `liveFloorPlan`'s own doc comment).
+  const resolvedFloor = useMemo(
+    () =>
+      boardDim === '3d'
+        ? resolveCanvasFloor(doc, liveFloorPlan)
+        : { cells: [], source: 'derived' as const },
+    [boardDim, doc, liveFloorPlan]
   );
+  const floorCells = resolvedFloor.cells;
 
   useEffect(() => {
     if (demo.isPlaying) {
@@ -477,6 +497,7 @@ export function CreationConcept({
             <div style={{ flex: 1, minHeight: 0 }}>
               <DungeonPreview3D
                 floorCells={floorCells}
+                floorSource={resolvedFloor.source}
                 doc={doc}
                 selectedPlacement={edit.selectedPlacement}
                 onSelect={(sel) => {

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -557,7 +557,11 @@ export function CreationConcept({
           Region is the live tool, matching every other tool-scoped panel
           in this concept. */}
       {selectedTool === 'region' && (
-        <RegionPanel doc={doc} regionEdit={regionEdit} />
+        <RegionPanel
+          doc={doc}
+          regionEdit={regionEdit}
+          liveFloorPlan={liveFloorPlan}
+        />
       )}
     </div>
   );

--- a/src/concepts/dungeon-builder/creation/RegionPanel.test.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * RegionPanel.test.tsx — v0.3 wire consumption unit (2026-08-05). Proves
+ * the region-tree source badge and drift warnings actually RENDER, not
+ * just that `regionTreeWire.ts`'s pure logic is correct
+ * (`regionTreeWire.test.ts` already covers that). No live server carries
+ * `FloorPlan.regions` yet (rpg-api-protos#214 conformance review finding
+ * A4), so every `FloorPlan` fixture here is hand-constructed — marked
+ * SYNTHETIC per this concept's existing fixtures.ts convention.
+ */
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createRegion,
+  parseDungeon,
+  toDungeonDoc,
+  type DungeonDoc,
+} from '../dungeonYaml';
+import { emptyCanvasYaml } from './emptyCanvasDoc';
+import { RegionPanel } from './RegionPanel';
+import type { RegionEditing } from './useRegionEditing';
+
+function docWithTwoSiblingRegions(): DungeonDoc {
+  const { cst, doc } = parseDungeon(emptyCanvasYaml(20, 20));
+  createRegion(cst, doc, 'north-alcove', 'chamber', [
+    [0, 0],
+    [0, 1],
+  ]);
+  const afterFirst = toDungeonDoc(cst);
+  createRegion(cst, afterFirst, 'east-annex', 'chamber', [
+    [10, 10],
+    [10, 11],
+  ]);
+  return toDungeonDoc(cst);
+}
+
+function stubRegionEdit(): RegionEditing {
+  return {
+    pendingCells: [],
+    togglePendingCell: vi.fn(),
+    setPendingCellMembership: vi.fn(),
+    clearPending: vi.fn(),
+    selectedRegionId: null,
+    selectRegion: vi.fn(),
+    justCreatedId: null,
+    handleCreate: vi.fn(),
+    handleToggleCellOnSelected: vi.fn(),
+    setSelectedRegionCellMembership: vi.fn(),
+    handleRename: vi.fn(),
+    handleSetArchetype: vi.fn(),
+    handleDelete: vi.fn(),
+    handleConnect: vi.fn(),
+  };
+}
+
+function floorPlanWithRegions(
+  regions: { id: string; parentId?: string }[]
+): FloorPlan {
+  return create(FloorPlanSchema, {
+    rooms: [],
+    connectors: [],
+    height: 0,
+    doorRow: 0,
+    floorCells: [],
+    regions: regions.map((r) => ({
+      id: r.id,
+      cells: [],
+      parentId: r.parentId,
+    })),
+  });
+}
+
+describe('RegionPanel — v0.3 wire consumption source badge/warnings', () => {
+  it('shows the DERIVED badge with no liveFloorPlan (fixtures mode / rollout gap)', () => {
+    const doc = docWithTwoSiblingRegions();
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={null}
+      />
+    );
+    expect(
+      screen.getByTestId('db-region-tree-source-indicator').textContent
+    ).toContain('REGIONS: DERIVED');
+    expect(screen.queryByTestId('db-region-tree-drift-warning')).toBeNull();
+  });
+
+  it('shows the DERIVED badge when a live response carries an EMPTY regions list (rollout gap, not "declares none")', () => {
+    const doc = docWithTwoSiblingRegions();
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlanWithRegions([])}
+      />
+    );
+    expect(
+      screen.getByTestId('db-region-tree-source-indicator').textContent
+    ).toContain('REGIONS: DERIVED');
+  });
+
+  it('shows the SERVER badge and no warning when the wire agrees with the derivation', () => {
+    const doc = docWithTwoSiblingRegions();
+    const floorPlan = floorPlanWithRegions([
+      { id: 'north-alcove' },
+      { id: 'east-annex' },
+    ]);
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlan}
+      />
+    );
+    expect(
+      screen.getByTestId('db-region-tree-source-indicator').textContent
+    ).toContain('REGIONS: SERVER');
+    expect(screen.queryByTestId('db-region-tree-drift-warning')).toBeNull();
+  });
+
+  it('renders a visible mismatch warning naming the region when the wire parent disagrees with the derivation', () => {
+    const doc = docWithTwoSiblingRegions();
+    // Disjoint siblings client-side, but the wire (incorrectly) claims
+    // east-annex nests under north-alcove — a real server/client
+    // containment disagreement.
+    const floorPlan = floorPlanWithRegions([
+      { id: 'north-alcove' },
+      { id: 'east-annex', parentId: 'north-alcove' },
+    ]);
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlan}
+      />
+    );
+    const warningText = screen.getByTestId(
+      'db-region-tree-drift-warning'
+    ).textContent;
+    expect(warningText).toContain('east-annex');
+    expect(warningText).toContain('north-alcove');
+    expect(warningText).toContain('disagreement');
+  });
+
+  it('renders a visible warning for a dangling parent_id, and still shows the region as a root row', () => {
+    const doc = docWithTwoSiblingRegions();
+    const floorPlan = floorPlanWithRegions([
+      { id: 'north-alcove', parentId: 'ghost-region' },
+      { id: 'east-annex' },
+    ]);
+    render(
+      <RegionPanel
+        doc={doc}
+        regionEdit={stubRegionEdit()}
+        liveFloorPlan={floorPlan}
+      />
+    );
+    const warningText = screen.getByTestId(
+      'db-region-tree-drift-warning'
+    ).textContent;
+    expect(warningText).toContain('north-alcove');
+    expect(warningText).toContain('ghost-region');
+    expect(warningText).toContain('treated as root');
+    // Still rendered as a normal clickable row, not dropped — throws if
+    // absent, which IS the assertion.
+    screen.getByText('north-alcove');
+  });
+});

--- a/src/concepts/dungeon-builder/creation/RegionPanel.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.tsx
@@ -8,14 +8,12 @@
  * "regions:" section) — edit mode renders any authored regions read-only
  * (`Board.tsx`), with no panel of its own yet.
  */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { useEffect, useRef, useState } from 'react';
 import type { DungeonDoc } from '../dungeonYaml';
 import { sharedBoundaryEdges } from '../regionGeometry';
-import {
-  buildRegionTree,
-  flattenRegionTree,
-  rootCellCount,
-} from '../regionTree';
+import { flattenRegionTree, rootCellCount } from '../regionTree';
+import { resolveRegionTree } from '../regionTreeWire';
 import { deriveCanvasFloorCells } from './canvasFloor';
 import type { RegionEditing } from './useRegionEditing';
 
@@ -36,6 +34,46 @@ function TargetDialectBadge() {
       }}
     >
       dialect
+    </span>
+  );
+}
+
+/** Region-tree source indicator (v0.3 wire consumption unit, 2026-08-05)
+ * — same "make drift visible, not silent" idiom as `Board.tsx`'s wall/
+ * door source badge (`db-wall-source-indicator`) and
+ * `preview3d/DungeonPreview3D.tsx`'s floor source badge
+ * (`db-floor-source-indicator`): distinguishes a real
+ * `FloorPlan.regions`/`parent_id` response from `regionTree.ts`'s
+ * client-derived containment fallback, which this panel used exclusively
+ * before this unit and still uses whenever a response carries no
+ * `regions` (every live server today — rollout gap A4, not a contract
+ * defect). */
+function RegionTreeSourceBadge({ source }: { source: 'server' | 'derived' }) {
+  return (
+    <span
+      data-testid="db-region-tree-source-indicator"
+      title={
+        source === 'server'
+          ? 'containment forest built from FloorPlanRegion.parent_id (rpg-api-protos v0.1.120+)'
+          : 'containment forest inferred client-side (regionTree.ts) — no live FloorPlan.regions carried yet'
+      }
+      style={{
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: 0.3,
+        borderRadius: 3,
+        padding: '1px 5px',
+        marginLeft: 6,
+        ...(source === 'server'
+          ? { color: '#100d0b', background: '#c9bfae' }
+          : {
+              color: '#e8e2d8',
+              background: 'rgba(90, 74, 58, 0.55)',
+              border: '1px dashed #8a7a5a',
+            }),
+      }}
+    >
+      {source === 'server' ? 'REGIONS: SERVER' : 'REGIONS: DERIVED'}
     </span>
   );
 }
@@ -93,9 +131,21 @@ const buttonStyle: React.CSSProperties = {
 interface RegionPanelProps {
   doc: DungeonDoc;
   regionEdit: RegionEditing;
+  /** The creation document's own live `PutDungeon(validate_only)` response
+   * (v0.3 wire consumption unit, 2026-08-05 —
+   * `usePutDungeonPreview.ts`'s `useCreationFloorPlanPreview`). `null` in
+   * fixtures mode, mid-debounce, or while a live server hasn't shipped
+   * `regions` yet (every server today). See `regionTreeWire.ts`'s
+   * `resolveRegionTree` for how this panel's tree flips to server truth
+   * once populated. */
+  liveFloorPlan: FloorPlan | null;
 }
 
-export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
+export function RegionPanel({
+  doc,
+  regionEdit,
+  liveFloorPlan,
+}: RegionPanelProps) {
   const {
     pendingCells,
     clearPending,
@@ -183,17 +233,61 @@ export function RegionPanel({ doc, regionEdit }: RegionPanelProps) {
   // painted, rather than only becoming honest once a first region exists. ---
   if (pendingCells.length === 0 && !editingRegion && !showConnectCallout) {
     const floorCells = deriveCanvasFloorCells(doc);
-    const tree = buildRegionTree(doc.regions);
+    const resolved = resolveRegionTree(doc.regions, liveFloorPlan);
+    const { tree, source, mismatches, dangling } = resolved;
     const rootCount = rootCellCount(floorCells, doc.regions);
     const rows = flattenRegionTree(tree);
     return (
       <div role="dialog" aria-label="Regions" style={panelStyle}>
         <h4 style={{ margin: '0 0 6px', fontSize: 13, color: '#3a9b6a' }}>
           Regions <TargetDialectBadge />
+          <RegionTreeSourceBadge source={source} />
         </h4>
         <div style={{ fontSize: 11, color: '#8a7a5a', marginBottom: 6 }}>
           Click a region to edit it, or paint new board cells to start another.
         </div>
+        {(mismatches.length > 0 || dangling.length > 0) && (
+          <div
+            data-testid="db-region-tree-drift-warning"
+            style={{
+              fontSize: 10,
+              color: '#ff9a8a',
+              background: '#2a1512',
+              border: '1px solid #5a2a20',
+              borderRadius: 4,
+              padding: '5px 8px',
+              marginBottom: 8,
+              lineHeight: 1.4,
+            }}
+          >
+            {mismatches.map((m) => {
+              const region = doc.regions.find((r) => r.id === m.regionId);
+              const label = (id: string | undefined) => {
+                if (id === undefined) return 'root';
+                const r = doc.regions.find((r) => r.id === id);
+                return `"${r?.name ?? id}"`;
+              };
+              return (
+                <div key={`mismatch-${m.regionId}`}>
+                  ⚠ "{region?.name ?? m.regionId}": server says parent{' '}
+                  {label(m.wireParentId)}, client derivation says parent{' '}
+                  {label(m.derivedParentId)} — server/client containment
+                  disagreement.
+                </div>
+              );
+            })}
+            {dangling.map((d) => {
+              const region = doc.regions.find((r) => r.id === d.regionId);
+              return (
+                <div key={`dangling-${d.regionId}`}>
+                  ⚠ "{region?.name ?? d.regionId}": server-declared parent "
+                  {d.danglingParentId}" is not a region on this response —
+                  treated as root.
+                </div>
+              );
+            })}
+          </div>
+        )}
         {tree.overlaps.length > 0 && (
           <div
             style={{

--- a/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.test.ts
@@ -1,3 +1,8 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { describe, expect, it } from 'vitest';
 import {
   addWallLine,
@@ -9,6 +14,8 @@ import {
 import {
   canvasPlacementRejectReason,
   deriveCanvasFloorCells,
+  resolveCanvasFloor,
+  sortCellsLexicographic,
 } from './canvasFloor';
 import { emptyCanvasYaml } from './emptyCanvasDoc';
 import { straightWallsFootprintSet } from './straightWallGeometry';
@@ -65,6 +72,116 @@ describe('deriveCanvasFloorCells', () => {
       holes: [[0, 0]],
     });
     expect(cells).toEqual([]);
+  });
+});
+
+describe('sortCellsLexicographic', () => {
+  it('sorts ascending by column, then row', () => {
+    const sorted = sortCellsLexicographic([
+      [2, 0],
+      [0, 1],
+      [0, 0],
+      [1, 5],
+    ]);
+    expect(sorted).toEqual([
+      [0, 0],
+      [0, 1],
+      [1, 5],
+      [2, 0],
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const input: [number, number][] = [
+      [1, 1],
+      [0, 0],
+    ];
+    sortCellsLexicographic(input);
+    expect(input).toEqual([
+      [1, 1],
+      [0, 0],
+    ]);
+  });
+});
+
+// v0.3 wire consumption unit (2026-08-05) — resolveCanvasFloor prefers a
+// live FloorPlan.floor_cells (rpg-api-protos v0.1.120) over the
+// client-derived fallback. No live server carries this field yet (the
+// rpg-api-protos#214 conformance review's finding A4 — canvas mode is
+// spec.md §1 group (c), not started server-side): every FloorPlan fixture
+// below is hand-constructed to exercise the shape the wire will carry
+// once Wave 0 ships, not a real recorded response. Marked SYNTHETIC per
+// this concept's existing fixtures.ts convention.
+describe('resolveCanvasFloor — v0.3 wire consumption (SYNTHETIC fixtures, no live server carries these fields yet)', () => {
+  const doc = {
+    canvas: { width: 3, height: 2 },
+    holes: [] as [number, number][],
+  };
+
+  function floorPlanWithCells(cells: [number, number][]): FloorPlan {
+    return create(FloorPlanSchema, {
+      rooms: [],
+      connectors: [],
+      height: 0,
+      doorRow: 0,
+      floorCells: cells.map(([column, row]) => ({ column, row })),
+      regions: [],
+    });
+  }
+
+  it('null floorPlan falls back to derived, labeled "derived"', () => {
+    const result = resolveCanvasFloor(doc, null);
+    expect(result.source).toBe('derived');
+    expect(result.cells).toEqual(
+      sortCellsLexicographic(deriveCanvasFloorCells(doc))
+    );
+  });
+
+  it('a live response with EMPTY floor_cells falls back to derived — rollout gap (A4), not "declares none"', () => {
+    const result = resolveCanvasFloor(doc, floorPlanWithCells([]));
+    expect(result.source).toBe('derived');
+    expect(result.cells).toEqual(
+      sortCellsLexicographic(deriveCanvasFloorCells(doc))
+    );
+  });
+
+  it('a live response with non-empty floor_cells renders from the wire, sort-normalized', () => {
+    // Deliberately authoring-order (not sorted) on the wire fixture, to
+    // prove resolveCanvasFloor normalizes rather than trusting response
+    // order verbatim.
+    const wireCells: [number, number][] = [
+      [2, 1],
+      [0, 0],
+      [1, 0],
+    ];
+    const result = resolveCanvasFloor(doc, floorPlanWithCells(wireCells));
+    expect(result.source).toBe('server');
+    expect(result.cells).toEqual(sortCellsLexicographic(wireCells));
+  });
+
+  it('server cells win even when they disagree with the derived set (e.g. a hole the server does not know about)', () => {
+    const docWithHole = {
+      canvas: { width: 3, height: 2 },
+      holes: [[1, 0]] as [number, number][],
+    };
+    // v0.3's canvas structural floor has no hole concept server-side
+    // (`holes:` is explicitly ABOVE v0.3, spec.md §2) — a real future
+    // server response would legitimately include [1,0] even though the
+    // client's own doc punches a hole there. Wire wins.
+    const wireCells: [number, number][] = [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ];
+    const result = resolveCanvasFloor(
+      docWithHole,
+      floorPlanWithCells(wireCells)
+    );
+    expect(result.source).toBe('server');
+    expect(result.cells.some(([c, r]) => c === 1 && r === 0)).toBe(true);
   });
 });
 

--- a/src/concepts/dungeon-builder/creation/canvasFloor.ts
+++ b/src/concepts/dungeon-builder/creation/canvasFloor.ts
@@ -22,10 +22,25 @@
  *
  * See TARGET-YAML.md's "canvas:" section for this semantic recorded
  * as a dialect note, not just left as an implementation detail here.
+ *
+ * **v0.3 wire consumption (this unit, 2026-08-05)**: `deriveCanvasFloorCells`
+ * above is now the FALLBACK, not the only source — `resolveCanvasFloor`
+ * below prefers a live `FloorPlan.floor_cells` (rpg-api-protos v0.1.120,
+ * spec.md §4.5.9) the moment a real response carries one. See
+ * `resolveCanvasFloor`'s own doc comment for the rollout discipline (spec
+ * §1 group (c) is not shipped server-side yet, so this path is dormant
+ * against every live server today — verified by the
+ * rpg-api-protos#214 conformance review's finding A4).
  */
+import type {
+  FloorPlan,
+  FloorPlanCell,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { isCellOccupied } from '../boardGeometry';
 import type { DungeonDoc } from '../dungeonYaml';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
+
+export type Cell = [number, number];
 
 /** Every `[col, row]` cell inside `doc.canvas`'s bounds (or
  * `DEFAULT_CANVAS` when the document carries none, matching
@@ -45,6 +60,84 @@ export function deriveCanvasFloorCells(
     }
   }
   return cells;
+}
+
+/** Ascending lexicographic `(column, row)` — the wire's own declared
+ * order for both `FloorPlan.floor_cells` and `FloorPlanRegion.cells`
+ * (rpg-api-protos v0.1.120's own field comments: "producers emit cells in
+ * ascending lexicographic (column, row) order"). `deriveCanvasFloorCells`
+ * above happens to already produce this order today (its column-major
+ * outer loop with an increasing-row inner loop IS ascending lexicographic
+ * whenever there are no holes to filter out — the hole filter only ever
+ * removes entries, never reorders the survivors), but its own doc comment
+ * explicitly does NOT promise that ("not spatially meaningful") — so any
+ * caller that needs to compare a wire cell list against a derived one
+ * (rpg-api-protos#214 conformance review, finding A5) normalizes BOTH
+ * sides through this function first rather than relying on the
+ * coincidence. Used both by `resolveCanvasFloor` below (so its returned
+ * cell list has one canonical order regardless of which source produced
+ * it) and by this concept's tests. */
+export function sortCellsLexicographic(cells: readonly Cell[]): Cell[] {
+  return [...cells].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+}
+
+function floorPlanCellToTuple(cell: FloorPlanCell): Cell {
+  return [cell.column, cell.row];
+}
+
+export type CanvasFloorSource = 'server' | 'derived';
+
+export interface ResolvedCanvasFloor {
+  /** Ascending-lexicographic-normalized (see `sortCellsLexicographic`),
+   * regardless of source. */
+  cells: Cell[];
+  source: CanvasFloorSource;
+}
+
+/**
+ * Chooses the creation canvas's floor cell set: the wire's own
+ * `FloorPlan.floor_cells` (rpg-api-protos v0.1.120, spec.md §4.5.9) when a
+ * live response carries a non-empty one, `deriveCanvasFloorCells` (this
+ * file, client-derived from `doc.canvas` bounds minus `doc.holes`)
+ * otherwise.
+ *
+ * **Rollout discipline (rpg-api-protos#214 conformance review, finding
+ * A4)**: canvas mode (spec.md §1 group (c), rpg-project#192) is not
+ * shipped server-side yet, and the client's own live capability probe
+ * records `canvas` as decode-unknown as of 2026-08-04
+ * (`capabilityProbe.ts`) — so an empty `floor_cells` from a REAL server
+ * today means "the producer hasn't shipped this," never "the document
+ * declares an empty floor." Gating on non-empty rather than on
+ * `floorPlan !== null` is exactly what keeps this fallback-safe: a live
+ * server that's reachable and answering, but pre-Wave-0, produces a
+ * `FloorPlan` with `floorCells: []` (the field's zero value, same as an
+ * unset repeated field), which this function treats identically to no
+ * `floorPlan` at all — never an empty rendered floor.
+ *
+ * Does not itself validate `floorPlan.width`/`floorPlan.height` against
+ * `doc.canvas` — `floor_cells` is a complete, self-describing absolute
+ * cell list per its own field comment ("clients MUST render this list,
+ * not infer floor from width and height"), so this function needs nothing
+ * else from the response to be correct. (`FloorPlan.height`'s canvas-mode
+ * meaning is independently ambiguous on the wire today — conformance
+ * review finding A1 — one more reason not to lean on it here.)
+ */
+export function resolveCanvasFloor(
+  doc: Pick<DungeonDoc, 'canvas' | 'holes'>,
+  floorPlan: FloorPlan | null
+): ResolvedCanvasFloor {
+  if (floorPlan && floorPlan.floorCells.length > 0) {
+    return {
+      cells: sortCellsLexicographic(
+        floorPlan.floorCells.map(floorPlanCellToTuple)
+      ),
+      source: 'server',
+    };
+  }
+  return {
+    cells: sortCellsLexicographic(deriveCanvasFloorCells(doc)),
+    source: 'derived',
+  };
 }
 
 /**

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -209,6 +209,17 @@ interface DungeonPreview3DProps {
    * marker) regardless of which floor-tile path won — see
    * `buildFloorTiles`'s own doc comment. */
   floorCells?: readonly [number, number][];
+  /** Which source produced `floorCells` — `creation/canvasFloor.ts`'s
+   * `resolveCanvasFloor` (v0.3 wire consumption unit, 2026-08-05). Purely
+   * a badge/label input, same "caller derives, this component just
+   * renders" discipline `floorCells` itself follows (see this prop's own
+   * doc comment) — this component does not itself decide server-vs-derived,
+   * only displays what the caller already decided. Omitted (or
+   * `undefined`) when `floorCells` itself is absent (edit mode,
+   * `floorPlan`-only) — there is no creation-canvas floor SOURCE to badge
+   * in that case, matching `Board.tsx`'s own edit-mode wall/door
+   * indicator, which this badge mirrors for creation mode's floor. */
+  floorSource?: 'server' | 'derived';
   doc: DungeonDoc;
   /** Kirk's 2026-08-02 "3D editing" arc, part 2 — the SAME
    * `PlacementSelection`/`onSelect` contract `Board.tsx` already uses for
@@ -1183,6 +1194,7 @@ const SELECTED_COLOR = '#ffd76a';
 export function DungeonPreview3D({
   floorPlan,
   floorCells,
+  floorSource,
   doc,
   selectedPlacement,
   onSelect,
@@ -1320,7 +1332,56 @@ export function DungeonPreview3D({
   };
 
   return (
-    <div style={{ width: '100%', height: '100%', background: '#0c0a08' }}>
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        background: '#0c0a08',
+      }}
+    >
+      {/* Canvas floor source indicator (v0.3 wire consumption unit,
+       * 2026-08-05) — same "make drift visible, not silent" idiom as
+       * `Board.tsx`'s wall/door source indicator (`db-wall-source-indicator`):
+       * distinguishes a real `FloorPlan.floor_cells` response
+       * (rpg-api-protos v0.1.120+) from `creation/canvasFloor.ts`'s
+       * client-derived fallback this preview used exclusively before this
+       * unit, and still uses whenever a response carries no floor_cells
+       * (every live server today — rollout gap A4, not a contract defect).
+       * Only rendered when `floorSource` is supplied at all — edit mode's
+       * `floorPlan`-only call site has no creation-canvas floor SOURCE to
+       * badge. */}
+      {floorSource && (
+        <div
+          data-testid="db-floor-source-indicator"
+          style={{
+            position: 'absolute',
+            top: 4,
+            left: 4,
+            zIndex: 5,
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: 0.3,
+            padding: '3px 7px',
+            borderRadius: 4,
+            pointerEvents: 'none',
+            ...(floorSource === 'server'
+              ? {
+                  color: '#100d0b',
+                  background: '#c9bfae',
+                }
+              : {
+                  color: '#e8e2d8',
+                  background: 'rgba(90, 74, 58, 0.55)',
+                  border: '1px dashed #8a7a5a',
+                }),
+          }}
+        >
+          {floorSource === 'server'
+            ? `FLOOR: SERVER (${floorCells?.length ?? 0} cells)`
+            : 'FLOOR: DERIVED'}
+        </div>
+      )}
       <Canvas
         camera={{ fov: 45, position: [10, 14, 10] }}
         onPointerMissed={() => onSelect?.(null)}

--- a/src/concepts/dungeon-builder/regionTreeWire.test.ts
+++ b/src/concepts/dungeon-builder/regionTreeWire.test.ts
@@ -1,0 +1,213 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { describe, expect, it } from 'vitest';
+import {
+  buildRegionTree,
+  flattenRegionTree,
+  type RegionLike,
+} from './regionTree';
+import { resolveRegionTree } from './regionTreeWire';
+
+function region(
+  id: string,
+  cells: [number, number][],
+  archetype = 'chamber'
+): RegionLike {
+  return { id, archetype, cells };
+}
+
+function floorPlanWithRegions(
+  regions: { id: string; parentId?: string }[]
+): FloorPlan {
+  return create(FloorPlanSchema, {
+    rooms: [],
+    connectors: [],
+    height: 0,
+    doorRow: 0,
+    floorCells: [],
+    regions: regions.map((r) => ({
+      id: r.id,
+      cells: [],
+      parentId: r.parentId,
+    })),
+  });
+}
+
+// v0.3 wire consumption unit (2026-08-05) — resolveRegionTree prefers a
+// live FloorPlan.regions (FloorPlanRegion.parent_id, rpg-api-protos
+// v0.1.120) over regionTree.ts's own client-derived containment. No live
+// server carries this field yet (rpg-api-protos#214 conformance review's
+// finding A4 — regions is spec.md §1 group (d), Wave 1, not started
+// server-side): every FloorPlan fixture below is hand-constructed to
+// exercise the shape the wire will carry once it ships, not a real
+// recorded response. Marked SYNTHETIC per this concept's existing
+// fixtures.ts convention.
+describe('resolveRegionTree — v0.3 wire consumption (SYNTHETIC fixtures, no live server carries these fields yet)', () => {
+  it('null floorPlan falls back to regionTree.ts derivation, labeled "derived"', () => {
+    const regions = [region('a', [[0, 0]]), region('b', [[5, 5]])];
+    const result = resolveRegionTree(regions, null);
+    expect(result.source).toBe('derived');
+    expect(result.mismatches).toEqual([]);
+    expect(result.dangling).toEqual([]);
+    expect(result.tree).toEqual(buildRegionTree(regions));
+  });
+
+  it('a live response with EMPTY regions falls back to derived — rollout gap (A4), not "declares none"', () => {
+    const regions = [region('a', [[0, 0]])];
+    const result = resolveRegionTree(regions, floorPlanWithRegions([]));
+    expect(result.source).toBe('derived');
+  });
+
+  it('a live response with non-empty regions renders the tree from parent_id, agreeing case has no mismatches', () => {
+    // Two regions whose cell sets ALSO nest (a strict subset), so the
+    // wire's parent_id and regionTree.ts's own cell-subset inference
+    // agree — the "everything lines up" baseline case.
+    const outer = region('shrine', [
+      [9, 2],
+      [9, 3],
+      [9, 4],
+      [10, 2],
+      [10, 3],
+      [10, 4],
+    ]);
+    const inner = region('shrine-altar', [
+      [9, 3],
+      [9, 4],
+    ]);
+    const regions = [outer, inner];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'shrine' }, // absent parentId = root
+      { id: 'shrine-altar', parentId: 'shrine' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.mismatches).toEqual([]);
+    expect(result.dangling).toEqual([]);
+    const rows = flattenRegionTree(result.tree);
+    expect(rows.map((r) => ({ id: r.region.id, depth: r.depth }))).toEqual([
+      { id: 'shrine', depth: 1 },
+      { id: 'shrine-altar', depth: 2 },
+    ]);
+  });
+
+  it('an absent parent_id on the wire means root, matching an un-nested derived sibling', () => {
+    const regions = [region('a', [[0, 0]]), region('b', [[5, 5]])];
+    const floorPlan = floorPlanWithRegions([{ id: 'a' }, { id: 'b' }]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.tree.roots).toHaveLength(2);
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it('flags a mismatch when the wire parent disagrees with the cell-subset derivation', () => {
+    // Two SIBLING (disjoint) cell sets — regionTree.ts's own derivation
+    // puts both at root. A wire response that (incorrectly, for this
+    // test) claims "b" is a child of "a" is exactly the drift class A2/A3
+    // name: the proto's derivation rule isn't parser-enforced, so an
+    // implementer — or a stale fixture — can produce a parent_id that
+    // disagrees with the cell sets.
+    const a = region('a', [
+      [0, 0],
+      [0, 1],
+    ]);
+    const b = region('b', [
+      [5, 5],
+      [5, 6],
+    ]);
+    const regions = [a, b];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'a' },
+      { id: 'b', parentId: 'a' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.mismatches).toEqual([
+      { regionId: 'b', wireParentId: 'a', derivedParentId: undefined },
+    ]);
+    // The tree still renders from the WIRE (parent_id authoritative) —
+    // "b" nests under "a" in the rendered tree despite the derived
+    // disagreement; the mismatch is a surfaced warning, not a silent
+    // override of the wire.
+    const rows = flattenRegionTree(result.tree);
+    expect(rows.map((r) => r.region.id)).toEqual(['a', 'b']);
+    expect(rows.find((r) => r.region.id === 'b')!.depth).toBe(2);
+  });
+
+  it('flags a mismatch the other direction too — derived says nested, wire says root', () => {
+    const outer = region('shrine', [
+      [9, 2],
+      [9, 3],
+    ]);
+    const inner = region('shrine-altar', [[9, 3]]); // a real subset of outer
+    const regions = [outer, inner];
+    // Wire (incorrectly) claims shrine-altar has no parent.
+    const floorPlan = floorPlanWithRegions([
+      { id: 'shrine' },
+      { id: 'shrine-altar' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.mismatches).toEqual([
+      {
+        regionId: 'shrine-altar',
+        wireParentId: undefined,
+        derivedParentId: 'shrine',
+      },
+    ]);
+  });
+
+  it('a dangling parent_id (points to a region not on this response) is treated as root AND warned', () => {
+    const regions = [region('a', [[0, 0]])];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'a', parentId: 'ghost-region' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.source).toBe('server');
+    expect(result.dangling).toEqual([
+      { regionId: 'a', danglingParentId: 'ghost-region' },
+    ]);
+    // Treated as root for tree-building purposes — no crash, no orphaned
+    // subtree, just a plain root row plus the warning.
+    expect(result.tree.roots).toHaveLength(1);
+    expect(result.tree.roots[0].region.id).toBe('a');
+    expect(result.tree.roots[0].depth).toBe(1);
+  });
+
+  it('a region present locally but absent from the wire response is skipped for mismatch-checking (not a false mismatch)', () => {
+    const regions = [region('a', [[0, 0]]), region('local-only', [[9, 9]])];
+    const floorPlan = floorPlanWithRegions([{ id: 'a' }]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it('handles a 3-deep nesting chain from the wire, matching flattenRegionTree depth semantics', () => {
+    const regions = [
+      region('outer', [
+        [0, 0],
+        [0, 1],
+        [0, 2],
+        [0, 3],
+      ]),
+      region('mid', [
+        [0, 1],
+        [0, 2],
+      ]),
+      region('inner', [[0, 1]]),
+    ];
+    const floorPlan = floorPlanWithRegions([
+      { id: 'outer' },
+      { id: 'mid', parentId: 'outer' },
+      { id: 'inner', parentId: 'mid' },
+    ]);
+    const result = resolveRegionTree(regions, floorPlan);
+    expect(result.mismatches).toEqual([]);
+    const rows = flattenRegionTree(result.tree);
+    expect(rows.map((r) => ({ id: r.region.id, depth: r.depth }))).toEqual([
+      { id: 'outer', depth: 1 },
+      { id: 'mid', depth: 2 },
+      { id: 'inner', depth: 3 },
+    ]);
+  });
+});

--- a/src/concepts/dungeon-builder/regionTreeWire.ts
+++ b/src/concepts/dungeon-builder/regionTreeWire.ts
@@ -1,0 +1,182 @@
+/**
+ * regionTreeWire — v0.3 wire consumption for the region containment forest
+ * (this unit, 2026-08-05). `regionTree.ts`'s `buildRegionTree` INFERS
+ * containment from cell-subset comparison; this module instead builds the
+ * SAME `RegionTree` shape directly from `FloorPlanRegion.parent_id`
+ * (rpg-api-protos v0.1.120, spec.md §4.10.4) when a live response carries
+ * one — the wire's `parent_id` field comment says it plainly ("Toolkit-derived
+ * direct declared parent ID"), so once it's present there is nothing left
+ * to infer: recomputing it client-side would just be re-deriving what the
+ * producer already computed authoritatively.
+ *
+ * Kept as a SEPARATE module from `regionTree.ts` rather than adding a
+ * `FloorPlan`-typed function there — `regionTree.ts`'s own header comment
+ * documents itself as deliberately dependency-free (no `DungeonDoc`/
+ * `RegionDoc`, let alone a wire proto type), reusable by both boards
+ * without pulling in this concept's network layer. This module is the one
+ * place that DOES import the wire type, the same split
+ * `creation/canvasFloor.ts`'s `resolveCanvasFloor` follows for the canvas
+ * floor's own wire-vs-derived choice.
+ *
+ * **Rollout discipline (rpg-api-protos#214 conformance review, finding
+ * A4)**: regions (spec.md §1 group (d), rpg-project#180/Wave 1) is not
+ * shipped server-side yet — a live server today always answers with an
+ * empty `FloorPlan.regions`, which this module treats identically to no
+ * `floorPlan` at all (never "the document declares zero regions").
+ *
+ * **Dangling `parent_id` (finding A2)**: the conformance review flagged
+ * that referential closure — `parent_id` resolving to another declared
+ * region's `id` — is a producer expectation the proto never states as a
+ * MUST, so a client has to defensively handle a dangling reference. This
+ * module treats a dangling `parent_id` as root for TREE-BUILDING purposes
+ * (same graceful behavior an absent `parent_id` gets) but still surfaces
+ * it as a named warning — a dangling parent is a real drift signal, not
+ * something to silently swallow.
+ */
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import {
+  buildRegionTree,
+  type RegionLike,
+  type RegionTree,
+  type RegionTreeNode,
+} from './regionTree';
+
+export type RegionTreeSource = 'server' | 'derived';
+
+/** One region where the wire's authoritative parent (once present)
+ * disagrees with what `regionTree.ts`'s own cell-subset inference would
+ * derive for the SAME region set — a server/client containment
+ * disagreement is exactly the drift class worth surfacing loudly rather
+ * than silently preferring one side. `undefined` on either side means
+ * "root" on that side. */
+export interface RegionParentMismatch {
+  regionId: string;
+  wireParentId: string | undefined;
+  derivedParentId: string | undefined;
+}
+
+/** A wire region's `parent_id` that does not resolve to another wire
+ * region's `id` (conformance review finding A2). */
+export interface DanglingParentWarning {
+  regionId: string;
+  danglingParentId: string;
+}
+
+export interface ResolvedRegionTree<T extends RegionLike = RegionLike> {
+  tree: RegionTree<T>;
+  source: RegionTreeSource;
+  /** Populated only when `source === 'server'` — the VERIFICATION
+   * comparison against `regionTree.ts`'s own derivation for the same
+   * regions. Empty when `source === 'derived'` (nothing to compare
+   * against — there is no second source). */
+  mismatches: RegionParentMismatch[];
+  /** Populated only when `source === 'server'`. */
+  dangling: DanglingParentWarning[];
+}
+
+function buildTreeFromParentPointers<T extends RegionLike>(
+  regions: readonly T[],
+  parentIdOf: (id: string) => string | undefined
+): { tree: RegionTree<T>; dangling: DanglingParentWarning[] } {
+  const nodeOf = new Map<string, RegionTreeNode<T>>();
+  for (const r of regions) {
+    nodeOf.set(r.id, { region: r, depth: 0, children: [] });
+  }
+
+  const dangling: DanglingParentWarning[] = [];
+  const roots: RegionTreeNode<T>[] = [];
+  for (const r of regions) {
+    const node = nodeOf.get(r.id)!;
+    const parentId = parentIdOf(r.id);
+    if (parentId === undefined) {
+      roots.push(node);
+      continue;
+    }
+    const parentNode = nodeOf.get(parentId);
+    if (!parentNode) {
+      // A4/A2: the wire named a parent that isn't one of the declared
+      // regions on this SAME response — treat as root (same graceful
+      // fallback an absent parent_id gets) but keep the warning so the
+      // caller can surface it, not swallow it.
+      dangling.push({ regionId: r.id, danglingParentId: parentId });
+      roots.push(node);
+      continue;
+    }
+    parentNode.children.push(node);
+  }
+
+  // Same depth convention as regionTree.ts's own buildRegionTree: a
+  // direct child of the implicit root is depth 1.
+  function assignDepth(node: RegionTreeNode<T>, depth: number): void {
+    node.depth = depth;
+    for (const child of node.children) assignDepth(child, depth + 1);
+  }
+  for (const root of roots) assignDepth(root, 1);
+
+  return { tree: { roots, overlaps: [] }, dangling };
+}
+
+/** Walks a `RegionTree` into a flat `regionId -> parentId` map
+ * (`undefined` = root) — used to compare `regionTree.ts`'s own derivation
+ * against the wire's `parent_id`s one region at a time. */
+function parentMapOf<T extends RegionLike>(
+  tree: RegionTree<T>
+): Map<string, string | undefined> {
+  const out = new Map<string, string | undefined>();
+  function walk(node: RegionTreeNode<T>, parentId: string | undefined): void {
+    out.set(node.region.id, parentId);
+    for (const child of node.children) walk(child, node.region.id);
+  }
+  for (const root of tree.roots) walk(root, undefined);
+  return out;
+}
+
+/**
+ * The consumption entry point `RegionPanel.tsx` calls: prefers the wire's
+ * `FloorPlanRegion.parent_id` (`floorPlan.regions`) the moment a live
+ * response carries a non-empty list, falling back to `regionTree.ts`'s own
+ * `buildRegionTree(regions)` otherwise.
+ *
+ * `regions` is always the CALLER's own authored `doc.regions` (the
+ * document being edited) — `floorPlan.regions`, when present, is that
+ * SAME document's server-compiled projection, not an independent region
+ * set. A region id present in `regions` but absent from
+ * `floorPlan.regions` (or vice versa) is a distinct drift class this
+ * function does not itself flag — out of scope for this pass, since a
+ * matching id set is exactly what a same-document round-trip should
+ * produce and no live server projects regions at all yet to observe
+ * otherwise.
+ */
+export function resolveRegionTree<T extends RegionLike>(
+  regions: readonly T[],
+  floorPlan: FloorPlan | null
+): ResolvedRegionTree<T> {
+  if (!floorPlan || floorPlan.regions.length === 0) {
+    return {
+      tree: buildRegionTree(regions),
+      source: 'derived',
+      mismatches: [],
+      dangling: [],
+    };
+  }
+
+  const wireById = new Map(floorPlan.regions.map((r) => [r.id, r] as const));
+  const { tree, dangling } = buildTreeFromParentPointers(
+    regions,
+    (id) => wireById.get(id)?.parentId
+  );
+
+  const derivedParentOf = parentMapOf(buildRegionTree(regions));
+  const mismatches: RegionParentMismatch[] = [];
+  for (const r of regions) {
+    const wireRegion = wireById.get(r.id);
+    if (!wireRegion) continue; // id-set drift — see this function's own doc comment.
+    const wireParentId = wireRegion.parentId;
+    const derivedParentId = derivedParentOf.get(r.id);
+    if (wireParentId !== derivedParentId) {
+      mismatches.push({ regionId: r.id, wireParentId, derivedParentId });
+    }
+  }
+
+  return { tree, source: 'server', mismatches, dangling };
+}

--- a/src/concepts/dungeon-builder/usePutDungeonPreview.ts
+++ b/src/concepts/dungeon-builder/usePutDungeonPreview.ts
@@ -48,6 +48,24 @@
  * `capabilities` resets to `null` the moment `serverState` leaves
  * `'live'` (gate-off/unreachable) — a capability observed against one
  * server is never carried into a fixtures-mode fallback.
+ *
+ * **v0.3 wire consumption (this unit, 2026-08-05)**: this file also
+ * exports `useCreationFloorPlanPreview`, a second, narrower hook for
+ * creation mode's OWN document — creation mode never called `PutDungeon`
+ * at all before this unit (its floor came exclusively from
+ * `creation/canvasFloor.ts`'s client-side `deriveCanvasFloorCells`). It
+ * deliberately does NOT re-run the mount-time reachability probe or the
+ * capability-probe suite above — `serverState`/`capabilities` describe
+ * the SERVER, not which document is being edited, so a second instance
+ * probing independently would double real network traffic (including the
+ * 17-request capability suite) for no new information, every time this
+ * component renders, regardless of which mode tab is even active (React's
+ * rules of hooks mean both hook calls run unconditionally in
+ * `DungeonBuilderConcept.tsx`). Callers pass the ALREADY-established
+ * `serverState`/`capabilities` from this hook's own instance instead. Both
+ * hooks share the same request-building/response-classification logic
+ * (`compileLive` below) so the two paths can't silently drift from each
+ * other.
  */
 import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';
@@ -111,6 +129,60 @@ function classifyFailure(err: unknown): 'gate-off' | 'unreachable' | 'other' {
   // A non-ConnectError throw (network layer never got a structured gRPC
   // response at all) is exactly the "can't reach the server" case too.
   return 'unreachable';
+}
+
+/** One live `validate_only` `PutDungeon` call, shaped and classified —
+ * the exact request-building/response-handling `usePutDungeonPreview`'s
+ * own per-edit effect used to inline, factored out so
+ * `useCreationFloorPlanPreview` (below) can run the identical request for
+ * a SECOND document without a second copy of this logic to drift out of
+ * sync with this one. Never throws. */
+type LiveCompileResult =
+  | { kind: 'unparseable' }
+  | { kind: 'success'; floorPlan: FloorPlan | null }
+  | { kind: 'field-errors'; fieldErrors: ValidationError[] }
+  | { kind: 'unreachable' }
+  | { kind: 'request-error'; message: string };
+
+async function compileLive(
+  doc: DungeonDoc,
+  yamlText: string,
+  capabilities: ServerCapabilities | null
+): Promise<LiveCompileResult> {
+  let subsetYaml: string;
+  try {
+    subsetYaml = stripToV1Subset(yamlText, capabilities ?? undefined).yaml;
+  } catch {
+    // Not even shape-parseable yet (mid-edit) — nothing to preview this
+    // tick. Not a request/field error; the YAML pane's own parse-error
+    // path (DungeonBuilderConcept's applyText) already owns surfacing
+    // this.
+    return { kind: 'unparseable' };
+  }
+  try {
+    const response = await authoringClient.putDungeon(
+      create(PutDungeonRequestSchema, {
+        key: doc.key,
+        yaml: subsetYaml,
+        validateOnly: true,
+      })
+    );
+    if (response.success) {
+      return { kind: 'success', floorPlan: response.floorPlan ?? null };
+    }
+    return { kind: 'field-errors', fieldErrors: response.fieldErrors };
+  } catch (err) {
+    const kind = classifyFailure(err);
+    if (kind === 'unreachable') return { kind: 'unreachable' };
+    // InvalidArgument (key/yaml mismatch, charset) reaching here means the
+    // editor itself constructed a malformed request — a programming
+    // error, never author feedback.
+    return {
+      kind: 'request-error',
+      message:
+        err instanceof ConnectError ? err.message : 'PutDungeon request failed',
+    };
+  }
 }
 
 export function usePutDungeonPreview(
@@ -181,49 +253,25 @@ export function usePutDungeonPreview(
     debounceRef.current = setTimeout(() => {
       (async () => {
         setRequestError(null);
-        let subsetYaml: string;
-        try {
-          subsetYaml = stripToV1Subset(
-            yamlText,
-            capabilities ?? undefined
-          ).yaml;
-        } catch {
-          // Not even shape-parseable yet (mid-edit) — nothing to preview
-          // this tick. Not a request/field error; the YAML pane's own
-          // parse-error path (DungeonBuilderConcept's applyText) already
-          // owns surfacing this.
-          return;
-        }
-        try {
-          const response = await authoringClient.putDungeon(
-            create(PutDungeonRequestSchema, {
-              key: doc.key,
-              yaml: subsetYaml,
-              validateOnly: true,
-            })
-          );
-          if (response.success) {
-            setLiveFloorPlan(response.floorPlan ?? null);
+        const result = await compileLive(doc, yamlText, capabilities);
+        switch (result.kind) {
+          case 'unparseable':
+            return;
+          case 'success':
+            setLiveFloorPlan(result.floorPlan);
             setFieldErrors([]);
-          } else {
-            setFieldErrors(response.fieldErrors);
+            return;
+          case 'field-errors':
+            setFieldErrors(result.fieldErrors);
             // Keep the last good floor plan on screen rather than blanking
             // the board on every keystroke of an in-progress edit.
-          }
-        } catch (err) {
-          const kind = classifyFailure(err);
-          if (kind === 'unreachable') {
+            return;
+          case 'unreachable':
             setServerState('unreachable');
             return;
-          }
-          // InvalidArgument (key/yaml mismatch, charset) reaching here
-          // means the editor itself constructed a malformed request — a
-          // programming error, never author feedback.
-          setRequestError(
-            err instanceof ConnectError
-              ? err.message
-              : 'PutDungeon request failed'
-          );
+          case 'request-error':
+            setRequestError(result.message);
+            return;
         }
       })();
     }, DEBOUNCE_MS);
@@ -252,4 +300,80 @@ export function usePutDungeonPreview(
     capabilities,
     refreshCapabilities: () => setCapabilitiesNonce((n) => n + 1),
   };
+}
+
+/**
+ * useCreationFloorPlanPreview — the creation-mode ("New Dungeon") canvas
+ * document's own live `PutDungeon(validate_only)` preview (v0.3 wire
+ * consumption unit, 2026-08-05). Creation mode never sent its document to
+ * the server at all before this unit — its floor came exclusively from
+ * `creation/canvasFloor.ts`'s client-side `deriveCanvasFloorCells`, and
+ * its regions panel (`creation/RegionPanel.tsx`) from client-derived
+ * containment alone. This hook is what makes a real `FloorPlan.floor_cells`
+ * / `FloorPlan.regions` response reachable for that document, so the
+ * consumers of THIS hook's `floorPlan` (`creation/canvasFloor.ts`'s
+ * `resolveCanvasFloor`, `RegionPanel.tsx`'s wire-vs-derived region tree
+ * comparison) have something real to render from once the server ships
+ * Wave 0/1 (rpg-project#169/#192/#180) — today it stays effectively
+ * dormant, since a live server's `floor_cells`/`regions` are both empty
+ * (decode-unknown fields, per the rpg-api-protos#214 conformance review's
+ * finding A4) and every consumer already falls back to its client-derived
+ * source on empty.
+ *
+ * Deliberately takes `serverState`/`capabilities` as PARAMETERS rather
+ * than probing for them itself — see this file's own header comment for
+ * why a second independent probe would double real network traffic for no
+ * new information. A transport failure on THIS document's own live call
+ * does NOT flip the shared `serverState` (unlike
+ * `usePutDungeonPreview`'s own per-edit effect, which owns that state) —
+ * the edit-mode instance's mount-time probe is the one canonical
+ * reachability signal; this hook just quietly keeps its last-good
+ * `floorPlan` (or `null` if it never had one) until the shared state
+ * itself recovers or the next debounced tick succeeds.
+ *
+ * Never fabricates a local compiled `FloorPlan` the way
+ * `usePutDungeonPreview`'s own `fallbackFloorPlan` does —
+ * `compileFloorPlanLocally` only knows the room-chain shape (rooms/
+ * connectors/entrance) and produces nothing useful for a canvas-mode
+ * document (empty `rooms`, no `floorCells`/`regions` at all), so callers
+ * would get the same "nothing from the wire" signal either way; returning
+ * `null` outright is the more honest of the two equally-empty options.
+ */
+export function useCreationFloorPlanPreview(
+  doc: DungeonDoc | null,
+  yamlText: string,
+  serverState: ServerState,
+  capabilities: ServerCapabilities | null
+): { floorPlan: FloorPlan | null } {
+  const [liveFloorPlan, setLiveFloorPlan] = useState<FloorPlan | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (serverState !== 'live' || !doc) {
+      // Leaving live mode (or having no document yet) invalidates any
+      // previously-fetched response — same "never leak a capability/
+      // response observed against one server into a different state"
+      // discipline `capabilities` itself follows above.
+      setLiveFloorPlan(null);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      compileLive(doc, yamlText, capabilities).then((result) => {
+        if (result.kind === 'success') setLiveFloorPlan(result.floorPlan);
+        // 'unparseable' (mid-edit)/'field-errors'/'unreachable'/
+        // 'request-error': keep the last-good floor plan on screen,
+        // matching `usePutDungeonPreview`'s own field-errors discipline —
+        // this hook has no field_errors surface of its own (creation
+        // mode's own validation feedback is out of this unit's scope),
+        // so every non-success outcome is treated the same way here:
+        // don't blank a plan that was already rendering.
+      });
+    }, DEBOUNCE_MS);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [serverState, doc, yamlText, capabilities]);
+
+  return { floorPlan: liveFloorPlan };
 }


### PR DESCRIPTION
## Summary

The region-tree half of the v0.3 wire consumption work, resumed now that #707 (unit-region-tree's `regionTree.ts` + scopes-tree UI) has merged to `dev`.

**Base is #710 (`unit/wire-v03-canvas-floor`), not `dev` — this is a real dependency, not leftover history.** Region-tree consumption reuses the live `FloorPlan` this document's own creation-mode preview fetches — the `useCreationFloorPlanPreview` hook, and the `liveFloorPlan` prop threaded from `DungeonBuilderConcept` → `CreationConcept`, both live entirely in #710. This PR only threads that same prop one level further, into `RegionPanel`. Once #710 merges to `dev`, retarget this PR's base to `dev` and its diff shrinks automatically to just this PR's own 7 files (verified locally: `git diff origin/unit/wire-v03-canvas-floor --stat` shows exactly this commit's own file list, nothing from #707 or #710 leaking in).

## What changed

- New `regionTreeWire.ts` — kept SEPARATE from `regionTree.ts` (#707) rather than adding a `FloorPlan`-typed function there, since that file documents itself as deliberately dependency-free (no wire proto type, reusable by both boards). `resolveRegionTree(regions, floorPlan)` prefers the wire's `FloorPlanRegion.parent_id` the moment a response carries a non-empty `regions` list — building the tree directly from parent pointers rather than re-inferring containment, since the wire's `parent_id` IS already the toolkit's own derived answer.
- Falls back to `regionTree.ts`'s `buildRegionTree` (cell-subset inference) when the wire is empty/absent — dormant against every live server today (rpg-api-protos#214 conformance review finding A4: `regions` is Wave 1, not shipped).
- **Verification, not just fallback**: when both sources exist, every region's wire-declared parent is compared against what `buildRegionTree` would derive for the same cell sets. A disagreement renders a named, visible warning (`db-region-tree-drift-warning`) — findings A2/A3's "the derivation rule isn't in the proto, an implementer can drift" made concrete as an actual drift detector. A dangling `parent_id` (resolves to no region on the same response) is treated as root (graceful, no crash) but still warned separately.
- `RegionPanel.tsx` gets a `REGIONS: SERVER` / `REGIONS: DERIVED` badge, same idiom as #710's `FLOOR: SERVER` / `FLOOR: DERIVED`.

## Tests

9 in `regionTreeWire.test.ts` (derived fallback, empty-regions rollout gap, agreeing nested case, sibling case, mismatch both directions, dangling parent, id-set drift silently skipped not falsely flagged, 3-deep chain), 5 in a new `RegionPanel.test.tsx` (badge/warnings actually RENDER, not just that the logic is correct). Full `src/concepts/dungeon-builder` suite against this branch: 360 tests / 19 files passing. `ci-check` clean. All fixtures hand-constructed/SYNTHETIC — no live server carries `regions` yet.

## Live verification

Same real, reachable-but-gate-off server as #710. Region panel's badge reads `REGIONS: DERIVED` — the only live-testable state today, since no server ships `regions`. The `server`/mismatch/dangling-parent paths are proven by the constructed-fixture tests above, not live.

— asset-pipeline agent, on behalf of KirkDiggler