### PR TITLE
unit: author walkthrough — player camera + lighting

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -5401,3 +5401,121 @@ frameloop="demand">` on-demand rendering was NOT adopted; this preview's
   `<Canvas>` stays continuous (unchanged from every earlier unit), matching
   Orbit/Walk's own existing behavior rather than introducing a third
   rendering discipline for one camera mode alone.
+
+## Regression fix: walls/doors "not loading" in Walk mode — two real bugs found, neither one a Play-mode regression (2026-08-06, rpg-project#169)
+
+Kirk's live report on the deployed Play-camera commit: "the wall assets and
+door assets are not loading." Investigated by reproducing his own flow
+(reload a saved dungeon YAML with `walls:`/`wallLines:`/`regions:` into
+creation mode, check 2D + all three 3D camera modes; also edit mode's
+compiled server-edge view) against a real dev server, not by reading code
+alone.
+
+### What did NOT reproduce
+
+Walls and doors render correctly in Orbit (both edit mode's server-truth
+`FloorPlan.edges` and creation mode's `doc.walls`/`doc.wallLines`, confirmed
+at native zoom AND zoomed in close on the actual geometry — edge-native
+solid boxes, amber door gaps with jamb+lintel, straight-wall segments with
+their own carved door gap, region tinting, all present) and in Walk mode's
+own INITIAL view before any movement. "Walls generically fail to render" is
+not what's happening.
+
+### What DID reproduce, and the two real root causes
+
+Walking forward in Walk mode for more than ~1.2 seconds reliably went solid
+black. Two genuinely separate bugs compounded, found by direct instrumentation
+(a temporary `window.__walkDebug` global dumping `camera.position`/`near`/
+`far`/`quaternion` every frame during the repro, removed before this commit)
+rather than guessed from screenshots:
+
+**Bug 1 — Walk mode's shared camera inherited Orbit's near-plane, sized for
+viewing the WHOLE dungeon from far away.** `DungeonPreview3D.tsx`'s `<Bounds
+fit clip>` sets the default camera's `near`/`far` ONCE, on mount
+(`Bounds.clip()`: `near = fittedDistance / 100`) — at this dungeon's scale
+that produced `near ≈ 0.77`. Fine for a bird's-eye Orbit view; badly wrong
+once the SAME camera drops to `WALK_EYE_HEIGHT` and gets close to anything —
+a wall a step away, even a nearby pillar, sits well within 0.77 units and
+gets clipped away entirely. `PlayCamera.tsx` never hit this (it creates its
+own separate camera with an explicit small `near: 0.1`, matching the real
+game's own value) — only `WalkCamera.tsx`, which reuses the shared default
+camera, needed to claim its own near/far. Fixed: `WalkCamera`'s mount effect
+now sets `near: 0.05, far: 1000` on entry and restores whatever the camera
+had on exit (the exact same capture/restore shape the prior unit's own
+camera-pose fix already established for position/quaternion).
+
+**Bug 2 — perimeter walls never actually blocked movement at all,
+independent of Bug 1.** With Bug 1 fixed, the black screen PERSISTED —
+direct position logging showed the player walking continuously, crossing
+multiple real cell boundaries, for the full 3 seconds, never once stopping.
+Root cause: `resolveWalkStep`'s original crossing check asked "does the
+TARGET point's nearest REAL cell differ from the source's, and is that pair
+in `blockedEdges`" — but a PERIMETER wall's far side was never a real,
+tracked floor tile in the first place (`FloorPlanEdge`'s own doc comment:
+"one endpoint may be outside the rendered floor-plan bounds" — confirmed
+directly against `SHOWCASE_FLOORPLAN.edges`, e.g. `{from: [0,7], to: [-1,
+7]}`). `nearestCell` can only ever return a REAL tracked cell, so it could
+never resolve a target point TO that nonexistent neighbor — the "did the
+nearest cell change" test simply never fired for any perimeter wall, and a
+walking player passed straight through every one of them into unmapped
+void, which then correctly rendered as nothing (a genuine collision gap,
+not a rendering-tree regression). Fixed at the root: `resolveWalkStep` now
+asks a geometrically different question — "does the CURRENT cell (always
+real; the player is standing in it) have a blocked edge in roughly the
+direction being moved" — using `boardGeometry.ts`'s own `neighborCell`
+(pure cube-coordinate math, needs no real tile on the far side) and
+`facingToRotationY` (the same world-angle-per-facing convention every other
+edge-aligned piece in this codebase already uses) to find the nearest of
+the 6 hex directions to the movement vector. This strictly subsumes the old
+interior-wall behavior (an interior wall's computed neighbor IS the real
+adjacent cell, so the identical `edgeKey` lookup still matches) while now
+also correctly blocking perimeter walls — and, as a welcome side effect,
+stops the player the MOMENT they try to move toward a blocked edge from
+anywhere in their current cell, rather than letting them approach flush
+against the unbuffered cell-Voronoi boundary first (a real, if secondary,
+finding along the way: that boundary sits close enough to a wall's own thin
+rendered box, `WallBox`'s `WALL_THICKNESS = 0.12`, to read as uncomfortably
+tight even where the crossing check DID fire correctly).
+
+An earlier attempt at Bug 2 (a `WALL_CLEARANCE` look-ahead buffer added to
+the OLD target-based check) is not in this commit — live-verified as
+ineffective (it still inherited the same "no real neighbor cell" blind
+spot for perimeter walls) and replaced outright by the directional check
+above, which is both simpler and strictly more correct.
+
+### Neither bug is a Play-mode regression
+
+Bug 1 and Bug 2 both reproduce identically on `a8307ea` (the walking
+camera's very first commit, before any Play-mode work existed) — confirmed
+directly by checking out that commit into a separate worktree and running
+the identical repro. Team-lead's original framing ("the Play-camera commit
+is the prime suspect") was a reasonable hypothesis given the timing, but
+the evidence doesn't support it: both bugs predate Play mode and are fixed
+here regardless, on the same branch, since they're real defects either way.
+
+### Live verification
+
+Real dev server, direct `window` instrumentation during the repro (added
+temporarily, removed before commit — the debug data itself, not screenshots
+alone, is what actually found Bug 1's `near: 0.77` and Bug 2's "never stops
+moving" pattern). Post-fix: the identical walk-into-a-wall repro now shows
+the player correctly stopping flush against the wall's own rendered face
+(not black) at the same timestamp that used to go solid black, and stays
+stopped for the remainder of the hold — re-run in a full rapid screenshot
+sequence (every 300ms across 3 seconds) confirming no regression at any
+point along the approach.
+
+### Tests
+
+3 new tests directly exercising the fix (`walkMovement.test.ts`'s
+`directional edge blocking` describe block): a blocked edge stops movement
+the moment it's attempted from anywhere in the current cell — built with a
+SINGLE tracked real cell and a blocked edge toward a coordinate that was
+NEVER added to `cellsByKey`, the exact perimeter-wall shape that broke the
+old check; the identical direction is walkable once the edge isn't blocked;
+a perpendicular, unrelated direction from the same cell is unaffected.
+These use real hex adjacency math (`cubeAtColRow`/`cubeToWorld`/
+`facingToRotationY`), not the rest of the file's simplified same-row
+fixtures, since the fix itself depends on that geometry. Full
+`dungeon-builder` suite: 389 tests, 19 files, all passing (up from 386/19).
+`ci-check` clean.

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -5215,3 +5215,189 @@ default-is-a-no-op + proportional-darkening math.
   annotated example already comments out as "P4+" is still exactly that —
   this unit implements the ambient knob plus prop-derived lights, not a
   hand-authored per-light override.
+
+## Author walkthrough follow-up: a third "Play" camera mode, the game's own tactical rig (2026-08-05, rpg-project#169)
+
+Kirk played the Walk mode from the unit above live and gave a real, specific
+verdict: "walk is pretty literal. that is not the view we have when playing.
+really cool though." The literal first-person eye doesn't match the game's
+actual play camera (the elevated tactical view the Discord activity uses).
+This unit adds a THIRD camera mode, **Play**, on the same branch/PR — Walk
+survives unchanged ("really cool though"), Orbit survives unchanged, and Play
+becomes the low-friction default path off Orbit.
+
+### What shipped
+
+**The camera-mode toggle is now a 3-way segmented control** (Orbit / Play /
+Walk, in that order — Play deliberately placed immediately next to Orbit:
+unlike Walk, Play needs no click-to-engage-pointer-lock step at all, so it's
+the lowest-friction way off Orbit, honoring "the fidelity-check mode he
+actually needs"). `handleSelectCameraMode` replaces the old boolean toggle
+handler — one entry point for all six possible transitions, still releasing
+an engaged pointer lock whenever WALK is the mode being LEFT (regardless of
+which mode is next), still gating both Walk and Play behind the same
+"real floor to walk on" check.
+
+**Play reuses Walk's own WASD+legality movement WHOLESALE, not
+re-implemented.** This was made literally true, not just claimed, by
+extracting the shared pieces out of `WalkCamera.tsx` into `walkMovement.ts`
+(`resolveMoveVector` — the raw-input-to-world-delta math, `KEY_TO_AXIS`) and
+a new `useWasdKeys.ts` hook (the WASD/arrow keydown/keyup/blur listener,
+shared verbatim by both camera components). `WalkCamera.tsx` itself was
+refactored to call these instead of its own private copies — a regression
+guard as much as a Play enabler: if the two components ever drift, it will
+be because someone edited the ONE shared function, not because two parallel
+implementations quietly diverged.
+
+**The camera itself is the real game's own tactical rig — every constant
+and formula cited, not re-derived**, read directly from
+`src/components/hex-grid/HexGrid.tsx` and its one caller of
+`src/components/hex-grid/useCameraControls.ts`:
+
+- **Orthographic projection** (`zoom: 80, near: 0.1, far: 1000`) —
+  `HexGrid.tsx`'s own `<Canvas orthographic camera={{...}}>` ("Lower
+  isometric angle similar to Stolen Realm," that file's own comment). This
+  is a genuinely different projection than Orbit/Walk's existing perspective
+  camera, not a repositioning of it — drei's `<OrthographicCamera
+makeDefault>` swaps in a second, independent camera object while Play is
+  active, restoring the previous default on unmount (the same `set({camera:
+...})`/cleanup pattern `PointerLockControls` itself already uses for
+  `makeDefault`, verified by reading both source files, not assumed to
+  match).
+- **Spherical camera-from-target math** — `useCameraControls.ts`'s own
+  `updateCamera`: `x = target.x + distance·sin(polarAngle)·cos(azimuth)`,
+  `y = target.y + distance·cos(polarAngle)`, `z = target.z +
+distance·sin(polarAngle)·sin(azimuth)`, `camera.lookAt(target)`.
+  `polarAngle: Math.PI / 3.5` (`HexGrid.tsx`'s own call-site "slightly
+  lower tactical angle" than the hook's own `PI/4` default), `azimuth`
+  starting at `Math.PI / 4` and `distance` starting at `20` (the hook's own
+  internal defaults — `HexGrid.tsx` never overrides either).
+- **Follow-lerp**: `factor = 1 - Math.pow(0.001, delta)` exponential
+  smoothing of the orbit target toward the player's own walked position —
+  the hook's own real `focusTarget` damping, here following the WASD-driven
+  walk position every frame instead of a multiplayer entity's server-driven
+  one.
+- **Q/E rotates azimuth**, **scroll wheel adjusts `camera.zoom`** (clamped
+  to `[30, 150]`, `HexGrid.tsx`'s own call-site values — the hook's
+  ORTHOGRAPHIC-camera wheel branch, since this rig genuinely is
+  orthographic), **right-click-drag also rotates azimuth** — all three
+  reattached against this component's own state (see below for why the hook
+  itself isn't reused directly).
+
+**The pure rig math lives in a new, independently-tested module,
+`playCameraRig.ts`** (no Three.js/R3F import) — `PlayCamera.tsx` is the thin
+glue that calls it each frame and applies the result to a real
+`THREE.OrthographicCamera`, the same "pure derivation, component just maps
+it to JSX" split this concept's other 3D modules already use.
+
+**The one deliberate departure from the cited rig, and why it has to be
+one**: `useCameraControls` itself is NOT reused directly — it binds W/A/S/D
+to PAN the camera's target, which would conflict with this authoring tool's
+own WASD-drives-the-WALKING-POSITION scheme. The real game never has this
+conflict because it doesn't use WASD for player movement at all
+(click-to-move pathing); this concept has no such system, so WASD is the
+only movement input available and is spent on walking, not panning. The
+orbit `target` is therefore driven by the player's own walked position every
+frame (through the identical follow-lerp), not by keyboard panning — "camera
+forward" for WASD purposes is derived from the rig's own current azimuth
+(the direction the tactical camera faces horizontally) rather than a
+first-person quaternion, the only sense in which "forward" can mean anything
+for a fixed-angle orbit rig; Q/E rotation therefore also rotates what
+forward means for WASD, the standard third-person/tactical-camera
+convention.
+
+**Lighting stays unconditional across all three modes** — no change needed
+here; the previous unit's `<ambientLight>`/`<directionalLight>`/point-light
+rendering already lived outside any per-mode branch.
+
+### A real bug, found live: a stale camera reference across a DIRECT Play→Walk transition
+
+Switching straight from Play to Walk (no Orbit stop in between) rendered a
+solid black canvas. Root cause, confirmed by reading React's own effect
+ordering, not guessed: `WalkCamera.tsx` used to destructure `const {camera}
+= useThree()` at RENDER time and use that closure both in its one-time mount
+`useEffect` and every `useFrame` tick. `PlayCamera`'s own
+`<OrthographicCamera makeDefault>` swaps `state.camera` to itself via a
+`useLayoutEffect`, and restores the PREVIOUS default via that same effect's
+cleanup on unmount. Because layout effects (all of them, across the whole
+commit) run before ANY passive effect in the same commit, but a component's
+own RENDER happens before its layout effects even fire, `WalkCamera`'s
+render-time `camera` snapshot could still be pointing at Play's own (about
+to be torn down) orthographic camera object — so `WalkCamera` was
+positioning and driving a camera nobody was actually rendering with anymore,
+while the REAL restored default camera sat untouched whereever it happened
+to be.
+
+**Fixed** by never trusting a render-time camera snapshot again in this
+file: the mount effect now reads `useThree(state => state.get)` (the SAME
+Zustand-style escape hatch drei's own `Bounds` component uses internally)
+and calls `get().camera` INSIDE the effect body — guaranteed fresh, since
+effects only run after every layout effect in the same commit has already
+settled `state.camera`. The per-frame `useFrame` callback was changed to
+read `state.camera` from its own guaranteed-fresh first argument instead of
+a closed-over variable, for the identical reason. Verified live: without
+this fix, Play → Walk (no Orbit stop) was a solid black canvas; with it, the
+same transition correctly shows the first-person corridor.
+
+### Live verification
+
+Real dev server (`vite --port 5190`), the SAME throwaway-Playwright-script
+discipline every prior 3D-preview round in this file uses (gitignored,
+deleted after the run) — this round specifically exercised every mode
+TRANSITION, not just each mode in isolation, since the one real bug found
+lived exactly in a transition edge case a per-mode-only test pass would have
+missed entirely:
+
+- Orbit → Play: initial framing is a genuine isometric/orthographic tactical
+  view (parallel projection, no perspective convergence — visibly distinct
+  from Walk's own perspective camera) matching HexGrid's own "Stolen
+  Realm"-style look.
+- Held `W` in Play: camera followed the walked position smoothly (the
+  follow-lerp reads as a real camera-chase, not a snap) into a corridor,
+  brazier light pools visible exactly as they are in every other mode.
+- `E` held: the whole tactical view visibly rotated around the player's
+  position — confirms Q/E rotate.
+- Scroll wheel: confirmed zoom-in, framing tightened correctly, clamped
+  range intact.
+- Play → Walk DIRECTLY (the bug's own repro path, re-run after the fix):
+  correctly shows the first-person corridor, not a black canvas.
+- Walk → Orbit (via the toggle, still mid-walk/locked): pointer lock
+  correctly released, camera correctly restored to the original bird's-eye
+  `<Bounds fit clip>` framing (the PRIOR unit's own fix, re-confirmed intact
+  after this round's refactor).
+- No console errors beyond the two pre-existing FIXTURES-MODE
+  `[unimplemented] AuthoringService` errors every prior round's own
+  live-verification section already notes.
+
+### Tests
+
+New: `preview3d/playCameraRig.test.ts` (pure camera-rig math — constants
+pinned against the cited real-game values so a future edit to either
+`HexGrid.tsx` or `useCameraControls.ts` surfaces as a failing test here
+too, not a silent drift; `sphericalCameraPosition`'s boundary cases —
+level/overhead/zero-distance and the real rig's own angle combination;
+`followLerp`'s convergence + framerate-independence; `azimuthForwardRight`'s
+unit-length/perpendicularity invariant; `clampZoomStep`/`dragRotateStep`'s
+sign and clamp behavior) plus `walkMovement.test.ts`'s new `resolveMoveVector`
+coverage (single-key/diagonal-normalization/opposite-key-cancellation/
+arrow-key-equivalence — the newly-extracted shared function both camera
+modes now call). Movement-reuse itself needed no new tests beyond this —
+`resolveWalkStep`'s own collision suite from the prior unit already covers
+it, and Play calls the exact same function. Full `dungeon-builder` suite:
+386 tests, 19 files, all passing (up from 358/18 — this unit's own net new:
+28 tests, 2 new files). Full repo suite: 2105 tests, 126 files, all passing.
+`ci-check` clean.
+
+### What did NOT ship this round — named, not silently dropped
+
+- No zoom-range/rotate-speed dial exposed to the author — every value is
+  the game's own fixed default, matching "match the game, don't invent."
+- Play mode does not persist camera state (azimuth/distance) across a
+  mode switch — re-entering Play always restarts at the rig's own default
+  azimuth/distance, the same "fresh per entry" behavior Walk's own eye-level
+  reset already has.
+- No `frameloop="demand"` — the real game's `<Canvas orthographic
+frameloop="demand">` on-demand rendering was NOT adopted; this preview's
+  `<Canvas>` stays continuous (unchanged from every earlier unit), matching
+  Orbit/Walk's own existing behavior rather than introducing a third
+  rendering discipline for one camera mode alone.

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -4993,3 +4993,225 @@ staleness this regeneration was the first full pass to surface.
   so this is a byte-shape change only, not a content change.
 - `ci-check` clean (format/lint/typecheck/build/test) after the prettier
   pass.
+
+## Author walkthrough: a player-perspective Walk camera + real lighting (2026-08-05, rpg-project#169)
+
+Kirk's day-one ask, verbatim: "really I want a 3d view from the player perspective
+that has the lighting loaded." Entirely client-side — no server, no proto,
+no new schema field for the camera itself (`lighting: {ambient}` already
+existed as a target-dialect field before this unit; it simply had no
+render consumer until now). One component change (`DungeonPreview3D.tsx`
+gains a camera-mode toggle), two new pure modules
+(`preview3d/walkMovement.ts`, `preview3d/walkLighting.ts`), one new R3F
+component (`preview3d/WalkCamera.tsx`) — works in BOTH 3D contexts
+(edit-mode compiled `FloorPlan`, creation-mode canvas), since walk mode
+lives entirely inside the one shared `DungeonPreview3D`, gated on
+internal state, not a prop either caller has to thread through.
+
+### What shipped
+
+**Camera toggle**: a `Walk`/`Exit Walk` button (same visual language as
+the existing 2D/3D toggle) overlays the 3D pane. Orbit (`<OrbitControls
+makeDefault>`) is unchanged and stays the default; Walk swaps in
+`WalkCamera.tsx`, which delegates mouse-look + pointer lock whole to
+drei's `PointerLockControls` (itself a thin wrapper over three-stdlib's
+own well-tested implementation — not reimplemented) and drives WASD
+movement itself via `useFrame`, reading the controls' own current facing
+vector (`getDirection`) each frame. `Esc` releasing the pointer is the
+BROWSER's native pointer-lock behavior; this component never installs
+its own Escape listener, so it can't race the pre-existing region-tool
+Escape-deselect handler in `creation/CreationBoard.tsx` (that handler is
+scoped to `tool === 'region'` and lives in a completely different DOM
+subtree from the 3D pane regardless — named as a real, if narrow,
+interaction this unit was asked to "mind," not something requiring code
+changes once traced).
+
+**Movement legality — reuses, does not reimplement, geometry**
+(`walkMovement.ts`). `buildWalkContext` builds one lookup index per
+render from data `DungeonPreview3D.tsx` already computes
+(`placeableCells`, `wallLineFootprint`) plus a few new sources it
+delegates to existing modules:
+
+- A straight wall's (`wallLines:`) footprint cell is impassable —
+  `creation/straightWallGeometry.ts`'s `straightWallFootprint`, the SAME
+  function the 2D hatch overlay and `canvasFloor.ts`'s placement-legality
+  gate already call.
+- A `place:`/room-`place:` entry whose `resolvePlacement(doc,
+p).blocksMovement` resolves true blocks its cell — the SAME
+  inherited-default-aware resolver `isEntranceBlocked` already reads, so
+  a `defaults:`-inherited block is honored here exactly like an explicit
+  one. A room's `boss:` cell is always blocked (a monster stands there;
+  `BossDoc` has no `blocks_movement` field to resolve, so this is a flat
+  rule).
+- An edge-native `walls:` entry (or, in edit mode, server-truth
+  `FloorPlan.edges` via the existing `edgesAdapter.ts`) with `kind ===
+'solid'` blocks CROSSING between two individually-walkable cells; `kind
+=== 'door'` does not — doors pass, matching `DoorGap`'s own rendering
+  (a genuine open span). A `wallLines:` door is handled one layer down: its
+  cell is excluded from the owning line's own footprint (already the
+  documented door traversability semantic — see this file's "Straight
+  walls: doors" entry), so it never enters `blockedCells`, and its
+  crossings fall out of `straightWallCrossedEdges`'s ordinary
+  both-clear-cells rule with no separate code needed here.
+
+`resolveWalkStep` resolves one frame's proposed world-space movement:
+tries the full diagonal step, then each axis independently (a
+slide-along-a-wall feel), then holds position — "simple grid-constrained
+motion," per the unit's own scope, never a physics engine. A
+`MAX_STEP_CONTAINMENT_DISTANCE` (`HEX_SIZE * 2`) cutoff on the
+nearest-cell lookup keeps an abnormally large single-frame delta from
+silently snapping through solid geometry onto whatever real floor cell
+happens to be globally nearest — caught by this unit's own test suite,
+not assumed safe. `resolveWalkStart` picks the doc's `start:` marker when
+it resolves to a real, standable cell, else the standable cell nearest
+the floor's own centroid, else the first standable cell found, else
+`null` (no floor to walk on — the toggle button rejects with an honest
+toast instead of entering a broken Walk mode).
+
+**Lighting — applies in BOTH camera modes, not gated to Walk only**
+(`walkLighting.ts`): a real improvement to the existing Orbit preview
+too, not a Walk-only special case, so one lighting path serves both.
+
+- Each placed prop whose ref matches the palette's Lighting category
+  (`brazier`/`candles`/`glowing-orb`) emits a `<pointLight>` at its own
+  already-resolved render position (whatever `buildOnePlacement` computed,
+  height included — "at its position (+height if set)," literally, no
+  separate flame-height offset invented on top).
+- Color/intensity/distance are a LOCAL COPY of the real game's own
+  `MOOD_LIGHT_SPEC_BY_PROP_REF` entries for these exact three refs
+  (`src/components/playtest/playtestMapHelpers.ts`, Kirk's original
+  POLYGON Dark Fortress reference), read as of this date, not
+  re-derived — brazier `#ff9d52`/2.8/5.5, candles `#3ddc84`/2/4.5,
+  glowing-orb `#3d84dc`/2/4.5, `decay: 2` matching `HexGrid.tsx`'s own
+  `<pointLight>` convention exactly. A COPY, not an import:
+  `playtestMapHelpers.ts` is game-route-coupled (its functions take
+  `RenderableEntity`/proto `Wall` shapes this concept doesn't have), and
+  this concept's own dialect-runs-ahead discipline
+  (TARGET-YAML.md) keeps its rendering self-contained.
+- `doc.lighting.ambient` (the pre-existing target-dialect field) now
+  drives the scene's `<ambientLight>` intensity DIRECTLY (not a secondary
+  multiplier on top of a baseline) — absent/omitted falls back to `0.8`,
+  the preview's own pre-existing hardcoded value, so a document authored
+  before this unit renders byte-identical. The two `<directionalLight>`
+  fixtures scale PROPORTIONALLY to `ambient / 0.8` — without this, a
+  `lighting: {ambient: 0.1}` document would still read nearly as bright
+  under the fixed 1.0-intensity key light, defeating "a dark room with low
+  ambient" as a renderable target; a document with no `lighting:` (or an
+  explicit `ambient: 0.8`, the annotated example's own value) scales by
+  exactly 1, byte-identical to every render before this unit.
+- Light cap: `WALK_LIGHT_BUDGET = 12` (mirrors the game's own
+  `MOOD_LIGHT_BUDGET` headroom reasoning, scaled to this concept's own
+  much smaller authoring surface), `capWalkLights` keeps the nearest-N to
+  a reference position — the player's own nearest cell in Walk mode
+  (updated only on a CELL CHANGE via `WalkCamera`'s `onCellChange`, not
+  every frame, to avoid a per-frame React re-render), a plain positional
+  slice in Orbit mode (no single camera position to center on) or before
+  Walk mode has resolved a player cell yet.
+
+**View-only, by construction**: every interaction prop
+(`onSelect`/`onPlace`/`onSelectConnector`, the empty-space
+`onPointerMissed` deselect) is wrapped to a no-op while `cameraMode ===
+'walk'` — the underlying hit-cells/props/doors stay mounted (cheap, no
+visual difference), so toggling back to Orbit needs no remount.
+
+### A real bug, found live, not by inspection
+
+`PointerLockControls.disconnect()` (three-stdlib's own implementation,
+called from `WalkCamera`'s unmount cleanup) only removes ITS OWN event
+listeners — it never calls `document.exitPointerLock()`. Clicking "Exit
+Walk" while still actively locked left the browser's pointer genuinely
+captured even after the component switched back to Orbit — verified live
+via Playwright: every subsequent click on the page, including ones with
+no relation to this component at all (a different tab's own button),
+started intermittently failing to land. Fixed at the toggle handler
+itself: `handleToggleCameraMode` now calls `document.exitPointerLock()`
+explicitly whenever `document.pointerLockElement` is set, before
+switching modes — unconditional and idempotent, so it costs nothing when
+the player had already released the pointer via Escape first.
+
+A second, related finding from the same live pass: with no camera reset
+at all, leaving Walk mode handed `<OrbitControls>` the camera wherever
+the player last stood — mid-corridor, at eye height, often facing a wall
+or open darkness — not the original `<Bounds fit clip>`-computed
+bird's-eye framing. Fixed in `WalkCamera.tsx`'s own mount effect: it
+captures the camera's pose the MOMENT Walk mode is entered (always
+Orbit's own already-fit framing, since Walk is only ever entered from
+Orbit) and restores it on unmount, rather than leaving the camera wherever
+WASD left it or resetting to an arbitrary hardcoded position.
+
+### Live verification
+
+Real dev server (`vite --port 5190`), `public/models/synty` rsync'd from
+a sibling worktree (same provenance precedent every prior 3D-preview
+round in this file documents). A throwaway Playwright script (gitignored
+scratch pattern, deleted after the run) drove the ACTUAL app in both 3D
+contexts:
+
+- **Edit mode** (`showcase.yaml`, its two real antechamber braziers,
+  `blocks_movement: true`): switched to the 3D board — the new lighting
+  already visibly changes Orbit's default render (warm brazier pools now
+  read against the floor, where before this unit there was flat ambient
+  light only). Added `lighting: {ambient: 0.08}` via the YAML pane's own
+  Apply flow — the room reads genuinely dark, brazier pools falling off
+  into shadow, exactly the "dark room with low ambient" target. Clicked
+  Walk, clicked the viewport to engage pointer lock (`document.
+pointerLockElement` confirmed `DIV` — genuinely locked, not just a
+  UI-state flag), held `W` for ~1.8s: the view moved from the entry room
+  into a corridor between two walls, one wall lit by a nearby brazier's
+  warm falloff, the other dark — the literal target screenshot ("Kirk
+  standing in a corridor watching brazier pools fall off into darkness").
+  Released the pointer programmatically (`document.exitPointerLock()`,
+  confirmed `pointerLockElement` back to `null`) — the "Click to look
+  around" prompt correctly reappeared. Clicked "Exit Walk" — camera
+  correctly restored to the original bird's-eye Orbit framing (the fix
+  above; before it, this screenshot was solid black).
+- **Creation mode** ("New Dungeon" → "▶ Play the pitch" demo script, a
+  freeform canvas doc with `walls:`, `start:`/`end:`, a monster
+  placement, no compiled `FloorPlan` at all): switched its own 3D board to
+  Walk, engaged pointer lock, moved with `W` — toggle/lock/movement all
+  fire with no console errors beyond the two pre-existing FIXTURES-MODE
+  `[unimplemented] AuthoringService` errors every prior round's own
+  live-verification section already notes (edit mode's preview probe
+  running regardless of active tab, unrelated to this unit). Confirms
+  "one component, both contexts" structurally, not just by code reading.
+
+### Tests
+
+34 new tests, `preview3d/walkMovement.test.ts` (21) +
+`preview3d/walkLighting.test.ts` (13) — full
+`src/concepts/dungeon-builder` suite: 358 tests, 18 files, all passing.
+`walkMovement.test.ts` is deliberately two-layered: `resolveWalkStep`/
+`canStandAt` against hand-built `WalkContext` fixtures (proves the
+step-resolution algorithm — stop / axis-separated slide / fully blocked
+— without depending on real hex geometry), and `buildWalkContext` against
+REAL parsed documents (`emptyCanvasYaml`, and `SHOWCASE_YAML`+
+`SHOWCASE_FLOORPLAN` for the room-scoped/boss/server-truth-edge cases —
+the antechamber's own `blocks_movement: true`/`false` braziers, the
+vault's `boss:` cell, and a non-zero `blockedEdges` count against a
+fixture that authors zero `doc.walls`/`wallLines` of its own, proving
+server-truth `FloorPlan.edges` genuinely contribute) — proves the
+WIRING, trusting the underlying geometry (`straightWallFootprint`/
+`straightWallCrossedEdges`/`resolvePlacement`/`floorPlanEdgesToServerEdges`)
+already proven correct by ITS OWN test suites elsewhere in this concept,
+not re-derived here. `walkLighting.test.ts` covers light derivation
+(known ref keys only, exact color/intensity/distance per spec), the cap
+(no-op under budget, positional slice without a reference, nearest-N
+with original order preserved, non-mutating), and the ambient/directional
+default-is-a-no-op + proportional-darkening math.
+
+### What did NOT ship this round — named, not silently dropped
+
+- No vertical movement (jumping/crouching) — `camera.position.y` is
+  pinned to `WALK_EYE_HEIGHT` always, per this unit's own scope
+  ("Simple grid-constrained motion is fine").
+- No editing while walking, no combat, no server calls — the toggle
+  returns to Orbit+edit for all of that, unchanged.
+- Region/wall/hole/start/end 2D-only tools stay exactly as 2D-only as the
+  creation-mode-3D-editing unit already left them; Walk mode doesn't
+  touch that boundary.
+- Mouse-look sensitivity/FOV are drei/three-stdlib's own defaults
+  (`pointerSpeed = 1`) — untouched, no dial exposed this round.
+- The per-source `lighting.sources:` config TARGET-YAML.md's own
+  annotated example already comments out as "P4+" is still exactly that —
+  this unit implements the ambient knob plus prop-derived lights, not a
+  hand-authored per-light override.

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -290,6 +290,17 @@ end: [19, 25]
 # (?wallHeight=/?wallCutaway=1/?floorPools=1 — calibrationConstants.ts,
 # EncounterMap.tsx) — this promotes that same direction from a runtime
 # query param to an AUTHORED, per-dungeon setting.
