### PR TITLE
unit: real wall + door assets (the game's face)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -5863,3 +5863,230 @@ empty-floor flash). The `server`/mismatch/dangling-parent paths are
 proven by `regionTreeWire.test.ts`/`RegionPanel.test.tsx`'s constructed
 fixtures, not live — there is nothing server-side to drive them against
 yet.
+
+## Real wall + door assets: the game's own Synty pieces replace the box/gap placeholders (2026-08-06, rpg-project#169)
+
+Kirk's verdict driving this unit, seen through the new Play camera: "walls are
+there they are just plain white. the door is there but it is a yellow
+placeholder looking thing... not the assets we typically load." Every rendered
+wall segment and door — edge-native (`doc.walls`/server-truth `FloorPlan.edges`)
+and straight `wallLines:` runs alike — now mounts the game's real Synty GLB
+pieces instead of `WallBox`/`DoorGap`'s procedural boxes, in BOTH edit mode
+(compiled `FloorPlan`) and creation mode (from-scratch canvas, `doc.walls`
+only — verified, see below).
+
+### What shipped
+
+**Two new files split the same way `WallRunMesh.tsx`/`SyntyHexWall.tsx`
+already split from their own pure-helper siblings**:
+
+- `preview3d/wallPieceHelpers.ts` — pure, no Three.js/R3F import:
+  `resolveWallPieceFacing` (which way should an asymmetric piece's detailed
+  face point — this concept has no `EnvelopeRun.facing`/room-envelope concept
+  to borrow, so it probes both perpendicular directions from a piece's own
+  midpoint against a caller-supplied `isOpenCell` predicate — real floor tile
+  membership for edge-native walls, floor tiles MINUS the run's own footprint
+  for `wallLines:` runs — and faces toward whichever side is actually
+  walkable; both/neither open falls back to the un-corrected direction, same
+  "no provably optimal choice" shape `ConnectorRun.facing`'s own doc comment
+  already accepts), `facingCutawayHeight` (cutaway classification against a
+  LIVE camera-ward vector rather than the game's fixed `CAMERA_WARD_XZ` — this
+  preview's Orbit/Play cameras are free to move, so a static direction doesn't
+  apply; the dot-product rule itself is the game's own `effectiveWallHeight`
+  logic, algebraically flipped since this file's facing convention points the
+  opposite way — see that function's own doc comment for the substitution
+  proof), `resolveDoorLocked` (a server-truth door's `doc.connectors[].locked`,
+  via the SAME `connectorIndexForDoorId` correlation `onSelectConnector`
+  already uses).
+- `preview3d/RealWallPieces.tsx` — the JSX: `RealEdgeWallPiece`/
+  `RealEdgeDoorPiece` (one hex-edge, matching `SyntyHexWall`'s own per-edge
+  convention — position at the edge's own `a` corner, not its midpoint, since
+  `wallVariantScale`'s squeeze-to-one-edge scale assumes an end-anchored
+  local origin) and `RealWallLineRun`/`RealWallLineDoorPiece` (a `wallLines:`
+  run, tiled via the game's own `tileWallSegment` — `WallRunMesh`'s modular
+  convention, reused directly, not re-derived) plus `CameraWardTracker` (the
+  live camera-ward feed for cutaway, throttled to a ~5.7° dot-product gate so
+  an Orbit drag doesn't re-render every wall's cutaway classification every
+  frame — the same "update only on a meaningful change" discipline
+  `WalkCamera`'s own `onCellChange`/`playerCell` already established in this
+  file).
+- `preview3d/placeholderWallPieces.tsx` — `WallBox`/`DoorGap` moved out of
+  `DungeonPreview3D.tsx` unchanged (plus a new optional `wallHeight` param,
+  defaulting to `WALL_HEIGHT` so every pre-existing call site is
+  byte-identical) so `RealWallPieces.tsx` can import them as its own
+  ErrorBoundary fallback without a `DungeonPreview3D.tsx` <-> `RealWallPieces.tsx`
+  import cycle.
+- `DungeonPreview3D.tsx` itself: `PlacedWall` gained `edgeA: WorldPos` (the
+  edge's own `a` corner, from `wallBoxTransform`'s existing `edgeBetweenCells`
+  call — already computed, previously discarded) and `WallLineSegment` gained
+  `start`/`end: WorldPos` (the same two endpoints `position`/`length`/
+  `rotationY` already imply, carried through directly rather than
+  reconstructed via trig) — both additive, both proven non-breaking by the
+  full existing test suite passing unchanged. The two render loops
+  (`[...serverWalls, ...authoredWalls].map`, `wallLineSegments.map`) now
+  resolve each piece's facing + cutaway height inline and hand off to the
+  `RealWallPieces.tsx` components instead of `WallBox`/`DoorGap` directly.
+
+### Piece provenance — which GLBs, which game files the conventions came from
+
+Every asset/formula is a direct import from the real game's own wall-rendering
+modules, not a copy or a re-derivation, per this concept's own operating-bar
+principle ("reuse the real game renderers directly"):
+
+| Piece                                                         | File(s)                                                              | Source of the scale/rotation formula                                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Edge-native wall (variety)                                    | `SM_Env_Wall_Half_01.glb` / `_Broken_Edge_01.glb` / `_Alcove_01.glb` | `syntyHexWallHelpers.ts`'s `WALL_VARIANTS`/`selectWallVariant`/`wallVariantScale` — the SAME per-edge deterministic pick `SyntyHexWall.tsx`'s boundary-edge branch uses                                                                                                                          |
+| `wallLines:` run (tiled, "plain" only)                        | `SM_Env_Wall_Half_01.glb`                                            | `wallRunMeshHelpers.ts`'s `tileWallSegment`, `WallRunMesh.tsx`'s own `RUN_WALL_VARIANT`/`NOMINAL_PIECE_WIDTH=1.0`/`RUN_WALL_PIVOT_RATIO`/`RUN_WALL_TILE_OVERLAP_MARGIN=0.08` constants (copied — those four are private, un-exported consts; the underlying `WALL_VARIANTS[0]` data IS imported) |
+| Door frame                                                    | `SM_Env_Door_Frame_01.glb`                                           | `syntyHexWallHelpers.ts`'s `DOOR_FRAME_FILE`/`doorFrameScale`                                                                                                                                                                                                                                    |
+| Door leaf (closed pose only — no open/close state this round) | `SM_Env_Door_01.glb`                                                 | `syntyHexWallHelpers.ts`'s `DOOR_LEAF_FILE`/`doorLeafScale`                                                                                                                                                                                                                                      |
+| Locked-door tint                                              | —                                                                    | `SyntyHexWall.tsx`'s `LOCKED_DOOR_TINT` value, COPIED not imported (it's a private, un-exported const there) — same "dialect-runs-ahead, stay self-contained" precedent `walkLighting.ts` already set in this file for the mood-light color specs                                                |
+| Loading/cloning/tinting/baking                                | —                                                                    | `GlbInstance` (`@/components/hex-grid/GlbInstance`), used directly, unmodified — the exact primitive `SyntyHexWall`/`WallRunMesh` both already use                                                                                                                                               |
+| Front/back facing correction                                  | —                                                                    | `wallRunMeshHelpers.ts`'s `facingCorrectedRotationY`, used directly                                                                                                                                                                                                                              |
+
+**Corner/end fittings (`classifyWallVertices`/`wallEndEdgeKeys`,
+`FITTINGS`/`SM_Env_Wall_Quarter_01.glb`) are OUT of scope this round** — both
+are built around the game's own `Wall[]`/cube-coordinate blocked-cell model;
+adapting them to this concept's two genuinely different wall shapes
+(edge-native col/row pairs, and corner-anchored world-space `wallLines:` runs,
+neither a `Wall[]`) is real, separable work. Two pieces meeting at a corner
+place independently today — no visible defect versus the box placeholder,
+possibly a small seam on a real GLB corner. Named as a real follow-up, not a
+silent gap.
+
+### Cutaway — Orbit/Play stub near-camera walls, Walk never does
+
+`facingCutawayHeight` gates on `cameraMode !== 'walk'` (`cutawayEnabled` in
+`DungeonPreview3D.tsx`) — Orbit and Play both get cutaway (a wall piece whose
+walkable-side facing points AWAY from the live camera-ward vector renders at
+`CUTAWAY_STUB_WALL_HEIGHT` instead of `WALL_HEIGHT`, matching the game's own
+`effectiveWallHeight` dot-product rule, substituted for this concept's
+opposite-sign facing convention — see that function's own doc comment for the
+algebra), Walk stays full-height always (`cutawayEnabled = false` there, per
+this unit's own brief: "you're inside; full walls"). The stub height is a real
+non-uniform GLB scale (`wallVariantScale(variant, CUTAWAY_STUB_WALL_HEIGHT,
+...)`), not a visual trick — the same "scale = height / rawHeight" formula the
+game's own `wallHeight`/`doorHeights` dial already uses, so a stubbed real
+piece squashes the same way a stubbed game wall does.
+
+**No per-frame re-render**: `CameraWardTracker` only calls back when the
+live camera-ward vector swings past a ~5.7° dot-product threshold (matching
+`WalkCamera`'s own `onCellChange`-not-every-frame discipline) — an Orbit drag
+does not thrash every wall piece's cutaway classification on every animation
+frame.
+
+### Fallback honesty — verified live, not just argued
+
+Every real piece (`RealEdgeWallPiece`/`RealEdgeDoorPiece`/`RealWallLineRun`/
+`RealWallLineDoorPiece`) is wrapped in its own `GlbFallbackBoundary` —
+`ErrorBoundary` (`@/components/ui/Feedback/ErrorBoundary`, the SAME component
+`HexGrid.tsx` already wraps `SyntyHexWall`/`WallRunMesh` in) whose fallback is
+the EXACT `WallBox`/`DoorGap` geometry that piece rendered as before this
+unit. Verified by routing every wall/door GLB request to a real 404
+(Playwright's `page.route`) against the live showcase dungeon: the whole
+perimeter fell back cleanly to the flat placeholder boxes — no crash, no
+blank canvas, no invisible wall — with exactly 4 deduped console warnings
+(one per distinct failed FILE — the 3 wall variants + the door frame; a door
+LEAF failure never separately logged because the frame's own boundary already
+wraps both GLBs in one group, see below) rather than one per failed instance
+(196 edges' worth). The dedup is `RealWallPieces.tsx`'s own
+`warnGlbFallbackOnce`; React's `ErrorBoundary` component itself still logs its
+own `console.error` once per catch (per-instance, not deduped — that's the
+shared component's existing behavior, unchanged by this unit) — a real, named
+tradeoff of per-wall (not per-scene) fallback granularity, not silently
+smoothed over.
+
+### Live verification
+
+Own dev server (`vite --port 5195`), `public/models/synty/` rsync'd from a
+sibling worktree (this file's own established provenance precedent),
+Chromium headless with `--use-angle=swiftshader --enable-unsafe-swiftshader`.
+
+- **Edit mode, showcase.yaml (server-truth `FloorPlan.edges`, 196
+  edges/2 doors)**: switched to 3D — Orbit's default framing already shows
+  the full room perimeter as real stone/brick wall panels (screenshot), not
+  flat white boxes; zoomed in close — visible per-edge variety (plain/broken/
+  alcove textures distinguishable at a glance), pillars, and the antechamber's
+  own braziers lit against the wall texture. Play mode: the game's own
+  tactical rig, same real walls, WASD-follow confirmed working (unchanged
+  from the prior unit — this round only changed what the walls/doors ARE
+  made of, not camera behavior). Walk mode: first-person corridor,
+  full-height real brick walls filling the frame, brazier warm light falling
+  across the texture — the literal "money shot" (a real-walled, lit
+  corridor), confirmed at both the initial spawn point and after ~1.2s of
+  forward movement (a visibly different wall face in frame, proving genuine
+  movement, not a frozen shot).
+- **Door pieces — confirmed via network request, not just a screenshot**:
+  headless Chromium's own request log shows `SM_Env_Door_Frame_01.glb` AND
+  `SM_Env_Door_01.glb` both fetched successfully during the edit-mode
+  session (alongside all 3 wall variants) — definitive proof the real door
+  piece mounted and loaded, even though this round's screenshot hunting
+  (multiple zoom/pan/rotate attempts around the antechamber↔shrine
+  connector) never isolated a single frame with the door piece unambiguously
+  in view at a scale a human could confirm by eye alone — named honestly as
+  this round's one incomplete piece of VISUAL (as opposed to load-confirmed)
+  evidence, not silently claimed.
+- **Fallback**: see "Fallback honesty" above — live-verified with real
+  simulated 404s, not just code-read.
+- **Creation mode (canvas doc, no `FloorPlan`, "▶ Play the pitch" demo
+  script — `doc.walls` only, no `wallLines:` in this particular scripted
+  demo)**: the demo's own drawn walls render as real Synty pieces in 3D
+  Orbit, confirming the edge-native path is genuinely mode-agnostic (no
+  `floorPlan` needed) rather than edit-mode-only — matches every prior
+  3D-preview round's own "confirms the component is genuinely mode-agnostic"
+  standard.
+- No unexpected console errors in any successful (non-404-simulated) run,
+  beyond the two pre-existing FIXTURES-MODE `[unimplemented] AuthoringService`
+  errors every prior round's own live-verification section already notes.
+
+**What this round's live pass did NOT independently exercise**: a `wallLines:`
+straight run + its own door in either mode (the demo script used for creation-
+mode verification authors `doc.walls` only, not `wallLines:`) — `RealWallLineRun`/
+`RealWallLineDoorPiece`'s own geometry (tiling, facing, door placement) is
+proven by `wallPieceHelpers.test.ts`/`DungeonPreview3D.test.ts`'s
+`buildWallLineSegments`/`start`/`end` tests instead, not a live screenshot this
+round. A real follow-up, not a silent gap.
+
+### Performance — piece counts, instancing
+
+`GlbInstance`'s own baked-geometry cache (keyed by `file|sx|sy|sz`) already
+gives per-edge walls near-maximal sharing for free: every "plain" edge-native
+piece uses the SAME calibrated scale (`wallVariantScale` always squeezes to
+exactly one hex edge, regardless of which specific edge), so all ~150+ plain
+edges in the showcase dungeon share ONE baked geometry entry per variant (3
+total: plain/broken/alcove) — no new instancing work needed, this falls out
+of reusing `GlbInstance` as-is. The showcase dungeon (196 edges, 2 doors)
+renders 196 wall/door GLB mounts plus 2×2 door frame/leaf mounts — the same
+order of magnitude as the box/gap placeholders it replaces (one mesh group
+per edge either way), not a multiplier.
+
+### Tests
+
+22 new: `wallPieceHelpers.test.ts` (18 — `resolveWallPieceFacing` against a
+REAL `hexEdgeBetween`-derived edge, not a synthetic point, cross-checking the
+facing direction via dot product against each side's true world-space center;
+`facingCutawayHeight`'s disabled/null/toward/away/boundary cases;
+`resolveDoorLocked`'s null-index/unlocked/locked/out-of-range cases) + 4 in
+`DungeonPreview3D.test.ts` (the existing single-edge `wallLines:` test
+extended to assert `start`/`end` match the same independently-derived corner
+points `position`/`length` already do). Full `src/concepts/dungeon-builder`
+suite: 425 tests passing (up from 403). `ci-check`-equivalent clean
+(`npm run typecheck`, `npm run lint`, `npx vitest run` all clean — `npm run
+build` not re-run separately this round beyond `tsc -b`'s own project-wide
+check, which passed).
+
+### What did NOT ship this round — named, not silently dropped
+
+- **Corner/end fittings** — see "Piece provenance" above.
+- **Door open/closed animation state** — always closed pose, matching this
+  unit's own scope ("the game's door asset mounted in the gap (closed
+  pose)"); the real game's `DOOR_OPEN_ROTATION_OFFSET` swing exists and is
+  reusable later if this concept ever needs an open-door state.
+- **A live screenshot of a `wallLines:` door or a door piece in isolated
+  close-up** — see "Live verification" above; covered by unit tests and a
+  network-load confirmation instead this round.
+- **Locked-door tint for `wallLines:` doors** — `WallLineDoorDoc` has no
+  `locked:` field in the current schema (only `doc.connectors[].locked`,
+  the room-chain shape), so `resolveDoorLocked` only ever applies to
+  edge-native server-truth doors; a `wallLines:` door always renders
+  unlocked-looking, honestly (there is no lock state to read, not a dropped
+  feature).

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -803,9 +803,10 @@ export function DungeonBuilderConcept() {
                     color: '#8a7a5a',
                   }}
                 >
-                  Spike: floor + props + monsters + drawn walls/doors (crude
-                  boxes — not the real game's tiled/mitered wall pieces) — no
-                  combat/fog. See CONTRACT.md's "3D preview spike" section.
+                  Floor + props + monsters + real Synty wall/door pieces
+                  (piece-per-edge, tiled straight runs, cutaway in Orbit/Play) —
+                  no combat/fog. See CONTRACT.md's "real wall/door assets"
+                  section.
                 </div>
                 <div style={{ flex: 1, minHeight: 0 }}>
                   <DungeonPreview3D

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.test.ts
@@ -320,6 +320,16 @@ describe('buildWallLineSegments — real 3D geometry for doc.wallLines', () => {
     // WallBox piece renders at, so the two wall vocabularies share one
     // architecture (this file's own header doc comment).
     expect(seg.position[1]).toBeCloseTo(WALL_HEIGHT / 2, 6);
+
+    // real-wall-assets unit (rpg-project#169): `start`/`end` are the SAME
+    // two endpoints `position`/`length`/`rotationY` already imply — proves
+    // `RealWallPieces.tsx`'s `tileWallSegment({start, end}, ...)` call
+    // spans the identical corner-to-corner extent, not a lossy
+    // reconstruction from the trig fields.
+    expect(seg.start.x).toBeCloseTo(a.x, 6);
+    expect(seg.start.z).toBeCloseTo(a.z, 6);
+    expect(seg.end.x).toBeCloseTo(b.x, 6);
+    expect(seg.end.z).toBeCloseTo(b.z, 6);
   });
 
   it('a door mid-line splits one line into solid, door, solid — in that order, all sharing the line’s own rotation', () => {

--- a/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
+++ b/src/concepts/dungeon-builder/preview3d/DungeonPreview3D.tsx
@@ -132,12 +132,16 @@ import {
   hexCorners,
   hexEdgeBetween,
   type CubeCoord,
+  type WorldPos,
 } from '@/components/hex-grid/hexMath';
 import { resolvePropVariant } from '@/components/hex-grid/propManifest';
 import { PropModel } from '@/components/hex-grid/PropModel';
 import { SyntyHexFloor } from '@/components/hex-grid/SyntyHexFloor';
 import type { AbsoluteFloorTile } from '@/hooks/dungeonMapGeometry';
-import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
+import {
+  CUTAWAY_STUB_WALL_HEIGHT,
+  WALL_HEIGHT,
+} from '@/rendering/calibrationConstants';
 import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { Billboard, Bounds, OrbitControls, Text } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
@@ -174,6 +178,13 @@ import { regionCentroid } from '../regionGeometry';
 import type { BoardTool, PaletteSelection, PlacementSelection } from '../types';
 import { PlayCamera } from './PlayCamera';
 import { PreviewMonsterModel } from './PreviewMonsterModel';
+import {
+  CameraWardTracker,
+  RealEdgeDoorPiece,
+  RealEdgeWallPiece,
+  RealWallLineDoorPiece,
+  RealWallLineRun,
+} from './RealWallPieces';
 import { WalkCamera } from './WalkCamera';
 import {
   capWalkLights,
@@ -188,6 +199,11 @@ import {
   floorCentroid,
   resolveWalkStart,
 } from './walkMovement';
+import {
+  facingCutawayHeight,
+  resolveDoorLocked,
+  resolveWallPieceFacing,
+} from './wallPieceHelpers';
 
 /** A canvas-native floor tile has no owning room ("no room chain exists
  * yet" — `creation/emptyCanvasDoc.ts`'s own doc comment) — a plain,
@@ -306,6 +322,17 @@ interface PlacedWall {
    * `undefined` for those. See `DungeonPreview3DProps.onSelectConnector`'s
    * own doc comment for what a defined value lets a click do. */
   doorId?: string;
+  /** The edge's own `a` corner (`hexEdgeBetween`'s `HexEdge.a`) — real-wall-
+   * assets unit (rpg-project#169): a real per-edge Synty piece is placed at
+   * this corner with `rotationY`, matching `SyntyHexWall.tsx`'s own
+   * per-edge convention (`position={edge.a}`), NOT `position` (this box's
+   * own thickness-centered midpoint) — `wallVariantScale`'s squeeze-to-one-
+   * edge scale assumes the piece's local origin anchors one END of the
+   * edge, not its center. Carried through here (rather than recomputed
+   * from `wall.from`/`wall.to` a second time) so `RealWallPieces.tsx` never
+   * re-derives `hexEdgeBetween` independently of this file's own
+   * `edgeBetweenCells`. */
+  edgeA: WorldPos;
 }
 
 interface PlacedMonster {
@@ -448,6 +475,7 @@ function edgeBetweenCells(
 function wallBoxTransform(wall: ServerEdge): {
   position: [number, number, number];
   rotationY: number;
+  edgeA: WorldPos;
 } {
   const edge = edgeBetweenCells(
     wall.from[0],
@@ -458,6 +486,7 @@ function wallBoxTransform(wall: ServerEdge): {
   return {
     position: [edge.mid.x, WALL_HEIGHT / 2, edge.mid.z],
     rotationY: edge.rotationY,
+    edgeA: edge.a,
   };
 }
 
@@ -474,13 +503,14 @@ function buildWalls(
   keyPrefix: string
 ): PlacedWall[] {
   return walls.map((wall) => {
-    const { position, rotationY } = wallBoxTransform(wall);
+    const { position, rotationY, edgeA } = wallBoxTransform(wall);
     return {
       key: `${keyPrefix}:${wall.from.join(',')}-${wall.to.join(',')}`,
       position,
       rotationY,
       isDoor: wall.kind === 'door',
       doorId: wall.doorId,
+      edgeA,
     };
   });
 }
@@ -792,13 +822,22 @@ function lerp(a: number, b: number, t: number): number {
 /** One render-ready piece of a `wallLines:` entry — either a solid run or
  * a door's own gap span. `position`/`rotationY` are ready to hand
  * straight to `WallBox`/`DoorGap` unchanged; `length` doubles as
- * `WallBox`'s box width and `DoorGap`'s gap `width`. */
+ * `WallBox`'s box width and `DoorGap`'s gap `width`. `start`/`end` (real-
+ * wall-assets unit, rpg-project#169) are the SAME two world points
+ * `position ± length/2` along `rotationY` already implies, carried through
+ * directly (not reconstructed from the trig) so `RealWallPieces.tsx` can
+ * hand a 'solid' piece straight to `wallRunMeshHelpers.tileWallSegment`
+ * (which wants a `{start, end}` pair, matching `WallRunMesh.tsx`'s own
+ * `WallRunSegment` shape) without a lossy round trip through
+ * position/rotationY/length first. */
 export interface WallLineSegment {
   key: string;
   kind: 'solid' | 'door';
   position: [number, number, number];
   rotationY: number;
   length: number;
+  start: WorldPos;
+  end: WorldPos;
 }
 
 /**
@@ -875,6 +914,8 @@ export function buildWallLineSegments(doc: DungeonDoc): WallLineSegment[] {
         position: [(x0 + x1) / 2, WALL_HEIGHT / 2, (z0 + z1) / 2],
         rotationY,
         length: Math.hypot(x1 - x0, z1 - z0),
+        start: { x: x0, z: z0 },
+        end: { x: x1, z: z1 },
       });
     };
 
@@ -1022,142 +1063,11 @@ function FloorHitCell({
   );
 }
 
-// Crude box-per-edge placeholder (this file's own doc comment) — NOT the
-// real game's tiled/mitered `WallRunMesh`. Solid vs. door reuses the
-// EXACT colors the 2D board's own target-dialect structural overlay already uses for
-// the same distinction (Board.tsx/CreationBoard.tsx: '#e8e2d8' solid,
-// '#ffb347' door) — one visual language for "this is a drawn wall" across
-// both previews, same principle the hole rendering already established.
-const WALL_SOLID_COLOR = '#e8e2d8';
-const WALL_DOOR_COLOR = '#ffb347';
-const WALL_THICKNESS = 0.12;
-
-/** `length` defaults to `HEX_SIZE` — a single edge-native `doc.walls`/
- * server-truth wall piece is always exactly one hex-edge long. A straight
- * `wallLines:` segment (`buildWallLineSegments`) is typically several
- * hexes long and passes its own real `length` instead — same box, same
- * material, genuinely variable length, so the two wall vocabularies read
- * as one architecture rather than two renderers. */
-function WallBox({
-  position,
-  rotationY,
-  length = HEX_SIZE,
-}: {
-  position: [number, number, number];
-  rotationY: number;
-  length?: number;
-}) {
-  return (
-    <mesh position={position} rotation={[0, rotationY, 0]}>
-      <boxGeometry args={[length, WALL_HEIGHT, WALL_THICKNESS]} />
-      <meshStandardMaterial color={WALL_SOLID_COLOR} />
-    </mesh>
-  );
-}
-
-// A genuine gap, not a shortened box (the "marked door, not a walkable
-// door" limitation this file's header doc comment used to name as the
-// next fidelity step — closed by this unit). Two solid jambs flank an
-// OPEN, walkable span; a thin lintel piece reads as a door frame without
-// blocking the opening below it. Kirk's own framing for the door-row void
-// this same construct answers on the floor side: "the gash becomes a real
-// doorway."
-const DOOR_JAMB_WIDTH = HEX_SIZE * 0.22;
-const DOOR_OPENING_HEIGHT = WALL_HEIGHT * 0.8;
-const DOOR_LINTEL_HEIGHT = WALL_HEIGHT - DOOR_OPENING_HEIGHT;
-// Wide/tall enough to comfortably catch a click near the opening without
-// competing with the floor hit-cell or an adjacent placement's own hit
-// area — invisible, `FloorHitCell`'s own "transparent but interactive"
-// pattern, not a new one.
-const DOOR_CLICK_HIT_THICKNESS = WALL_THICKNESS * 2.5;
-
-/** Local-space X offset (along the wall's OWN length, before rotation)
- * rotated into a world-space `{dx, dz}` pair — Three.js's standard Y-axis
- * rotation matrix (`x' = x·cos θ + z·sin θ`, `z' = -x·sin θ + z·cos θ`,
- * evaluated at local `z = 0`). Used to place the two door jambs
- * symmetrically about the wall's own midpoint without hand-deriving a new
- * rotation per caller. */
-function rotateLocalXOffset(
-  rotationY: number,
-  localX: number
-): { dx: number; dz: number } {
-  return {
-    dx: localX * Math.cos(rotationY),
-    dz: -localX * Math.sin(rotationY),
-  };
-}
-
-/** `width` defaults to `HEX_SIZE` (an edge-native door's own fixed gap
- * span) — a straight `wallLines:` door's gap (`buildWallLineSegments`)
- * passes its own real interval width instead, since a corner-anchored
- * line's clip interval through its door cell isn't necessarily a full hex
- * width. Jamb width is clamped to `width / 2` so a genuinely narrow gap
- * (a shallow clip near a cell's edge) still produces two jambs meeting in
- * the middle rather than overlapping/inverting; the opening (and its
- * lintel) shrinks to fill whatever's left, never negative. */
-function DoorGap({
-  position,
-  rotationY,
-  width = HEX_SIZE,
-  onSelectDoor,
-}: {
-  position: [number, number, number];
-  rotationY: number;
-  width?: number;
-  onSelectDoor?: () => void;
-}) {
-  const jambWidth = Math.min(DOOR_JAMB_WIDTH, width / 2);
-  const openingWidth = Math.max(width - jambWidth * 2, 0);
-  const jambOffset = width / 2 - jambWidth / 2;
-  const left = rotateLocalXOffset(rotationY, jambOffset);
-  const right = rotateLocalXOffset(rotationY, -jambOffset);
-  return (
-    <group>
-      <mesh
-        position={[position[0] + left.dx, position[1], position[2] + left.dz]}
-        rotation={[0, rotationY, 0]}
-      >
-        <boxGeometry args={[jambWidth, WALL_HEIGHT, WALL_THICKNESS]} />
-        <meshStandardMaterial color={WALL_DOOR_COLOR} />
-      </mesh>
-      <mesh
-        position={[position[0] + right.dx, position[1], position[2] + right.dz]}
-        rotation={[0, rotationY, 0]}
-      >
-        <boxGeometry args={[jambWidth, WALL_HEIGHT, WALL_THICKNESS]} />
-        <meshStandardMaterial color={WALL_DOOR_COLOR} />
-      </mesh>
-      {openingWidth > 0 && (
-        <mesh
-          position={[
-            position[0],
-            DOOR_OPENING_HEIGHT + DOOR_LINTEL_HEIGHT / 2,
-            position[2],
-          ]}
-          rotation={[0, rotationY, 0]}
-        >
-          <boxGeometry
-            args={[openingWidth, DOOR_LINTEL_HEIGHT, WALL_THICKNESS]}
-          />
-          <meshStandardMaterial color={WALL_DOOR_COLOR} />
-        </mesh>
-      )}
-      {onSelectDoor && (
-        <mesh
-          position={position}
-          rotation={[0, rotationY, 0]}
-          onClick={(e) => {
-            e.stopPropagation();
-            onSelectDoor();
-          }}
-        >
-          <boxGeometry args={[width, WALL_HEIGHT, DOOR_CLICK_HIT_THICKNESS]} />
-          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
-        </mesh>
-      )}
-    </group>
-  );
-}
+// Placeholder box-per-edge wall/door pieces (`placeholderWallPieces.tsx`,
+// moved out this unit — rpg-project#169's real-wall-assets unit) now serve
+// as the explicit FALLBACK tier: `RealWallPieces.tsx` renders real Synty
+// GLB pieces and falls back to these, per-instance, only when a GLB fails
+// to load — see that file's own doc comment.
 
 /** Start/end/entrance markers — genuinely ABSENT from this preview before
  * Kirk's 2026-08-02 "3D editing" arc's alignment audit named them as a
@@ -1316,6 +1226,35 @@ export function DungeonPreview3D({
   const isWalking = cameraMode === 'walk';
   const isPlaying = cameraMode === 'play';
   const isWalkingOrPlaying = isWalking || isPlaying;
+
+  // Cutaway (real-wall-assets unit, rpg-project#169): "Orbit/Play views
+  // can't see into rooms" once walls stand at real height — Walk mode
+  // stays OFF (you're inside; full walls, per this unit's own scope).
+  // `cameraWard` is the LIVE "which way is the camera, from the dungeon's
+  // own center" vector `CameraWardTracker` (mounted inside the Canvas
+  // below) feeds via a throttled `onChange` — see `wallPieceHelpers.ts`'s
+  // own header doc comment for why a fixed direction (the game's own
+  // `CAMERA_WARD_XZ`) doesn't apply to this preview's free Orbit/Play
+  // cameras. `null` until the tracker's first frame — every piece renders
+  // TALL until then, matching `facingCutawayHeight`'s own "no ward yet
+  // defaults tall" fallback.
+  const cutawayEnabled = !isWalking;
+  const [cameraWard, setCameraWard] = useState<WorldPos | null>(null);
+  const wardReference = useMemo(() => {
+    const centroid = floorCentroid(walkContext);
+    return centroid
+      ? { x: centroid.worldX, z: centroid.worldZ }
+      : { x: 0, z: 0 };
+  }, [walkContext]);
+  // "Can a player actually stand here and look at this wall?" — the
+  // per-piece facing resolver's own `isOpenCell` predicate (see
+  // `resolveWallPieceFacing`'s doc comment). Edge-native walls: real floor
+  // tile membership. `wallLines:` runs: real floor tile membership MINUS
+  // the run's own footprint (a footprint cell has a floor tile but isn't
+  // traversable — `buildWallLineFootprint`'s own doc comment).
+  const isOpenFloorCell = (key: string) => floorTiles.has(key);
+  const isOpenWallLineCell = (key: string) =>
+    floorTiles.has(key) && !wallLineFootprint.has(key);
 
   // Single entry point for every mode transition — both Walk and Play
   // need the SAME "release an engaged pointer lock before leaving Walk"
@@ -1597,43 +1536,100 @@ export function DungeonPreview3D({
                   onClickCell={handleClickCell}
                 />
               ))}
-              {[...serverWalls, ...authoredWalls].map((w) =>
-                w.isDoor ? (
-                  <DoorGap
+              {[...serverWalls, ...authoredWalls].map((w) => {
+                const edgeMid: WorldPos = {
+                  x: w.position[0],
+                  z: w.position[2],
+                };
+                const facing = resolveWallPieceFacing(
+                  edgeMid.x,
+                  edgeMid.z,
+                  w.rotationY,
+                  isOpenFloorCell
+                );
+                const wallHeight = facingCutawayHeight(
+                  facing,
+                  cameraWard,
+                  cutawayEnabled,
+                  WALL_HEIGHT,
+                  CUTAWAY_STUB_WALL_HEIGHT
+                );
+                if (w.isDoor) {
+                  const connectorIndex = floorPlan
+                    ? connectorIndexForDoorId(floorPlan, w.doorId)
+                    : null;
+                  const locked = resolveDoorLocked(
+                    doc.connectors,
+                    connectorIndex
+                  );
+                  return (
+                    <RealEdgeDoorPiece
+                      key={w.key}
+                      edgeMid={edgeMid}
+                      edgeA={w.edgeA}
+                      rotationY={w.rotationY}
+                      facing={facing}
+                      wallHeight={wallHeight}
+                      locked={locked}
+                      onSelectDoor={doorSelectHandler(
+                        w,
+                        floorPlan,
+                        effectiveOnSelectConnector
+                      )}
+                    />
+                  );
+                }
+                return (
+                  <RealEdgeWallPiece
                     key={w.key}
-                    position={w.position}
+                    edgeKey={w.key}
+                    edgeA={w.edgeA}
                     rotationY={w.rotationY}
-                    onSelectDoor={doorSelectHandler(
-                      w,
-                      floorPlan,
-                      effectiveOnSelectConnector
-                    )}
+                    facing={facing}
+                    wallHeight={wallHeight}
                   />
-                ) : (
-                  <WallBox
-                    key={w.key}
-                    position={w.position}
-                    rotationY={w.rotationY}
-                  />
-                )
-              )}
-              {wallLineSegments.map((seg) =>
-                seg.kind === 'door' ? (
-                  <DoorGap
+                );
+              })}
+              {wallLineSegments.map((seg) => {
+                const facing = resolveWallPieceFacing(
+                  seg.position[0],
+                  seg.position[2],
+                  seg.rotationY,
+                  isOpenWallLineCell
+                );
+                const wallHeight = facingCutawayHeight(
+                  facing,
+                  cameraWard,
+                  cutawayEnabled,
+                  WALL_HEIGHT,
+                  CUTAWAY_STUB_WALL_HEIGHT
+                );
+                if (seg.kind === 'door') {
+                  return (
+                    <RealWallLineDoorPiece
+                      key={seg.key}
+                      segKey={seg.key}
+                      position={{ x: seg.position[0], z: seg.position[2] }}
+                      rotationY={seg.rotationY}
+                      length={seg.length}
+                      facing={facing}
+                      wallHeight={wallHeight}
+                    />
+                  );
+                }
+                return (
+                  <RealWallLineRun
                     key={seg.key}
-                    position={seg.position}
-                    rotationY={seg.rotationY}
-                    width={seg.length}
-                  />
-                ) : (
-                  <WallBox
-                    key={seg.key}
-                    position={seg.position}
+                    segKey={seg.key}
+                    start={seg.start}
+                    end={seg.end}
                     rotationY={seg.rotationY}
                     length={seg.length}
+                    facing={facing}
+                    wallHeight={wallHeight}
                   />
-                )
-              )}
+                );
+              })}
               {props.map((p) => {
                 const variant = resolvePropVariant(p.variantRef);
                 if (!variant) return null;
@@ -1728,6 +1724,19 @@ export function DungeonPreview3D({
                 })()}
             </Bounds>
           </Suspense>
+          {/* Live camera-ward tracker for cutaway (real-wall-assets unit) —
+              always mounted, regardless of camera mode: cheap (throttled
+              per-frame dot product, `wallPieceHelpers.facingCutawayHeight`
+              already no-ops the RESULT while Walk is active via
+              `cutawayEnabled`), and avoids racing a mount/unmount against
+              camera-mode switches the way a conditionally-mounted tracker
+              would (this file's own "stale camera reference" bug, fixed
+              in the Play/Walk transition above, is exactly the class of
+              defect that class of conditional mounting invites). */}
+          <CameraWardTracker
+            reference={wardReference}
+            onChange={setCameraWard}
+          />
           {isWalking && walkStart ? (
             <WalkCamera
               ctx={walkContext}

--- a/src/concepts/dungeon-builder/preview3d/RealWallPieces.tsx
+++ b/src/concepts/dungeon-builder/preview3d/RealWallPieces.tsx
@@ -1,0 +1,456 @@
+/**
+ * RealWallPieces — the game's own Synty wall/door GLBs, mounted in place of
+ * `WallBox`/`DoorGap`'s procedural boxes (real-wall-assets unit,
+ * rpg-project#169). Kirk's verdict driving this, seen through the new Play
+ * camera: "walls are there they are just plain white. the door is there but
+ * it is a yellow placeholder looking thing... not the assets we typically
+ * load."
+ *
+ * **Reuses the real game renderers' own building blocks directly, not a
+ * re-implementation** — the same "REUSES the REAL game renderers" principle
+ * this file's sibling `DungeonPreview3D.tsx` already follows for
+ * `SyntyHexFloor`/`PropModel`:
+ * - `GlbInstance` (`@/components/hex-grid/GlbInstance`) for load/clone/
+ *   tint/bake — the exact primitive `SyntyHexWall`/`WallRunMesh` both use.
+ * - `WALL_VARIANTS`/`selectWallVariant`/`wallVariantScale`/`DOOR_FRAME_FILE`/
+ *   `DOOR_LEAF_FILE`/`doorFrameScale`/`doorLeafScale`
+ *   (`@/components/hex-grid/syntyHexWallHelpers`) — the game's own
+ *   calibrated file names/scale formulas, unchanged.
+ * - `facingCorrectedRotationY`/`tileWallSegment`
+ *   (`@/components/hex-grid/wallRunMeshHelpers`) — the game's own
+ *   front/back-asymmetric-piece and modular-tiling math, unchanged.
+ *
+ * **What this concept genuinely can't borrow**: the game's `EnvelopeRun`/
+ * `ConnectorRun.facing` (a room-envelope/connector concept this freeform
+ * authoring surface has no equivalent of) and its fixed-camera
+ * `CAMERA_WARD_XZ` cutaway test (invalid for this preview's free Orbit/Play
+ * cameras). Both are re-derived for this concept's own data/camera shape in
+ * `wallPieceHelpers.ts` — see that file's own header doc comment.
+ *
+ * **Piece-per-edge for edge-native walls, tiled for `wallLines:` runs** —
+ * matches `SyntyHexWall`'s own per-edge convention for the former (a single
+ * `WALL_VARIANTS` piece, `selectWallVariant`-chosen for edge-level variety,
+ * exactly one hex-edge wide) and `WallRunMesh`'s own tiling convention for
+ * the latter (repeated `RUN_WALL_VARIANT` ("plain" only — "a long straight
+ * run reads as deliberate architecture, not per-edge rubble variety",
+ * `WallRunMesh.tsx`'s own doc comment) instances, `tileWallSegment`'s own
+ * even-division-across-the-run scale-to-fit — the SAME choice the game
+ * makes for a run whose length isn't an exact multiple of the nominal
+ * piece width, reused here rather than inventing separate "partial end
+ * piece" handling: a run is NEVER left with a leftover partial piece,
+ * every tile is evenly (near-imperceptibly) stretched/squeezed to fill its
+ * own even slot instead).
+ *
+ * **Doors always render at their calibrated nominal width** (`DOOR_FRAME_
+ * CALIBRATED_WIDTH = 1.0`, centered on the door's own real midpoint) even
+ * for a `wallLines:` door whose own clip interval is narrower or wider —
+ * deliberate: the door frame/leaf GLBs are authored art, not a
+ * procedurally-any-width box like `DoorGap`, and non-uniformly stretching
+ * them to fit an arbitrary interval would visibly distort the asset. Only
+ * the FLANKING solid tiling honors the exact clip boundary; the door
+ * itself borrows the game's own "doors are always exactly one calibrated
+ * width" convention (no `ConnectorRun`/`SyntyHexWall` door is ever
+ * stretched either).
+ *
+ * **Corner/end fittings are OUT of scope this round** — `classifyWallVertices`/
+ * `wallEndEdgeKeys` (`syntyHexWallHelpers.ts`) are built around the game's
+ * own `Wall[]`/cube-coordinate model; adapting them to this concept's two
+ * genuinely different wall shapes (edge-native col/row pairs AND
+ * corner-anchored world-space runs, neither a `Wall[]`) is real, separable
+ * work, not a quick reuse — named here as a real follow-up, not a silent
+ * gap. Two edge/run pieces meeting at a corner simply place independently
+ * today (no visible defect for a box-shaped placeholder; a real GLB piece
+ * may show a small seam at a corner until fittings land).
+ *
+ * **Fallback honesty**: every real piece is wrapped in its own
+ * `GlbFallbackBoundary` — a GLB load failure for THIS wall/door falls back
+ * to exactly the `WallBox`/`DoorGap` geometry that same wall/door rendered
+ * as before this unit (never a crash, never an invisible wall), with a
+ * console warning deduped per (asset, error) pair so a systemically broken
+ * file doesn't spam the console once per instance.
+ */
+import { GlbInstance } from '@/components/hex-grid/GlbInstance';
+import type { WorldPos } from '@/components/hex-grid/hexMath';
+import {
+  DOOR_FRAME_FILE,
+  DOOR_LEAF_FILE,
+  doorFrameScale,
+  doorLeafScale,
+  selectWallVariant,
+  WALL_VARIANTS,
+  wallVariantScale,
+} from '@/components/hex-grid/syntyHexWallHelpers';
+import {
+  facingCorrectedRotationY,
+  tileWallSegment,
+} from '@/components/hex-grid/wallRunMeshHelpers';
+import { ErrorBoundary } from '@/components/ui/Feedback/ErrorBoundary';
+import { SYNTY_SCALE } from '@/rendering/calibrationConstants';
+import { useFrame } from '@react-three/fiber';
+import { useMemo, useRef, type ReactNode } from 'react';
+import * as THREE from 'three';
+import { DoorGap, WallBox } from './placeholderWallPieces';
+
+// The game's own tiling variant for a straight RUN (WallRunMesh.tsx's
+// `RUN_WALL_VARIANT`/`NOMINAL_PIECE_WIDTH`/`RUN_WALL_PIVOT_RATIO`/
+// `RUN_WALL_TILE_OVERLAP_MARGIN` — copied, not imported: those four are
+// `const`s private to that file, not exported, and re-deriving them from
+// `WALL_VARIANTS[0]` here is a two-line read of already-public data, not a
+// second source of truth for the underlying numbers (`WALL_VARIANTS`
+// itself IS imported, unchanged).
+const RUN_WALL_VARIANT = WALL_VARIANTS[0]!;
+const RUN_NOMINAL_PIECE_WIDTH = 1.0;
+const RUN_WALL_PIVOT_RATIO =
+  RUN_WALL_VARIANT.rawMinX / RUN_WALL_VARIANT.rawWidth;
+const RUN_WALL_TILE_OVERLAP_MARGIN = 0.08;
+
+// SyntyHexWall.tsx's own `LOCKED_DOOR_TINT` — a COPY, not an import (same
+// "dialect-runs-ahead, stay self-contained" precedent `walkLighting.ts`
+// already set for this concept when it copied the game's mood-light specs
+// rather than importing a game-route-coupled module).
+const LOCKED_DOOR_TINT = new THREE.Color(0.36, 0.31, 0.27);
+
+let glbFallbackWarnings: Set<string> | undefined;
+
+/** One console.warn per (asset, error message) pair for the life of the
+ * page — a systemically missing/broken GLB fails for every instance that
+ * requests it (every edge of a long wall run, say), and this concept's own
+ * testing discipline never mounts the real `<Canvas>` tree (jsdom can't
+ * render WebGL), so this can't be exercised by a unit test either way;
+ * kept simple rather than plumbed through as a prop nobody would test. */
+function warnGlbFallbackOnce(assetLabel: string, error: Error): void {
+  glbFallbackWarnings ??= new Set<string>();
+  const key = `${assetLabel}::${error.message}`;
+  if (glbFallbackWarnings.has(key)) return;
+  glbFallbackWarnings.add(key);
+  console.warn(
+    `[DungeonPreview3D] real wall asset failed to load (${assetLabel}) — falling back to the placeholder box/gap.`,
+    error
+  );
+}
+
+/** Wraps `children` (real GLB pieces) in an `ErrorBoundary` whose fallback
+ * is the exact placeholder geometry that piece rendered as before this
+ * unit — "the placeholder tier becomes the explicit fallback tier," not a
+ * competing look. */
+function GlbFallbackBoundary({
+  assetLabel,
+  fallback,
+  children,
+}: {
+  assetLabel: string;
+  fallback: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <ErrorBoundary
+      fallback={fallback}
+      onError={(error) => warnGlbFallbackOnce(assetLabel, error)}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+/**
+ * A single hex-edge wall piece (`doc.walls`/server-truth `FloorPlan.edges`,
+ * always exactly one hex-edge long) — `SyntyHexWall`'s own per-edge
+ * convention: one `selectWallVariant`-chosen piece, positioned at the
+ * edge's own `a` corner (NOT its midpoint — `wallVariantScale`'s
+ * squeeze-to-one-edge scale assumes the piece's local origin anchors one
+ * END of the edge, matching every other per-edge Synty piece in this
+ * codebase), facing-corrected so its detailed face points toward the
+ * walkable side.
+ */
+export function RealEdgeWallPiece({
+  edgeKey,
+  edgeA,
+  rotationY,
+  facing,
+  wallHeight,
+}: {
+  /** `WallEdgeSegment.key`-shaped stable id (this concept's own
+   * `PlacedWall.key` works fine) — deterministic per-edge variant
+   * selection, matching `selectWallVariant`'s own doc comment ("the same
+   * edge always picks the same variant across renders"). */
+  edgeKey: string;
+  edgeA: WorldPos;
+  rotationY: number;
+  facing: WorldPos;
+  wallHeight: number;
+}) {
+  const variant = useMemo(() => selectWallVariant(edgeKey), [edgeKey]);
+  const correctedRotationY = facingCorrectedRotationY(rotationY, facing);
+  return (
+    <GlbFallbackBoundary
+      assetLabel={variant.file}
+      fallback={
+        <WallBox
+          position={[
+            /* placeholder's own thickness-centered box wants the edge's
+             * MIDPOINT, not `edgeA` — recovered from `edgeA`/`rotationY`
+             * by walking back HALF the calibrated edge width along the
+             * (un-corrected) direction, since `WallBox`'s own rotation
+             * doesn't care about front/back (a symmetric box). */
+            edgeA.x + Math.cos(rotationY) * 0.5,
+            wallHeight / 2,
+            edgeA.z - Math.sin(rotationY) * 0.5,
+          ]}
+          rotationY={rotationY}
+          wallHeight={wallHeight}
+        />
+      }
+    >
+      <GlbInstance
+        file={variant.file}
+        position={edgeA}
+        rotationY={correctedRotationY}
+        scale={wallVariantScale(variant, wallHeight, SYNTY_SCALE)}
+      />
+    </GlbFallbackBoundary>
+  );
+}
+
+/**
+ * A single hex-edge door (frame + leaf, closed pose) — server-truth OR
+ * authored `doc.walls`, both share this component (matches the pre-this-
+ * unit `DoorGap` behavior: "both go through the same branch now").
+ */
+export function RealEdgeDoorPiece({
+  edgeMid,
+  edgeA,
+  rotationY,
+  facing,
+  wallHeight,
+  locked,
+  onSelectDoor,
+}: {
+  edgeMid: WorldPos;
+  edgeA: WorldPos;
+  rotationY: number;
+  facing: WorldPos;
+  wallHeight: number;
+  locked: boolean;
+  onSelectDoor?: () => void;
+}) {
+  const correctedRotationY = facingCorrectedRotationY(rotationY, facing);
+  return (
+    <GlbFallbackBoundary
+      assetLabel={DOOR_FRAME_FILE}
+      fallback={
+        <DoorGap
+          position={[edgeMid.x, wallHeight / 2, edgeMid.z]}
+          rotationY={rotationY}
+          wallHeight={wallHeight}
+          onSelectDoor={onSelectDoor}
+        />
+      }
+    >
+      <group>
+        <GlbInstance
+          file={DOOR_FRAME_FILE}
+          position={edgeMid}
+          rotationY={correctedRotationY}
+          scale={doorFrameScale(wallHeight)}
+        />
+        <GlbInstance
+          file={DOOR_LEAF_FILE}
+          position={edgeA}
+          rotationY={correctedRotationY}
+          scale={doorLeafScale(wallHeight)}
+          tint={locked ? LOCKED_DOOR_TINT : undefined}
+        />
+        {onSelectDoor && (
+          <mesh
+            position={[edgeMid.x, wallHeight / 2, edgeMid.z]}
+            rotation={[0, rotationY, 0]}
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelectDoor();
+            }}
+          >
+            <boxGeometry args={[1.0, wallHeight, 0.3]} />
+            <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+          </mesh>
+        )}
+      </group>
+    </GlbFallbackBoundary>
+  );
+}
+
+/**
+ * A `wallLines:` straight run's own SOLID piece — tiled real Synty pieces
+ * (`tileWallSegment`, the game's own modular-run convention), one
+ * `GlbFallbackBoundary` for the WHOLE run-piece (a broken/missing GLB
+ * affects every tile identically, since they all request the same file —
+ * one boundary matches that failure shape, and avoids one class-component
+ * instance per tile).
+ */
+export function RealWallLineRun({
+  segKey,
+  start,
+  end,
+  rotationY,
+  length,
+  facing,
+  wallHeight,
+}: {
+  segKey: string;
+  start: WorldPos;
+  end: WorldPos;
+  rotationY: number;
+  length: number;
+  facing: WorldPos;
+  wallHeight: number;
+}) {
+  const pieces = useMemo(
+    () =>
+      tileWallSegment(
+        { start, end },
+        RUN_NOMINAL_PIECE_WIDTH,
+        RUN_WALL_PIVOT_RATIO,
+        facing,
+        RUN_WALL_TILE_OVERLAP_MARGIN
+      ),
+    [start, end, facing]
+  );
+  const position: [number, number, number] = [
+    (start.x + end.x) / 2,
+    wallHeight / 2,
+    (start.z + end.z) / 2,
+  ];
+  return (
+    <GlbFallbackBoundary
+      assetLabel={`${RUN_WALL_VARIANT.file} (run ${segKey})`}
+      fallback={
+        <WallBox
+          position={position}
+          rotationY={rotationY}
+          length={length}
+          wallHeight={wallHeight}
+        />
+      }
+    >
+      <>
+        {pieces.map((piece, i) => (
+          <GlbInstance
+            key={`${segKey}-${i}`}
+            file={RUN_WALL_VARIANT.file}
+            position={piece.position}
+            rotationY={piece.rotationY}
+            scale={[
+              piece.pieceWidth / RUN_WALL_VARIANT.rawWidth,
+              wallHeight / RUN_WALL_VARIANT.rawHeight,
+              SYNTY_SCALE,
+            ]}
+          />
+        ))}
+      </>
+    </GlbFallbackBoundary>
+  );
+}
+
+/**
+ * A `wallLines:` door segment — see this file's own header doc comment for
+ * why it renders at the calibrated nominal width (1.0) centered on the
+ * segment's own midpoint rather than stretched to `length`. No
+ * `onSelectDoor` — a `wallLines:` door has no connector/doorId
+ * correlation, matching the pre-this-unit `DoorGap` call site for this
+ * same segment (never wired either).
+ */
+export function RealWallLineDoorPiece({
+  segKey,
+  position,
+  rotationY,
+  length,
+  facing,
+  wallHeight,
+}: {
+  segKey: string;
+  position: WorldPos;
+  rotationY: number;
+  length: number;
+  facing: WorldPos;
+  wallHeight: number;
+}) {
+  const correctedRotationY = facingCorrectedRotationY(rotationY, facing);
+  // Leaf pivot offset — half the calibrated nominal width, along the
+  // CORRECTED direction (matches `SyntyHexWall.tsx`'s own plane-override
+  // leaf-offset formula: `dirX = cos(rotationY)`, `dirZ = -sin(rotationY)`,
+  // applied post-correction so the leaf sits flush against whichever side
+  // of the frame the correction actually left facing "forward").
+  const dirX = Math.cos(correctedRotationY);
+  const dirZ = -Math.sin(correctedRotationY);
+  const leafPos: WorldPos = {
+    x: position.x - dirX * 0.5,
+    z: position.z - dirZ * 0.5,
+  };
+  return (
+    <GlbFallbackBoundary
+      assetLabel={`${DOOR_FRAME_FILE} (wallLine ${segKey})`}
+      fallback={
+        <DoorGap
+          position={[position.x, wallHeight / 2, position.z]}
+          rotationY={rotationY}
+          width={length}
+          wallHeight={wallHeight}
+        />
+      }
+    >
+      <group>
+        <GlbInstance
+          file={DOOR_FRAME_FILE}
+          position={position}
+          rotationY={correctedRotationY}
+          scale={doorFrameScale(wallHeight)}
+        />
+        <GlbInstance
+          file={DOOR_LEAF_FILE}
+          position={leafPos}
+          rotationY={correctedRotationY}
+          scale={doorLeafScale(wallHeight)}
+        />
+      </group>
+    </GlbFallbackBoundary>
+  );
+}
+
+// Dot-product threshold gating a camera-ward update (~5.7 degrees) — see
+// `CameraWardTracker`'s own doc comment for why this exists at all
+// (avoiding a React re-render on every Orbit-drag frame).
+const CAMERA_WARD_UPDATE_DOT_THRESHOLD = 0.995;
+
+/**
+ * Live camera-ward tracker — mounted once inside `<Canvas>`, feeds
+ * `wallPieceHelpers.facingCutawayHeight` a per-frame-fresh (but
+ * update-throttled) "which way is the camera, from the dungeon's own
+ * center" vector, since this preview's Orbit/Play cameras are free to move
+ * (unlike the game's own fixed isometric rig `CAMERA_WARD_XZ` is
+ * calibrated against — see `wallPieceHelpers.ts`'s own header doc
+ * comment). Returns `null` (renders nothing) — it's a pure side-channel
+ * that calls `onChange`, not a visual component.
+ */
+export function CameraWardTracker({
+  reference,
+  onChange,
+}: {
+  reference: WorldPos;
+  onChange: (ward: WorldPos) => void;
+}) {
+  const lastRef = useRef<WorldPos | null>(null);
+  useFrame(({ camera }) => {
+    const dx = camera.position.x - reference.x;
+    const dz = camera.position.z - reference.z;
+    const len = Math.hypot(dx, dz);
+    if (len < 1e-6) return; // camera directly overhead — no defensible XZ ward this frame, keep the last one
+    const ward: WorldPos = { x: dx / len, z: dz / len };
+    const last = lastRef.current;
+    if (last) {
+      const dot = last.x * ward.x + last.z * ward.z;
+      if (dot > CAMERA_WARD_UPDATE_DOT_THRESHOLD) return;
+    }
+    lastRef.current = ward;
+    onChange(ward);
+  });
+  return null;
+}

--- a/src/concepts/dungeon-builder/preview3d/placeholderWallPieces.tsx
+++ b/src/concepts/dungeon-builder/preview3d/placeholderWallPieces.tsx
@@ -1,0 +1,159 @@
+/**
+ * placeholderWallPieces — the crude box-per-edge wall/door renderer
+ * `DungeonPreview3D.tsx` used exclusively before the real-wall-assets unit
+ * (rpg-project#169). Split out (unchanged behavior — a pure move, not a
+ * rewrite) so the new real-Synty-piece renderer (`RealWallPieces.tsx`) can
+ * import these as its own ErrorBoundary fallback: "when a wall GLB fails to
+ * load/missing, fall back to the current WallBox/DoorGap (never crash,
+ * never invisible)" — the placeholder tier becomes the explicit fallback
+ * tier, not a competing implementation `DungeonPreview3D.tsx` would
+ * otherwise have to import from two directions (a real
+ * `RealWallPieces.tsx` <-> `DungeonPreview3D.tsx` cycle, since the real
+ * renderer needs these as its own fallback).
+ *
+ * One behavioral widening over the pre-move version: both now accept an
+ * optional `wallHeight` (defaulting to `WALL_HEIGHT`, so every pre-existing
+ * caller renders byte-identical) — the cutaway unit's stub height applies
+ * to a FALLBACK box exactly like it applies to a real GLB piece, so a
+ * broken-asset wall reads as "the same wall, cruder," not as a wall that
+ * ignores cutaway entirely and stands full-height next to stubbed real
+ * neighbors.
+ */
+import { HEX_SIZE } from '@/components/hex-grid/hexMath';
+import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
+
+// Solid vs. door reuses the EXACT colors the 2D board's own target-dialect
+// structural overlay already uses for the same distinction
+// (Board.tsx/CreationBoard.tsx: '#e8e2d8' solid, '#ffb347' door) — one
+// visual language for "this is a drawn wall" across both previews, same
+// principle the hole rendering already established.
+const WALL_SOLID_COLOR = '#e8e2d8';
+const WALL_DOOR_COLOR = '#ffb347';
+const WALL_THICKNESS = 0.12;
+
+/** `length` defaults to `HEX_SIZE` — a single edge-native `doc.walls`/
+ * server-truth wall piece is always exactly one hex-edge long. A straight
+ * `wallLines:` segment (`buildWallLineSegments`) is typically several
+ * hexes long and passes its own real `length` instead — same box, same
+ * material, genuinely variable length, so the two wall vocabularies read
+ * as one architecture rather than two renderers. */
+export function WallBox({
+  position,
+  rotationY,
+  length = HEX_SIZE,
+  wallHeight = WALL_HEIGHT,
+}: {
+  position: [number, number, number];
+  rotationY: number;
+  length?: number;
+  wallHeight?: number;
+}) {
+  return (
+    <mesh position={position} rotation={[0, rotationY, 0]}>
+      <boxGeometry args={[length, wallHeight, WALL_THICKNESS]} />
+      <meshStandardMaterial color={WALL_SOLID_COLOR} />
+    </mesh>
+  );
+}
+
+const DOOR_JAMB_WIDTH = HEX_SIZE * 0.22;
+// Wide/tall enough to comfortably catch a click near the opening without
+// competing with the floor hit-cell or an adjacent placement's own hit
+// area — invisible, `FloorHitCell`'s own "transparent but interactive"
+// pattern, not a new one.
+const DOOR_CLICK_HIT_THICKNESS = WALL_THICKNESS * 2.5;
+
+/** Local-space X offset (along the wall's OWN length, before rotation)
+ * rotated into a world-space `{dx, dz}` pair — Three.js's standard Y-axis
+ * rotation matrix (`x' = x·cos θ + z·sin θ`, `z' = -x·sin θ + z·cos θ`,
+ * evaluated at local `z = 0`). Used to place the two door jambs
+ * symmetrically about the wall's own midpoint without hand-deriving a new
+ * rotation per caller. */
+function rotateLocalXOffset(
+  rotationY: number,
+  localX: number
+): { dx: number; dz: number } {
+  return {
+    dx: localX * Math.cos(rotationY),
+    dz: -localX * Math.sin(rotationY),
+  };
+}
+
+/** A genuine gap, not a shortened box — two solid jambs flank an OPEN,
+ * walkable span; a thin lintel piece reads as a door frame without
+ * blocking the opening below it. `width` defaults to `HEX_SIZE` (an
+ * edge-native door's own fixed gap span) — a straight `wallLines:` door's
+ * gap (`buildWallLineSegments`) passes its own real interval width
+ * instead, since a corner-anchored line's clip interval through its door
+ * cell isn't necessarily a full hex width. Jamb width is clamped to
+ * `width / 2` so a genuinely narrow gap (a shallow clip near a cell's
+ * edge) still produces two jambs meeting in the middle rather than
+ * overlapping/inverting; the opening (and its lintel) shrinks to fill
+ * whatever's left, never negative. */
+export function DoorGap({
+  position,
+  rotationY,
+  width = HEX_SIZE,
+  wallHeight = WALL_HEIGHT,
+  onSelectDoor,
+}: {
+  position: [number, number, number];
+  rotationY: number;
+  width?: number;
+  wallHeight?: number;
+  onSelectDoor?: () => void;
+}) {
+  const doorOpeningHeight = wallHeight * 0.8;
+  const doorLintelHeight = wallHeight - doorOpeningHeight;
+  const jambWidth = Math.min(DOOR_JAMB_WIDTH, width / 2);
+  const openingWidth = Math.max(width - jambWidth * 2, 0);
+  const jambOffset = width / 2 - jambWidth / 2;
+  const left = rotateLocalXOffset(rotationY, jambOffset);
+  const right = rotateLocalXOffset(rotationY, -jambOffset);
+  return (
+    <group>
+      <mesh
+        position={[position[0] + left.dx, position[1], position[2] + left.dz]}
+        rotation={[0, rotationY, 0]}
+      >
+        <boxGeometry args={[jambWidth, wallHeight, WALL_THICKNESS]} />
+        <meshStandardMaterial color={WALL_DOOR_COLOR} />
+      </mesh>
+      <mesh
+        position={[position[0] + right.dx, position[1], position[2] + right.dz]}
+        rotation={[0, rotationY, 0]}
+      >
+        <boxGeometry args={[jambWidth, wallHeight, WALL_THICKNESS]} />
+        <meshStandardMaterial color={WALL_DOOR_COLOR} />
+      </mesh>
+      {openingWidth > 0 && (
+        <mesh
+          position={[
+            position[0],
+            doorOpeningHeight + doorLintelHeight / 2,
+            position[2],
+          ]}
+          rotation={[0, rotationY, 0]}
+        >
+          <boxGeometry
+            args={[openingWidth, doorLintelHeight, WALL_THICKNESS]}
+          />
+          <meshStandardMaterial color={WALL_DOOR_COLOR} />
+        </mesh>
+      )}
+      {onSelectDoor && (
+        <mesh
+          position={position}
+          rotation={[0, rotationY, 0]}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelectDoor();
+          }}
+        >
+          <boxGeometry args={[width, wallHeight, DOOR_CLICK_HIT_THICKNESS]} />
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+        </mesh>
+      )}
+    </group>
+  );
+}

--- a/src/concepts/dungeon-builder/preview3d/wallPieceHelpers.test.ts
+++ b/src/concepts/dungeon-builder/preview3d/wallPieceHelpers.test.ts
@@ -1,0 +1,170 @@
+import {
+  coordToKey,
+  cubeToWorld,
+  HEX_SIZE,
+  hexEdgeBetween,
+} from '@/components/hex-grid/hexMath';
+import { describe, expect, it } from 'vitest';
+import type { ConnectorDoc } from '../dungeonYaml';
+import { cubeAtColRow } from '../hexLayout';
+import {
+  facingCutawayHeight,
+  frontDirection,
+  resolveDoorLocked,
+  resolveWallPieceFacing,
+} from './wallPieceHelpers';
+
+describe('frontDirection — the same frontX/frontZ convention facingCorrectedRotationY derives inline', () => {
+  it('rotationY=0 points along +z (frontX=sin(0)=0, frontZ=cos(0)=1)', () => {
+    const front = frontDirection(0);
+    expect(front.x).toBeCloseTo(0, 10);
+    expect(front.z).toBeCloseTo(1, 10);
+  });
+
+  it('rotationY=PI/2 points along +x', () => {
+    const front = frontDirection(Math.PI / 2);
+    expect(front.x).toBeCloseTo(1, 10);
+    expect(front.z).toBeCloseTo(0, 10);
+  });
+});
+
+describe('resolveWallPieceFacing — which side of the wall is actually walkable floor', () => {
+  // A real hex edge between two adjacent cells (SAME primitive
+  // DungeonPreview3D.tsx's own `edgeBetweenCells` uses), not a hand-picked
+  // world point — proves the probe distance/direction against genuine hex
+  // geometry rather than an arbitrary synthetic case.
+  const fromCell = cubeAtColRow(5, 5);
+  const toCell = cubeAtColRow(6, 5);
+  const edge = hexEdgeBetween(fromCell, toCell, HEX_SIZE);
+  const fromKey = coordToKey(fromCell);
+  const toKey = coordToKey(toCell);
+
+  it('faces toward the "from" side when only it is open', () => {
+    const facing = resolveWallPieceFacing(
+      edge.mid.x,
+      edge.mid.z,
+      edge.rotationY,
+      (key) => key === fromKey
+    );
+    const fromCenter = cubeToWorld(fromCell, HEX_SIZE);
+    const towardFrom = {
+      x: fromCenter.x - edge.mid.x,
+      z: fromCenter.z - edge.mid.z,
+    };
+    const dot = facing.x * towardFrom.x + facing.z * towardFrom.z;
+    expect(dot).toBeGreaterThan(0);
+  });
+
+  it('faces toward the "to" side when only it is open (the reverse of the un-corrected front)', () => {
+    const facing = resolveWallPieceFacing(
+      edge.mid.x,
+      edge.mid.z,
+      edge.rotationY,
+      (key) => key === toKey
+    );
+    const toCenter = cubeToWorld(toCell, HEX_SIZE);
+    const towardTo = { x: toCenter.x - edge.mid.x, z: toCenter.z - edge.mid.z };
+    const dot = facing.x * towardTo.x + facing.z * towardTo.z;
+    expect(dot).toBeGreaterThan(0);
+  });
+
+  it('falls back to the un-corrected front direction when BOTH sides are open (interior wall, no single preferred side)', () => {
+    const facing = resolveWallPieceFacing(
+      edge.mid.x,
+      edge.mid.z,
+      edge.rotationY,
+      () => true
+    );
+    expect(facing).toEqual(frontDirection(edge.rotationY));
+  });
+
+  it('falls back to the un-corrected front direction when NEITHER side is open (a wall authored with no floor on either side)', () => {
+    const facing = resolveWallPieceFacing(
+      edge.mid.x,
+      edge.mid.z,
+      edge.rotationY,
+      () => false
+    );
+    expect(facing).toEqual(frontDirection(edge.rotationY));
+  });
+});
+
+describe('facingCutawayHeight — cutaway classification against a LIVE camera-ward vector', () => {
+  const tall = 2.4;
+  const stub = 0.3;
+
+  it('always returns tallHeight when cutaway is disabled, regardless of facing/ward', () => {
+    const height = facingCutawayHeight(
+      { x: 1, z: 0 },
+      { x: -1, z: 0 },
+      false,
+      tall,
+      stub
+    );
+    expect(height).toBe(tall);
+  });
+
+  it('always returns tallHeight when cameraWard has not been measured yet (null)', () => {
+    const height = facingCutawayHeight({ x: 1, z: 0 }, null, true, tall, stub);
+    expect(height).toBe(tall);
+  });
+
+  it('stubs when the walkable-side facing points AWAY from the camera (the camera is on the far side of this wall from the room)', () => {
+    // facing points toward the room (+x); camera-ward points the OPPOSITE
+    // way (-x) — the camera sits on the wall's far/outward side, meaning
+    // this wall is between the camera and the room's interior.
+    const height = facingCutawayHeight(
+      { x: 1, z: 0 },
+      { x: -1, z: 0 },
+      true,
+      tall,
+      stub
+    );
+    expect(height).toBe(stub);
+  });
+
+  it('stays tall when the walkable-side facing points TOWARD the camera (the camera is already inside/beyond the room, this wall is the far wall)', () => {
+    const height = facingCutawayHeight(
+      { x: 1, z: 0 },
+      { x: 1, z: 0 },
+      true,
+      tall,
+      stub
+    );
+    expect(height).toBe(tall);
+  });
+
+  it('stays tall at exactly a perpendicular ward (dot=0) — the strict "<0" boundary matches effectiveWallHeight\'s own ">0" boundary algebraically', () => {
+    const height = facingCutawayHeight(
+      { x: 1, z: 0 },
+      { x: 0, z: 1 },
+      true,
+      tall,
+      stub
+    );
+    expect(height).toBe(tall);
+  });
+});
+
+describe('resolveDoorLocked — locked state only resolvable via a server-truth connector correlation', () => {
+  const connectors: ConnectorDoc[] = [
+    { from: 'a', to: 'b', locked: null },
+    { from: 'b', to: 'c', locked: { dc: 15, ability: 'STR' } },
+  ];
+
+  it('returns false when there is no connector correlation at all (an authored doc.walls/wallLines door)', () => {
+    expect(resolveDoorLocked(connectors, null)).toBe(false);
+  });
+
+  it('returns false for a real connector with no locked: block', () => {
+    expect(resolveDoorLocked(connectors, 0)).toBe(false);
+  });
+
+  it('returns true for a real connector carrying a locked: block', () => {
+    expect(resolveDoorLocked(connectors, 1)).toBe(true);
+  });
+
+  it('returns false for an out-of-range index rather than throwing', () => {
+    expect(resolveDoorLocked(connectors, 99)).toBe(false);
+  });
+});

--- a/src/concepts/dungeon-builder/preview3d/wallPieceHelpers.ts
+++ b/src/concepts/dungeon-builder/preview3d/wallPieceHelpers.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure helpers for `RealWallPieces.tsx` — split out per this codebase's own
+ * convention (`wallRunMeshHelpers.ts`/`syntyHexWallHelpers.ts` vs.
+ * `WallRunMesh.tsx`/`SyntyHexWall.tsx`: pure geometry stays independent of
+ * GLB loading and react-three-fiber so it's directly unit-testable). No
+ * Three.js/R3F import here, matching `playCameraRig.ts`'s identical split.
+ *
+ * Real-wall-assets unit (rpg-project#169): mounts the game's own Synty
+ * wall/door GLBs in place of `WallBox`/`DoorGap`'s procedural boxes. Two
+ * genuinely new geometry problems this concept's own data model didn't
+ * need an answer for while walls were symmetric boxes, both solved here:
+ *
+ * 1. **Which way should an asymmetric piece face?** (`resolveWallPieceFacing`)
+ *    — the same "featureless dark slab" defect `wallRunMeshHelpers.
+ *    facingCorrectedRotationY`'s own doc comment describes for the game's
+ *    room-envelope runs, but THIS concept has no room-envelope/`facing`
+ *    concept of its own (`doc.walls`/`doc.wallLines` are freeform authored
+ *    edges/lines, not room sides with a computed outward normal) — so
+ *    there's no `EnvelopeRun.facing` to borrow. Derived here instead by
+ *    sampling which side of the piece is actually walkable floor.
+ * 2. **When should a wall stub down for cutaway?** (`facingCutawayHeight`)
+ *    — the game's own `wallRunMeshHelpers.effectiveWallHeight` dots a run's
+ *    facing against `calibrationConstants.CAMERA_WARD_XZ`, a FIXED
+ *    direction that's only valid because `HexGrid.tsx`'s camera sits at a
+ *    fixed isometric offset. This concept's Orbit/Play cameras are free to
+ *    move, so cutaway here dots against a LIVE camera-ward vector
+ *    (`CameraWardTracker` in `RealWallPieces.tsx` supplies it) instead of a
+ *    module constant — same dot-product shape, different (live, not
+ *    static) right-hand side.
+ */
+import {
+  coordToKey,
+  cubeRound,
+  HEX_SIZE,
+  worldToCube,
+  type WorldPos,
+} from '@/components/hex-grid/hexMath';
+import type { ConnectorDoc } from '../dungeonYaml';
+
+/** Local-Z ("front") world direction for a Y rotation — the SAME
+ * frontX/frontZ convention `wallRunMeshHelpers.facingCorrectedRotationY`
+ * derives inline (Three's standard Y-axis rotation applied to local
+ * +Z = (0,0,1): `frontX = sin(rotationY)`, `frontZ = cos(rotationY)`),
+ * pulled out here since both this file's `resolveWallPieceFacing` and
+ * `RealWallPieces.tsx`'s per-piece rendering need the identical vector. */
+export function frontDirection(rotationY: number): WorldPos {
+  return { x: Math.sin(rotationY), z: Math.cos(rotationY) };
+}
+
+// Just past the wall's own thickness (WALL_THICKNESS = 0.12) and safely
+// inside whichever neighboring cell the probe lands in — close enough that
+// a probe on a genuinely open cell always resolves TO that cell (not some
+// third cell further along), far enough that it clears the wall's own
+// footprint. 0.55 of a hex radius comfortably satisfies both for every
+// wall shape this file places pieces on (single-edge and multi-edge runs
+// alike — the probe is always perpendicular to the wall's own length, so
+// run length never enters into it).
+const FACING_PROBE_DISTANCE = HEX_SIZE * 0.55;
+
+/** Nearest hex cell's key (`floorTiles`/`wallLineFootprint`'s own
+ * `${x},${y},${z}` cube-coordinate format — `coordToKey`'s format exactly)
+ * for a world XZ point. */
+function worldPointCellKey(x: number, z: number): string {
+  return coordToKey(cubeRound(worldToCube({ x, z }, HEX_SIZE)));
+}
+
+/**
+ * Which way should THIS wall/door piece's detailed face point? Probes both
+ * perpendicular directions from the piece's own midpoint (`rotationY`'s
+ * `frontDirection` and its reverse) against `isOpenCell` — the caller's own
+ * "this cell is where a player can actually stand and look at this wall"
+ * predicate (edge-native walls: real floor tile membership;
+ * `wallLines:` runs: real floor tile membership MINUS the run's own
+ * footprint, since a footprint cell has a floor tile but isn't traversable
+ * — see `buildWallLineFootprint`'s own doc comment). Returns whichever
+ * probe direction resolves to an open cell; if BOTH or NEITHER do
+ * (interior wall between two rooms, or a wall authored with no floor tile
+ * on either side at all), falls back to the un-corrected front direction —
+ * a defensible, deterministic default, same shape as
+ * `ConnectorRun.facing`'s own "no provably optimal choice" precedent in
+ * `wallRuns.ts` for a wall with no single preferred side.
+ *
+ * Deliberately world-space, not cell-adjacency — this concept's two wall
+ * shapes (edge-native `{from, to}` cell pairs, and corner-anchored
+ * `wallLines:` runs with no cell-pair of their own at all) don't share a
+ * single "the two adjacent cells" representation, but they DO share a
+ * midpoint + rotationY once rendered, so probing world-space geometry
+ * (rather than, say, taking `wall.from`/`wall.to` directly) is the one
+ * approach that works unmodified for both callers in `RealWallPieces.tsx`.
+ */
+export function resolveWallPieceFacing(
+  midX: number,
+  midZ: number,
+  rotationY: number,
+  isOpenCell: (cellKey: string) => boolean
+): WorldPos {
+  const front = frontDirection(rotationY);
+  const aheadKey = worldPointCellKey(
+    midX + front.x * FACING_PROBE_DISTANCE,
+    midZ + front.z * FACING_PROBE_DISTANCE
+  );
+  const behindKey = worldPointCellKey(
+    midX - front.x * FACING_PROBE_DISTANCE,
+    midZ - front.z * FACING_PROBE_DISTANCE
+  );
+  const aheadOpen = isOpenCell(aheadKey);
+  const behindOpen = isOpenCell(behindKey);
+  if (behindOpen && !aheadOpen) return { x: -front.x, z: -front.z };
+  return front;
+}
+
+/**
+ * Cutaway classification for a wall/door piece, keyed off a LIVE
+ * camera-ward vector rather than the game's fixed `CAMERA_WARD_XZ` (see
+ * this file's own header doc comment for why a fixed direction doesn't
+ * apply to a free Orbit/Play camera). `facing` here is
+ * `resolveWallPieceFacing`'s own return value — which points TOWARD the
+ * walkable/open side (see that function's doc comment), the OPPOSITE
+ * convention from the game's `EnvelopeRun.facing` (points AWAY from the
+ * room, outward). `wallRunMeshHelpers.effectiveWallHeight`'s own rule is
+ * "outward-facing dot camera-ward > 0 => stub" (the wall's outward side
+ * faces the camera, so it sits between the camera and the room's
+ * interior); substituting `facing = -outward` flips the comparison
+ * algebraically to "inward-facing dot camera-ward < 0 => stub" — verified
+ * by direct substitution, not a re-derivation from scratch, so this stays
+ * the SAME rule the game uses, just applied to this file's own
+ * opposite-sign facing vector.
+ *
+ * `cameraWard: null` (camera-ward not yet measured, or cutaway disabled)
+ * always returns `tallHeight` — matches `effectiveWallHeight`'s own "no
+ * facing at all defaults tall" fallback.
+ */
+export function facingCutawayHeight(
+  facing: WorldPos,
+  cameraWard: WorldPos | null,
+  cutawayEnabled: boolean,
+  tallHeight: number,
+  stubHeight: number
+): number {
+  if (!cutawayEnabled || !cameraWard) return tallHeight;
+  const dot = facing.x * cameraWard.x + facing.z * cameraWard.z;
+  return dot < 0 ? stubHeight : tallHeight;
+}
+
+/**
+ * A server-truth door's locked state, read off `doc.connectors` (the ONLY
+ * place `locked:` is authorable today — `WallDoc`/`WallLineDoorDoc` have no
+ * `locked` field, see `dungeonYaml.ts`'s own `ConnectorDoc`/`WallLineDoorDoc`
+ * doc comments) via the SAME `connectorIndex` `edgesAdapter.ts`'s
+ * `connectorIndexForDoorId` already resolves for `onSelectConnector`
+ * wiring — no second doorId→connector lookup invented here.
+ * `connectorIndex: null` (no server-truth correlation — an authored
+ * `doc.walls`/`wallLines` door, or a doorId that doesn't resolve) means
+ * "can't know," not "unlocked": returns `false`, the same as a genuinely
+ * unlocked door, since this concept's UI has no way to represent "unknown"
+ * lock state and an authored door has never been lockable to begin with.
+ */
+export function resolveDoorLocked(
+  connectors: readonly ConnectorDoc[],
+  connectorIndex: number | null
+): boolean {
+  if (connectorIndex === null) return false;
+  return connectors[connectorIndex]?.locked != null;
+}


### PR DESCRIPTION
## Summary

Replaces `DungeonPreview3D`'s white `WallBox`/amber `DoorGap` placeholders with the real game's Synty GLB wall and door pieces — Kirk's verdict driving this, seen through the new Play camera: "walls are there they are just plain white. the door is there but it is a yellow placeholder looking thing... not the assets we typically load."

- **Edge-native walls/doors** (`doc.walls` / server-truth `FloorPlan.edges`): one `SyntyHexWall`-style piece per hex edge, deterministic per-edge variety (plain/broken/alcove) via `selectWallVariant`.
- **Straight `wallLines:` runs**: tiled via the game's own `tileWallSegment` (`WallRunMesh`'s modular convention), same "plain" variant only.
- **Doors**: the game's real `SM_Env_Door_Frame_01.glb` + `SM_Env_Door_01.glb`, closed pose, locked-door tint when resolvable via `doc.connectors`.
- **Facing correction**: this concept has no room-envelope `facing` concept to borrow from the game, so `resolveWallPieceFacing` derives one by probing which side of a piece is actually walkable floor, then feeds it through the game's own `facingCorrectedRotationY`.
- **Cutaway** (Orbit/Play only, never Walk): a live camera-ward vector (this preview's cameras are free, unlike the game's fixed isometric rig), same dot-product rule as the game's `effectiveWallHeight`, algebraically adapted.
- **Fallback honesty**: every real piece is wrapped in its own `ErrorBoundary`, falling back to the original `WallBox`/`DoorGap` geometry on a GLB load failure — verified live against simulated 404s (deduped console warning, no crash, no invisible wall).

Full writeup (piece provenance table, cutaway math, fallback verification, performance notes, what didn't ship) in `src/concepts/dungeon-builder/CONTRACT.md`'s new ledger entry.

## Test plan

- [x] `npm run format:check` / `npm run lint` / `npm run typecheck` / `npm run build` all clean
- [x] Full test suite: 2159 tests, 130 files passing (up from 2137/128 — 22 new tests: `wallPieceHelpers.test.ts` + `DungeonPreview3D.test.ts` additions)
- [x] Live-verified against a real dev server (rsync'd `public/models/synty/`): edit mode (showcase.yaml, 196 edges/2 doors) in Orbit/Play/Walk, creation mode (canvas doc, `doc.walls`), and a simulated GLB-404 fallback pass
- [x] Confirmed via network log that both `SM_Env_Door_Frame_01.glb` and `SM_Env_Door_01.glb` load successfully alongside all 3 wall variants

Scope: 3D piece rendering + cutaway only. 2D board unchanged. No schema changes.

— asset-pipeline agent, on behalf of KirkDiggler