+#
+# STATUS (2026-08-05, rpg-project#169's author-walkthrough unit):
+# renders-in-concept, not-yet-compiled. `ambient` now genuinely drives
+# `DungeonPreview3D.tsx`'s scene lighting client-side (both Orbit and the
+# new Walk camera) — a low value darkens the room and the floor's own
+# placed light-family props (brazier/candles/glowing-orb) light real
+# `<pointLight>` pools, matching the game's own mood-lighting palette.
+# Still dropped entirely by `stripToV1Subset` — no server compiles this
+# field, unchanged. See CONTRACT.md's "Author walkthrough" ledger entry
+# for the full render writeup (`preview3d/walkLighting.ts`); `sources:`
+# below remains exactly as unimplemented as it was before this unit.
 lighting:
   ambient: 0.8 # 0..1, dungeon-wide multiplier. The only knob today.
   # sources:      # P4+: per-source config, once this exists at all.

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -141,7 +141,7 @@ import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { Billboard, Bounds, OrbitControls, Text } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
-import { Suspense, useMemo } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { DoubleSide, Shape } from 'three';
 import {
   facingToRotationY,
@@ -173,6 +173,20 @@ import { END_COLOR, regionArchetypeColor, START_COLOR } from '../markerStyle';
 import { regionCentroid } from '../regionGeometry';
 import type { BoardTool, PaletteSelection, PlacementSelection } from '../types';
 import { PreviewMonsterModel } from './PreviewMonsterModel';
+import { WalkCamera } from './WalkCamera';
+import {
+  capWalkLights,
+  deriveWalkLights,
+  resolveAmbientIntensity,
+  resolveDirectionalScale,
+  WALK_LIGHT_BUDGET,
+  WALK_LIGHT_DECAY,
+} from './walkLighting';
+import {
+  buildWalkContext,
+  floorCentroid,
+  resolveWalkStart,
+} from './walkMovement';
 
 /** A canvas-native floor tile has no owning room ("no room chain exists
  * yet" — `creation/emptyCanvasDoc.ts`'s own doc comment) — a plain,
@@ -1249,6 +1263,84 @@ export function DungeonPreview3D({
   );
   const hitShape = useMemo(() => buildHexHitShape(), []);
 
+  // --- Walk mode (rpg-project#169's author-walkthrough unit) ---
+  // 'orbit' (existing, unchanged default) vs. 'walk' (player-perspective,
+  // view-only — see WalkCamera.tsx's own header doc comment). Local to
+  // this component, not lifted to either caller: neither
+  // `DungeonBuilderConcept.tsx`'s edit-mode call site nor
+  // `CreationConcept.tsx`'s creation-mode one needs to know which camera
+  // is currently driving — "one component" per this unit's own scope.
+  const [cameraMode, setCameraMode] = useState<'orbit' | 'walk'>('orbit');
+  const [walkLocked, setWalkLocked] = useState(false);
+  // The player's own nearest cell, updated only on a CELL CHANGE (not
+  // every frame — WalkCamera.tsx's own `onCellChange` doc comment) —
+  // drives light-cap recentering below without a per-frame re-render.
+  const [playerCell, setPlayerCell] = useState<PlaceableCell | null>(null);
+
+  const walkContext = useMemo(
+    () => buildWalkContext(floorPlan, doc, placeableCells, wallLineFootprint),
+    [floorPlan, doc, placeableCells, wallLineFootprint]
+  );
+  const walkStart = useMemo(
+    () => resolveWalkStart(walkContext, doc),
+    [walkContext, doc]
+  );
+  const walkLookToward = useMemo(
+    () => floorCentroid(walkContext) ?? walkStart,
+    [walkContext, walkStart]
+  );
+
+  const isWalking = cameraMode === 'walk';
+
+  const handleToggleCameraMode = () => {
+    if (isWalking) {
+      // `PointerLockControls.disconnect()` (WalkCamera's own unmount
+      // cleanup) only removes ITS event listeners — it never calls
+      // `document.exitPointerLock()` (verified live: leaving Walk mode
+      // via this button while still locked left the browser's pointer
+      // genuinely captured, breaking every click on the page afterward,
+      // including ones with no relation to this component at all). Exit
+      // explicitly here so leaving Walk mode always returns the page to
+      // an ordinary, unlocked mouse regardless of whether the player had
+      // engaged mouse-look at all.
+      if (document.pointerLockElement) document.exitPointerLock();
+      setCameraMode('orbit');
+      return;
+    }
+    if (!walkStart) {
+      onReject?.('No floor to walk on yet.');
+      return;
+    }
+    setCameraMode('walk');
+  };
+
+  // Lighting (Kirk's day-one ask, same unit: "has the lighting loaded")
+  // — applies in BOTH camera modes, not gated to Walk only: it's a real
+  // improvement to the existing Orbit preview too, and keeping one
+  // lighting path (rather than a walk-only special case) is simpler.
+  const rawWalkLights = useMemo(() => deriveWalkLights(props), [props]);
+  const walkLights = useMemo(
+    () =>
+      capWalkLights(
+        rawWalkLights,
+        WALK_LIGHT_BUDGET,
+        playerCell ? [playerCell.worldX, playerCell.worldZ] : undefined
+      ),
+    [rawWalkLights, playerCell]
+  );
+  const ambientIntensity = resolveAmbientIntensity(doc);
+  const directionalScale = resolveDirectionalScale(doc);
+
+  // View-only while walking (this unit's own scope: "no editing while
+  // walking") — every interaction prop degrades to inert rather than
+  // this component growing a parallel walk-mode render tree. Selection/
+  // placement/connector clicks and the empty-space deselect all no-op;
+  // the underlying hit-cells/props/doors stay mounted (cheap, no visual
+  // difference) so toggling back to Orbit needs no remount.
+  const effectiveOnSelect = isWalking ? undefined : onSelect;
+  const effectiveOnPlace = isWalking ? undefined : onPlace;
+  const effectiveOnSelectConnector = isWalking ? undefined : onSelectConnector;
+
   // Mirrors Board.tsx's own click-to-place cell handler for the edit-mode
   // (floorPlan present) branch — same messages, same boss/occupied rules,
   // still silent on `occupied` there (no toast, matching Board.tsx's own
@@ -1264,7 +1356,8 @@ export function DungeonPreview3D({
   // 2D brush now consults), not a fresh room/door-row lookup — there is
   // no room chain or door row on a canvas to check against.
   const handleClickCell = (cell: PlaceableCell) => {
-    if (!selectedPalette || !onPlace) {
+    if (isWalking) return; // view-only — see this component's own "Walk mode" section above
+    if (!selectedPalette || !effectiveOnPlace) {
       onReject?.(
         selectedTool
           ? 'That tool is 2D-only for now — switch to the 2D board to use it, or pick a palette item to place something here.'
@@ -1272,6 +1365,7 @@ export function DungeonPreview3D({
       );
       return;
     }
+    const onPlace = effectiveOnPlace;
     if (!floorPlan) {
       // Boss stays room-scoped even in the target dialect (dungeonspec's
       // validateBossCardinality needs an owning archetype:boss room) — a
@@ -1320,204 +1414,299 @@ export function DungeonPreview3D({
   };
 
   return (
-    <div style={{ width: '100%', height: '100%', background: '#0c0a08' }}>
-      <Canvas
-        camera={{ fov: 45, position: [10, 14, 10] }}
-        onPointerMissed={() => onSelect?.(null)}
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        background: '#0c0a08',
+      }}
+    >
+      {/* The Canvas-covering element `WalkCamera`'s `PointerLockControls`
+          treats as "click here to engage mouse-look" (its own `selector`
+          prop below). Deliberately does NOT wrap the mode-toggle button
+          further down — that button is a SIBLING of this div, not a
+          descendant, specifically so clicking it (to LEAVE Walk mode)
+          never also bubbles into this element's own click-to-lock
+          listener and re-engages pointer lock in the same tick. */}
+      <div
+        className="dg-walk-viewport"
+        style={{ width: '100%', height: '100%' }}
       >
-        <ambientLight intensity={0.8} />
-        <directionalLight position={[6, 10, 4]} intensity={1.0} />
-        <directionalLight position={[-6, 4, -4]} intensity={0.35} />
-        <Suspense fallback={null}>
-          <Bounds fit clip margin={1.25}>
-            <SyntyHexFloor floorTiles={floorTiles} hexSize={HEX_SIZE} />
-            {doc.regions.map((region) => {
-              const color = regionArchetypeColor(region.archetype);
-              const centroid = regionCentroid(region.cells);
-              const labelPos = worldPosition(
-                centroid.col,
-                centroid.row,
-                REGION_LABEL_HEIGHT
-              );
-              return (
-                <group key={`region-${region.id}`}>
-                  {region.cells.map(([col, row]) => {
-                    const [wx, , wz] = worldPosition(col, row);
-                    return (
-                      <RegionTintCell
-                        key={`region-${region.id}-${col}-${row}`}
-                        worldX={wx}
-                        worldZ={wz}
-                        shape={hitShape}
+        <Canvas
+          camera={{ fov: 45, position: [10, 14, 10] }}
+          onPointerMissed={() => effectiveOnSelect?.(null)}
+        >
+          <ambientLight intensity={ambientIntensity} />
+          <directionalLight
+            position={[6, 10, 4]}
+            intensity={1.0 * directionalScale}
+          />
+          <directionalLight
+            position={[-6, 4, -4]}
+            intensity={0.35 * directionalScale}
+          />
+          {walkLights.map((light) => (
+            <pointLight
+              key={light.key}
+              position={light.position}
+              color={light.color}
+              intensity={light.intensity}
+              distance={light.distance}
+              decay={WALK_LIGHT_DECAY}
+            />
+          ))}
+          <Suspense fallback={null}>
+            <Bounds fit clip margin={1.25}>
+              <SyntyHexFloor floorTiles={floorTiles} hexSize={HEX_SIZE} />
+              {doc.regions.map((region) => {
+                const color = regionArchetypeColor(region.archetype);
+                const centroid = regionCentroid(region.cells);
+                const labelPos = worldPosition(
+                  centroid.col,
+                  centroid.row,
+                  REGION_LABEL_HEIGHT
+                );
+                return (
+                  <group key={`region-${region.id}`}>
+                    {region.cells.map(([col, row]) => {
+                      const [wx, , wz] = worldPosition(col, row);
+                      return (
+                        <RegionTintCell
+                          key={`region-${region.id}-${col}-${row}`}
+                          worldX={wx}
+                          worldZ={wz}
+                          shape={hitShape}
+                          color={color}
+                        />
+                      );
+                    })}
+                    <Billboard position={labelPos}>
+                      <Text
+                        fontSize={REGION_LABEL_FONT_SIZE}
                         color={color}
-                      />
-                    );
-                  })}
-                  <Billboard position={labelPos}>
-                    <Text
-                      fontSize={REGION_LABEL_FONT_SIZE}
-                      color={color}
-                      anchorX="center"
-                      anchorY="middle"
-                      outlineWidth={0.016}
-                      outlineColor={REGION_LABEL_OUTLINE_COLOR}
-                    >
-                      {region.name ?? region.id}
-                    </Text>
-                  </Billboard>
-                </group>
-              );
-            })}
-            {[...wallLineFootprint].map((key) => {
-              const [col, row] = key.split(',').map(Number);
-              const [wx, , wz] = worldPosition(col, row);
-              return (
-                <FootprintDimCell
-                  key={`wallline-fp-${key}`}
-                  worldX={wx}
-                  worldZ={wz}
+                        anchorX="center"
+                        anchorY="middle"
+                        outlineWidth={0.016}
+                        outlineColor={REGION_LABEL_OUTLINE_COLOR}
+                      >
+                        {region.name ?? region.id}
+                      </Text>
+                    </Billboard>
+                  </group>
+                );
+              })}
+              {[...wallLineFootprint].map((key) => {
+                const [col, row] = key.split(',').map(Number);
+                const [wx, , wz] = worldPosition(col, row);
+                return (
+                  <FootprintDimCell
+                    key={`wallline-fp-${key}`}
+                    worldX={wx}
+                    worldZ={wz}
+                    shape={hitShape}
+                  />
+                );
+              })}
+              {placeableCells.map((cell) => (
+                <FloorHitCell
+                  key={cell.key}
+                  cell={cell}
                   shape={hitShape}
+                  placing={!isWalking && !!selectedPalette}
+                  onClickCell={handleClickCell}
                 />
-              );
-            })}
-            {placeableCells.map((cell) => (
-              <FloorHitCell
-                key={cell.key}
-                cell={cell}
-                shape={hitShape}
-                placing={!!selectedPalette}
-                onClickCell={handleClickCell}
-              />
-            ))}
-            {[...serverWalls, ...authoredWalls].map((w) =>
-              w.isDoor ? (
-                <DoorGap
-                  key={w.key}
-                  position={w.position}
-                  rotationY={w.rotationY}
-                  onSelectDoor={doorSelectHandler(
-                    w,
-                    floorPlan,
-                    onSelectConnector
-                  )}
-                />
-              ) : (
-                <WallBox
-                  key={w.key}
-                  position={w.position}
-                  rotationY={w.rotationY}
-                />
-              )
-            )}
-            {wallLineSegments.map((seg) =>
-              seg.kind === 'door' ? (
-                <DoorGap
-                  key={seg.key}
-                  position={seg.position}
-                  rotationY={seg.rotationY}
-                  width={seg.length}
-                />
-              ) : (
-                <WallBox
-                  key={seg.key}
-                  position={seg.position}
-                  rotationY={seg.rotationY}
-                  length={seg.length}
-                />
-              )
-            )}
-            {props.map((p) => {
-              const variant = resolvePropVariant(p.variantRef);
-              if (!variant) return null;
-              const selected = isSameSelection(selectedPlacement, p.sel);
-              return (
-                <group
-                  key={p.key}
-                  onClick={(e) => {
-                    if (!onSelect) return;
-                    e.stopPropagation();
-                    onSelect(p.sel);
-                  }}
-                >
-                  {selected && (
-                    <PointMarker
-                      worldX={p.position[0]}
-                      worldZ={p.position[2]}
-                      color={SELECTED_COLOR}
+              ))}
+              {[...serverWalls, ...authoredWalls].map((w) =>
+                w.isDoor ? (
+                  <DoorGap
+                    key={w.key}
+                    position={w.position}
+                    rotationY={w.rotationY}
+                    onSelectDoor={doorSelectHandler(
+                      w,
+                      floorPlan,
+                      effectiveOnSelectConnector
+                    )}
+                  />
+                ) : (
+                  <WallBox
+                    key={w.key}
+                    position={w.position}
+                    rotationY={w.rotationY}
+                  />
+                )
+              )}
+              {wallLineSegments.map((seg) =>
+                seg.kind === 'door' ? (
+                  <DoorGap
+                    key={seg.key}
+                    position={seg.position}
+                    rotationY={seg.rotationY}
+                    width={seg.length}
+                  />
+                ) : (
+                  <WallBox
+                    key={seg.key}
+                    position={seg.position}
+                    rotationY={seg.rotationY}
+                    length={seg.length}
+                  />
+                )
+              )}
+              {props.map((p) => {
+                const variant = resolvePropVariant(p.variantRef);
+                if (!variant) return null;
+                const selected = isSameSelection(selectedPlacement, p.sel);
+                return (
+                  <group
+                    key={p.key}
+                    onClick={(e) => {
+                      if (!effectiveOnSelect) return;
+                      e.stopPropagation();
+                      effectiveOnSelect(p.sel);
+                    }}
+                  >
+                    {selected && (
+                      <PointMarker
+                        worldX={p.position[0]}
+                        worldZ={p.position[2]}
+                        color={SELECTED_COLOR}
+                      />
+                    )}
+                    <PropModel
+                      variant={variant}
+                      position={p.position}
+                      rotationY={p.rotationY}
                     />
-                  )}
-                  <PropModel
-                    variant={variant}
-                    position={p.position}
-                    rotationY={p.rotationY}
-                  />
-                </group>
-              );
-            })}
-            {monsters.map((m) => {
-              const selected = isSameSelection(selectedPlacement, m.sel);
-              return (
-                <group
-                  key={m.key}
-                  onClick={(e) => {
-                    if (!onSelect) return;
-                    e.stopPropagation();
-                    onSelect(m.sel);
-                  }}
-                >
-                  {selected && (
-                    <PointMarker
-                      worldX={m.position[0]}
-                      worldZ={m.position[2]}
-                      color={SELECTED_COLOR}
+                  </group>
+                );
+              })}
+              {monsters.map((m) => {
+                const selected = isSameSelection(selectedPlacement, m.sel);
+                return (
+                  <group
+                    key={m.key}
+                    onClick={(e) => {
+                      if (!effectiveOnSelect) return;
+                      e.stopPropagation();
+                      effectiveOnSelect(m.sel);
+                    }}
+                  >
+                    {selected && (
+                      <PointMarker
+                        worldX={m.position[0]}
+                        worldZ={m.position[2]}
+                        color={SELECTED_COLOR}
+                      />
+                    )}
+                    <PreviewMonsterModel
+                      monsterRefId={m.monsterRefId}
+                      position={m.position}
                     />
-                  )}
-                  <PreviewMonsterModel
-                    monsterRefId={m.monsterRefId}
-                    position={m.position}
-                  />
-                </group>
-              );
-            })}
-            {doc.start &&
-              (() => {
-                const w = worldPosition(doc.start[0], doc.start[1]);
-                return (
-                  <PointMarker
-                    worldX={w[0]}
-                    worldZ={w[2]}
-                    color={START_COLOR}
-                  />
+                  </group>
                 );
-              })()}
-            {doc.end &&
-              (() => {
-                const w = worldPosition(doc.end[0], doc.end[1]);
-                return (
-                  <PointMarker worldX={w[0]} worldZ={w[2]} color={END_COLOR} />
-                );
-              })()}
-            {floorPlan?.entrance &&
-              (() => {
-                const entrance = floorPlan.entrance;
-                if (!entrance) return null;
-                const w = worldPosition(entrance.column, entrance.row);
-                return (
-                  <PointMarker
-                    worldX={w[0]}
-                    worldZ={w[2]}
-                    color={
-                      entranceBlocked
-                        ? ENTRANCE_BLOCKED_COLOR
-                        : ENTRANCE_CLEAR_COLOR
-                    }
-                  />
-                );
-              })()}
-          </Bounds>
-        </Suspense>
-        <OrbitControls makeDefault />
-      </Canvas>
+              })}
+              {doc.start &&
+                (() => {
+                  const w = worldPosition(doc.start[0], doc.start[1]);
+                  return (
+                    <PointMarker
+                      worldX={w[0]}
+                      worldZ={w[2]}
+                      color={START_COLOR}
+                    />
+                  );
+                })()}
+              {doc.end &&
+                (() => {
+                  const w = worldPosition(doc.end[0], doc.end[1]);
+                  return (
+                    <PointMarker
+                      worldX={w[0]}
+                      worldZ={w[2]}
+                      color={END_COLOR}
+                    />
+                  );
+                })()}
+              {floorPlan?.entrance &&
+                (() => {
+                  const entrance = floorPlan.entrance;
+                  if (!entrance) return null;
+                  const w = worldPosition(entrance.column, entrance.row);
+                  return (
+                    <PointMarker
+                      worldX={w[0]}
+                      worldZ={w[2]}
+                      color={
+                        entranceBlocked
+                          ? ENTRANCE_BLOCKED_COLOR
+                          : ENTRANCE_CLEAR_COLOR
+                      }
+                    />
+                  );
+                })()}
+            </Bounds>
+          </Suspense>
+          {isWalking && walkStart ? (
+            <WalkCamera
+              ctx={walkContext}
+              start={walkStart}
+              lookToward={walkLookToward ?? walkStart}
+              domSelector=".dg-walk-viewport"
+              onLockedChange={setWalkLocked}
+              onCellChange={setPlayerCell}
+            />
+          ) : (
+            <OrbitControls makeDefault />
+          )}
+        </Canvas>
+        {isWalking && !walkLocked && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              textAlign: 'center',
+              background: 'rgba(12,10,8,0.6)',
+              color: '#e8e2d8',
+              fontSize: 13,
+              cursor: 'pointer',
+              pointerEvents: 'none', // the click itself is caught by dg-walk-viewport's own PointerLockControls listener, not this overlay
+            }}
+          >
+            Click to look around — WASD to move, mouse to look, Esc to release
+            the mouse.
+          </div>
+        )}
+      </div>
+      <button
+        onClick={handleToggleCameraMode}
+        title={
+          isWalking
+            ? 'Return to the orbit camera and resume editing'
+            : walkStart
+              ? 'Walk the dungeon at player eye height (view-only)'
+              : 'No floor to walk on yet'
+        }
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          padding: '4px 10px',
+          fontSize: 11.5,
+          fontWeight: 600,
+          borderRadius: 5,
+          border: '1px solid var(--border-primary)',
+          cursor: 'pointer',
+          background: isWalking ? '#5fd1c9' : 'transparent',
+          color: isWalking ? '#14110f' : '#e8e2d8',
+        }}
+      >
+        {isWalking ? 'Exit Walk' : 'Walk'}
+      </button>
     </div>
   );
 }

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -172,6 +172,7 @@ import { BOARD_HEX_SIZE, cubeAtColRow, hexColumn, hexRow } from '../hexLayout';
 import { END_COLOR, regionArchetypeColor, START_COLOR } from '../markerStyle';
 import { regionCentroid } from '../regionGeometry';
 import type { BoardTool, PaletteSelection, PlacementSelection } from '../types';
+import { PlayCamera } from './PlayCamera';
 import { PreviewMonsterModel } from './PreviewMonsterModel';
 import { WalkCamera } from './WalkCamera';
 import {
@@ -1263,18 +1264,28 @@ export function DungeonPreview3D({
   );
   const hitShape = useMemo(() => buildHexHitShape(), []);
 
-  // --- Walk mode (rpg-project#169's author-walkthrough unit) ---
-  // 'orbit' (existing, unchanged default) vs. 'walk' (player-perspective,
-  // view-only — see WalkCamera.tsx's own header doc comment). Local to
-  // this component, not lifted to either caller: neither
-  // `DungeonBuilderConcept.tsx`'s edit-mode call site nor
-  // `CreationConcept.tsx`'s creation-mode one needs to know which camera
-  // is currently driving — "one component" per this unit's own scope.
-  const [cameraMode, setCameraMode] = useState<'orbit' | 'walk'>('orbit');
+  // --- Walk / Play modes (rpg-project#169's author-walkthrough unit) ---
+  // 'orbit' (existing, unchanged default) vs. 'walk' (literal
+  // player-perspective — see WalkCamera.tsx's own header doc comment) vs.
+  // 'play' (rpg-project#169 FOLLOW-UP unit — Kirk played Walk live: "walk
+  // is pretty literal. that is not the view we have when playing. really
+  // cool though" — Play drives the SAME walked position through the real
+  // game's own tactical camera rig instead; see PlayCamera.tsx's own
+  // header doc comment for the full citation of every constant/formula).
+  // Both Walk and Play are view-only. Local to this component, not lifted
+  // to either caller: neither `DungeonBuilderConcept.tsx`'s edit-mode
+  // call site nor `CreationConcept.tsx`'s creation-mode one needs to know
+  // which camera is currently driving — "one component" per this unit's
+  // own scope.
+  const [cameraMode, setCameraMode] = useState<'orbit' | 'walk' | 'play'>(
+    'orbit'
+  );
   const [walkLocked, setWalkLocked] = useState(false);
   // The player's own nearest cell, updated only on a CELL CHANGE (not
   // every frame — WalkCamera.tsx's own `onCellChange` doc comment) —
   // drives light-cap recentering below without a per-frame re-render.
+  // Shared by both Walk and Play — whichever is active is the only one
+  // calling `setPlayerCell` at a time.
   const [playerCell, setPlayerCell] = useState<PlaceableCell | null>(null);
 
   const walkContext = useMemo(
@@ -1291,8 +1302,16 @@ export function DungeonPreview3D({
   );
 
   const isWalking = cameraMode === 'walk';
+  const isPlaying = cameraMode === 'play';
+  const isWalkingOrPlaying = isWalking || isPlaying;
 
-  const handleToggleCameraMode = () => {
+  // Single entry point for every mode transition — both Walk and Play
+  // need the SAME "release an engaged pointer lock before leaving Walk"
+  // guard (only Walk ever engages one, but the guard has to run whenever
+  // Walk is the mode being LEFT, regardless of which mode is next) and
+  // the SAME "no floor, honest reject" gate before entering either.
+  const handleSelectCameraMode = (mode: 'orbit' | 'walk' | 'play') => {
+    if (mode === cameraMode) return;
     if (isWalking) {
       // `PointerLockControls.disconnect()` (WalkCamera's own unmount
       // cleanup) only removes ITS event listeners — it never calls
@@ -1304,20 +1323,19 @@ export function DungeonPreview3D({
       // an ordinary, unlocked mouse regardless of whether the player had
       // engaged mouse-look at all.
       if (document.pointerLockElement) document.exitPointerLock();
-      setCameraMode('orbit');
-      return;
     }
-    if (!walkStart) {
+    if ((mode === 'walk' || mode === 'play') && !walkStart) {
       onReject?.('No floor to walk on yet.');
       return;
     }
-    setCameraMode('walk');
+    setCameraMode(mode);
   };
 
   // Lighting (Kirk's day-one ask, same unit: "has the lighting loaded")
-  // — applies in BOTH camera modes, not gated to Walk only: it's a real
-  // improvement to the existing Orbit preview too, and keeping one
-  // lighting path (rather than a walk-only special case) is simpler.
+  // — applies in ALL THREE camera modes, not gated to Walk/Play only:
+  // it's a real improvement to the existing Orbit preview too, and
+  // keeping one lighting path (rather than a per-mode special case) is
+  // simpler.
   const rawWalkLights = useMemo(() => deriveWalkLights(props), [props]);
   const walkLights = useMemo(
     () =>
@@ -1331,15 +1349,19 @@ export function DungeonPreview3D({
   const ambientIntensity = resolveAmbientIntensity(doc);
   const directionalScale = resolveDirectionalScale(doc);
 
-  // View-only while walking (this unit's own scope: "no editing while
-  // walking") — every interaction prop degrades to inert rather than
-  // this component growing a parallel walk-mode render tree. Selection/
-  // placement/connector clicks and the empty-space deselect all no-op;
-  // the underlying hit-cells/props/doors stay mounted (cheap, no visual
-  // difference) so toggling back to Orbit needs no remount.
-  const effectiveOnSelect = isWalking ? undefined : onSelect;
-  const effectiveOnPlace = isWalking ? undefined : onPlace;
-  const effectiveOnSelectConnector = isWalking ? undefined : onSelectConnector;
+  // View-only while walking OR playing (this unit's own scope: "no
+  // editing while walking," extended to Play — it's the same
+  // fidelity-check idea, not an editing surface either) — every
+  // interaction prop degrades to inert rather than this component
+  // growing a parallel render tree per mode. Selection/placement/
+  // connector clicks and the empty-space deselect all no-op; the
+  // underlying hit-cells/props/doors stay mounted (cheap, no visual
+  // difference) so switching modes needs no remount.
+  const effectiveOnSelect = isWalkingOrPlaying ? undefined : onSelect;
+  const effectiveOnPlace = isWalkingOrPlaying ? undefined : onPlace;
+  const effectiveOnSelectConnector = isWalkingOrPlaying
+    ? undefined
+    : onSelectConnector;
 
   // Mirrors Board.tsx's own click-to-place cell handler for the edit-mode
   // (floorPlan present) branch — same messages, same boss/occupied rules,
@@ -1356,7 +1378,7 @@ export function DungeonPreview3D({
   // 2D brush now consults), not a fresh room/door-row lookup — there is
   // no room chain or door row on a canvas to check against.
   const handleClickCell = (cell: PlaceableCell) => {
-    if (isWalking) return; // view-only — see this component's own "Walk mode" section above
+    if (isWalkingOrPlaying) return; // view-only — see this component's own "Walk / Play modes" section above
     if (!selectedPalette || !effectiveOnPlace) {
       onReject?.(
         selectedTool
@@ -1513,7 +1535,7 @@ export function DungeonPreview3D({
                   key={cell.key}
                   cell={cell}
                   shape={hitShape}
-                  placing={!isWalking && !!selectedPalette}
+                  placing={!isWalkingOrPlaying && !!selectedPalette}
                   onClickCell={handleClickCell}
                 />
               ))}
@@ -1657,6 +1679,12 @@ export function DungeonPreview3D({
               onLockedChange={setWalkLocked}
               onCellChange={setPlayerCell}
             />
+          ) : isPlaying && walkStart ? (
+            <PlayCamera
+              ctx={walkContext}
+              start={walkStart}
+              onCellChange={setPlayerCell}
+            />
           ) : (
             <OrbitControls makeDefault />
           )}
@@ -1681,32 +1709,79 @@ export function DungeonPreview3D({
             the mouse.
           </div>
         )}
+        {isPlaying && (
+          <div
+            style={{
+              position: 'absolute',
+              bottom: 8,
+              left: 8,
+              padding: '4px 8px',
+              background: 'rgba(12,10,8,0.6)',
+              color: '#8a7a5a',
+              fontSize: 11,
+              borderRadius: 4,
+              pointerEvents: 'none',
+            }}
+          >
+            WASD to move · Q/E or right-drag to rotate · scroll to zoom — the
+            game's own tactical camera.
+          </div>
+        )}
       </div>
-      <button
-        onClick={handleToggleCameraMode}
-        title={
-          isWalking
-            ? 'Return to the orbit camera and resume editing'
-            : walkStart
-              ? 'Walk the dungeon at player eye height (view-only)'
-              : 'No floor to walk on yet'
-        }
+      {/* Orbit / Play / Walk — Play ordered right after Orbit
+          (deliberately, not alphabetically): it needs no click-to-lock
+          step at all, so it's the lowest-friction way off Orbit — "the
+          fidelity-check mode he actually needs" (Kirk, on Play vs. the
+          literal Walk mode). */}
+      <div
+        role="group"
+        aria-label="Camera mode"
         style={{
           position: 'absolute',
           top: 8,
           right: 8,
-          padding: '4px 10px',
-          fontSize: 11.5,
-          fontWeight: 600,
-          borderRadius: 5,
+          display: 'flex',
+          gap: 2,
           border: '1px solid var(--border-primary)',
-          cursor: 'pointer',
-          background: isWalking ? '#5fd1c9' : 'transparent',
-          color: isWalking ? '#14110f' : '#e8e2d8',
+          borderRadius: 5,
+          padding: 2,
+          background: '#14110f',
         }}
       >
-        {isWalking ? 'Exit Walk' : 'Walk'}
-      </button>
+        {(
+          [
+            { mode: 'orbit' as const, label: 'Orbit' },
+            { mode: 'play' as const, label: 'Play' },
+            { mode: 'walk' as const, label: 'Walk' },
+          ] as const
+        ).map(({ mode, label }) => (
+          <button
+            key={mode}
+            onClick={() => handleSelectCameraMode(mode)}
+            title={
+              mode === 'orbit'
+                ? 'Orbit camera — edit/select/place'
+                : !walkStart
+                  ? 'No floor to walk on yet'
+                  : mode === 'play'
+                    ? "The game's own tactical camera, following WASD movement (view-only)"
+                    : 'Player-perspective eye-level camera, WASD + mouse-look (view-only)'
+            }
+            style={{
+              padding: '3px 10px',
+              fontSize: 11.5,
+              fontWeight: 600,
+              borderRadius: 3,
+              border: 'none',
+              cursor: 'pointer',
+              background: cameraMode === mode ? '#5fd1c9' : 'transparent',
+              color: cameraMode === mode ? '#14110f' : '#e8e2d8',
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/concepts/dungeon-builder/preview3d/PlayCamera.tsx
+++ b/src/concepts/dungeon-builder/preview3d/PlayCamera.tsx
@@ -1,0 +1,238 @@
+/**
+ * PlayCamera — the author-walkthrough's THIRD camera mode (rpg-project
+ * #169 follow-up unit). Kirk played the literal first-person Walk mode
+ * live and gave a real, specific verdict: "walk is pretty literal. that
+ * is not the view we have when playing. really cool though." Play
+ * reuses Walk's own WASD+legality movement WHOLESALE (`walkMovement.ts`'s
+ * `resolveWalkStep`/`resolveMoveVector`, the identical `useWasdKeys`
+ * listener) and replaces only the CAMERA: instead of an eye-level,
+ * mouse-look first-person view, this drives the REAL game's own tactical
+ * camera rig, so moving through the dungeon shows exactly what a player
+ * at the table sees — lighting (this unit's sibling work, unconditional
+ * across all three modes) included.
+ *
+ * The camera-rig MATH itself (every constant/formula, cited to the real
+ * game's own camera code, not re-derived) lives in `playCameraRig.ts` —
+ * a pure module with no Three.js/R3F import, independently unit-tested.
+ * This file is the thin glue: read input, call the pure functions, apply
+ * the result to a real `THREE.OrthographicCamera` each frame.
+ *
+ * **What's necessarily different from the real game's rig, and why — the
+ * ONE deliberate departure `playCameraRig.ts` doesn't cover.** The real
+ * game's own `useCameraControls` hook is NOT reused directly: it binds
+ * W/A/S/D to PAN the camera's `target`, which would conflict with this
+ * authoring tool's own WASD-drives-the-WALKING-POSITION scheme. The real
+ * game never has this conflict because it doesn't use WASD for player
+ * movement at all (click-to-move pathing) — this concept has no such
+ * system, so WASD is the only movement input available and is spent on
+ * walking, not panning. `target` is therefore driven by the player's own
+ * walked position every frame (through the identical follow-lerp), not
+ * by keyboard panning — every other piece of the rig (projection, angle,
+ * zoom range, rotate, follow smoothing) is the SAME formula, unmodified.
+ */
+import { OrthographicCamera } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import { useEffect, useRef } from 'react';
+import type { OrthographicCamera as OrthographicCameraImpl } from 'three';
+import type { PlaceableCell } from './DungeonPreview3D';
+import {
+  azimuthForwardRight,
+  clampZoomStep,
+  dragRotateStep,
+  followLerp,
+  INITIAL_AZIMUTH,
+  INITIAL_DISTANCE,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  ORTHO_FAR,
+  ORTHO_NEAR,
+  ORTHO_ZOOM,
+  POLAR_ANGLE,
+  ROTATE_SPEED,
+  sphericalCameraPosition,
+} from './playCameraRig';
+import { useWasdKeys } from './useWasdKeys';
+import { WALK_SPEED } from './WalkCamera';
+import {
+  nearestCell,
+  resolveMoveVector,
+  resolveWalkStep,
+  type WalkContext,
+} from './walkMovement';
+
+/** The tactical target sits at the FLOOR plane (`y: 0`), matching
+ * `useCameraControls.ts`'s own real usage (`focusTarget`'s `y` is always
+ * `0` there too) — the elevated LOOK comes entirely from
+ * `POLAR_ANGLE`/`INITIAL_DISTANCE`, not from raising the target. */
+const TARGET_HEIGHT = 0;
+
+export interface PlayCameraProps {
+  ctx: WalkContext;
+  start: PlaceableCell;
+  onCellChange: (cell: PlaceableCell | null) => void;
+}
+
+export function PlayCamera({ ctx, start, onCellChange }: PlayCameraProps) {
+  const cameraRef = useRef<OrthographicCameraImpl | null>(null);
+  const pressedKeys = useWasdKeys();
+  const lastCellKey = useRef<string | null>(null);
+
+  // Player's own walked world position (x, z) — driven by the identical
+  // resolveWalkStep collision this concept's Walk mode already uses.
+  const playerPos = useRef({ x: start.worldX, z: start.worldZ });
+  // Camera orbit target — follow-lerps toward playerPos every frame
+  // (playCameraRig.ts's followLerp) rather than snapping instantly.
+  const target = useRef({ x: start.worldX, z: start.worldZ });
+  const azimuth = useRef(INITIAL_AZIMUTH);
+  const distance = useRef(INITIAL_DISTANCE);
+  const rotateKeys = useRef({ q: false, e: false });
+  const rightDrag = useRef({ down: false, lastX: 0 });
+
+  useEffect(() => {
+    playerPos.current = { x: start.worldX, z: start.worldZ };
+    target.current = { x: start.worldX, z: start.worldZ };
+    azimuth.current = INITIAL_AZIMUTH;
+    distance.current = INITIAL_DISTANCE;
+    lastCellKey.current = `${start.col},${start.row}`;
+    onCellChange(start);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Q/E rotate — a dedicated key set, deliberately SEPARATE from the
+  // shared `useWasdKeys` movement listener: Q/E has no movement meaning
+  // in this rig, only camera rotation, and Play's WASD is spent on
+  // movement, not panning (this file's own header doc comment), so
+  // conflating the two into one listener would blur that boundary.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.target as HTMLElement)?.tagName === 'TEXTAREA') return;
+      if (e.code === 'KeyQ') rotateKeys.current.q = true;
+      if (e.code === 'KeyE') rotateKeys.current.e = true;
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code === 'KeyQ') rotateKeys.current.q = false;
+      if (e.code === 'KeyE') rotateKeys.current.e = false;
+    };
+    const onBlur = () => {
+      rotateKeys.current.q = false;
+      rotateKeys.current.e = false;
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, []);
+
+  // Scroll-wheel zoom + right-click-drag rotate — useCameraControls.ts's
+  // own handleWheel (orthographic branch) / handleMouseMove behavior,
+  // reattached against this component's own camera/state (this
+  // component doesn't use that hook at all — see this file's own header
+  // doc comment for why).
+  useEffect(() => {
+    const onWheel = (e: WheelEvent) => {
+      const cam = cameraRef.current;
+      if (!cam) return;
+      e.preventDefault();
+      cam.zoom = clampZoomStep(cam.zoom, e.deltaY, MIN_ZOOM, MAX_ZOOM);
+      cam.updateProjectionMatrix();
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.button === 2) rightDrag.current = { down: true, lastX: e.clientX };
+    };
+    const onMouseUp = (e: MouseEvent) => {
+      if (e.button === 2) rightDrag.current.down = false;
+    };
+    const onMouseMove = (e: MouseEvent) => {
+      if (!rightDrag.current.down) return;
+      azimuth.current = dragRotateStep(
+        azimuth.current,
+        e.clientX - rightDrag.current.lastX
+      );
+      rightDrag.current.lastX = e.clientX;
+    };
+    const onContextMenu = (e: MouseEvent) => e.preventDefault();
+    window.addEventListener('wheel', onWheel, { passive: false });
+    window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('contextmenu', onContextMenu);
+    return () => {
+      window.removeEventListener('wheel', onWheel);
+      window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('contextmenu', onContextMenu);
+    };
+  }, []);
+
+  useFrame((_state, delta) => {
+    // Movement — identical to WalkCamera, "forward" derived from the
+    // rig's own azimuth (the direction the tactical camera currently
+    // faces horizontally) rather than a first-person quaternion, since
+    // this camera never looks anywhere but straight at `target`. Camera
+    // rotation (Q/E, right-drag) therefore also rotates what "forward"
+    // means for WASD — the standard third-person/tactical-camera
+    // convention, and the only sense in which "forward" can mean
+    // anything at all for a fixed-angle orbit rig.
+    const { forward, right } = azimuthForwardRight(azimuth.current);
+    const { dx, dz } = resolveMoveVector(
+      pressedKeys.current,
+      forward,
+      right,
+      WALK_SPEED,
+      delta
+    );
+    if (dx !== 0 || dz !== 0) {
+      const { x, z } = resolveWalkStep(
+        ctx,
+        playerPos.current.x,
+        playerPos.current.z,
+        dx,
+        dz
+      );
+      playerPos.current = { x, z };
+
+      const cell = nearestCell(ctx, x, z);
+      const key = cell ? `${cell.col},${cell.row}` : null;
+      if (key !== lastCellKey.current) {
+        lastCellKey.current = key;
+        onCellChange(cell);
+      }
+    }
+
+    // Q/E rotate — per-frame increment, matching useCameraControls.ts's
+    // own per-frame `azimuth.current += rotateSpeed` while held.
+    if (rotateKeys.current.q) azimuth.current += ROTATE_SPEED;
+    if (rotateKeys.current.e) azimuth.current -= ROTATE_SPEED;
+
+    target.current = followLerp(target.current, playerPos.current, delta);
+
+    const cam = cameraRef.current;
+    if (!cam) return;
+    const pos = sphericalCameraPosition(
+      { x: target.current.x, y: TARGET_HEIGHT, z: target.current.z },
+      POLAR_ANGLE,
+      azimuth.current,
+      distance.current
+    );
+    cam.position.set(pos.x, pos.y, pos.z);
+    cam.lookAt(target.current.x, TARGET_HEIGHT, target.current.z);
+  });
+
+  return (
+    // left/right/top/bottom are left to drei's own default (the full
+    // canvas size in pixels — OrthographicCamera.js's own JSX) — the
+    // same frustum shape the real game's Canvas gets implicitly too.
+    <OrthographicCamera
+      ref={cameraRef}
+      makeDefault
+      zoom={ORTHO_ZOOM}
+      near={ORTHO_NEAR}
+      far={ORTHO_FAR}
+    />
+  );
+}

--- a/src/concepts/dungeon-builder/preview3d/WalkCamera.tsx
+++ b/src/concepts/dungeon-builder/preview3d/WalkCamera.tsx
@@ -27,7 +27,7 @@ import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
 import { PointerLockControls } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
 import { useEffect, useRef } from 'react';
-import { Euler, Vector3 } from 'three';
+import { Euler, PerspectiveCamera, Vector3 } from 'three';
 import type { PointerLockControls as PointerLockControlsImpl } from 'three-stdlib';
 import type { PlaceableCell } from './DungeonPreview3D';
 import { useWasdKeys } from './useWasdKeys';
@@ -51,6 +51,32 @@ export const WALK_EYE_HEIGHT = WALL_HEIGHT * 0.7;
  * crawling) in live verification. Shared with `PlayCamera.tsx` — the
  * SAME pace either way, only the camera differs. */
 export const WALK_SPEED = 3;
+
+/** Walk mode's own near/far clipping planes — rpg-project#169 regression
+ * fix. `DungeonPreview3D.tsx`'s `<Bounds fit clip>` sets the SHARED
+ * default camera's `near`/`far` ONCE, sized for the wide bird's-eye Orbit
+ * view (drei's own `Bounds.clip()`: `near = fittedDistance / 100`) — at
+ * this dungeon's scale that fitted distance is large enough to produce a
+ * `near` around 0.7-0.8 world units. Fine for viewing an entire dungeon
+ * from far away; badly wrong for a first-person camera walking at human
+ * eye height, where a wall one step away, or even a nearby pillar, sits
+ * well WITHIN that near distance and gets clipped away entirely — found
+ * live, not assumed: Kirk's own "walls/doors not loading" report
+ * reproduced as a solid black screen after walking a short distance, and
+ * a direct `camera.near`/`camera.far` dump during that exact repro read
+ * `near: 0.77` — confirmed the culprit, not a collision or rendering-tree
+ * regression (movement itself was working correctly the whole time).
+ * `PlayCamera.tsx` never hits this because it creates its OWN camera with
+ * an explicit small `near` (matching the real game's own `0.1`); Walk
+ * reuses the shared default camera, so it has to claim its own
+ * appropriate near/far the same way, and hand them back on exit. `0.05`
+ * is comfortably smaller than any real geometry at this scale (a wall's
+ * own thickness, `WallBox`'s `WALL_THICKNESS = 0.12`, is still more than
+ * double it) without being so small it invites z-fighting; `far: 1000`
+ * matches `PlayCamera.tsx`'s own value for consistency and is generous
+ * at this dungeon's scale. */
+const WALK_NEAR = 0.05;
+const WALK_FAR = 1000;
 
 export interface WalkCameraProps {
   ctx: WalkContext;
@@ -119,6 +145,16 @@ export function WalkCamera({
     const camera = getThree().camera;
     const restorePosition = camera.position.clone();
     const restoreQuaternion = camera.quaternion.clone();
+    // Only a PerspectiveCamera actually carries near/far (the base
+    // THREE.Camera type this hook is statically typed against doesn't) —
+    // true at runtime for every caller of this component today (Orbit's
+    // own default camera, the only one Walk is ever handed, per
+    // `DungeonPreview3D.tsx`'s Canvas setup). Guarded rather than
+    // asserted so a future non-perspective default camera degrades to
+    // "don't touch near/far" instead of throwing.
+    const isPerspective = camera instanceof PerspectiveCamera;
+    const restoreNear = isPerspective ? camera.near : undefined;
+    const restoreFar = isPerspective ? camera.far : undefined;
 
     camera.position.set(start.worldX, WALK_EYE_HEIGHT, start.worldZ);
     const yaw = Math.atan2(
@@ -126,12 +162,30 @@ export function WalkCamera({
       lookToward.worldX - start.worldX
     );
     camera.quaternion.setFromEuler(new Euler(0, yaw, 0, 'YXZ'));
+    if (isPerspective) {
+      // See WALK_NEAR/WALK_FAR's own doc comment — the shared default
+      // camera's near/far were sized for Orbit's wide bird's-eye view
+      // (`Bounds.clip()`), which clips away nearby geometry entirely once
+      // the camera drops to walking eye height.
+      camera.near = WALK_NEAR;
+      camera.far = WALK_FAR;
+      camera.updateProjectionMatrix();
+    }
     lastCellKey.current = `${start.col},${start.row}`;
     onCellChange(start);
 
     return () => {
       camera.position.copy(restorePosition);
       camera.quaternion.copy(restoreQuaternion);
+      if (
+        isPerspective &&
+        restoreNear !== undefined &&
+        restoreFar !== undefined
+      ) {
+        camera.near = restoreNear;
+        camera.far = restoreFar;
+        camera.updateProjectionMatrix();
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/concepts/dungeon-builder/preview3d/WalkCamera.tsx
+++ b/src/concepts/dungeon-builder/preview3d/WalkCamera.tsx
@@ -30,7 +30,13 @@ import { useEffect, useRef } from 'react';
 import { Euler, Vector3 } from 'three';
 import type { PointerLockControls as PointerLockControlsImpl } from 'three-stdlib';
 import type { PlaceableCell } from './DungeonPreview3D';
-import { nearestCell, resolveWalkStep, type WalkContext } from './walkMovement';
+import { useWasdKeys } from './useWasdKeys';
+import {
+  nearestCell,
+  resolveMoveVector,
+  resolveWalkStep,
+  type WalkContext,
+} from './walkMovement';
 
 /** Player eye height, world units — derived from `WALL_HEIGHT` (2.4
  * world units; `calibrationConstants.ts`'s own doc comment: Synty packs,
@@ -42,21 +48,9 @@ export const WALK_EYE_HEIGHT = WALL_HEIGHT * 0.7;
 /** World units/second — a brisk walking pace. Not tuned against any
  * real-world figure beyond "covers a hex-ish distance in comfortably
  * under a second," which is what reads as WALKING (not sprinting, not
- * crawling) in live verification. */
-const WALK_SPEED = 3;
-
-type MoveAxis = 'forward' | 'back' | 'left' | 'right';
-
-const KEY_TO_AXIS: Record<string, MoveAxis> = {
-  KeyW: 'forward',
-  ArrowUp: 'forward',
-  KeyS: 'back',
-  ArrowDown: 'back',
-  KeyA: 'left',
-  ArrowLeft: 'left',
-  KeyD: 'right',
-  ArrowRight: 'right',
-};
+ * crawling) in live verification. Shared with `PlayCamera.tsx` — the
+ * SAME pace either way, only the camera differs. */
+export const WALK_SPEED = 3;
 
 export interface WalkCameraProps {
   ctx: WalkContext;
@@ -86,9 +80,25 @@ export function WalkCamera({
   onLockedChange,
   onCellChange,
 }: WalkCameraProps) {
-  const { camera } = useThree();
+  // `get()` (R3F's own Zustand-style escape hatch — the SAME one drei's
+  // `Bounds` itself uses) rather than destructuring `camera` at render
+  // time. Real, found-live reason: switching cameras DIRECTLY from Play
+  // mode (whose `<OrthographicCamera makeDefault>` swaps `state.camera`
+  // to itself, then restores the PREVIOUS default via a LAYOUT-effect
+  // cleanup on unmount) straight into Walk skips ever passing through
+  // Orbit — React runs Play's layout-effect cleanup and mounts this
+  // component in the SAME commit, but this component's own render
+  // happens BEFORE that cleanup fires, so a plain `const {camera} =
+  // useThree()` captured at render time could still point at Play's own
+  // (about to be disposed) orthographic camera instead of the real
+  // default. `get().camera`, called from INSIDE the effect body (which
+  // only runs in the passive-effects phase, strictly after every layout
+  // effect in the same commit has already settled `state.camera`), reads
+  // the correct, final camera instead. Confirmed live: without this fix,
+  // Play -> Walk (no Orbit stop between) rendered a solid black canvas.
+  const getThree = useThree((s) => s.get);
   const controlsRef = useRef<PointerLockControlsImpl | null>(null);
-  const pressedKeys = useRef(new Set<string>());
+  const pressedKeys = useWasdKeys();
   const lastCellKey = useRef<string | null>(null);
   const forward = useRef(new Vector3());
   const right = useRef(new Vector3());
@@ -99,13 +109,14 @@ export function WalkCamera({
   // changes underneath them, which it legitimately can if this is
   // creation mode's own live-edited canvas). The cleanup restores
   // whatever pose the camera had the MOMENT Walk mode was entered
-  // (always Orbit's own `<Bounds fit clip>`-computed framing, since Walk
-  // mode is only ever entered from Orbit) — live-verified finding: with
-  // no reset at all, leaving Walk mode handed `<OrbitControls>` the
-  // camera wherever the player last stood (mid-corridor, at eye height,
-  // often facing a wall or open darkness), not the original bird's-eye
-  // framing — a real UX papercut, not a hypothetical one.
+  // (Orbit's own `<Bounds fit clip>`-computed framing, whenever Walk is
+  // entered from Orbit) — live-verified finding: with no reset at all,
+  // leaving Walk mode handed `<OrbitControls>` the camera wherever the
+  // player last stood (mid-corridor, at eye height, often facing a wall
+  // or open darkness), not the original bird's-eye framing — a real UX
+  // papercut, not a hypothetical one.
   useEffect(() => {
+    const camera = getThree().camera;
     const restorePosition = camera.position.clone();
     const restoreQuaternion = camera.quaternion.clone();
 
@@ -125,45 +136,13 @@ export function WalkCamera({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    const keys = pressedKeys.current;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.target as HTMLElement)?.tagName === 'TEXTAREA') return;
-      if (KEY_TO_AXIS[e.code]) keys.add(e.code);
-    };
-    const onKeyUp = (e: KeyboardEvent) => {
-      keys.delete(e.code);
-    };
-    window.addEventListener('keydown', onKeyDown);
-    window.addEventListener('keyup', onKeyUp);
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-      window.removeEventListener('keyup', onKeyUp);
-      keys.clear();
-    };
-  }, []);
-
-  useFrame((_state, delta) => {
+  useFrame((state, delta) => {
     if (!controlsRef.current?.isLocked) return;
-    let f = 0;
-    let r = 0;
-    for (const code of pressedKeys.current) {
-      switch (KEY_TO_AXIS[code]) {
-        case 'forward':
-          f += 1;
-          break;
-        case 'back':
-          f -= 1;
-          break;
-        case 'right':
-          r += 1;
-          break;
-        case 'left':
-          r -= 1;
-          break;
-      }
-    }
-    if (f === 0 && r === 0) return;
+    // `state.camera` — R3F's OWN live current-frame camera, never a
+    // render-time closure — same staleness reasoning as the mount
+    // effect's `get().camera` above, just via useFrame's own guaranteed-
+    // fresh parameter instead.
+    const camera = state.camera;
 
     controlsRef.current.getDirection(forward.current);
     forward.current.y = 0;
@@ -174,12 +153,14 @@ export function WalkCamera({
     // conventional "right" for a camera looking down -Z).
     right.current.set(-forward.current.z, 0, forward.current.x);
 
-    // Normalize the (f, r) input vector so a diagonal (W+D) press moves
-    // at the same speed as a single key, not faster.
-    const inputLen = Math.hypot(f, r) || 1;
-    const step = (WALK_SPEED * delta) / inputLen;
-    const dx = (forward.current.x * f + right.current.x * r) * step;
-    const dz = (forward.current.z * f + right.current.z * r) * step;
+    const { dx, dz } = resolveMoveVector(
+      pressedKeys.current,
+      forward.current,
+      right.current,
+      WALK_SPEED,
+      delta
+    );
+    if (dx === 0 && dz === 0) return;
 
     const { x, z } = resolveWalkStep(
       ctx,

--- a/src/concepts/dungeon-builder/preview3d/WalkCamera.tsx
+++ b/src/concepts/dungeon-builder/preview3d/WalkCamera.tsx
@@ -1,0 +1,212 @@
+/**
+ * WalkCamera — the author-walkthrough's Walk-mode camera driver
+ * (rpg-project#169, Kirk's day-one ask: "a 3d view from the player
+ * perspective that has the lighting loaded"). Owns exactly two things:
+ *
+ * - **Mouse-look + pointer lock**, delegated whole to drei's
+ *   `PointerLockControls` (itself a thin wrapper over three-stdlib's own
+ *   well-tested implementation) — not reimplemented here. `Esc` releasing
+ *   the pointer is the BROWSER's own native pointer-lock behavior
+ *   (`document.exitPointerLock()` fires on Escape unconditionally); this
+ *   component only listens for the resulting `unlock` event to update its
+ *   own "click to look around" prompt, it never installs its OWN Escape
+ *   handler — so it can never race the pre-existing region-tool
+ *   Escape-deselect handler (`creation/CreationBoard.tsx`) the way a
+ *   second, independent Escape listener could.
+ * - **WASD movement**, collision-checked against `walkMovement.ts`'s pure
+ *   `resolveWalkStep` every frame — this component only reads keyboard
+ *   state and the controls' own current facing vector
+ *   (`PointerLockControls.getDirection`), it never decides legality
+ *   itself.
+ *
+ * View-only by construction: this component has no prop that could
+ * mutate the document — it only moves the shared default camera (`y`
+ * pinned to `WALK_EYE_HEIGHT` always; no vertical movement/jumping).
+ */
+import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
+import { PointerLockControls } from '@react-three/drei';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useEffect, useRef } from 'react';
+import { Euler, Vector3 } from 'three';
+import type { PointerLockControls as PointerLockControlsImpl } from 'three-stdlib';
+import type { PlaceableCell } from './DungeonPreview3D';
+import { nearestCell, resolveWalkStep, type WalkContext } from './walkMovement';
+
+/** Player eye height, world units — derived from `WALL_HEIGHT` (2.4
+ * world units; `calibrationConstants.ts`'s own doc comment: Synty packs,
+ * and by extension this scale, are authored in real-world meters). An
+ * average adult's eye height (~1.6-1.7m) is roughly 68-71% of a 2.4m
+ * wall; 0.7 lands at 1.68 — squarely in that range. */
+export const WALK_EYE_HEIGHT = WALL_HEIGHT * 0.7;
+
+/** World units/second — a brisk walking pace. Not tuned against any
+ * real-world figure beyond "covers a hex-ish distance in comfortably
+ * under a second," which is what reads as WALKING (not sprinting, not
+ * crawling) in live verification. */
+const WALK_SPEED = 3;
+
+type MoveAxis = 'forward' | 'back' | 'left' | 'right';
+
+const KEY_TO_AXIS: Record<string, MoveAxis> = {
+  KeyW: 'forward',
+  ArrowUp: 'forward',
+  KeyS: 'back',
+  ArrowDown: 'back',
+  KeyA: 'left',
+  ArrowLeft: 'left',
+  KeyD: 'right',
+  ArrowRight: 'right',
+};
+
+export interface WalkCameraProps {
+  ctx: WalkContext;
+  start: PlaceableCell;
+  /** Initial look-at target (typically the floor's own centroid,
+   * `walkMovement.ts`'s `floorCentroid`) — so entering Walk mode faces
+   * roughly into the dungeon instead of an arbitrary default heading. */
+  lookToward: { worldX: number; worldZ: number };
+  /** CSS selector for the element `PointerLockControls` should treat as
+   * "click here to engage mouse-look" — the caller's own canvas-covering
+   * wrapper, deliberately NOT including the mode-toggle button (see
+   * `DungeonPreview3D.tsx`'s own layout doc comment for why that
+   * exclusion matters). */
+  domSelector: string;
+  onLockedChange: (locked: boolean) => void;
+  /** Fires only when the player's NEAREST cell changes (not every frame)
+   * — cheap enough to drive a React state update (light-cap recentering)
+   * unlike a per-frame position stream would be. */
+  onCellChange: (cell: PlaceableCell | null) => void;
+}
+
+export function WalkCamera({
+  ctx,
+  start,
+  lookToward,
+  domSelector,
+  onLockedChange,
+  onCellChange,
+}: WalkCameraProps) {
+  const { camera } = useThree();
+  const controlsRef = useRef<PointerLockControlsImpl | null>(null);
+  const pressedKeys = useRef(new Set<string>());
+  const lastCellKey = useRef<string | null>(null);
+  const forward = useRef(new Vector3());
+  const right = useRef(new Vector3());
+
+  // Position + orient the camera once, on entering Walk mode — NOT a
+  // dependency-driven effect (re-running on every `ctx`/`start` render
+  // would fight the player's own movement each time the document
+  // changes underneath them, which it legitimately can if this is
+  // creation mode's own live-edited canvas). The cleanup restores
+  // whatever pose the camera had the MOMENT Walk mode was entered
+  // (always Orbit's own `<Bounds fit clip>`-computed framing, since Walk
+  // mode is only ever entered from Orbit) — live-verified finding: with
+  // no reset at all, leaving Walk mode handed `<OrbitControls>` the
+  // camera wherever the player last stood (mid-corridor, at eye height,
+  // often facing a wall or open darkness), not the original bird's-eye
+  // framing — a real UX papercut, not a hypothetical one.
+  useEffect(() => {
+    const restorePosition = camera.position.clone();
+    const restoreQuaternion = camera.quaternion.clone();
+
+    camera.position.set(start.worldX, WALK_EYE_HEIGHT, start.worldZ);
+    const yaw = Math.atan2(
+      -(lookToward.worldZ - start.worldZ),
+      lookToward.worldX - start.worldX
+    );
+    camera.quaternion.setFromEuler(new Euler(0, yaw, 0, 'YXZ'));
+    lastCellKey.current = `${start.col},${start.row}`;
+    onCellChange(start);
+
+    return () => {
+      camera.position.copy(restorePosition);
+      camera.quaternion.copy(restoreQuaternion);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const keys = pressedKeys.current;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.target as HTMLElement)?.tagName === 'TEXTAREA') return;
+      if (KEY_TO_AXIS[e.code]) keys.add(e.code);
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      keys.delete(e.code);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      keys.clear();
+    };
+  }, []);
+
+  useFrame((_state, delta) => {
+    if (!controlsRef.current?.isLocked) return;
+    let f = 0;
+    let r = 0;
+    for (const code of pressedKeys.current) {
+      switch (KEY_TO_AXIS[code]) {
+        case 'forward':
+          f += 1;
+          break;
+        case 'back':
+          f -= 1;
+          break;
+        case 'right':
+          r += 1;
+          break;
+        case 'left':
+          r -= 1;
+          break;
+      }
+    }
+    if (f === 0 && r === 0) return;
+
+    controlsRef.current.getDirection(forward.current);
+    forward.current.y = 0;
+    forward.current.normalize();
+    // Right = forward × world-up, the standard right-hand cross product
+    // (`(-fz, 0, fx)` for `up = (0,1,0)`) — verified against the default
+    // camera facing (`forward = (0,0,-1)` gives `right = (1,0,0)`, +X, the
+    // conventional "right" for a camera looking down -Z).
+    right.current.set(-forward.current.z, 0, forward.current.x);
+
+    // Normalize the (f, r) input vector so a diagonal (W+D) press moves
+    // at the same speed as a single key, not faster.
+    const inputLen = Math.hypot(f, r) || 1;
+    const step = (WALK_SPEED * delta) / inputLen;
+    const dx = (forward.current.x * f + right.current.x * r) * step;
+    const dz = (forward.current.z * f + right.current.z * r) * step;
+
+    const { x, z } = resolveWalkStep(
+      ctx,
+      camera.position.x,
+      camera.position.z,
+      dx,
+      dz
+    );
+    camera.position.x = x;
+    camera.position.z = z;
+    camera.position.y = WALK_EYE_HEIGHT;
+
+    const cell = nearestCell(ctx, x, z);
+    const key = cell ? `${cell.col},${cell.row}` : null;
+    if (key !== lastCellKey.current) {
+      lastCellKey.current = key;
+      onCellChange(cell);
+    }
+  });
+
+  return (
+    <PointerLockControls
+      ref={controlsRef}
+      makeDefault
+      selector={domSelector}
+      onLock={() => onLockedChange(true)}
+      onUnlock={() => onLockedChange(false)}
+    />
+  );
+}

--- a/src/concepts/dungeon-builder/preview3d/playCameraRig.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/playCameraRig.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  azimuthForwardRight,
+  clampZoomStep,
+  dragRotateStep,
+  followLerp,
+  INITIAL_AZIMUTH,
+  INITIAL_DISTANCE,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  ORTHO_FAR,
+  ORTHO_NEAR,
+  ORTHO_ZOOM,
+  POLAR_ANGLE,
+  ROTATE_SPEED,
+  sphericalCameraPosition,
+} from './playCameraRig';
+
+// Every constant is a direct citation of the real game's own camera code
+// (HexGrid.tsx / useCameraControls.ts) — these tests pin the LITERAL
+// values so a future edit to either file surfaces as a failing test
+// here too, not just a silent drift.
+describe('camera-rig constants match the real game (HexGrid.tsx / useCameraControls.ts)', () => {
+  it("polarAngle: PI/3.5 — HexGrid.tsx's own call-site tactical angle", () => {
+    expect(POLAR_ANGLE).toBeCloseTo(Math.PI / 3.5);
+  });
+  it("azimuth/distance start at useCameraControls.ts's own internal defaults", () => {
+    expect(INITIAL_AZIMUTH).toBeCloseTo(Math.PI / 4);
+    expect(INITIAL_DISTANCE).toBe(20);
+  });
+  it("rotateSpeed/minZoom/maxZoom match HexGrid.tsx's own call-site values", () => {
+    expect(ROTATE_SPEED).toBe(0.02);
+    expect(MIN_ZOOM).toBe(30);
+    expect(MAX_ZOOM).toBe(150);
+  });
+  it("orthographic projection matches HexGrid.tsx's own <Canvas> props", () => {
+    expect(ORTHO_ZOOM).toBe(80);
+    expect(ORTHO_NEAR).toBe(0.1);
+    expect(ORTHO_FAR).toBe(1000);
+  });
+});
+
+describe('sphericalCameraPosition', () => {
+  it('at azimuth 0, polarAngle PI/2 (level with target): camera sits directly on +X, same Y as target', () => {
+    const pos = sphericalCameraPosition(
+      { x: 5, y: 1, z: 5 },
+      Math.PI / 2,
+      0,
+      10
+    );
+    expect(pos.x).toBeCloseTo(15);
+    expect(pos.y).toBeCloseTo(1); // cos(PI/2) ~ 0
+    expect(pos.z).toBeCloseTo(5);
+  });
+
+  it('at polarAngle 0 (looking straight down): camera sits directly above the target, XZ unchanged', () => {
+    const pos = sphericalCameraPosition({ x: 2, y: 0, z: 3 }, 0, 1.234, 7);
+    expect(pos.x).toBeCloseTo(2);
+    expect(pos.z).toBeCloseTo(3);
+    expect(pos.y).toBeCloseTo(7); // cos(0) = 1
+  });
+
+  it('distance 0 collapses the camera onto the target regardless of angle', () => {
+    const pos = sphericalCameraPosition(
+      { x: 4, y: 2, z: -1 },
+      POLAR_ANGLE,
+      1.9,
+      0
+    );
+    expect(pos).toEqual({ x: 4, y: 2, z: -1 });
+  });
+
+  it("at the real rig's own POLAR_ANGLE/INITIAL_AZIMUTH/INITIAL_DISTANCE, the offset from target has the expected magnitude", () => {
+    const target = { x: 0, y: 0, z: 0 };
+    const pos = sphericalCameraPosition(
+      target,
+      POLAR_ANGLE,
+      INITIAL_AZIMUTH,
+      INITIAL_DISTANCE
+    );
+    // The full 3D distance from target to camera must equal INITIAL_DISTANCE
+    // exactly (spherical coordinates preserve radius by construction).
+    const dist = Math.hypot(pos.x, pos.y, pos.z);
+    expect(dist).toBeCloseTo(INITIAL_DISTANCE);
+    // A "lower tactical angle" (PI/3.5 ~ 51.4 degrees from vertical) means
+    // more Y than a 45-degree angle would give, but less than a fully
+    // overhead one — sanity-check it sits strictly between level (Y=0)
+    // and directly-overhead (Y=distance).
+    expect(pos.y).toBeGreaterThan(0);
+    expect(pos.y).toBeLessThan(INITIAL_DISTANCE);
+  });
+});
+
+describe('followLerp', () => {
+  it('a tiny delta barely moves current toward goal', () => {
+    const result = followLerp({ x: 0, z: 0 }, { x: 10, z: 0 }, 0.001);
+    expect(result.x).toBeGreaterThan(0);
+    expect(result.x).toBeLessThan(1);
+  });
+
+  it('a large delta converges close to the goal (exponential smoothing, not overshoot)', () => {
+    const result = followLerp({ x: 0, z: 0 }, { x: 10, z: 10 }, 2);
+    expect(result.x).toBeCloseTo(10, 0);
+    expect(result.z).toBeCloseTo(10, 0);
+  });
+
+  it('already at the goal stays there', () => {
+    const result = followLerp({ x: 5, z: 5 }, { x: 5, z: 5 }, 0.5);
+    expect(result).toEqual({ x: 5, z: 5 });
+  });
+
+  it('is framerate-independent: two half-steps converge to about the same place as one full step', () => {
+    const goal = { x: 20, z: 0 };
+    const twoHalfSteps = followLerp(
+      followLerp({ x: 0, z: 0 }, goal, 0.05),
+      goal,
+      0.05
+    );
+    const oneFullStep = followLerp({ x: 0, z: 0 }, goal, 0.1);
+    expect(twoHalfSteps.x).toBeCloseTo(oneFullStep.x, 2);
+  });
+});
+
+describe('azimuthForwardRight', () => {
+  it("azimuth 0: forward points toward -X, right toward -Z (matches the spherical formula's own convention)", () => {
+    const { forward, right } = azimuthForwardRight(0);
+    expect(forward.x).toBeCloseTo(-1);
+    expect(forward.z).toBeCloseTo(0);
+    expect(right.x).toBeCloseTo(0);
+    expect(right.z).toBeCloseTo(-1);
+  });
+
+  it('forward and right are always unit-length and perpendicular', () => {
+    for (const az of [0, 0.7, Math.PI / 3, Math.PI, -1.4]) {
+      const { forward, right } = azimuthForwardRight(az);
+      expect(Math.hypot(forward.x, forward.z)).toBeCloseTo(1);
+      expect(Math.hypot(right.x, right.z)).toBeCloseTo(1);
+      expect(forward.x * right.x + forward.z * right.z).toBeCloseTo(0);
+    }
+  });
+});
+
+describe('clampZoomStep', () => {
+  it('positive deltaY (scroll down/away) zooms out (decreases zoom)', () => {
+    expect(clampZoomStep(80, 50)).toBeLessThan(80);
+  });
+  it('negative deltaY (scroll up/toward) zooms in (increases zoom)', () => {
+    expect(clampZoomStep(80, -50)).toBeGreaterThan(80);
+  });
+  it("clamps to minZoom/maxZoom — the real game's own 30..150 range", () => {
+    expect(clampZoomStep(35, 1000)).toBe(MIN_ZOOM);
+    expect(clampZoomStep(145, -1000)).toBe(MAX_ZOOM);
+  });
+});
+
+describe('dragRotateStep', () => {
+  it('a positive clientX delta (dragging right) rotates azimuth negative', () => {
+    expect(dragRotateStep(1, 50)).toBeLessThan(1);
+  });
+  it('a negative clientX delta (dragging left) rotates azimuth positive', () => {
+    expect(dragRotateStep(1, -50)).toBeGreaterThan(1);
+  });
+  it("matches the real hook's own 0.01 sensitivity exactly", () => {
+    expect(dragRotateStep(0, 100)).toBeCloseTo(-1);
+  });
+});

--- a/src/concepts/dungeon-builder/preview3d/playCameraRig.ts
+++ b/src/concepts/dungeon-builder/preview3d/playCameraRig.ts
@@ -1,0 +1,129 @@
+/**
+ * playCameraRig — the pure, testable half of `PlayCamera.tsx` (the
+ * author-walkthrough's tactical camera mode, rpg-project#169 follow-up
+ * unit: Kirk played the literal Walk mode live and asked for the real
+ * game's own camera instead — "walk is pretty literal. that is not the
+ * view we have when playing... really cool though"). No Three.js/R3F
+ * import — plain numbers in, plain numbers out — so the spherical
+ * offset/angle math and the follow/zoom derivations can be unit-tested
+ * directly, the same "pure derivation, component just applies it" split
+ * this concept's other 3D modules already use.
+ *
+ * **Every constant and formula below is lifted from the real game's own
+ * camera code, cited, not re-derived** — see `PlayCamera.tsx`'s own
+ * header doc comment for the full citation writeup (which file/line each
+ * value came from and why). This module only re-states them as pure,
+ * named functions so they're independently checkable.
+ */
+
+/** `HexGrid.tsx`'s own call-site value — "slightly lower tactical angle"
+ * than `useCameraControls.ts`'s own `PI/4` default. */
+export const POLAR_ANGLE = Math.PI / 3.5;
+/** `useCameraControls.ts`'s own internal starting values — `HexGrid.tsx`
+ * never overrides either (the hook doesn't even accept a `distance`
+ * prop). */
+export const INITIAL_AZIMUTH = Math.PI / 4;
+export const INITIAL_DISTANCE = 20;
+/** `HexGrid.tsx`'s own call-site values, passed to `useCameraControls`. */
+export const ROTATE_SPEED = 0.02;
+export const MIN_ZOOM = 30;
+export const MAX_ZOOM = 150;
+/** `HexGrid.tsx`'s own `<Canvas orthographic camera={{...}}>` values —
+ * "Lower isometric angle similar to Stolen Realm" per that file's own
+ * comment. */
+export const ORTHO_ZOOM = 80;
+export const ORTHO_NEAR = 0.1;
+export const ORTHO_FAR = 1000;
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * The camera's world position for a given orbit target/angle/azimuth/
+ * distance — `useCameraControls.ts`'s own `updateCamera` formula,
+ * verbatim: `x = target.x + distance·sin(polarAngle)·cos(azimuth)`,
+ * `y = target.y + distance·cos(polarAngle)`, `z = target.z +
+ * distance·sin(polarAngle)·sin(azimuth)`. The caller still owns
+ * `camera.lookAt(target)` — a pure function has no camera to call it on.
+ */
+export function sphericalCameraPosition(
+  target: Vec3,
+  polarAngle: number,
+  azimuth: number,
+  distance: number
+): Vec3 {
+  return {
+    x: target.x + distance * Math.sin(polarAngle) * Math.cos(azimuth),
+    y: target.y + distance * Math.cos(polarAngle),
+    z: target.z + distance * Math.sin(polarAngle) * Math.sin(azimuth),
+  };
+}
+
+/**
+ * One frame's exponential-smoothing step of `current` toward `goal` —
+ * `useCameraControls.ts`'s own `focusTarget` follow-lerp:
+ * `factor = 1 - Math.pow(0.001, delta)`, `target.lerp(goal, factor)`.
+ * Framerate-independent by construction (a `THREE.Vector3.lerp`-style
+ * factor derived from `delta`, not a fixed per-frame constant) — a
+ * dropped frame (`delta` doubles) still converges at the same real-time
+ * rate, just via one bigger step instead of two smaller ones.
+ */
+export function followLerp(
+  current: { x: number; z: number },
+  goal: { x: number; z: number },
+  delta: number
+): { x: number; z: number } {
+  const factor = 1 - Math.pow(0.001, delta);
+  return {
+    x: current.x + (goal.x - current.x) * factor,
+    z: current.z + (goal.z - current.z) * factor,
+  };
+}
+
+/**
+ * Camera-relative forward/right unit-ish vectors for a given azimuth —
+ * "forward" is the direction FROM the camera TOWARD its orbit target
+ * (derived by negating `sphericalCameraPosition`'s own XZ offset
+ * direction, since the camera always looks straight at that target);
+ * "right" is that vector rotated -90° in the XZ plane, the same
+ * `(-fz, fx)` cross-product convention `WalkCamera.tsx` already uses for
+ * its own (first-person) forward/right pair — one shared convention for
+ * both walking camera modes, not two independently-invented ones.
+ */
+export function azimuthForwardRight(azimuth: number): {
+  forward: { x: number; z: number };
+  right: { x: number; z: number };
+} {
+  const forward = { x: -Math.cos(azimuth), z: -Math.sin(azimuth) };
+  return { forward, right: { x: -forward.z, z: forward.x } };
+}
+
+/**
+ * Scroll-wheel zoom step for an ORTHOGRAPHIC camera —
+ * `useCameraControls.ts`'s own wheel handler, orthographic branch:
+ * `zoom = clamp(zoom - deltaY * 0.1, minZoom, maxZoom)`. The perspective
+ * branch (adjusting `distance` instead) does not apply here — this rig
+ * IS orthographic (see `ORTHO_ZOOM` above), matching the real game.
+ */
+export function clampZoomStep(
+  currentZoom: number,
+  wheelDeltaY: number,
+  minZoom: number = MIN_ZOOM,
+  maxZoom: number = MAX_ZOOM
+): number {
+  return Math.max(minZoom, Math.min(maxZoom, currentZoom - wheelDeltaY * 0.1));
+}
+
+/**
+ * Right-click-drag rotate step — `useCameraControls.ts`'s own
+ * `handleMouseMove` while `isRightDown`: `azimuth -= deltaX * 0.01`.
+ */
+export function dragRotateStep(
+  currentAzimuth: number,
+  clientXDelta: number
+): number {
+  return currentAzimuth - clientXDelta * 0.01;
+}

--- a/src/concepts/dungeon-builder/preview3d/useWasdKeys.ts
+++ b/src/concepts/dungeon-builder/preview3d/useWasdKeys.ts
@@ -1,0 +1,39 @@
+/**
+ * useWasdKeys — the one WASD/arrow-key listener both walking camera
+ * modes share (`WalkCamera.tsx`, `PlayCamera.tsx`) — rpg-project#169
+ * follow-up unit. Returns a live `Set<KeyboardEvent['code']>` ref (not
+ * React state — a per-frame `useFrame` read has no reason to trigger a
+ * re-render on every keystroke) for `walkMovement.ts`'s
+ * `resolveMoveVector` to read each frame. Same TEXTAREA-target guard
+ * every other keydown listener in this concept already follows (typing
+ * in the YAML pane must never double as movement input).
+ */
+import { useEffect, useRef } from 'react';
+import { KEY_TO_AXIS } from './walkMovement';
+
+export function useWasdKeys(): React.RefObject<Set<string>> {
+  const pressedKeys = useRef(new Set<string>());
+
+  useEffect(() => {
+    const keys = pressedKeys.current;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.target as HTMLElement)?.tagName === 'TEXTAREA') return;
+      if (KEY_TO_AXIS[e.code]) keys.add(e.code);
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      keys.delete(e.code);
+    };
+    const onBlur = () => keys.clear();
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+      keys.clear();
+    };
+  }, []);
+
+  return pressedKeys;
+}

--- a/src/concepts/dungeon-builder/preview3d/walkLighting.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkLighting.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  capWalkLights,
+  deriveWalkLights,
+  resolveAmbientIntensity,
+  resolveDirectionalScale,
+  WALK_LIGHT_DECAY,
+  type LightableProp,
+  type WalkPointLight,
+} from './walkLighting';
+
+function prop(
+  key: string,
+  ref: string,
+  position: [number, number, number]
+): LightableProp {
+  return { key, position, variantRef: ref };
+}
+
+describe('deriveWalkLights', () => {
+  it('produces one light per placed prop matching the Lighting category (brazier/candles/glowing-orb)', () => {
+    const props: LightableProp[] = [
+      prop('a', 'dnd5e:props:brazier', [1, 0, 2]),
+      prop('b', 'dnd5e:props:candles', [3, 1.2, 4]),
+      prop('c', 'dnd5e:props:glowing-orb', [5, 0, 6]),
+    ];
+    const lights = deriveWalkLights(props);
+    expect(lights).toHaveLength(3);
+    expect(lights.map((l) => l.position)).toEqual([
+      [1, 0, 2],
+      [3, 1.2, 4],
+      [5, 0, 6],
+    ]);
+  });
+
+  it('skips a placed prop whose ref is not a known light source', () => {
+    const props: LightableProp[] = [
+      prop('a', 'dnd5e:props:pillar', [0, 0, 0]),
+      prop('b', 'dnd5e:props:statue-reaper', [1, 0, 1]),
+    ];
+    expect(deriveWalkLights(props)).toEqual([]);
+  });
+
+  it('a brazier gets the warm-orange, largest-reach spec; candles/glowing-orb their own cool accents', () => {
+    const [brazier, candles, orb] = deriveWalkLights([
+      prop('a', 'dnd5e:props:brazier', [0, 0, 0]),
+      prop('b', 'dnd5e:props:candles', [0, 0, 0]),
+      prop('c', 'dnd5e:props:glowing-orb', [0, 0, 0]),
+    ]);
+    expect(brazier).toMatchObject({
+      color: '#ff9d52',
+      intensity: 2.8,
+      distance: 5.5,
+    });
+    expect(candles).toMatchObject({
+      color: '#3ddc84',
+      intensity: 2,
+      distance: 4.5,
+    });
+    expect(orb).toMatchObject({
+      color: '#3d84dc',
+      intensity: 2,
+      distance: 4.5,
+    });
+  });
+
+  it('honors the prop key even with a namespaced multi-segment ref', () => {
+    const lights = deriveWalkLights([
+      prop('a', 'someother:namespace:brazier', [0, 0, 0]),
+    ]);
+    expect(lights).toHaveLength(1);
+  });
+
+  it('WALK_LIGHT_DECAY matches the game convention (2)', () => {
+    expect(WALK_LIGHT_DECAY).toBe(2);
+  });
+});
+
+function light(key: string, x: number, z: number): WalkPointLight {
+  return { key, position: [x, 0, z], color: '#fff', intensity: 1, distance: 1 };
+}
+
+describe('capWalkLights', () => {
+  it('is a no-op under budget', () => {
+    const lights = [light('a', 0, 0), light('b', 1, 1)];
+    expect(capWalkLights(lights, 5)).toEqual(lights);
+  });
+
+  it('without a reference, takes a plain positional slice', () => {
+    const lights = [light('a', 0, 0), light('b', 1, 1), light('c', 2, 2)];
+    const capped = capWalkLights(lights, 2);
+    expect(capped.map((l) => l.key)).toEqual(['a', 'b']);
+  });
+
+  it('with a reference, keeps the nearest N — but preserves ORIGINAL array order in the result', () => {
+    const lights = [
+      light('far', 100, 100),
+      light('near', 1, 0),
+      light('mid', 10, 0),
+    ];
+    const capped = capWalkLights(lights, 2, [0, 0]);
+    // near+mid are the 2 closest to (0,0); far is dropped.
+    expect(capped.map((l) => l.key)).toEqual(['near', 'mid']);
+  });
+
+  it('does not mutate the input array', () => {
+    const lights = [light('a', 0, 0), light('b', 1, 1), light('c', 2, 2)];
+    const original = [...lights];
+    capWalkLights(lights, 1, [0, 0]);
+    expect(lights).toEqual(original);
+  });
+});
+
+describe('resolveAmbientIntensity / resolveDirectionalScale', () => {
+  it('defaults to 0.8 ambient / scale 1 when the doc has no lighting: block', () => {
+    expect(resolveAmbientIntensity({ lighting: null })).toBe(0.8);
+    expect(resolveDirectionalScale({ lighting: null })).toBe(1);
+  });
+
+  it('an explicit ambient: 0.8 (the annotated example’s own value) is a byte-identical no-op', () => {
+    expect(resolveAmbientIntensity({ lighting: { ambient: 0.8 } })).toBe(0.8);
+    expect(resolveDirectionalScale({ lighting: { ambient: 0.8 } })).toBe(1);
+  });
+
+  it('a low ambient darkens both the ambient value AND the directional scale proportionally', () => {
+    expect(resolveAmbientIntensity({ lighting: { ambient: 0.1 } })).toBe(0.1);
+    expect(resolveDirectionalScale({ lighting: { ambient: 0.1 } })).toBeCloseTo(
+      0.125
+    );
+  });
+
+  it('a bright ambient (near 1) scales directional lights up proportionally too', () => {
+    expect(resolveDirectionalScale({ lighting: { ambient: 1 } })).toBeCloseTo(
+      1.25
+    );
+  });
+});

--- a/src/concepts/dungeon-builder/preview3d/walkLighting.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkLighting.ts
@@ -1,0 +1,186 @@
+/**
+ * walkLighting — derives R3F point-light configs from placed light-family
+ * props (`paletteData.ts`'s Lighting category: brazier/candles/
+ * glowing-orb) plus the doc's own `lighting: {ambient}` dialect knob
+ * (TARGET-YAML.md), for the author-walkthrough's Walk mode (rpg-project
+ * #169, Kirk's day-one ask: "a 3d view from the player perspective that
+ * has the lighting loaded"). Pure — no Three.js/R3F import — the same
+ * "pure derivation, component just maps it to JSX" shape this file's
+ * neighbor `DungeonPreview3D.tsx` already uses throughout (`buildWalls`,
+ * `buildPlacements`, etc.).
+ *
+ * **Color/intensity/distance provenance — game-derived, not guessed.**
+ * The three specs below are a LOCAL COPY of the real game's own
+ * `MOOD_LIGHT_SPEC_BY_PROP_REF` entries for these exact three refs
+ * (`src/components/playtest/playtestMapHelpers.ts`, Kirk's original
+ * POLYGON Dark Fortress reference — "near-dark ambient with sickly green
+ * pools of light around light-source props, warm orange around
+ * braziers/torches"), read as of 2026-08-05, not re-derived from first
+ * principles — so this concept's lighting reads like the game's own mood
+ * lighting instead of an independently-guessed palette. Deliberately a
+ * COPY, not an import: `playtestMapHelpers.ts` is game-route-coupled (its
+ * own functions take `RenderableEntity`/proto `Wall` shapes this concept
+ * doesn't have and never will — TARGET-YAML.md's whole "dialect runs
+ * ahead" discipline keeps this concept's own rendering self-contained
+ * rather than reaching into game rendering code for values that happen to
+ * be reusable). `decay: 2` (not itself part of a `MoodLightSpec`, since
+ * the game hardcodes it identically on every `<pointLight>`) matches
+ * `HexGrid.tsx`'s own convention exactly, same reasoning.
+ */
+import type { DungeonDoc } from '../dungeonYaml';
+
+export interface WalkPointLight {
+  key: string;
+  position: [number, number, number];
+  color: string;
+  intensity: number;
+  distance: number;
+}
+
+/** Structural subset of `DungeonPreview3D.tsx`'s own (unexported)
+ * `PlacedProp` — every field this module actually reads. Kept as a local
+ * duck-type rather than importing/exporting `PlacedProp` itself so this
+ * module stays a one-directional consumer of already-resolved render
+ * data, not a second thing `DungeonPreview3D.tsx` has to keep in sync. */
+export interface LightableProp {
+  key: string;
+  position: [number, number, number];
+  variantRef: string;
+}
+
+interface LightSpec {
+  color: string;
+  intensity: number;
+  distance: number;
+}
+
+/** Warm-orange glow — shared by brazier here, same as the game's own
+ * palette (`WARM_LIGHT_COLOR`, shared there by 5 fixtures) — kept as one
+ * named constant rather than a repeated literal for the same "one warm
+ * family" reasoning, even though only one entry uses it in this
+ * concept's smaller 3-key palette. */
+const WARM_LIGHT_COLOR = '#ff9d52';
+/** Saturated rune-blue — the game's own `RUNE_BLUE_COLOR`, reused here
+ * for `glowing-orb` exactly as the game uses it for that same ref. */
+const RUNE_BLUE_COLOR = '#3d84dc';
+
+/** propRef (last `:`-separated segment, matching `paletteData.ts`'s
+ * `LIGHTING_PROP_KEYS` membership) -> light spec. Exactly the three keys
+ * this concept's own Lighting palette category offers — a prop ref this
+ * concept can't even place never needs an entry here. */
+const LIGHT_SPEC_BY_PROP_REF: Record<string, LightSpec> = {
+  candles: { color: '#3ddc84', intensity: 2, distance: 4.5 },
+  'glowing-orb': { color: RUNE_BLUE_COLOR, intensity: 2, distance: 4.5 },
+  brazier: { color: WARM_LIGHT_COLOR, intensity: 2.8, distance: 5.5 },
+};
+
+/** Every `<pointLight>` renders at `decay={2}` — `HexGrid.tsx`'s own
+ * fixed convention for every mood point light, reused verbatim rather
+ * than re-tuned. */
+export const WALK_LIGHT_DECAY = 2;
+
+/**
+ * One light per placed prop whose ref matches the Lighting category —
+ * position is the prop's OWN already-resolved render position
+ * (`DungeonPreview3D.tsx`'s `buildOnePlacement`, which already applies
+ * `resolvePlacement(...).height`), so a floating candle's light floats
+ * with it and a floor-standing brazier's light sits at the floor —
+ * literally "at its position (+height if set)," no separate flame-height
+ * offset invented on top. A prop whose ref isn't a known light source is
+ * skipped, matching the game's own `buildCryptMoodLights`'s "adding
+ * non-light dressing never produces a light" behavior.
+ */
+export function deriveWalkLights(
+  props: readonly LightableProp[]
+): WalkPointLight[] {
+  const lights: WalkPointLight[] = [];
+  for (const p of props) {
+    const refKey = p.variantRef.split(':').pop();
+    const spec = refKey ? LIGHT_SPEC_BY_PROP_REF[refKey] : undefined;
+    if (!spec) continue;
+    lights.push({ key: `light:${p.key}`, position: p.position, ...spec });
+  }
+  return lights;
+}
+
+/** Upper bound on simultaneous point lights — mirrors the game's own
+ * `MOOD_LIGHT_BUDGET` headroom reasoning (a densely-dressed room can
+ * legitimately place more light-family props than is free to light
+ * individually; "performance is a standing requirement" per that file's
+ * own doc comment) at this concept's own, much smaller authoring scale —
+ * 12 comfortably exceeds any hand-authored showcase content today while
+ * still bounding a hypothetical dense one. */
+export const WALK_LIGHT_BUDGET = 12;
+
+/**
+ * Cap `lights` at `maxCount`, keeping the ones nearest `referenceXZ` when
+ * given — the SAME shape as the game's own `capMoodLights`
+ * (`playtestMapHelpers.ts`): a no-op under budget, a plain positional
+ * slice with no reference (Orbit mode, or before Walk mode has resolved a
+ * player cell), else nearest-first selection with the ORIGINAL relative
+ * order preserved in the return value (not sorted by distance) — so a
+ * `<pointLight key={i}>`-style consumer never has a light's identity
+ * silently reassigned to a different array slot between renders as the
+ * reference moves. This concept's own local copy rather than an import
+ * for the same "game-route-coupled module" reason `LIGHT_SPEC_BY_PROP_REF`
+ * above is a copy, not a shared import.
+ */
+export function capWalkLights(
+  lights: readonly WalkPointLight[],
+  maxCount: number,
+  referenceXZ?: readonly [number, number]
+): WalkPointLight[] {
+  if (lights.length <= maxCount) return [...lights];
+  if (!referenceXZ) return lights.slice(0, maxCount);
+  const [refX, refZ] = referenceXZ;
+  const sqDistance = (light: WalkPointLight) =>
+    (light.position[0] - refX) ** 2 + (light.position[2] - refZ) ** 2;
+  const nearest = [...lights]
+    .sort((a, b) => sqDistance(a) - sqDistance(b))
+    .slice(0, maxCount);
+  const kept = new Set(nearest);
+  return lights.filter((light) => kept.has(light));
+}
+
+/** This preview's own pre-existing hardcoded `<ambientLight
+ * intensity={0.8}>` — the fallback `resolveAmbientIntensity` returns for
+ * every document with no `lighting:` block, so a document authored before
+ * this field existed (the overwhelming majority) renders byte-identical
+ * ambient to before this unit. Also the reference baseline
+ * `resolveDirectionalScale` measures against — see that function's own
+ * doc comment for why. */
+const DEFAULT_AMBIENT = 0.8;
+
+/** The doc's `lighting.ambient` dialect field (TARGET-YAML.md: "an
+ * intensity knob now... 0..1, dungeon-wide multiplier. The only knob
+ * today"), read as a DIRECT intensity value for the scene's
+ * `<ambientLight>` — not a secondary multiplier layered on top of
+ * `DEFAULT_AMBIENT`, so the annotated example's own `ambient: 0.8` (the
+ * exact current default) renders as a genuine no-op, matching "default =
+ * current preview ambient." target-dialect-only: real today only in this
+ * concept's own render, never sent to `PutDungeon` (`stripToV1Subset`
+ * drops `lighting:` entirely, unchanged by this unit). */
+export function resolveAmbientIntensity(
+  doc: Pick<DungeonDoc, 'lighting'>
+): number {
+  return doc.lighting?.ambient ?? DEFAULT_AMBIENT;
+}
+
+/**
+ * Scale factor for the preview's two `<directionalLight>` fixtures,
+ * relative to `DEFAULT_AMBIENT` — so lowering `lighting.ambient` actually
+ * darkens the WHOLE scene, not just the flat ambient term. Without this,
+ * a `lighting: {ambient: 0.1}` document would still render nearly as
+ * bright as today under the fixed key/fill directional lights, defeating
+ * "a dark room with low ambient" as a renderable target (this unit's own
+ * verification goal) — the point-light pools would barely read against
+ * an otherwise fully "of-course-it's-lit" room. A document with no
+ * `lighting:`, or an explicit `ambient: 0.8` (the annotated example's own
+ * value), scales by exactly 1 — byte-identical directional intensities
+ * to every render before this unit.
+ */
+export function resolveDirectionalScale(
+  doc: Pick<DungeonDoc, 'lighting'>
+): number {
+  return resolveAmbientIntensity(doc) / DEFAULT_AMBIENT;
+}

--- a/src/concepts/dungeon-builder/preview3d/walkMovement.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkMovement.test.ts
@@ -40,6 +40,7 @@ import {
   canStandAt,
   edgeKey,
   nearestCell,
+  resolveMoveVector,
   resolveWalkStart,
   resolveWalkStep,
   type WalkContext,
@@ -328,5 +329,124 @@ describe('resolveWalkStart', () => {
       blockedEdges: new Set(),
     };
     expect(resolveWalkStart(ctx, { start: null })).toBeNull();
+  });
+});
+
+// resolveMoveVector — shared by BOTH walking camera modes (WalkCamera's
+// first-person facing, PlayCamera's azimuth-derived facing); each
+// component supplies its own forward/right, this function does the rest
+// identically either way.
+describe('resolveMoveVector', () => {
+  const FORWARD_NEG_Z = { x: 0, z: -1 };
+  const RIGHT_POS_X = { x: 1, z: 0 };
+
+  it('no keys pressed produces zero movement', () => {
+    const { dx, dz } = resolveMoveVector(
+      new Set(),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      1
+    );
+    expect(dx).toBe(0);
+    expect(dz).toBe(0);
+  });
+
+  it('W alone moves the full speed*delta along forward', () => {
+    const { dx, dz } = resolveMoveVector(
+      new Set(['KeyW']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    expect(dx).toBeCloseTo(0);
+    expect(dz).toBeCloseTo(-1.5); // 3 * 0.5, along -Z
+  });
+
+  it('S alone moves backward (negated forward)', () => {
+    const { dx, dz } = resolveMoveVector(
+      new Set(['KeyS']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    expect(dx).toBeCloseTo(0);
+    expect(dz).toBeCloseTo(1.5);
+  });
+
+  it('D alone strafes along right', () => {
+    const { dx, dz } = resolveMoveVector(
+      new Set(['KeyD']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    expect(dx).toBeCloseTo(1.5);
+    expect(dz).toBeCloseTo(0);
+  });
+
+  it('W+D (diagonal) is normalized — same magnitude as a single key, not faster', () => {
+    const single = resolveMoveVector(
+      new Set(['KeyW']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    const singleMag = Math.hypot(single.dx, single.dz);
+    const diagonal = resolveMoveVector(
+      new Set(['KeyW', 'KeyD']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    const diagonalMag = Math.hypot(diagonal.dx, diagonal.dz);
+    expect(diagonalMag).toBeCloseTo(singleMag);
+  });
+
+  it('opposite keys (W+S) cancel to zero', () => {
+    const { dx, dz } = resolveMoveVector(
+      new Set(['KeyW', 'KeyS']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    expect(dx).toBeCloseTo(0);
+    expect(dz).toBeCloseTo(0);
+  });
+
+  it('arrow keys are equivalent to WASD', () => {
+    const wasd = resolveMoveVector(
+      new Set(['KeyW']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    const arrows = resolveMoveVector(
+      new Set(['ArrowUp']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    expect(arrows).toEqual(wasd);
+  });
+
+  it('an unrelated key code is ignored', () => {
+    const { dx, dz } = resolveMoveVector(
+      new Set(['KeyQ']),
+      FORWARD_NEG_Z,
+      RIGHT_POS_X,
+      3,
+      0.5
+    );
+    expect(dx).toBe(0);
+    expect(dz).toBe(0);
   });
 });

--- a/src/concepts/dungeon-builder/preview3d/walkMovement.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkMovement.test.ts
@@ -1,0 +1,332 @@
+/**
+ * walkMovement.test.ts — the author-walkthrough's movement-legality unit
+ * (rpg-project#169). Two layers, deliberately separated:
+ *
+ * 1. `resolveWalkStep`/`canStandAt` against HAND-BUILT `WalkContext`
+ *    fixtures — proves the STEP-RESOLUTION algorithm itself (stop vs.
+ *    slide-along-an-axis vs. fully blocked) without depending on real hex
+ *    geometry at all.
+ * 2. `buildWalkContext` against REAL parsed documents (`emptyCanvasYaml`/
+ *    `SHOWCASE_YAML`+`SHOWCASE_FLOORPLAN`) — proves the WIRING: each of
+ *    the five legality sources (`wallLineFootprint`, a blocking
+ *    room-scoped placement, a blocking top-level placement, a room's
+ *    `boss:` cell, `doc.walls`/server-truth edges) actually lands in
+ *    `blockedCells`/`blockedEdges`. The underlying geometry those sources
+ *    delegate to (`straightWallFootprint`/`straightWallCrossedEdges`,
+ *    `resolvePlacement`, `floorPlanEdgesToServerEdges`) is already proven
+ *    correct by its own test suites elsewhere in this concept — this file
+ *    does not re-derive that math, only that this module actually calls
+ *    it and reacts to its output.
+ */
+import { describe, expect, it } from 'vitest';
+import { emptyCanvasYaml } from '../creation/emptyCanvasDoc';
+import {
+  addWallLine,
+  parseDungeon,
+  placeItem,
+  setPlacementFlags,
+  setWallEdge,
+  toDungeonDoc,
+} from '../dungeonYaml';
+import { SHOWCASE_FLOORPLAN, SHOWCASE_YAML } from '../fixtures';
+import {
+  buildFloorTiles,
+  buildPlaceableCells,
+  buildWallLineFootprint,
+  type PlaceableCell,
+} from './DungeonPreview3D';
+import {
+  buildWalkContext,
+  canStandAt,
+  edgeKey,
+  nearestCell,
+  resolveWalkStart,
+  resolveWalkStep,
+  type WalkContext,
+} from './walkMovement';
+
+function cell(
+  col: number,
+  row: number,
+  worldX: number,
+  worldZ: number
+): PlaceableCell {
+  return {
+    key: `${col},${row}`,
+    col,
+    row,
+    roomId: 'r',
+    worldX,
+    worldZ,
+    occupied: false,
+  };
+}
+
+// A tiny 3x1 straight-line "corridor" in world space (X axis, one world
+// unit apart) — enough to exercise stop/slide/blocked without needing
+// real hex adjacency at all.
+function makeContext(overrides: Partial<WalkContext> = {}): WalkContext {
+  const cells = [cell(0, 0, 0, 0), cell(1, 0, 1, 0), cell(2, 0, 2, 0)];
+  const cellsByKey = new Map(cells.map((c) => [`${c.col},${c.row}`, c]));
+  return {
+    cellList: cells,
+    cellsByKey,
+    blockedCells: new Set(),
+    blockedEdges: new Set(),
+    ...overrides,
+  };
+}
+
+describe('resolveWalkStep — pure step resolution against a hand-built context', () => {
+  it('a small step within the same cell is accepted unchanged', () => {
+    const ctx = makeContext();
+    const result = resolveWalkStep(ctx, 0, 0, 0.1, 0);
+    expect(result).toEqual({ x: 0.1, z: 0 });
+  });
+
+  it('stepping toward an adjacent standable cell is accepted', () => {
+    const ctx = makeContext();
+    const result = resolveWalkStep(ctx, 0.4, 0, 0.4, 0);
+    expect(result.x).toBeCloseTo(0.8);
+  });
+
+  it('stepping off the floor entirely (no cell there) holds position', () => {
+    const ctx = makeContext();
+    const result = resolveWalkStep(ctx, 0, 0, 0, 5); // no cell anywhere near z=5
+    expect(result).toEqual({ x: 0, z: 0 });
+  });
+
+  it('stepping into a BLOCKED cell holds position', () => {
+    const ctx = makeContext({ blockedCells: new Set(['1,0']) });
+    const result = resolveWalkStep(ctx, 0.4, 0, 0.4, 0); // would land nearest to cell (1,0)
+    expect(result).toEqual({ x: 0.4, z: 0 });
+  });
+
+  it('crossing a BLOCKED EDGE between two otherwise-standable cells holds position', () => {
+    const ctx = makeContext({ blockedEdges: new Set([edgeKey(0, 0, 1, 0)]) });
+    const result = resolveWalkStep(ctx, 0.4, 0, 0.4, 0);
+    expect(result).toEqual({ x: 0.4, z: 0 });
+  });
+
+  it('a diagonal step blocked on one axis slides along the other (axis-separated fallback)', () => {
+    const cells = [
+      cell(0, 0, 0, 0),
+      cell(1, 0, 1, 0), // blocked
+      cell(0, 1, 0, 1),
+    ];
+    const ctx: WalkContext = {
+      cellList: cells,
+      cellsByKey: new Map(cells.map((c) => [`${c.col},${c.row}`, c])),
+      blockedCells: new Set(['1,0']),
+      blockedEdges: new Set(),
+    };
+    // The full diagonal step (+0.7, +0.3) lands nearest (1,0) — blocked —
+    // and so does the x-only component alone (+0.7, 0), since that target
+    // is ALSO nearest (1,0). The z-only component (0, +0.3) lands nearest
+    // (0,0) — clear — so it should slide along z, dropping x entirely.
+    const result = resolveWalkStep(ctx, 0, 0, 0.7, 0.3);
+    expect(result.x).toBeCloseTo(0);
+    expect(result.z).toBeCloseTo(0.3);
+  });
+
+  it('a step landing nowhere near any real cell (either full or per-axis) holds position exactly', () => {
+    const cells = [cell(0, 0, 0, 0)];
+    const ctx: WalkContext = {
+      cellList: cells,
+      cellsByKey: new Map([['0,0', cells[0]!]]),
+      blockedCells: new Set(),
+      blockedEdges: new Set(),
+    };
+    // Every candidate target (the full diagonal AND each axis alone) is
+    // well beyond MAX_STEP_CONTAINMENT_DISTANCE from the one real cell.
+    const result = resolveWalkStep(ctx, 0, 0, 5, 5);
+    expect(result).toEqual({ x: 0, z: 0 });
+  });
+});
+
+describe('canStandAt / nearestCell — hand-built context', () => {
+  it('a real, unblocked cell is standable', () => {
+    expect(canStandAt(makeContext(), 0, 0)).toBe(true);
+  });
+
+  it('a cell with no floor tile at all is never standable', () => {
+    expect(canStandAt(makeContext(), 99, 99)).toBe(false);
+  });
+
+  it('a blocked cell is not standable even though it has floor', () => {
+    const ctx = makeContext({ blockedCells: new Set(['1,0']) });
+    expect(canStandAt(ctx, 1, 0)).toBe(false);
+  });
+
+  it('nearestCell finds the closest cell by world XZ distance, blocked or not', () => {
+    const ctx = makeContext();
+    expect(nearestCell(ctx, 1.4, 0)?.col).toBe(1);
+    expect(nearestCell(ctx, 1.6, 0)?.col).toBe(2);
+  });
+});
+
+// --- buildWalkContext wiring, against real parsed documents ---
+
+function canvasContextFromDoc(doc: ReturnType<typeof toDungeonDoc>) {
+  const wallLineFootprint = buildWallLineFootprint(doc);
+  // A from-scratch canvas has no `floorPlan` — mirror
+  // `CreationConcept.tsx`'s own derivation (`deriveCanvasFloorCells`) via
+  // the SAME `buildFloorTiles`/`buildPlaceableCells` this concept's 3D
+  // preview already uses, just fed a full-canvas cell list directly.
+  const grid = doc.canvas ?? { width: 20, height: 30 };
+  const floorCells: [number, number][] = [];
+  for (let col = 0; col < grid.width; col++) {
+    for (let row = 0; row < grid.height; row++) floorCells.push([col, row]);
+  }
+  const floorTiles = buildFloorTiles(undefined, doc.holes, floorCells);
+  const cells = buildPlaceableCells(
+    undefined,
+    doc,
+    floorTiles,
+    wallLineFootprint
+  );
+  return { doc, cells, wallLineFootprint, floorTiles };
+}
+
+describe('buildWalkContext — straight-wall (wallLines) footprint wiring', () => {
+  it('a wallLines footprint cell is not standable; its floor-neighbor is', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    // Same fixture canvasFloor.test.ts's own integration test uses — this
+    // line's footprint is exactly [[5, 4]] (verified there, not re-proven
+    // here).
+    addWallLine(cst, { cell: [5, 4], corner: 2 }, { cell: [5, 4], corner: 5 });
+    const doc = toDungeonDoc(cst);
+    const wallLineFootprint = buildWallLineFootprint(doc);
+    const grid = doc.canvas!;
+    const floorCells: [number, number][] = [];
+    for (let col = 0; col < grid.width; col++)
+      for (let row = 0; row < grid.height; row++) floorCells.push([col, row]);
+    const tiles = buildFloorTiles(undefined, doc.holes, floorCells);
+    const cells = buildPlaceableCells(undefined, doc, tiles, wallLineFootprint);
+    const ctx = buildWalkContext(undefined, doc, cells, wallLineFootprint);
+    expect(canStandAt(ctx, 5, 4)).toBe(false);
+    expect(canStandAt(ctx, 5, 5)).toBe(true);
+    expect(canStandAt(ctx, 6, 5)).toBe(true);
+  });
+});
+
+describe('buildWalkContext — placement blocksMovement wiring (top-level)', () => {
+  it('a blocking top-level placement makes its cell unstandable; a non-blocking one does not', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    placeItem(cst, null, 'dnd5e:props:brazier', [3, 3]);
+    setPlacementFlags(cst, null, 0, { blocksMovement: true, blocksLos: false });
+    placeItem(cst, null, 'dnd5e:props:pillar', [8, 8]);
+    setPlacementFlags(cst, null, 1, {
+      blocksMovement: false,
+      blocksLos: false,
+    });
+    const { doc, cells, wallLineFootprint } = canvasContextFromDoc(
+      toDungeonDoc(cst)
+    );
+    const ctx = buildWalkContext(undefined, doc, cells, wallLineFootprint);
+    expect(canStandAt(ctx, 3, 3)).toBe(false);
+    expect(canStandAt(ctx, 8, 8)).toBe(true);
+  });
+});
+
+describe('buildWalkContext — edge-native doc.walls: solid blocks crossing, door does not', () => {
+  it('a solid wall blocks the crossing; a door on a different edge does not', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    setWallEdge(cst, [5, 5], [5, 6], 'solid', true);
+    setWallEdge(cst, [7, 5], [7, 6], 'door', true);
+    const { doc, cells, wallLineFootprint } = canvasContextFromDoc(
+      toDungeonDoc(cst)
+    );
+    const ctx = buildWalkContext(undefined, doc, cells, wallLineFootprint);
+    expect(ctx.blockedEdges.has(edgeKey(5, 5, 5, 6))).toBe(true);
+    expect(ctx.blockedEdges.has(edgeKey(7, 5, 7, 6))).toBe(false);
+    // Both cells on either side of EITHER wall stay standable on their
+    // own — a solid wall blocks the CROSSING (proven above via
+    // `blockedEdges` membership), not the two cells it separates.
+    expect(canStandAt(ctx, 5, 5)).toBe(true);
+    expect(canStandAt(ctx, 5, 6)).toBe(true);
+    expect(canStandAt(ctx, 7, 5)).toBe(true);
+    expect(canStandAt(ctx, 7, 6)).toBe(true);
+  });
+});
+
+describe('buildWalkContext — real showcase document (floorPlan present)', () => {
+  const { cst } = parseDungeon(SHOWCASE_YAML);
+  const doc = toDungeonDoc(cst);
+  const floorPlan = SHOWCASE_FLOORPLAN;
+  const floorTiles = buildFloorTiles(floorPlan, doc.holes, undefined);
+  const wallLineFootprint = buildWallLineFootprint(doc);
+  const cells = buildPlaceableCells(
+    floorPlan,
+    doc,
+    floorTiles,
+    wallLineFootprint
+  );
+  const ctx = buildWalkContext(floorPlan, doc, cells, wallLineFootprint);
+
+  it('a room-scoped blocking placement (antechamber brazier, blocks_movement: true) blocks its absolute cell', () => {
+    // antechamber startColumn 0, brazier at room-local [1,1] -> absolute [1,1].
+    expect(canStandAt(ctx, 1, 1)).toBe(false);
+  });
+
+  it('a room-scoped NON-blocking placement (antechamber bone-pile, blocks_movement: false) leaves its cell standable', () => {
+    expect(canStandAt(ctx, 4, 6)).toBe(true);
+  });
+
+  it("the boss's own cell is always blocked (a monster stands there)", () => {
+    // vault startColumn 22, boss at room-local [5,5] -> absolute [27,5].
+    expect(canStandAt(ctx, 27, 5)).toBe(false);
+  });
+
+  it('server-truth FloorPlan.edges genuinely contribute blocked edges — this fixture authors zero doc.walls/wallLines of its own', () => {
+    expect(doc.walls).toEqual([]);
+    expect(doc.wallLines).toEqual([]);
+    expect(ctx.blockedEdges.size).toBeGreaterThan(0);
+  });
+});
+
+describe('resolveWalkStart', () => {
+  it("prefers the doc's own start: marker when it resolves to a standable cell", () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(10, 10));
+    placeItem(cst, null, 'dnd5e:props:pillar', [9, 9]); // decoy occupant elsewhere
+    const doc = toDungeonDoc(cst);
+    // start: is not set in the empty canvas fixture — use a doc override.
+    const docWithStart = { ...doc, start: [3, 4] as [number, number] };
+    const wallLineFootprint = buildWallLineFootprint(doc);
+    const grid = doc.canvas!;
+    const floorCells: [number, number][] = [];
+    for (let col = 0; col < grid.width; col++)
+      for (let row = 0; row < grid.height; row++) floorCells.push([col, row]);
+    const tiles = buildFloorTiles(undefined, doc.holes, floorCells);
+    const cells = buildPlaceableCells(undefined, doc, tiles, wallLineFootprint);
+    const ctx = buildWalkContext(undefined, doc, cells, wallLineFootprint);
+    const start = resolveWalkStart(ctx, docWithStart);
+    expect(start?.col).toBe(3);
+    expect(start?.row).toBe(4);
+  });
+
+  it('falls back to the standable cell nearest the floor centroid when start: is unset', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(4, 4));
+    const doc = toDungeonDoc(cst);
+    const wallLineFootprint = buildWallLineFootprint(doc);
+    const floorCells: [number, number][] = [];
+    for (let col = 0; col < 4; col++)
+      for (let row = 0; row < 4; row++) floorCells.push([col, row]);
+    const tiles = buildFloorTiles(undefined, doc.holes, floorCells);
+    const cells = buildPlaceableCells(undefined, doc, tiles, wallLineFootprint);
+    const ctx = buildWalkContext(undefined, doc, cells, wallLineFootprint);
+    const start = resolveWalkStart(ctx, doc);
+    expect(start).not.toBeNull();
+    expect(canStandAt(ctx, start!.col, start!.row)).toBe(true);
+  });
+
+  it('returns null when there is no floor to walk on at all', () => {
+    const ctx: WalkContext = {
+      cellList: [],
+      cellsByKey: new Map(),
+      blockedCells: new Set(),
+      blockedEdges: new Set(),
+    };
+    expect(resolveWalkStart(ctx, { start: null })).toBeNull();
+  });
+});

--- a/src/concepts/dungeon-builder/preview3d/walkMovement.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkMovement.test.ts
@@ -18,7 +18,9 @@
  *    does not re-derive that math, only that this module actually calls
  *    it and reacts to its output.
  */
+import { cubeToWorld, HEX_SIZE } from '@/components/hex-grid/hexMath';
 import { describe, expect, it } from 'vitest';
+import { facingToRotationY } from '../boardGeometry';
 import { emptyCanvasYaml } from '../creation/emptyCanvasDoc';
 import {
   addWallLine,
@@ -29,6 +31,7 @@ import {
   toDungeonDoc,
 } from '../dungeonYaml';
 import { SHOWCASE_FLOORPLAN, SHOWCASE_YAML } from '../fixtures';
+import { cubeAtColRow } from '../hexLayout';
 import {
   buildFloorTiles,
   buildPlaceableCells,
@@ -142,6 +145,121 @@ describe('resolveWalkStep — pure step resolution against a hand-built context'
     // well beyond MAX_STEP_CONTAINMENT_DISTANCE from the one real cell.
     const result = resolveWalkStep(ctx, 0, 0, 5, 5);
     expect(result).toEqual({ x: 0, z: 0 });
+  });
+
+  // rpg-project#169 regression fix — live-verified finding: the
+  // ORIGINAL crossing check ("does the TARGET point's nearest cell
+  // differ from the source, and is that pair blocked") silently never
+  // fires for a PERIMETER wall, because `FloorPlan.edges`' own boundary
+  // edges have a far side that was never a real, tracked floor tile
+  // (`FloorPlanEdge`'s own doc comment: "one endpoint may be outside the
+  // rendered floor-plan bounds" — confirmed directly against
+  // `SHOWCASE_FLOORPLAN.edges`, e.g. `{from:[0,7], to:[-1,7]}`) —
+  // `nearestCell` can never resolve a target point TO a nonexistent
+  // neighbor, so the "did the nearest cell change" test never trips, and
+  // a walking player passed straight through every perimeter wall in the
+  // dungeon into unmapped void (which then correctly rendered as
+  // nothing — a real collision gap, not a rendering bug, and reproduced
+  // identically on the walking camera's very first commit, before any
+  // Play-mode work existed). `resolveWalkStep` now asks a different
+  // question — "does the CURRENT cell (definitely real; the player is
+  // standing in it) have a blocked edge in roughly the direction being
+  // moved" — which needs no real cell on the far side to work at all.
+  // This fixture uses REAL adjacent-hex spacing/coordinates (matching
+  // `hexMath.ts`'s own `HEX_SIZE = 1` geometry via `cubeAtColRow`, not
+  // the other tests' simplified same-row 1-unit spacing) since the fix
+  // itself depends on real hex adjacency math (`boardGeometry.ts`'s
+  // `neighborCell`/`facingToRotationY`).
+  describe('directional edge blocking — the actual fix (perimeter walls, not just interior ones)', () => {
+    function realCell(col: number, row: number): PlaceableCell {
+      const cube = cubeAtColRow(col, row);
+      const world = cubeToWorld(cube, HEX_SIZE);
+      return {
+        key: `${col},${row}`,
+        col,
+        row,
+        roomId: 'r',
+        worldX: world.x,
+        worldZ: world.z,
+        occupied: false,
+      };
+    }
+
+    it('a blocked edge stops movement the moment it is attempted, from anywhere in the current cell — not just once flush against the boundary', () => {
+      // Only ONE real cell tracked — (1,0)'s own neighbor across this
+      // edge is never in cellsByKey at all, exactly the perimeter-wall
+      // shape that broke the old nearestCell-based check.
+      const cells = [realCell(0, 0)];
+      const ctx: WalkContext = {
+        cellList: cells,
+        cellsByKey: new Map([['0,0', cells[0]!]]),
+        blockedCells: new Set(),
+        blockedEdges: new Set([edgeKey(0, 0, 1, 0)]),
+      };
+      const start = cells[0]!;
+      // Move toward the blocked neighbor's own direction — resolved the
+      // same way the real component does (facing 0's own world angle).
+      const dir = facingToRotationY(0);
+      const dx = Math.cos(dir) * 0.1;
+      const dz = -Math.sin(dir) * 0.1;
+      let { x, z } = { x: start.worldX, z: start.worldZ };
+      const origin = { x, z };
+      for (let i = 0; i < 20; i++) {
+        ({ x, z } = resolveWalkStep(ctx, x, z, dx, dz));
+      }
+      // The old (removed) approach would have let the player walk
+      // straight through — 20 steps of 0.1 would reach 2.0 units away.
+      // The fix rejects every one of these 20 attempts outright, since
+      // they all point toward the SAME blocked direction from the SAME
+      // starting cell.
+      expect(x).toBeCloseTo(origin.x);
+      expect(z).toBeCloseTo(origin.z);
+    });
+
+    it('the identical direction is walkable once the edge is NOT in blockedEdges', () => {
+      const cells = [realCell(0, 0), realCell(1, 0)];
+      const ctx: WalkContext = {
+        cellList: cells,
+        cellsByKey: new Map(cells.map((c) => [`${c.col},${c.row}`, c])),
+        blockedCells: new Set(),
+        blockedEdges: new Set(), // open
+      };
+      const dir = facingToRotationY(0);
+      const dx = Math.cos(dir) * 0.1;
+      const dz = -Math.sin(dir) * 0.1;
+      let { x, z } = { x: cells[0]!.worldX, z: cells[0]!.worldZ };
+      const origin = { x, z };
+      for (let i = 0; i < 5; i++) {
+        ({ x, z } = resolveWalkStep(ctx, x, z, dx, dz));
+      }
+      const traveled = Math.hypot(x - origin.x, z - origin.z);
+      expect(traveled).toBeCloseTo(0.5, 5); // 5 unobstructed 0.1 steps
+    });
+
+    it('a perpendicular (non-blocked) direction from the same cell is unaffected by the blocked edge', () => {
+      const cells = [realCell(0, 0), realCell(0, 1)];
+      const ctx: WalkContext = {
+        cellList: cells,
+        cellsByKey: new Map(cells.map((c) => [`${c.col},${c.row}`, c])),
+        blockedCells: new Set(),
+        // Block the direction toward a DIFFERENT, unrelated neighbor —
+        // (2,0), never placed as a real cell either (perimeter-shaped),
+        // and never the direction actually walked in this test.
+        blockedEdges: new Set([edgeKey(0, 0, 2, 0)]),
+      };
+      const target = cells[1]!; // (0,1) — genuinely open
+      const dx0 = target.worldX - cells[0]!.worldX;
+      const dz0 = target.worldZ - cells[0]!.worldZ;
+      const len = Math.hypot(dx0, dz0);
+      const dx = (dx0 / len) * 0.1;
+      const dz = (dz0 / len) * 0.1;
+      let { x, z } = { x: cells[0]!.worldX, z: cells[0]!.worldZ };
+      for (let i = 0; i < 5; i++) {
+        ({ x, z } = resolveWalkStep(ctx, x, z, dx, dz));
+      }
+      const traveled = Math.hypot(x - cells[0]!.worldX, z - cells[0]!.worldZ);
+      expect(traveled).toBeCloseTo(0.5, 5);
+    });
   });
 });
 

--- a/src/concepts/dungeon-builder/preview3d/walkMovement.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkMovement.ts
@@ -321,3 +321,73 @@ export function resolveWalkStep(
 }
 
 export { edgeKey };
+
+// --- Shared WASD input, reused by BOTH camera modes that walk
+// (`WalkCamera.tsx`'s first-person mode, `PlayCamera.tsx`'s tactical
+// mode) — rpg-project#169 follow-up unit (Kirk, live: "walk is pretty
+// literal. that is not the view we have when playing... really cool
+// though" — Play reuses this exact movement, only the CAMERA rig
+// differs). Kept here, not per-component, so "movement identical to
+// Walk" is a real, enforced-by-sharing fact, not a claim two separate
+// implementations happen to agree with today. ---
+
+export type MoveAxis = 'forward' | 'back' | 'left' | 'right';
+
+/** Keyboard-code -> movement axis, shared by every walking camera mode.
+ * Arrow keys included alongside WASD for the same reason any other
+ * movement-key convention would: no reason to support one and not the
+ * other once either is being handled at all. */
+export const KEY_TO_AXIS: Record<string, MoveAxis> = {
+  KeyW: 'forward',
+  ArrowUp: 'forward',
+  KeyS: 'back',
+  ArrowDown: 'back',
+  KeyA: 'left',
+  ArrowLeft: 'left',
+  KeyD: 'right',
+  ArrowRight: 'right',
+};
+
+/**
+ * The raw world-space (dx, dz) a frame's held keys produce, given the
+ * caller's own notion of "forward"/"right" (a first-person camera's own
+ * facing for `WalkCamera`; the tactical rig's azimuth-derived heading for
+ * `PlayCamera` — see that component's own doc comment for why the two
+ * necessarily differ even though the KEYS and the resulting MOVEMENT
+ * resolution — `resolveWalkStep`, below — are identical). Pure: takes the
+ * already-read key set, not a live listener. Diagonal input (e.g. W+D) is
+ * normalized so it doesn't move faster than a single key.
+ */
+export function resolveMoveVector(
+  pressedKeys: ReadonlySet<string>,
+  forward: { x: number; z: number },
+  right: { x: number; z: number },
+  speed: number,
+  delta: number
+): { dx: number; dz: number } {
+  let f = 0;
+  let r = 0;
+  for (const code of pressedKeys) {
+    switch (KEY_TO_AXIS[code]) {
+      case 'forward':
+        f += 1;
+        break;
+      case 'back':
+        f -= 1;
+        break;
+      case 'right':
+        r += 1;
+        break;
+      case 'left':
+        r -= 1;
+        break;
+    }
+  }
+  if (f === 0 && r === 0) return { dx: 0, dz: 0 };
+  const inputLen = Math.hypot(f, r) || 1;
+  const step = (speed * delta) / inputLen;
+  return {
+    dx: (forward.x * f + right.x * r) * step,
+    dz: (forward.z * f + right.z * r) * step,
+  };
+}

--- a/src/concepts/dungeon-builder/preview3d/walkMovement.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkMovement.ts
@@ -1,0 +1,323 @@
+/**
+ * walkMovement — pure movement-legality for the author-walkthrough's Walk
+ * mode (rpg-project#169, Kirk's day-one ask: "a 3d view from the player
+ * perspective that has the lighting loaded"). Answers exactly one
+ * question, in world space: given a proposed step, where does the camera
+ * actually end up, honoring the SAME document truth every other view in
+ * this concept already renders?
+ *
+ * **Reuses the existing legality/footprint/crossing modules, does not
+ * reimplement geometry** (this unit's own scope note): a straight wall's
+ * FOOTPRINT and CROSSED-EDGE math come straight from
+ * `creation/straightWallGeometry.ts` (`straightWallFootprint`,
+ * `straightWallCrossedEdges`) — the exact functions the 2D board's own
+ * hatch/warning overlays and `canvasFloor.ts`'s placement-legality gate
+ * already call, not a parallel derivation. The floor-cell set this module
+ * walks (`cells: PlaceableCell[]`) is `DungeonPreview3D.tsx`'s own
+ * `buildPlaceableCells` output — the SAME per-cell col/row/world-position
+ * list click-to-place already resolves against, so "which cell is the
+ * camera standing in" and "which cell would a click place into" can never
+ * disagree.
+ *
+ * **Blocking rule, matched to Kirk's own rule for a drawn straight wall**
+ * ("any hex that is not 100% uncovered would not be traversable") and
+ * generalized to every source of impassability this document can author:
+ * a cell is walkable floor MINUS three things — a straight-wall
+ * (`wallLines:`) footprint cell, a `place:`/room-`place:` entry whose
+ * `resolvePlacement(...).blocksMovement` resolves true (the SAME
+ * inherited-default-aware resolver `isEntranceBlocked` already reads, so
+ * a `defaults:`-inherited block is honored here exactly like an explicit
+ * one), and a room's `boss:` cell (a monster standing there is always an
+ * obstacle — `BossDoc` carries no `blocks_movement` field to resolve, so
+ * this is a flat rule, not a resolved one). Separately, EDGE-crossing
+ * between two individually-walkable cells is blocked by an edge-native
+ * `walls:` (or server-truth `FloorPlan.edges`) entry whose `kind ===
+ * 'solid'` — a `kind: 'door'` edge is deliberately NOT added to the
+ * blocked-edge set, so a door is simply passable, matching this file's
+ * neighbor `DungeonPreview3D.tsx`'s own `DoorGap` rendering (a genuine
+ * open span, not a shortened solid box). A `wallLines:` door is already
+ * handled one layer down: its cell is excluded from the OWNING line's own
+ * footprint (`WallLineDoorDoc`'s own doc comment — "as if the line never
+ * clipped it"), so it never enters `blockedCells`, and its own boundary
+ * crossings fall out of `straightWallCrossedEdges`'s ordinary
+ * both-clear-cells rule with no separate door-crossing code needed here
+ * either.
+ */
+import { HEX_SIZE } from '@/components/hex-grid/hexMath';
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { DEFAULT_CANVAS } from '../creation/emptyCanvasDoc';
+import {
+  cellKey,
+  straightWallCrossedEdges,
+  straightWallFootprint,
+} from '../creation/straightWallGeometry';
+import {
+  resolvePlacement,
+  type DungeonDoc,
+  type PlacementDoc,
+} from '../dungeonYaml';
+import { floorPlanEdgesToServerEdges, hasServerEdges } from '../edgesAdapter';
+import type { PlaceableCell } from './DungeonPreview3D';
+
+/** A cell-pair key with no notion of direction — `edgeKey(a,b) ===
+ * edgeKey(b,a)` always, by sorting the two `[col,row]` pairs
+ * lexicographically before joining them. Deliberately independent of
+ * `creationGeometry.ts`'s own `canonicalHexEdge` (a facing-derived
+ * convention) — this module ingests edges from THREE different sources
+ * (`doc.walls`, server-truth `FloorPlan.edges`, and
+ * `straightWallCrossedEdges`'s own `EdgeGeometry.cellA/cellB`, itself
+ * already canonical under a DIFFERENT rule), so a single self-contained
+ * key format that only needs the two endpoints — not which cell a caller
+ * happened to start from, nor which of the three sources produced it —
+ * is simpler than reconciling three conventions into one. */
+function edgeKey(
+  colA: number,
+  rowA: number,
+  colB: number,
+  rowB: number
+): string {
+  const a = cellKey(colA, rowA);
+  const b = cellKey(colB, rowB);
+  return a <= b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+export interface WalkContext {
+  cellList: readonly PlaceableCell[];
+  cellsByKey: ReadonlyMap<string, PlaceableCell>;
+  blockedCells: ReadonlySet<string>;
+  blockedEdges: ReadonlySet<string>;
+}
+
+/** Build the walk-time legality index once per render (memoized by the
+ * caller, same as every other derived structure `DungeonPreview3D.tsx`
+ * already computes) — everything below is a plain lookup against this,
+ * no re-derivation per frame. */
+export function buildWalkContext(
+  floorPlan: FloorPlan | undefined,
+  doc: DungeonDoc,
+  cells: readonly PlaceableCell[],
+  wallLineFootprint: ReadonlySet<string>
+): WalkContext {
+  const cellsByKey = new Map<string, PlaceableCell>();
+  for (const c of cells) cellsByKey.set(cellKey(c.col, c.row), c);
+
+  const blockedCells = new Set<string>(wallLineFootprint);
+  const addIfBlocking = (p: PlacementDoc, absCol: number, row: number) => {
+    if (resolvePlacement(doc, p).blocksMovement) {
+      blockedCells.add(cellKey(absCol, row));
+    }
+  };
+  if (floorPlan) {
+    for (const room of doc.rooms) {
+      const fpRoom = floorPlan.rooms.find((r) => r.id === room.id);
+      if (!fpRoom) continue;
+      for (const p of room.place) {
+        addIfBlocking(p, fpRoom.startColumn + p.at[0], p.at[1]);
+      }
+      if (room.boss) {
+        blockedCells.add(
+          cellKey(fpRoom.startColumn + room.boss.at[0], room.boss.at[1])
+        );
+      }
+    }
+  }
+  for (const p of doc.place) addIfBlocking(p, p.at[0], p.at[1]);
+
+  const blockedEdges = new Set<string>();
+  for (const w of doc.walls) {
+    if (w.kind === 'solid') {
+      blockedEdges.add(edgeKey(w.from[0], w.from[1], w.to[0], w.to[1]));
+    }
+  }
+  if (floorPlan && hasServerEdges(floorPlan)) {
+    for (const e of floorPlanEdgesToServerEdges(floorPlan)) {
+      if (e.kind === 'solid') {
+        blockedEdges.add(edgeKey(e.from[0], e.from[1], e.to[0], e.to[1]));
+      }
+    }
+  }
+  const grid = doc.canvas ?? DEFAULT_CANVAS;
+  for (const line of doc.wallLines) {
+    const doorCells = line.doors.map((d) => d.cell);
+    const footprint = straightWallFootprint(
+      line.from,
+      line.to,
+      grid,
+      doorCells
+    );
+    for (const edge of straightWallCrossedEdges(
+      line.from,
+      line.to,
+      grid,
+      footprint
+    )) {
+      blockedEdges.add(
+        edgeKey(edge.cellA[0], edge.cellA[1], edge.cellB[0], edge.cellB[1])
+      );
+    }
+  }
+
+  return { cellList: cells, cellsByKey, blockedCells, blockedEdges };
+}
+
+/** Whether `(col, row)` is real floor AND not blocked — the single
+ * per-cell legality check every function below composes from. */
+export function canStandAt(
+  ctx: WalkContext,
+  col: number,
+  row: number
+): boolean {
+  const key = cellKey(col, row);
+  return ctx.cellsByKey.has(key) && !ctx.blockedCells.has(key);
+}
+
+/** Nearest cell (standable or not — callers that need "which cell would
+ * this land in" use this, then apply their own legality check) to a
+ * world-space point, by squared XZ distance. Brute-force over `cellList`,
+ * the same "simpler and cheaper to verify than a closed-form inverse"
+ * reasoning `boardGeometry.ts`'s own `nearestCell` already uses — this
+ * one is cheaper still, since it only ever scans the real floor-cell list
+ * `buildPlaceableCells` already produced, not a full bounding rectangle. */
+export function nearestCell(
+  ctx: WalkContext,
+  worldX: number,
+  worldZ: number
+): PlaceableCell | null {
+  let best: PlaceableCell | null = null;
+  let bestDistSq = Infinity;
+  for (const c of ctx.cellList) {
+    const d = (c.worldX - worldX) ** 2 + (c.worldZ - worldZ) ** 2;
+    if (d < bestDistSq) {
+      bestDistSq = d;
+      best = c;
+    }
+  }
+  return best;
+}
+
+function nearestStandableCell(
+  ctx: WalkContext,
+  worldX: number,
+  worldZ: number
+): PlaceableCell | null {
+  let best: PlaceableCell | null = null;
+  let bestDistSq = Infinity;
+  for (const c of ctx.cellList) {
+    if (!canStandAt(ctx, c.col, c.row)) continue;
+    const d = (c.worldX - worldX) ** 2 + (c.worldZ - worldZ) ** 2;
+    if (d < bestDistSq) {
+      bestDistSq = d;
+      best = c;
+    }
+  }
+  return best;
+}
+
+/** The mean world position across every real floor cell — NOT
+ * `doc.canvas`'s nominal bounds center (`canvasFloor.ts`'s own "every
+ * cell inside canvas bounds, minus holes" semantic means the drawn floor
+ * can be a small, off-center subset of a much larger declared canvas).
+ * `null` for an empty floor. Shared by `resolveWalkStart`'s own fallback
+ * below and `WalkCamera.tsx`'s default look-at target — "roughly toward
+ * the middle of the dungeon" is the same useful direction for both. */
+export function floorCentroid(
+  ctx: WalkContext
+): { worldX: number; worldZ: number } | null {
+  if (ctx.cellList.length === 0) return null;
+  let sumX = 0;
+  let sumZ = 0;
+  for (const c of ctx.cellList) {
+    sumX += c.worldX;
+    sumZ += c.worldZ;
+  }
+  return {
+    worldX: sumX / ctx.cellList.length,
+    worldZ: sumZ / ctx.cellList.length,
+  };
+}
+
+/** Where Walk mode starts: the doc's own `start:` marker when it resolves
+ * to a real, standable cell; else the standable cell nearest the floor's
+ * own centroid (`floorCentroid`, above); else the first standable cell
+ * found at all (an exotic fully-surrounded `start:` with no better
+ * fallback); else `null` (no floor to walk on — the caller's own honest
+ * degrade, not this module's). */
+export function resolveWalkStart(
+  ctx: WalkContext,
+  doc: Pick<DungeonDoc, 'start'>
+): PlaceableCell | null {
+  if (doc.start) {
+    const [col, row] = doc.start;
+    if (canStandAt(ctx, col, row)) {
+      const cell = ctx.cellsByKey.get(cellKey(col, row));
+      if (cell) return cell;
+    }
+  }
+  const centroid = floorCentroid(ctx);
+  if (!centroid) return null;
+  const nearest = nearestStandableCell(ctx, centroid.worldX, centroid.worldZ);
+  if (nearest) return nearest;
+  return ctx.cellList.find((c) => canStandAt(ctx, c.col, c.row)) ?? null;
+}
+
+/** How far a target point may sit from the nearest real floor cell and
+ * still be considered "standing in" that cell, for `resolveWalkStep`'s
+ * own collision check — `nearestCell` itself always returns SOMETHING
+ * (the closest cell in the list, however far), which is correct for a
+ * query like "which real cell is closest to this centroid"
+ * (`resolveWalkStart`) but wrong for per-frame collision: without a
+ * cutoff, an abnormally large single-frame delta (a dropped frame, a
+ * runaway input) would silently snap the camera onto whatever real floor
+ * cell happens to be globally nearest, potentially straight through
+ * solid geometry in between, rather than correctly reading as "this step
+ * doesn't land on any floor at all." `HEX_SIZE * 2` is generous against
+ * real adjacent-hex spacing (~1.73 world units center-to-center at
+ * `HEX_SIZE = 1`) — comfortably larger than any single frame's real
+ * movement at `WalkCamera.tsx`'s own walk speed, so it never rejects a
+ * genuine step, only a wildly out-of-range one. */
+const MAX_STEP_CONTAINMENT_DISTANCE = HEX_SIZE * 2;
+
+/** One frame's worth of proposed movement, resolved against the walk
+ * context — "simple grid-constrained motion... slide-along or stop at
+ * blocks" (this unit's own scope): tries the full diagonal step first,
+ * then each axis independently (the slide-along-a-wall feel), and
+ * finally gives up and holds position — never a physics engine, never
+ * anything more than three legality checks against cells already
+ * resolved above. `x`/`z` and `dx`/`dz` are all world-space units; `y`
+ * (eye height) is the caller's own fixed constant, untouched here. */
+export function resolveWalkStep(
+  ctx: WalkContext,
+  x: number,
+  z: number,
+  dx: number,
+  dz: number
+): { x: number; z: number } {
+  const canMove = (ndx: number, ndz: number): boolean => {
+    if (ndx === 0 && ndz === 0) return false;
+    const targetX = x + ndx;
+    const targetZ = z + ndz;
+    const toCell = nearestCell(ctx, targetX, targetZ);
+    if (!toCell) return false;
+    const distSq =
+      (toCell.worldX - targetX) ** 2 + (toCell.worldZ - targetZ) ** 2;
+    if (distSq > MAX_STEP_CONTAINMENT_DISTANCE ** 2) return false;
+    if (!canStandAt(ctx, toCell.col, toCell.row)) return false;
+    const fromCell = nearestCell(ctx, x, z);
+    if (
+      fromCell &&
+      (fromCell.col !== toCell.col || fromCell.row !== toCell.row) &&
+      ctx.blockedEdges.has(
+        edgeKey(fromCell.col, fromCell.row, toCell.col, toCell.row)
+      )
+    ) {
+      return false;
+    }
+    return true;
+  };
+  if (canMove(dx, dz)) return { x: x + dx, z: z + dz };
+  if (canMove(dx, 0)) return { x: x + dx, z };
+  if (canMove(0, dz)) return { x, z: z + dz };
+  return { x, z };
+}
+
+export { edgeKey };

--- a/src/concepts/dungeon-builder/preview3d/walkMovement.ts
+++ b/src/concepts/dungeon-builder/preview3d/walkMovement.ts
@@ -45,6 +45,7 @@
  */
 import { HEX_SIZE } from '@/components/hex-grid/hexMath';
 import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { facingToRotationY, neighborCell } from '../boardGeometry';
 import { DEFAULT_CANVAS } from '../creation/emptyCanvasDoc';
 import {
   cellKey,
@@ -277,6 +278,67 @@ export function resolveWalkStart(
  * genuine step, only a wildly out-of-range one. */
 const MAX_STEP_CONTAINMENT_DISTANCE = HEX_SIZE * 2;
 
+/**
+ * Whether moving in world-space direction `(ndx, ndz)` from `fromCell`
+ * would cross one of `fromCell`'s own blocked edges — rpg-project#169
+ * regression fix. Deliberately does NOT ask "which cell does the TARGET
+ * point belong to, and is THAT pair blocked" (the earlier approach,
+ * `nearestCell`-based): found live that this silently failed for any
+ * PERIMETER wall, because a `FloorPlan.edges` boundary edge's own far
+ * side is a col/row that was never a real, tracked floor tile
+ * (`FloorPlanEdge`'s own doc comment: "one endpoint may be outside the
+ * rendered floor-plan bounds" — verified directly against
+ * `SHOWCASE_FLOORPLAN.edges`, e.g. `{from:[0,7], to:[-1,7]}`) — so
+ * `nearestCell` could never resolve a target point TO that nonexistent
+ * neighbor, the "did the nearest cell change" crossing test never
+ * fired, and the player walked straight through every perimeter wall in
+ * the dungeon into unmapped void (which then correctly rendered as
+ * nothing — not a rendering bug, a genuine collision gap).
+ *
+ * This version asks a geometrically different, correct question
+ * instead: "does `fromCell` — a cell that's DEFINITELY real, since the
+ * player is standing in it — have a blocked edge in roughly the
+ * direction I'm trying to move," using `boardGeometry.ts`'s own
+ * `neighborCell` (pure cube-coordinate math — it computes where a
+ * neighbor WOULD be regardless of whether that coordinate is a tracked
+ * floor tile) and `facingToRotationY` (the same world-angle-per-facing
+ * convention every other edge-aligned piece in this codebase uses) to
+ * find the nearest of the 6 hex directions to the movement vector. This
+ * strictly subsumes the old interior-wall behavior (an interior wall's
+ * computed neighbor IS the real adjacent cell, so the same `edgeKey`
+ * lookup still matches) while now ALSO correctly blocking perimeter
+ * walls, and — as a welcome side effect — stops the player from ANY
+ * point inside their current cell the moment they try to move toward a
+ * blocked edge, rather than letting them approach all the way to the
+ * unbuffered cell-Voronoi boundary first (itself close enough to a
+ * wall's own thin rendered geometry, `WallBox`'s `WALL_THICKNESS =
+ * 0.12`, to read as uncomfortably flush against it).
+ */
+function directionCrossesBlockedEdge(
+  blockedEdges: ReadonlySet<string>,
+  fromCol: number,
+  fromRow: number,
+  ndx: number,
+  ndz: number
+): boolean {
+  if (ndx === 0 && ndz === 0) return false;
+  const angle = Math.atan2(-ndz, ndx);
+  let bestFacing = 0;
+  let bestDist = Infinity;
+  for (let facing = 0; facing < 6; facing++) {
+    const raw = Math.abs(angle - facingToRotationY(facing)) % (2 * Math.PI);
+    const dist = Math.min(raw, 2 * Math.PI - raw);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestFacing = facing;
+    }
+  }
+  const neighbor = neighborCell(fromCol, fromRow, bestFacing);
+  return blockedEdges.has(
+    edgeKey(fromCol, fromRow, neighbor.col, neighbor.row)
+  );
+}
+
 /** One frame's worth of proposed movement, resolved against the walk
  * context — "simple grid-constrained motion... slide-along or stop at
  * blocks" (this unit's own scope): tries the full diagonal step first,
@@ -294,6 +356,19 @@ export function resolveWalkStep(
 ): { x: number; z: number } {
   const canMove = (ndx: number, ndz: number): boolean => {
     if (ndx === 0 && ndz === 0) return false;
+    const fromCell = nearestCell(ctx, x, z);
+    if (
+      fromCell &&
+      directionCrossesBlockedEdge(
+        ctx.blockedEdges,
+        fromCell.col,
+        fromCell.row,
+        ndx,
+        ndz
+      )
+    ) {
+      return false;
+    }
     const targetX = x + ndx;
     const targetZ = z + ndz;
     const toCell = nearestCell(ctx, targetX, targetZ);
@@ -302,16 +377,6 @@ export function resolveWalkStep(
       (toCell.worldX - targetX) ** 2 + (toCell.worldZ - targetZ) ** 2;
     if (distSq > MAX_STEP_CONTAINMENT_DISTANCE ** 2) return false;
     if (!canStandAt(ctx, toCell.col, toCell.row)) return false;
-    const fromCell = nearestCell(ctx, x, z);
-    if (
-      fromCell &&
-      (fromCell.col !== toCell.col || fromCell.row !== toCell.row) &&
-      ctx.blockedEdges.has(
-        edgeKey(fromCell.col, fromCell.row, toCell.col, toCell.row)
-      )
-    ) {
-      return false;
-    }
     return true;
   };
   if (canMove(dx, dz)) return { x: x + dx, z: z + dz };


### PR DESCRIPTION
## Summary

Kirk's day-one ask, verbatim: "really I want a 3d view from the player perspective that has the lighting loaded." Entirely client-side — no server, no proto changes.

- **Walk/Orbit camera toggle** on `DungeonPreview3D` — Orbit (existing, unchanged) or Walk: player-perspective at eye height (derived from `WALL_HEIGHT`), WASD + pointer-lock mouse-look (drei's `PointerLockControls`, not reimplemented). View-only — no editing/combat/server calls while walking.
- **Movement respects the document's own truth** — reuses the existing legality/footprint/crossing modules (`creation/straightWallGeometry.ts`, `boardGeometry.ts`, `edgesAdapter.ts`) rather than reimplementing geometry: straight-wall footprints and blocking placements (`resolvePlacement(...).blocksMovement`, inherited defaults included) are impassable; edge-native `walls:`/server-truth `FloorPlan.edges` block crossing when `kind: solid`; doors pass.
- **Real lighting, in both camera modes** — placed light-family props (brazier/candles/glowing-orb) emit point lights using the game's own mood-lighting palette (`playtestMapHelpers.ts`'s `MOOD_LIGHT_SPEC_BY_PROP_REF`, copied not imported — game-route-coupled), capped at 12 simultaneous lights (nearest-to-player once walking). The pre-existing `lighting.ambient` dialect field now genuinely drives scene brightness (directional lights scale proportionally so a low ambient reads as a real dark room, not just a dimmer flat term).
- **One component, both 3D contexts** — edit-mode's compiled `FloorPlan` and creation-mode's from-scratch canvas both get Walk mode for free.

Two real bugs found via live verification and fixed:
- Leaving Walk mode never released an active pointer lock (`PointerLockControls.disconnect()` doesn't call `document.exitPointerLock()`) — left the browser's pointer captured, breaking clicks elsewhere on the page.
- The camera never reset when returning to Orbit — left the player stuck at eye height wherever they'd walked instead of the original `<Bounds fit clip>`-framed view.

## Test plan

- [x] `preview3d/walkMovement.test.ts` (21 tests) — step resolution (stop/slide/blocked) against hand-built contexts, `buildWalkContext` wiring against real parsed docs (straight-wall footprint, blocking placement, boss cell, edge-native solid-vs-door, server-truth `FloorPlan.edges`)
- [x] `preview3d/walkLighting.test.ts` (13 tests) — light derivation, cap, ambient/directional math
- [x] Full `dungeon-builder` suite: 358 tests, 18 files, passing
- [x] `ci-check` clean (format/lint/typecheck/build/test)
- [x] Live-verified against the real dev server (edit mode + creation mode): pointer lock genuinely engages/releases, WASD movement into a corridor with visible brazier light falloff, dark-ambient room, mode toggle round-trip

See `src/concepts/dungeon-builder/CONTRACT.md`'s "Author walkthrough" ledger entry for the full writeup.

— asset-pipeline agent, on behalf of KirkDiggler