### PR TITLE
unit: region brush honesty (skip + show + true blockers)

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -6090,3 +6090,191 @@ check, which passed).
   edge-native server-truth doors; a `wallLines:` door always renders
   unlocked-looking, honestly (there is no lock state to read, not a dropped
   feature).
+
+## Region-brush honesty round: overlap evidence, skip-not-reject, probe-aware canvas blocker (2026-08-06, rpg-project#180)
+
+Three fixes for live authoring friction Kirk hit painting two regions across
+a straight wall, plus a Save & Play tooltip that misled him into a dead end.
+
+**Kirk's own diagnosis, verbatim** — (a) "it says 'one or more cells already
+belong to another region'" with no indication which cells or whose; (b)
+"the shared hexes look like the unplayable piece the wall goes through" —
+his first region's brush swept up a straight wall's FOOTPRINT cells
+(rpg-project#169's own footprint hatch reads as "wall," not "claimed
+floor"), so painting a second region up to the same wall from the other
+side collided on that band and the generic message sent him hunting blind;
+(c) he then added a whole boss REGION trying to satisfy the Save & Play
+blocker "needs exactly one boss-archetype room" on a from-scratch canvas
+doc — which can never unblock it (the server rejects `canvas:` entirely
+until platform Wave 0 — rpg-project#192), so the message sent him chasing a
+ghost.
+
+### 1. Overlap rejection now names its evidence
+
+`dungeonYaml.ts`'s new `findRegionCellOverlap(doc, cells, excludeRegionId?)`
+returns which of `cells` collide and which EXISTING region owns them
+(`{ownerId, ownerName?, cells, cellCount}`), capped at the same
+`OVERLAP_SAMPLE_CELLS = 6` the region-tree unit's own `RegionOverlapWarning`
+already established as this concept's "representative handful" convention
+for an overlap cell list — now exported from `regionTree.ts` and imported
+here rather than a second copy of the same number.
+`validateRegionCells`'s overlap branch uses it to produce a concrete
+message — `"3 cells already belong to 'entrance'"` — replacing the old
+`"one or more cells already belong to another region"`.
+`cellsOverlapAnotherRegion` is now a thin boolean wrapper over the same
+function, not a second implementation.
+
+### 2. The brush paints what it can and reports what it skips
+
+Before this round, the two paint paths behaved differently and both were
+wrong in their own way:
+
+- **Painting a NOT-YET-CREATED region** (`pendingCells`,
+  `setPendingCellMembership`) did ZERO overlap validation during the brush
+  — cells silently entered `pendingCells` even if another region already
+  owned them — and only failed, ALL AT ONCE, when the Create button was
+  clicked (`createRegion`'s own whole-set `validateRegionCells` call). This
+  was the genuinely all-or-nothing case: one rejection for the entire
+  candidate set, no partial credit, no indication which of many painted
+  cells were the problem.
+- **Editing an EXISTING selected region** (`setSelectedRegionCellMembership`)
+  already skipped a rejected cell and kept going (per-cell
+  `addCellToRegion` calls), but flashed an IMMEDIATE toast per rejected
+  cell — `DungeonBuilderConcept.tsx`'s `flashToast` is a single-slot,
+  3200ms-decay banner, not a queue, so a drag crossing several owned cells
+  just flickered through several rapid replacements and only the LAST
+  message was ever actually readable.
+
+Both are now unified: `useRegionEditing.ts` gained a per-stroke accumulator
+(`beginStroke`/`endStroke`, bracketing one paint gesture — a plain click is
+just a 1-cell stroke) and both mutators pre-check
+`findRegionCellOverlap(doc, [cell], ...)` before touching state. A
+collision is recorded into the active stroke's tally
+(`recordOverlapSkip`), not applied and not immediately toasted;
+`endStroke` flushes ONE summary — `"painted 12, skipped 4 cells owned by
+'entrance'"` — grouped by owner when a stroke grazes more than one
+region's territory, and silent when nothing was skipped (matching this
+concept's existing "no toast on a clean success" convention). Non-overlap
+rejections (contiguity on add; disconnect/last-cell on erase) are
+UNCHANGED — still immediate per-cell toasts, since those aren't the
+flood-prone case this round targets and are rare single-shot events, not
+worth folding into the summary. `CreationBoard.tsx`'s region-tool pointer
+handlers call `beginStroke()` right before the first cell's own mutator
+call and `endStroke()` from the shared `handlePointerUp`.
+
+`conflictFlash` (`{cells, ownerId, ownerName?}`, cleared on the same
+3200ms timer as its paired toast) is the visual half — the exact
+cells the stroke skipped, or (via `handleCreate`'s own catch, a
+defense-in-depth path for a hand-edited YAML collision) the exact cells a
+whole-set Create rejection collided on. `CreationBoard.tsx` renders it as
+a pulsing white-outline polygon (`<animate>` on `stroke-opacity`,
+0.9s cycle) drawn LAST in the SVG child order so it always wins paint
+order regardless of what's underneath — deliberately distinct from every
+other overlay this file draws (a region's own colored tint, the footprint
+hatch's crimson diagonal, the open-boundary line's solid red).
+
+**Footprint membership, made unmistakable.** Kirk's (b) diagnosis was a
+real render-order bug: the straight-wall footprint hatch
+(`straightWallEls`, crimson diagonal pattern) painted AFTER `regionEls` in
+the old SVG child order, so it visually sat ON TOP of a region's own tint
+AND the pre-existing "⚠ footprint" warning text, burying both — a real
+membership fact read as invisible. Fixed by splitting that per-footprint-
+cell rendering into its own `regionFootprintClaimEls` array (same
+`inFootprint` check, same region color, stronger 0.55 fill opacity vs the
+base 0.18/0.32) and drawing it AFTER `straightWallEls`/`straightPreviewEls`
+instead of interleaved with the base region tint — the claim now tints
+OVER the hatch. Footprint cells remain fully paintable region members
+throughout (semantic vs. physical footprint is settled prior art — see
+rpg-project#169's own footprint unit) — this is a visibility fix, never a
+membership restriction.
+
+### 3. Probe-aware canvas save blocker
+
+`stripToV1Subset`'s `compilableBlockers` computation used to run
+dungeonspec's real chain-mode minimums (`minRooms = 2`, "exactly one
+boss-archetype room with a declared boss") UNCONDITIONALLY — including
+against a from-scratch CANVAS document, which has no `rooms:`/`boss:`
+chain at all (`emptyCanvasDoc.ts`: "a from-scratch canvas has nothing...
+no fictional room standing in for one"). A canvas doc's `strippedDoc.rooms`
+is always `[]`, so it ALWAYS failed both chain checks, and the tooltip
+told the author to fix a boss room — Kirk did exactly that, live, and it
+could never have worked: the server rejects `canvas:` itself, before
+validation ever reaches boss cardinality.
+
+Now gated on the ORIGINAL parsed `doc.canvas` (captured before this
+function's own `cst.delete('canvas')` erases the signal for the
+not-accepted case): a canvas document reports exactly one blocker,
+written against the live probe result — `accepted('canvas')` — not
+hardcoded: `"from-scratch canvas documents aren't accepted by this server
+yet (platform Wave 0 — rpg-project#192)"` when not accepted, and an EMPTY
+blocker list when it is (no invented guess at canvas's own future
+validation rules takes the old message's place — a real save attempt will
+surface whatever the server's real canvas validation turns out to
+require, once #192 ships and it's knowable). A real room-chain document
+(`!doc.canvas`) is completely unaffected — same `minRooms`/boss checks as
+before. `YamlPane.tsx`'s `SaveAndPlayButton` needed no changes at all —
+it already renders whatever `compilableBlockers` it's given verbatim;
+only the computation changed. `creation/ProposedYamlPane.tsx`'s own doc
+comment (previously describing the exact stale "needs 2 rooms" behavior
+this fix replaces) is updated to match.
+
+### Tests
+
+14 new: `dungeonYaml.test.ts` — 6 for `findRegionCellOverlap` (null on no
+collision, single-cell shape with owner name, `ownerName` vs `ownerId`
+fallback, `excludeRegionId` self-check, `OVERLAP_SAMPLE_CELLS` capping vs.
+the true `cellCount`, first-region-wins on a multi-region collision) plus
+4 for the canvas-mode `compilableBlockers` gate (not-accepted, accepted,
+no-capabilities/fixtures-mode, and a real room-chain doc proving the
+chain rules are untouched); 1 existing test's expectation updated to the
+new evidence-bearing message. `creation/useRegionEditing.test.ts` (new
+file) — 10 tests: pending-region skip-not-silently-accept, the defensive
+immediate-toast fallback outside an active stroke, a whole stroke's
+paint/skip split with the single summary toast, a clean stroke's silence,
+Kirk's own two-regions-across-a-wall-band scenario end to end (including
+that Create now succeeds first try since the band cells were never in
+`pendingCells`), the selected-region-edit path's same skip/accumulate
+behavior with non-overlap rejections staying immediate, and
+`handleCreate`'s defense-in-depth conflict-flash path. Full
+`src/concepts/dungeon-builder` suite: 460 tests, `tsc -b --noEmit` and
+`eslint` both clean.
+
+### Live verification
+
+Fresh worktree, own dev server (`public/models/synty/` rsync'd from a
+sibling worktree — a fresh worktree never has it). Reproduced Kirk's own
+scenario via a real Playwright script (native pointer events on the SVG,
+board-space→screen-space via the SAME `getScreenCTM()` transform
+`CreationBoard.tsx`'s own `toBoardPoint` uses, so click math can't drift
+from the app's real coordinate space): drew a `wallLines:` entry via the
+YAML pane, painted "Entrance Hall" straddling its real footprint band
+(verified empirically — the footprint clips to the corner-anchored line's
+actual geometry, not the nominal `cell:` coordinate the line is addressed
+from), created it, then brushed "Hallway" from the far side straight
+across into the shared band.
+
+- `docs/evidence/region-brush-honesty-footprint-tint.png` — Entrance Hall
+  alone, its 3 footprint-band cells rendering a visibly stronger tint
+  layered OVER the crimson hatch (plus the "⚠" marker), unmistakably
+  distinct from the wall's own un-owned footprint cells continuing past
+  the region's edge.
+- `docs/evidence/region-brush-honesty-collision-flash.png` — the collision
+  moment: Hallway's 8 legal pending cells (amber), Entrance Hall's 3
+  skipped footprint cells carrying BOTH the footprint-claim tint and the
+  pulsing white conflictFlash outline at once.
+- `docs/evidence/region-brush-honesty-skip-toast-fullpage.png` — full page,
+  toast banner reading `painted 8, skipped 4 cells owned by 'Entrance
+Hall'`.
+- `docs/evidence/region-brush-honesty-final-state.png` — both regions
+  committed, YAML pane confirming Entrance Hall's and Hallway's real cell
+  lists (the shared band cells appear in `entrance`'s list only).
+
+**What this round did NOT live-verify**: the canvas-mode Wave 0/#192
+tooltip specifically — no rpg-api/envoy container was running in this
+session (`serverState` stayed `unreachable`, confirmed showing the OTHER,
+also-correct branch of the same tooltip: "Server unreachable or authoring
+disabled — nothing to save to."). Covered instead by the 4 dedicated
+`stripToV1Subset` canvas-blocker tests above plus `YamlPane.test.tsx`'s
+existing (unmodified, still-passing) tests proving `SaveAndPlayButton`
+renders whatever `v1CompilableBlockers` it's handed verbatim — the exact
+seam this fix's computation feeds.

--- a/src/concepts/dungeon-builder/creation/CreationBoard.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationBoard.tsx
@@ -699,9 +699,12 @@ export function CreationBoard({
         // erase (the "modifier... removes" affordance) regardless of
         // this cell's own state; otherwise erase iff this cell is
         // already a member, matching the pre-drag-brush single-click
-        // toggle feel. `addCellToRegion`'s own overlap validation still
-        // catches a cell that belongs to another region (surfaces a
-        // toast), same as before.
+        // toggle feel. `beginStroke` opens this gesture's paint/skip
+        // tally BEFORE the first cell's own mutator call so that cell is
+        // counted too — `setSelectedRegionCellMembership` now pre-checks
+        // overlap per cell and accumulates a rejected one into the tally
+        // instead of flooding an immediate toast (region-brush honesty
+        // round — see `useRegionEditing.ts`'s own header comment).
         const region = doc.regions.find(
           (r) => r.id === regionEdit.selectedRegionId
         );
@@ -713,6 +716,7 @@ export function CreationBoard({
           : isMember
             ? 'erase'
             : 'add';
+        regionEdit.beginStroke();
         regionEdit.setSelectedRegionCellMembership(cell, mode === 'add');
         setRegionStroke({ mode, touched: new Set([cellKey]) });
         return;
@@ -747,6 +751,7 @@ export function CreationBoard({
         : isPending
           ? 'erase'
           : 'add';
+      regionEdit.beginStroke();
       regionEdit.setPendingCellMembership(cell, mode === 'add');
       setRegionStroke({ mode, touched: new Set([cellKey]) });
       return;
@@ -964,6 +969,11 @@ export function CreationBoard({
     setStroke(null);
     setDragPlacement(null);
     setRegionStroke(null);
+    // Flushes the region brush's own paint/skip tally (region-brush
+    // honesty round) — a no-op when no region-tool stroke was active this
+    // gesture (every OTHER tool's pointer-up passes through this same
+    // shared handler, and `endStroke` itself guards on that).
+    regionEdit.endStroke();
     if (draggingEndpoint) {
       const line = doc.wallLines[draggingEndpoint.lineIndex];
       const otherEnd =
@@ -1299,6 +1309,22 @@ export function CreationBoard({
   // `Board.tsx`'s read-only overlay) so a nested region's overlay draws
   // on top of its container's, "innermost visible."
   const regionEls: ReactElement[] = [];
+  // A region's claim over a straight wall's FOOTPRINT band, rendered
+  // SEPARATELY from `regionEls` and painted much later in this
+  // component's own SVG child order (after `straightWallEls`, see the
+  // return below) — region-brush honesty round, 2026-08-06. Kirk, live
+  // authoring: "the shared hexes look like the unplayable piece the wall
+  // goes through" — his first region's brush swept up a wall's footprint
+  // cells, and the crimson hatch (drawn LATER than `regionEls` in the old
+  // paint order, so it visually sat ON TOP) buried both the region's own
+  // tint AND this file's existing "⚠" warning underneath it, making a
+  // real membership fact unreadable. The fix is paint order, not new
+  // data: same `inFootprint` cells, same region color, just drawn AFTER
+  // the hatch instead of before it, at a stronger opacity so the claim is
+  // unmistakable rather than a second faint layer under a loud one. Doors
+  // NOT footprint cells are unaffected — this list is empty whenever
+  // `inFootprint` never fires for a region's own cells.
+  const regionFootprintClaimEls: ReactElement[] = [];
   for (const region of regionsByPaintOrder(doc.regions)) {
     const color = regionArchetypeColor(region.archetype);
     const selected = regionEdit.selectedRegionId === region.id;
@@ -1323,9 +1349,21 @@ export function CreationBoard({
       // makes the cell impassable, but membership is an authoring fact
       // this tool has no business silently rewriting (same "flag, don't
       // delete" discipline the placement/start/end checks below follow).
+      // Do NOT make footprint cells unpaintable — they're legal region
+      // members (semantic vs physical, settled) — this is visibility
+      // only, never a membership restriction.
       if (inFootprint(col, row)) {
         const c = creationCellCenter(col, row);
-        regionEls.push(
+        regionFootprintClaimEls.push(
+          <polygon
+            key={`region-${region.id}-${col}-${row}-fp-claim`}
+            points={corners}
+            fill={color}
+            fillOpacity={0.55}
+            stroke={color}
+            strokeWidth={2}
+            pointerEvents="none"
+          />,
           <text
             key={`region-${region.id}-${col}-${row}-fp-warn`}
             x={c.x}
@@ -1409,6 +1447,45 @@ export function CreationBoard({
       );
     }
   );
+
+  // The board's own evidence for the most recent rejected/partial region
+  // paint or create (region-brush honesty round, 2026-08-06) — Kirk: "it
+  // says 'one or more cells already belong to another region'... with NO
+  // indication which cells." `regionEdit.conflictFlash` names WHICH
+  // cells and whose (the toast, flashed by the same caller, names the
+  // owning region); this renders those cells with a pulsing white
+  // outline — deliberately distinct from every other overlay this file
+  // draws (a region's own colored tint, the footprint hatch's crimson
+  // diagonal, the open-boundary line's solid red) so "look here, THIS is
+  // what collided" can't be confused with an existing steady-state
+  // warning. Rendered LAST (see the return below) so it always wins the
+  // paint order regardless of what else is under it. SVG-native
+  // `<animate>`, not a CSS keyframe — this file has no stylesheet of its
+  // own to add one to, and this is the only element that needs to pulse.
+  const conflictFlashEls: ReactElement[] = (
+    regionEdit.conflictFlash?.cells ?? []
+  ).map(([col, row]) => {
+    const corners = creationCellPolygon(col, row, CELL_SIZE * 0.98)
+      .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+      .join(' ');
+    return (
+      <polygon
+        key={`region-conflict-${col}-${row}`}
+        points={corners}
+        fill="none"
+        stroke="#ffffff"
+        strokeWidth={3}
+        pointerEvents="none"
+      >
+        <animate
+          attributeName="stroke-opacity"
+          values="1;0.15;1"
+          dur="0.9s"
+          repeatCount="indefinite"
+        />
+      </polygon>
+    );
+  });
 
   const renderPlacement = (
     ref: string,
@@ -1558,6 +1635,11 @@ export function CreationBoard({
       {straightPreviewEls}
       {straightWallHandleEls}
       {holeEls}
+      {/* Drawn AFTER the straight-wall footprint hatch above so a
+          region's claim over a footprint/band cell tints OVER the hatch
+          instead of sitting invisibly under it — see this array's own
+          doc comment. */}
+      {regionFootprintClaimEls}
 
       {hoverEdge && (tool === 'wall' || tool === 'door') && (
         <line
@@ -1636,6 +1718,7 @@ export function CreationBoard({
         })()}
 
       {placementEls}
+      {conflictFlashEls}
     </svg>
   );
 }

--- a/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
+++ b/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
@@ -19,19 +19,25 @@
  * `stripToV1Subset` result computed in `DungeonBuilderConcept.tsx` — one
  * gating implementation, not two that could drift.
  *
- * **Why the button still reads disabled in practice, today**: creation
- * mode has no "declare a room" UI (`emptyCanvasDoc.ts`'s own doc comment
- * — `rooms: []` is the only shape this mode's board ever produces) and
- * dungeonspec's real `minRooms = 2` + "exactly one boss-archetype room"
- * requirements are unconditional, independent of which target-dialect
- * fields the server accepts (see `stripToV1Subset`'s own
- * `compilableBlockers`). So a from-scratch canvas is STILL genuinely
- * unsavable today — but the button now says so with the SPECIFIC real
- * reason ("needs at least 2 rooms (has 0)") instead of the old blanket
- * "proposed schema" claim, and an author who hand-types `rooms:`
- * declarations into this very pane (it's a real, editable CST — see
- * this doc comment's own opening) would see the button light up the
- * moment the document actually becomes compilable, same as edit mode.
+ * **Why the button still reads disabled in practice, today**: this is
+ * still a from-scratch CANVAS document (`doc.canvas` — `emptyCanvasDoc.ts`'s
+ * own doc comment: "a from-scratch canvas has nothing... no fictional
+ * room standing in for one"), and no server has shipped platform Wave 0
+ * (rpg-project#192) yet — `canvas:` itself isn't accepted. `stripToV1Subset`'s
+ * `compilableBlockers` says exactly that ("from-scratch canvas documents
+ * aren't accepted by this server yet (platform Wave 0 — rpg-project#192)")
+ * rather than dungeonspec's chain-mode `minRooms = 2`/"exactly one
+ * boss-archetype room" rules — region-brush honesty round, 2026-08-06:
+ * those rules are real, but they're validate.go's real minimums for a
+ * `rooms:` CHAIN, a shape a canvas document doesn't have and can't be
+ * made to have by adding a boss room (Kirk hit exactly this live: added
+ * a boss region trying to satisfy "needs a boss," which could never
+ * unblock a canvas doc since the server rejects `canvas:` before
+ * validation ever reaches boss cardinality). An author who hand-types a
+ * real `rooms:`/`connectors:` chain into this very pane instead of using
+ * `canvas:` (it's a real, editable CST — see this doc comment's own
+ * opening) is no longer canvas-mode and gets the chain-mode blockers
+ * back, same as edit mode.
  */
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import type { ServerCapabilities } from '../capabilityProbe';

--- a/src/concepts/dungeon-builder/creation/RegionPanel.test.tsx
+++ b/src/concepts/dungeon-builder/creation/RegionPanel.test.tsx
@@ -54,6 +54,9 @@ function stubRegionEdit(): RegionEditing {
     handleSetArchetype: vi.fn(),
     handleDelete: vi.fn(),
     handleConnect: vi.fn(),
+    conflictFlash: null,
+    beginStroke: vi.fn(),
+    endStroke: vi.fn(),
   };
 }
 

--- a/src/concepts/dungeon-builder/creation/useRegionEditing.test.ts
+++ b/src/concepts/dungeon-builder/creation/useRegionEditing.test.ts
@@ -149,6 +149,37 @@ describe('useRegionEditing — pending (not-yet-created) region paint', () => {
     expect(view.result.current.conflictFlash).toBeNull();
   });
 
+  it('an ERASE-mode stroke only counts ACTUAL removals in `painted` — dragging back over already-absent cells is a true no-op, not a phantom paint (Copilot review, PR #714)', () => {
+    const { view, flashToast, commitRegion } = setup();
+    // Seed two pending cells first, then commit a region elsewhere so
+    // this SAME stroke can also exercise an overlap skip — a pure erase
+    // stroke never skips anything (erasing can't collide), so `painted`
+    // would otherwise never surface in an observable toast at all; mixing
+    // in one skip is what makes the erase count directly assertable.
+    act(() => {
+      view.result.current.setPendingCellMembership([0, 0], true);
+      view.result.current.setPendingCellMembership([1, 0], true);
+    });
+    commitRegion('owner', 'chamber', [[9, 9]]);
+
+    act(() => {
+      view.result.current.beginStroke();
+      view.result.current.setPendingCellMembership([0, 0], false); // real removal
+      view.result.current.setPendingCellMembership([5, 5], false); // absent — no-op
+      view.result.current.setPendingCellMembership([1, 0], false); // real removal
+      view.result.current.setPendingCellMembership([5, 5], false); // absent again — still a no-op
+      view.result.current.setPendingCellMembership([9, 9], true); // owned by 'owner' — skipped
+      view.result.current.endStroke();
+    });
+
+    expect(view.result.current.pendingCells).toEqual([]);
+    // painted=2 (the two REAL removals only) — not 4 for every erase call
+    // this stroke made, and not 5 counting the skip too.
+    expect(flashToast).toHaveBeenCalledWith(
+      "painted 2, skipped 1 cell owned by 'owner'"
+    );
+  });
+
   it("Kirk's exact scenario: painting a second region up to a wall band the first region already claims skips the band, keeps the rest, and names the first region", () => {
     const { view, flashToast, commitRegion, getDoc } = setup();
     // Region A ("entrance") swept up a straight wall's footprint band —

--- a/src/concepts/dungeon-builder/creation/useRegionEditing.test.ts
+++ b/src/concepts/dungeon-builder/creation/useRegionEditing.test.ts
@@ -1,0 +1,289 @@
+/**
+ * useRegionEditing.test.ts — region-brush honesty round (2026-08-06).
+ * Covers the two behavior changes this round made to the hook (see its
+ * own header comment for the full "why"): per-cell overlap pre-checking
+ * that SKIPS an already-owned cell instead of rejecting the whole
+ * gesture, and the `beginStroke`/`endStroke` accumulator that flushes
+ * ONE honest "painted N, skipped M owned by 'X'" summary instead of a
+ * per-cell toast flood.
+ *
+ * `useRegionEditing` is a plain controlled hook — `cst`/`doc` are
+ * arguments, not internal state — so the test drives it the same way
+ * `DungeonBuilderConcept.tsx` does: a `resync()` that re-derives `doc`
+ * from the (in-place-mutated) `cst`, then `rerender()` to feed the fresh
+ * `doc` back in for the NEXT gesture. `commitRegion` bundles "create a
+ * SETUP region directly via `createRegion`, then resync+rerender" since
+ * that mutator doesn't go through the hook's own `syncFromCst`. Mid-stroke
+ * calls never need a resync/rerender: the overlap check only ever looks
+ * at OTHER regions' already-committed cells, which don't change within
+ * one stroke.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createRegion, parseDungeon, toDungeonDoc } from '../dungeonYaml';
+import type { Cell } from '../regionGeometry';
+import { emptyCanvasYaml } from './emptyCanvasDoc';
+import { useRegionEditing } from './useRegionEditing';
+
+function setup() {
+  const { cst, doc: initialDoc } = parseDungeon(emptyCanvasYaml(20, 20));
+  let doc = initialDoc;
+  const flashToast = vi.fn();
+  const syncFromCst = () => {
+    doc = toDungeonDoc(cst);
+  };
+  const view = renderHook(() =>
+    useRegionEditing(cst, doc, syncFromCst, flashToast)
+  );
+  const resync = () => {
+    doc = toDungeonDoc(cst);
+  };
+  /** Directly creates a region via the raw `dungeonYaml.ts` mutator (NOT
+   * the hook's own `handleCreate` — this is SETUP, establishing a region
+   * that already exists before the gesture under test starts) and
+   * resyncs/rerenders so the hook's next call sees it. */
+  const commitRegion = (
+    id: string,
+    archetype: string,
+    cells: Cell[],
+    name?: string
+  ) => {
+    createRegion(cst, doc, id, archetype, cells, name);
+    resync();
+    view.rerender();
+  };
+  return { cst, view, flashToast, getDoc: () => doc, commitRegion };
+}
+
+describe('useRegionEditing — pending (not-yet-created) region paint', () => {
+  it('adds a legal cell to pendingCells with no toast', () => {
+    const { view, flashToast } = setup();
+    act(() => {
+      view.result.current.setPendingCellMembership([1, 1], true);
+    });
+    expect(view.result.current.pendingCells).toEqual([[1, 1]]);
+    expect(flashToast).not.toHaveBeenCalled();
+  });
+
+  it('a cell already owned by an existing region is SKIPPED (never enters pendingCells), not silently accepted', () => {
+    const { view, commitRegion } = setup();
+    commitRegion('entrance', 'entrance', [[5, 5]]);
+
+    act(() => {
+      view.result.current.setPendingCellMembership([5, 5], true);
+    });
+
+    expect(view.result.current.pendingCells).toEqual([]);
+  });
+
+  it('outside an active stroke (defensive path), a skipped cell still flashes an immediate, evidence-bearing toast + conflictFlash', () => {
+    const { view, flashToast, commitRegion } = setup();
+    commitRegion('entrance', 'entrance', [[5, 5]]);
+
+    act(() => {
+      view.result.current.setPendingCellMembership([5, 5], true);
+    });
+
+    expect(flashToast).toHaveBeenCalledWith(
+      "cell [5,5] already belongs to 'entrance'"
+    );
+    expect(view.result.current.conflictFlash).toEqual({
+      cells: [[5, 5]],
+      ownerId: 'entrance',
+      ownerName: undefined,
+    });
+  });
+
+  it('a WHOLE STROKE paints every legal cell and skips owned ones, flushing ONE summary toast at endStroke — not a flood', () => {
+    const { view, flashToast, commitRegion } = setup();
+    commitRegion('entrance', 'entrance', [
+      [5, 5],
+      [6, 5],
+      [7, 5],
+    ]);
+
+    act(() => {
+      view.result.current.beginStroke();
+      // A stroke crossing 5 cells: 2 legal, 3 already owned by 'entrance'.
+      view.result.current.setPendingCellMembership([0, 0], true);
+      view.result.current.setPendingCellMembership([5, 5], true);
+      view.result.current.setPendingCellMembership([6, 5], true);
+      view.result.current.setPendingCellMembership([7, 5], true);
+      view.result.current.setPendingCellMembership([1, 0], true);
+    });
+    // No toast yet — the whole point is one summary at the END of the
+    // stroke, not one per rejected cell.
+    expect(flashToast).not.toHaveBeenCalled();
+
+    act(() => {
+      view.result.current.endStroke();
+    });
+
+    expect(view.result.current.pendingCells).toEqual([
+      [0, 0],
+      [1, 0],
+    ]);
+    expect(flashToast).toHaveBeenCalledTimes(1);
+    expect(flashToast).toHaveBeenCalledWith(
+      "painted 2, skipped 3 cells owned by 'entrance'"
+    );
+    expect(view.result.current.conflictFlash?.ownerId).toBe('entrance');
+    expect(view.result.current.conflictFlash?.cells).toEqual(
+      expect.arrayContaining([
+        [5, 5],
+        [6, 5],
+        [7, 5],
+      ])
+    );
+  });
+
+  it('a fully clean stroke (nothing skipped) ends silently — no toast, matching this concept\'s "no toast on success" convention', () => {
+    const { view, flashToast } = setup();
+    act(() => {
+      view.result.current.beginStroke();
+      view.result.current.setPendingCellMembership([0, 0], true);
+      view.result.current.setPendingCellMembership([1, 0], true);
+      view.result.current.endStroke();
+    });
+    expect(flashToast).not.toHaveBeenCalled();
+    expect(view.result.current.conflictFlash).toBeNull();
+  });
+
+  it("Kirk's exact scenario: painting a second region up to a wall band the first region already claims skips the band, keeps the rest, and names the first region", () => {
+    const { view, flashToast, commitRegion, getDoc } = setup();
+    // Region A ("entrance") swept up a straight wall's footprint band —
+    // cells [3,0]/[4,0]/[5,0] stand in for that band here (the actual
+    // footprint geometry is CreationBoard.tsx's concern, not this hook's
+    // — the hook only ever sees "cells," never whether they're a
+    // footprint).
+    commitRegion('entrance', 'entrance', [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+      [4, 0],
+      [5, 0],
+    ]);
+
+    // Brushing region B up to the SAME wall from the other side: 3 new
+    // legal cells, plus the 3 band cells entrance already owns.
+    act(() => {
+      view.result.current.beginStroke();
+      view.result.current.setPendingCellMembership([3, 0], true);
+      view.result.current.setPendingCellMembership([4, 0], true);
+      view.result.current.setPendingCellMembership([5, 0], true);
+      view.result.current.setPendingCellMembership([3, 1], true);
+      view.result.current.setPendingCellMembership([4, 1], true);
+      view.result.current.setPendingCellMembership([5, 1], true);
+      view.result.current.endStroke();
+    });
+
+    expect(view.result.current.pendingCells).toEqual(
+      expect.arrayContaining([
+        [3, 1],
+        [4, 1],
+        [5, 1],
+      ])
+    );
+    expect(view.result.current.pendingCells).toHaveLength(3);
+    expect(flashToast).toHaveBeenCalledWith(
+      "painted 3, skipped 3 cells owned by 'entrance'"
+    );
+
+    // The Create button now succeeds on the first try — the band cells
+    // were never in pendingCells to begin with, so createRegion's own
+    // whole-set overlap check has nothing left to reject.
+    act(() => {
+      view.result.current.handleCreate('hallway', 'corridor');
+    });
+    expect(getDoc().regions.map((r) => r.id)).toEqual(['entrance', 'hallway']);
+  });
+});
+
+describe('useRegionEditing — editing an existing SELECTED region', () => {
+  function selectRegionSetup() {
+    const s = setup();
+    s.commitRegion('owner', 'chamber', [[8, 8]]);
+    s.commitRegion('target', 'chamber', [[2, 2]]);
+    act(() => {
+      s.view.result.current.selectRegion('target');
+    });
+    return s;
+  }
+
+  it('adds a legal cell via addCellToRegion, no toast', () => {
+    const s = selectRegionSetup();
+    act(() => {
+      s.view.result.current.beginStroke();
+      s.view.result.current.setSelectedRegionCellMembership([3, 2], true);
+      s.view.result.current.endStroke();
+    });
+    expect(s.flashToast).not.toHaveBeenCalled();
+    const region = s.getDoc().regions.find((r) => r.id === 'target');
+    expect(region?.cells).toEqual(
+      expect.arrayContaining([
+        [2, 2],
+        [3, 2],
+      ])
+    );
+  });
+
+  it('an ADD that collides with another region is skipped and accumulated into the stroke summary, not applied and not immediately toasted', () => {
+    const s = selectRegionSetup();
+    act(() => {
+      s.view.result.current.beginStroke();
+      s.view.result.current.setSelectedRegionCellMembership([8, 8], true); // owned by 'owner'
+      s.view.result.current.setSelectedRegionCellMembership([3, 2], true); // legal
+    });
+    expect(s.flashToast).not.toHaveBeenCalled();
+
+    act(() => {
+      s.view.result.current.endStroke();
+    });
+    expect(s.flashToast).toHaveBeenCalledWith(
+      "painted 1, skipped 1 cell owned by 'owner'"
+    );
+    const region = s.getDoc().regions.find((r) => r.id === 'target');
+    expect(region?.cells.some((c) => c[0] === 8 && c[1] === 8)).toBe(false);
+  });
+
+  it('a non-overlap rejection (contiguity) still surfaces an IMMEDIATE toast, unchanged from before this round', () => {
+    const s = selectRegionSetup();
+    act(() => {
+      s.view.result.current.beginStroke();
+      // [19,19] is nowhere near 'target's existing cell [2,2] — a real
+      // contiguity break, not an overlap.
+      s.view.result.current.setSelectedRegionCellMembership([19, 19], true);
+    });
+    expect(s.flashToast).toHaveBeenCalledWith(
+      expect.stringMatching(/contiguous/)
+    );
+  });
+});
+
+describe('useRegionEditing — handleCreate (all-or-nothing Create-button path)', () => {
+  it('an overlap rejection from a hand-edited pendingCells set still flashes conflictFlash with the real colliding cells', () => {
+    // This path is defense-in-depth (the per-cell brush pre-check means
+    // pendingCells should never itself contain an owned cell in practice
+    // — see this file's own header comment) — exercised here by
+    // painting into pendingCells via the hook, then committing a region
+    // over that SAME cell out from under it (simulating a hand-edited
+    // YAML pane change) before Create is clicked.
+    const { view, flashToast, commitRegion } = setup();
+    act(() => {
+      view.result.current.setPendingCellMembership([9, 9], true);
+    });
+    commitRegion('late', 'chamber', [[9, 9]]);
+
+    act(() => {
+      view.result.current.handleCreate('new-region', 'chamber');
+    });
+
+    expect(flashToast).toHaveBeenCalledWith("1 cell already belongs to 'late'");
+    expect(view.result.current.conflictFlash).toEqual({
+      cells: [[9, 9]],
+      ownerId: 'late',
+      ownerName: undefined,
+    });
+  });
+});

--- a/src/concepts/dungeon-builder/creation/useRegionEditing.ts
+++ b/src/concepts/dungeon-builder/creation/useRegionEditing.ts
@@ -13,14 +13,50 @@
  * there is no edit-mode equivalent of this hook yet; edit mode renders any
  * authored `regions:` read-only (`Board.tsx`), it just doesn't offer a way
  * to create/edit them.
+ *
+ * **Region-brush honesty round (2026-08-06)**: Kirk, live authoring —
+ * (a) an overlap rejection named neither the colliding cells nor the
+ * region that owned them; (b) his own diagnosis of why: his first
+ * region's brush swept up a straight wall's FOOTPRINT cells (they read as
+ * "the wall," not "claimed floor"), so painting a SECOND region up to the
+ * same wall from the other side collided on that band, and the generic
+ * message sent him hunting blind. Two changes here:
+ *
+ * 1. **`setPendingCellMembership`/`setSelectedRegionCellMembership` now
+ *    pre-check overlap PER CELL** (`findRegionCellOverlap`, one cell at a
+ *    time — cheap, and the only shape a brush stroke ever asks) instead of
+ *    silently accepting anything into `pendingCells` and only discovering
+ *    the collision at a whole-set `handleCreate` call (genuinely
+ *    all-or-nothing before this round — see git history). A colliding
+ *    cell is never added; it's recorded into the ACTIVE stroke's
+ *    accumulator (`beginStroke`/`endStroke` below) instead of flashing an
+ *    immediate per-cell toast, so a drag crossing 4 owned cells doesn't
+ *    flood 4 toasts (each replacing the last — `DungeonBuilderConcept.tsx`'s
+ *    `flashToast` is a single-slot, no queue) and lose all but the final
+ *    one. Non-overlap rejections (contiguity, disconnect-on-erase,
+ *    last-cell-removal) are unaffected — still immediate, unchanged; they
+ *    aren't the flood-prone case this round targets.
+ * 2. **`beginStroke`/`endStroke` bracket one paint gesture** (a single
+ *    click is just a 1-cell stroke — `CreationBoard.tsx` brackets both the
+ *    same way) and flush ONE honest summary at the end: "painted 12,
+ *    skipped 4 owned by 'entrance'". Silent when nothing was skipped —
+ *    matches this concept's existing "no toast on a clean success"
+ *    convention (wall/hole painting shows none either). `conflictFlash`
+ *    is the visual half — the exact skipped/rejected cells, for
+ *    `CreationBoard.tsx`'s own flash-highlight overlay — shared with
+ *    `handleCreate`'s own all-or-nothing rejection path below, which sets
+ *    the SAME state so a Create-button collision gets the identical
+ *    evidence a brush-stroke skip does.
  */
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { Document } from 'yaml';
 import {
   addCellToRegion,
   connectRegions,
   createRegion,
   deleteRegion,
+  findRegionCellOverlap,
+  pluralCount,
   RegionValidationError,
   removeCellFromRegion,
   renameRegion,
@@ -28,9 +64,31 @@ import {
   type DungeonDoc,
 } from '../dungeonYaml';
 import type { Cell } from '../regionGeometry';
+import { OVERLAP_SAMPLE_CELLS } from '../regionTree';
 
 function cellIn(cells: readonly Cell[], cell: Cell): boolean {
   return cells.some((c) => c[0] === cell[0] && c[1] === cell[1]);
+}
+
+/** The evidence a rejected paint/create action surfaces on the board —
+ * `CreationBoard.tsx` flash-highlights exactly `cells`, the toast (already
+ * flashed by whoever set this) names `ownerName ?? ownerId` separately. */
+export interface RegionConflictFlash {
+  cells: Cell[];
+  ownerId: string;
+  ownerName?: string;
+}
+
+/** One in-progress brush stroke's tally — `painted` counts cells actually
+ * applied (add OR erase, whichever this stroke's mode is), `skippedByOwner`
+ * buckets add-mode overlap skips by the region that already owns them
+ * (almost always one bucket; a stroke that grazes two different regions'
+ * territory gets two). Erase-mode strokes never populate `skippedByOwner`
+ * — removing a cell can't collide with anything — so `endStroke` is a
+ * silent no-op for them, same as a fully clean add stroke. */
+interface StrokeStats {
+  painted: number;
+  skippedByOwner: Map<string, { name?: string; count: number; cells: Cell[] }>;
 }
 
 export function useRegionEditing(
@@ -46,6 +104,97 @@ export function useRegionEditing(
    * by selecting/deleting/connecting, so it never lingers past the moment
    * it's relevant. */
   const [justCreatedId, setJustCreatedId] = useState<string | null>(null);
+  /** The board's own flash-highlight evidence for the MOST RECENT
+   * rejected/partial paint or create — see this file's own header comment
+   * ("Region-brush honesty round"). `null` when nothing is currently
+   * flashing. */
+  const [conflictFlash, setConflictFlashState] =
+    useState<RegionConflictFlash | null>(null);
+  const conflictFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Sets `conflictFlash` and (re)starts its auto-clear timer — same
+   * 3200ms window `DungeonBuilderConcept.tsx`'s `flashToast` uses for the
+   * paired toast, so the highlight and the message it explains fade
+   * together. */
+  const flashConflict = (
+    cells: Cell[],
+    ownerId: string,
+    ownerName?: string
+  ) => {
+    setConflictFlashState({ cells, ownerId, ownerName });
+    if (conflictFlashTimer.current) clearTimeout(conflictFlashTimer.current);
+    conflictFlashTimer.current = setTimeout(
+      () => setConflictFlashState(null),
+      3200
+    );
+  };
+  /** The currently in-progress brush stroke's tally, or `null` between
+   * strokes — a `useRef`, not `useState`: it's written many times per
+   * stroke (every cell the drag crosses) and read only once, at
+   * `endStroke`, so it never needs to drive a render itself. */
+  const strokeStatsRef = useRef<StrokeStats | null>(null);
+
+  /** Starts accumulating a new brush stroke's paint/skip tally —
+   * `CreationBoard.tsx` calls this once, right before the FIRST cell's
+   * own mutator call, for every region-tool paint gesture (a plain click
+   * is just a 1-cell stroke, bracketed the same way). */
+  const beginStroke = () => {
+    strokeStatsRef.current = { painted: 0, skippedByOwner: new Map() };
+  };
+
+  /** Records one cell the active stroke couldn't paint because another
+   * region already owns it. Falls back to an immediate single-cell toast
+   * when called OUTSIDE an active stroke (defensive — every real caller
+   * today always brackets with `beginStroke`/`endStroke`, but a future
+   * direct caller still gets a truthful message instead of a silently
+   * swallowed skip). */
+  const recordOverlapSkip = (
+    cell: Cell,
+    overlap: { ownerId: string; ownerName?: string }
+  ) => {
+    const stats = strokeStatsRef.current;
+    if (!stats) {
+      const label = overlap.ownerName ?? overlap.ownerId;
+      flashToast(`cell [${cell[0]},${cell[1]}] already belongs to '${label}'`);
+      flashConflict([cell], overlap.ownerId, overlap.ownerName);
+      return;
+    }
+    const entry = stats.skippedByOwner.get(overlap.ownerId) ?? {
+      name: overlap.ownerName,
+      count: 0,
+      cells: [] as Cell[],
+    };
+    entry.count++;
+    if (entry.cells.length < OVERLAP_SAMPLE_CELLS) entry.cells.push(cell);
+    stats.skippedByOwner.set(overlap.ownerId, entry);
+  };
+
+  /** Ends the active brush stroke and, if anything was skipped, flushes
+   * ONE honest summary — "painted 12, skipped 4 owned by 'entrance'" —
+   * instead of the per-cell toast flood a naive "call flashToast on every
+   * rejection" loop would produce (`DungeonBuilderConcept.tsx`'s
+   * `flashToast` is single-slot; only the LAST of many rapid calls would
+   * ever have been visible). Silent when the stroke painted cleanly — no
+   * `skippedByOwner` entries — matching this concept's "no toast on a
+   * clean success" convention elsewhere (wall/hole painting shows none
+   * either). Safe to call with no active stroke (every tool's
+   * `handlePointerUp` in `CreationBoard.tsx` is shared, so this fires on
+   * every pointer-up regardless of which tool was active). */
+  const endStroke = () => {
+    const stats = strokeStatsRef.current;
+    strokeStatsRef.current = null;
+    if (!stats || stats.skippedByOwner.size === 0) return;
+    const parts: string[] = [];
+    const flashCells: Cell[] = [];
+    let firstOwner: { ownerId: string; ownerName?: string } | null = null;
+    for (const [ownerId, entry] of stats.skippedByOwner) {
+      const label = entry.name ?? ownerId;
+      parts.push(`${pluralCount(entry.count, 'cell')} owned by '${label}'`);
+      flashCells.push(...entry.cells);
+      if (!firstOwner) firstOwner = { ownerId, ownerName: entry.name };
+    }
+    flashToast(`painted ${stats.painted}, skipped ${parts.join('; ')}`);
+    flashConflict(flashCells, firstOwner!.ownerId, firstOwner!.ownerName);
+  };
 
   const reportError = (err: unknown) => {
     flashToast(
@@ -55,10 +204,14 @@ export function useRegionEditing(
 
   /** Toggle a cell in the NOT-YET-CREATED region's pending set — the
    * Region tool's paint interaction before a region exists at all.
-   * Deliberately does not validate contiguity/overlap on every click
-   * (that would make painting a shape one cell at a time impossible the
-   * moment two disconnected starting clicks land) — validation runs once,
-   * at `handleCreate`, via `dungeonYaml.ts`'s own `createRegion`. */
+   * Deliberately does not validate contiguity on every click (that would
+   * make painting a shape one cell at a time impossible the moment two
+   * disconnected starting clicks land) — contiguity validation runs once,
+   * at `handleCreate`, via `dungeonYaml.ts`'s own `createRegion`. Overlap
+   * is a separate concern from contiguity (a single cell either belongs
+   * to an existing region or it doesn't, independent of the pending set's
+   * eventual shape) and is NOT deferred — see `setPendingCellMembership`
+   * below, the caller every real interaction actually uses. */
   const togglePendingCell = (cell: Cell) => {
     setPendingCells((prev) =>
       cellIn(prev, cell)
@@ -82,15 +235,32 @@ export function useRegionEditing(
    * drag started. A single click still reads as a toggle to the author
    * (`CreationBoard.tsx` computes `included = !cellIn(pendingCells, cell)`
    * for the drag's own first cell), so this doesn't change single-click
-   * behavior — it only makes the multi-cell case correct. */
+   * behavior — it only makes the multi-cell case correct.
+   *
+   * **Region-brush honesty round**: an ADD that collides with an existing
+   * region's cell is now rejected PER CELL, right here, instead of
+   * silently entering `pendingCells` and only surfacing at a later
+   * whole-set `handleCreate` call — this is what makes painting a second
+   * region up against a wall a first-class-legal band NOT collide
+   * invisibly (see this file's own header comment). A rejected cell is
+   * recorded into the active stroke's tally (`recordOverlapSkip`), never
+   * added. */
   const setPendingCellMembership = (cell: Cell, included: boolean) => {
-    setPendingCells((prev) => {
-      const has = cellIn(prev, cell);
-      if (included === has) return prev;
-      return included
-        ? [...prev, cell]
-        : prev.filter((c) => !(c[0] === cell[0] && c[1] === cell[1]));
-    });
+    if (!included) {
+      setPendingCells((prev) =>
+        prev.filter((c) => !(c[0] === cell[0] && c[1] === cell[1]))
+      );
+      if (strokeStatsRef.current) strokeStatsRef.current.painted++;
+      return;
+    }
+    if (cellIn(pendingCells, cell)) return;
+    const overlap = findRegionCellOverlap(doc, [cell]);
+    if (overlap) {
+      recordOverlapSkip(cell, overlap);
+      return;
+    }
+    setPendingCells((prev) => [...prev, cell]);
+    if (strokeStatsRef.current) strokeStatsRef.current.painted++;
   };
 
   const clearPending = () => setPendingCells([]);
@@ -114,6 +284,18 @@ export function useRegionEditing(
       setJustCreatedId(id);
     } catch (err) {
       reportError(err);
+      // The per-cell overlap pre-check in `setPendingCellMembership` means
+      // `pendingCells` should never itself contain an owned cell by the
+      // time Create is clicked — but a hand-edited YAML pane change to
+      // `regions:` between painting and clicking Create (or a future
+      // caller that bypasses the brush) could still produce this
+      // rejection here, so the SAME evidence still surfaces: re-derive
+      // which cells collide with which region and flash them, exactly
+      // like a brush-stroke skip would.
+      const overlap = findRegionCellOverlap(doc, pendingCells);
+      if (overlap) {
+        flashConflict(overlap.cells, overlap.ownerId, overlap.ownerName);
+      }
     }
   };
 
@@ -139,17 +321,31 @@ export function useRegionEditing(
   /** IDEMPOTENT sibling of `handleToggleCellOnSelected`, same reason
    * `setPendingCellMembership` exists alongside `togglePendingCell` — the
    * region-brush drag needs to apply ONE decided mode across every cell a
-   * stroke crosses, not re-toggle each one. A rejected `addCellToRegion`/
-   * `removeCellFromRegion` (contiguity/overlap) surfaces as a toast per
-   * cell, same as the single-click path — a drag that crosses into
-   * another region's territory rejects THAT cell and keeps going, rather
-   * than aborting the whole stroke. */
+   * stroke crosses, not re-toggle each one.
+   *
+   * **Region-brush honesty round**: an ADD overlap is now pre-checked
+   * (`findRegionCellOverlap`) and recorded into the active stroke's tally
+   * (`recordOverlapSkip`) WITHOUT even attempting `addCellToRegion` — same
+   * "skip silently into the summary, don't flood a toast" treatment
+   * `setPendingCellMembership` gives the not-yet-created-region path.
+   * Every OTHER rejection (contiguity on add; disconnect/last-cell on
+   * erase) still goes through `addCellToRegion`/`removeCellFromRegion`
+   * and still surfaces as an IMMEDIATE toast, unchanged from before this
+   * round — those aren't the flood-prone "many already-owned cells in one
+   * stroke" case this round targets. */
   const setSelectedRegionCellMembership = (cell: Cell, included: boolean) => {
     if (!selectedRegionId) return;
     const region = doc.regions.find((r) => r.id === selectedRegionId);
     if (!region) return;
     const has = cellIn(region.cells, cell);
     if (included === has) return;
+    if (included) {
+      const overlap = findRegionCellOverlap(doc, [cell], selectedRegionId);
+      if (overlap) {
+        recordOverlapSkip(cell, overlap);
+        return;
+      }
+    }
     try {
       if (included) {
         addCellToRegion(cst, doc, selectedRegionId, cell);
@@ -157,6 +353,7 @@ export function useRegionEditing(
         removeCellFromRegion(cst, doc, selectedRegionId, cell);
       }
       syncFromCst(cst);
+      if (strokeStatsRef.current) strokeStatsRef.current.painted++;
     } catch (err) {
       reportError(err);
     }
@@ -220,6 +417,16 @@ export function useRegionEditing(
     handleSetArchetype,
     handleDelete,
     handleConnect,
+    /** Board-side evidence for the most recent rejected/partial paint or
+     * create — `CreationBoard.tsx` renders `conflictFlash.cells` as a
+     * flash-highlight overlay. See this file's own header comment. */
+    conflictFlash,
+    /** Brackets one paint gesture (drag OR a plain click, which is just a
+     * 1-cell stroke) — `CreationBoard.tsx` calls `beginStroke` right
+     * before the FIRST cell's own mutator call and `endStroke` from its
+     * shared `handlePointerUp`. */
+    beginStroke,
+    endStroke,
   };
 }
 

--- a/src/concepts/dungeon-builder/creation/useRegionEditing.ts
+++ b/src/concepts/dungeon-builder/creation/useRegionEditing.ts
@@ -48,7 +48,7 @@
  *    the SAME state so a Create-button collision gets the identical
  *    evidence a brush-stroke skip does.
  */
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Document } from 'yaml';
 import {
   addCellToRegion,
@@ -98,6 +98,26 @@ export function useRegionEditing(
   flashToast: (message: string) => void
 ) {
   const [pendingCells, setPendingCells] = useState<Cell[]>([]);
+  /** Mirrors `pendingCells`, updated SYNCHRONOUSLY and manually on every
+   * write (never via a `useState` updater callback) — the authoritative
+   * "current membership" source for `setPendingCellMembership`'s own
+   * decision-making (Copilot review, PR #714). React does not guarantee
+   * a `setState(prev => ...)` updater runs synchronously the moment the
+   * setter is called — under batching it can be deferred, which broke an
+   * earlier attempt at this fix that tried to read a closure variable
+   * assigned INSIDE the updater immediately after calling `setPendingCells`
+   * (verified broken by this file's own tests: `painted` undercounted
+   * every time more than one mutation landed in the same `act()`/batch).
+   * A plain ref sidesteps the whole question — every mutator below reads
+   * and writes `pendingCellsRef.current` directly and synchronously, then
+   * mirrors the result into React state via `commitPendingCells` purely
+   * for rendering; the ref is the source of truth for the NEXT mutator
+   * call to reason about, drag or no drag, batch or no batch. */
+  const pendingCellsRef = useRef<Cell[]>([]);
+  const commitPendingCells = (next: Cell[]) => {
+    pendingCellsRef.current = next;
+    setPendingCells(next);
+  };
   const [selectedRegionId, setSelectedRegionId] = useState<string | null>(null);
   /** The id `createRegion` just successfully created — drives
    * `RegionPanel.tsx`'s "Connect to '<previous region>'?" callout. Cleared
@@ -111,6 +131,18 @@ export function useRegionEditing(
   const [conflictFlash, setConflictFlashState] =
     useState<RegionConflictFlash | null>(null);
   const conflictFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Clears any pending auto-clear timer on unmount (Copilot review, PR
+  // #714) — without this, a timer started right before the owning
+  // component unmounts would still fire `setConflictFlashState` on a
+  // gone component, and would keep running regardless.
+  useEffect(() => {
+    return () => {
+      if (conflictFlashTimer.current) {
+        clearTimeout(conflictFlashTimer.current);
+        conflictFlashTimer.current = null;
+      }
+    };
+  }, []);
   /** Sets `conflictFlash` and (re)starts its auto-clear timer — same
    * 3200ms window `DungeonBuilderConcept.tsx`'s `flashToast` uses for the
    * paired toast, so the highlight and the message it explains fade
@@ -213,7 +245,8 @@ export function useRegionEditing(
    * eventual shape) and is NOT deferred — see `setPendingCellMembership`
    * below, the caller every real interaction actually uses. */
   const togglePendingCell = (cell: Cell) => {
-    setPendingCells((prev) =>
+    const prev = pendingCellsRef.current;
+    commitPendingCells(
       cellIn(prev, cell)
         ? prev.filter((c) => !(c[0] === cell[0] && c[1] === cell[1]))
         : [...prev, cell]
@@ -244,26 +277,47 @@ export function useRegionEditing(
    * region up against a wall a first-class-legal band NOT collide
    * invisibly (see this file's own header comment). A rejected cell is
    * recorded into the active stroke's tally (`recordOverlapSkip`), never
-   * added. */
+   * added.
+   *
+   * **Membership is decided against `pendingCellsRef`, never the
+   * render-closure `pendingCells` state variable** (Copilot review, PR
+   * #714) — a drag fires many of these calls in quick succession, and
+   * reading `pendingCells` (or trying to smuggle the outcome out of a
+   * `useState` updater callback via a closed-over variable — a first
+   * attempt at this fix that this file's own tests caught as broken:
+   * `setState` updaters are not guaranteed to run synchronously the
+   * instant the setter is called, so code reading that variable
+   * immediately after could observe stale `false`/`null` even though the
+   * update landed correctly) risks a stale snapshot under React's
+   * batching. `pendingCellsRef.current` is written manually and
+   * synchronously by `commitPendingCells` on every mutation, so it is
+   * ALWAYS the true current membership, independent of when React
+   * chooses to re-render or flush a batch. An absent cell's erase is a
+   * genuine no-op (ref left untouched, nothing counted), matching
+   * `painted`'s own contract: it counts cells actually applied, not
+   * cells merely touched. */
   const setPendingCellMembership = (cell: Cell, included: boolean) => {
+    const prev = pendingCellsRef.current;
     if (!included) {
-      setPendingCells((prev) =>
+      const has = cellIn(prev, cell);
+      if (!has) return; // already absent — true no-op, nothing to commit or count
+      commitPendingCells(
         prev.filter((c) => !(c[0] === cell[0] && c[1] === cell[1]))
       );
       if (strokeStatsRef.current) strokeStatsRef.current.painted++;
       return;
     }
-    if (cellIn(pendingCells, cell)) return;
+    if (cellIn(prev, cell)) return; // already present — true no-op
     const overlap = findRegionCellOverlap(doc, [cell]);
     if (overlap) {
       recordOverlapSkip(cell, overlap);
       return;
     }
-    setPendingCells((prev) => [...prev, cell]);
+    commitPendingCells([...prev, cell]);
     if (strokeStatsRef.current) strokeStatsRef.current.painted++;
   };
 
-  const clearPending = () => setPendingCells([]);
+  const clearPending = () => commitPendingCells([]);
 
   /** Select an existing region for membership/metadata editing, or `null`
    * to deselect. Always clears any in-progress NEW-region paint session —
@@ -272,15 +326,15 @@ export function useRegionEditing(
    * this concept. */
   const selectRegion = (regionId: string | null) => {
     setSelectedRegionId(regionId);
-    setPendingCells([]);
+    commitPendingCells([]);
     setJustCreatedId(null);
   };
 
   const handleCreate = (id: string, archetype: string, name?: string) => {
     try {
-      createRegion(cst, doc, id, archetype, pendingCells, name);
+      createRegion(cst, doc, id, archetype, pendingCellsRef.current, name);
       syncFromCst(cst);
-      setPendingCells([]);
+      commitPendingCells([]);
       setJustCreatedId(id);
     } catch (err) {
       reportError(err);
@@ -292,7 +346,7 @@ export function useRegionEditing(
       // rejection here, so the SAME evidence still surfaces: re-derive
       // which cells collide with which region and flash them, exactly
       // like a brush-stroke skip would.
-      const overlap = findRegionCellOverlap(doc, pendingCells);
+      const overlap = findRegionCellOverlap(doc, pendingCellsRef.current);
       if (overlap) {
         flashConflict(overlap.cells, overlap.ownerId, overlap.ownerName);
       }

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -59,6 +59,7 @@ import {
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
 import { cubeAtColRow } from './hexLayout';
+import { OVERLAP_SAMPLE_CELLS } from './regionTree';
 
 describe('parseDungeon', () => {
   it('parses showcase.yaml into the expected room chain', () => {
@@ -1889,7 +1890,7 @@ regions:
       const doc2 = toDungeonDoc(cst);
       const overlap = findRegionCellOverlap(doc2, owned);
       expect(overlap?.cellCount).toBe(9);
-      expect(overlap?.cells).toHaveLength(6); // OVERLAP_SAMPLE_CELLS
+      expect(overlap?.cells).toHaveLength(OVERLAP_SAMPLE_CELLS);
     });
 
     it('only reports the FIRST region a candidate set collides with, when it touches more than one', () => {

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -1749,12 +1749,16 @@ regions:
         [2, 1],
       ]);
       const doc2 = toDungeonDoc(cst);
+      // Region-brush honesty round: the message now names the exact
+      // collision (count + owning region), not a generic "another
+      // region" — Kirk's own ask, "with NO indication which cells or
+      // whose."
       expect(
         validateRegionCells(doc2, [
           [2, 1],
           [3, 1],
         ])
-      ).toMatch(/already belong to another region/);
+      ).toBe("1 cell already belongs to 'r1'");
       // Excluding r1's own id lets r1's proposed new cell set (which still
       // legitimately reuses its own current cells) validate cleanly.
       expect(

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -7,6 +7,7 @@ import {
   type DialectField,
   type ServerCapabilities,
 } from './capabilityProbe';
+import { emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import { canonicalCorner } from './creation/hexCorner';
 import {
   addCellToRegion,
@@ -19,6 +20,7 @@ import {
   deletePlacement,
   deleteRegion,
   DungeonParseError,
+  findRegionCellOverlap,
   movePlacement,
   movePlacementAcrossLists,
   parseDungeon,
@@ -1326,6 +1328,59 @@ connectors:
       expect(result.compilable).toBe(true);
       expect(result.compilableBlockers).toEqual([]);
     });
+
+    describe('canvas-mode compilableBlockers (region-brush honesty round, 2026-08-06)', () => {
+      // Kirk, live authoring: added a boss region trying to satisfy "needs
+      // exactly one boss-archetype room" on a from-scratch canvas doc —
+      // which can never unblock it, since the server rejects `canvas:`
+      // itself before validation ever reaches boss cardinality. These
+      // prove the blocker names THAT fact instead of the chain-mode
+      // room/boss rules once a document is canvas-mode.
+      it('a canvas doc with canvas NOT accepted reports the real Wave 0/#192 blocker, not the room/boss chain rules', () => {
+        const result = stripToV1Subset(
+          emptyCanvasYaml(20, 20),
+          caps([]) // canvas not accepted — every server today
+        );
+        expect(result.compilable).toBe(false);
+        expect(result.compilableBlockers).toEqual([
+          "from-scratch canvas documents aren't accepted by this server yet (platform Wave 0 — rpg-project#192)",
+        ]);
+      });
+
+      it('the same canvas doc reports NO blockers once canvas IS accepted — no invented chain-rule guess takes its place', () => {
+        const result = stripToV1Subset(
+          emptyCanvasYaml(20, 20),
+          caps(['canvas'])
+        );
+        expect(result.compilableBlockers).toEqual([]);
+        expect(result.compilable).toBe(true);
+      });
+
+      it('with no capabilities at all (fixtures mode / probe not yet complete), a canvas doc still reports the Wave 0 blocker, not room/boss', () => {
+        const result = stripToV1Subset(emptyCanvasYaml(20, 20));
+        expect(result.compilableBlockers).toEqual([
+          "from-scratch canvas documents aren't accepted by this server yet (platform Wave 0 — rpg-project#192)",
+        ]);
+      });
+
+      it('a real ROOM-chain document is unaffected — still reports the chain-mode blockers, canvas or not', () => {
+        const oneRoom = `
+version: 1
+key: bare
+name: "Bare"
+height: 8
+rooms:
+  - id: only
+    archetype: entrance
+    width: 6
+connectors: []
+`;
+        const result = stripToV1Subset(oneRoom, caps(['canvas']));
+        expect(result.compilableBlockers).toEqual(
+          expect.arrayContaining(['needs at least 2 rooms (has 1)'])
+        );
+      });
+    });
   });
 
   describe('generalized placement mutators (roomId: null = top-level)', () => {
@@ -1772,6 +1827,82 @@ regions:
           'r1'
         )
       ).toBeNull();
+    });
+  });
+
+  describe('findRegionCellOverlap (region-brush honesty round, 2026-08-06)', () => {
+    it('returns null when the candidate cells collide with nothing', () => {
+      const { doc } = parseDungeon(SHOWCASE_YAML);
+      expect(findRegionCellOverlap(doc, [[5, 5]])).toBeNull();
+    });
+
+    it('names the owning region and the exact colliding cells for a single-cell check — the brush per-cell shape', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'entrance', 'entrance', [
+        [0, 0],
+        [1, 0],
+      ]);
+      const doc2 = toDungeonDoc(cst);
+      const overlap = findRegionCellOverlap(doc2, [[1, 0]]);
+      expect(overlap).toEqual({
+        ownerId: 'entrance',
+        ownerName: undefined,
+        cells: [[1, 0]],
+        cellCount: 1,
+      });
+    });
+
+    it('reports the region NAME when one is set, not just the id', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [[3, 3]], 'The Vault');
+      const doc2 = toDungeonDoc(cst);
+      const overlap = findRegionCellOverlap(doc2, [[3, 3]]);
+      expect(overlap?.ownerName).toBe('The Vault');
+    });
+
+    it('excludeRegionId lets a region check its own proposed cell set without self-colliding', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'r1', 'chamber', [
+        [1, 1],
+        [2, 1],
+      ]);
+      const doc2 = toDungeonDoc(cst);
+      expect(
+        findRegionCellOverlap(
+          doc2,
+          [
+            [1, 1],
+            [2, 1],
+          ],
+          'r1'
+        )
+      ).toBeNull();
+    });
+
+    it('caps the reported cell sample at OVERLAP_SAMPLE_CELLS but keeps the TRUE count uncapped', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      const owned: [number, number][] = Array.from({ length: 9 }, (_, i) => [
+        i,
+        0,
+      ]);
+      createRegion(cst, doc, 'wide', 'chamber', owned);
+      const doc2 = toDungeonDoc(cst);
+      const overlap = findRegionCellOverlap(doc2, owned);
+      expect(overlap?.cellCount).toBe(9);
+      expect(overlap?.cells).toHaveLength(6); // OVERLAP_SAMPLE_CELLS
+    });
+
+    it('only reports the FIRST region a candidate set collides with, when it touches more than one', () => {
+      const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+      createRegion(cst, doc, 'first', 'chamber', [[0, 0]]);
+      const afterFirst = toDungeonDoc(cst);
+      createRegion(cst, afterFirst, 'second', 'chamber', [[5, 5]]);
+      const doc2 = toDungeonDoc(cst);
+      const overlap = findRegionCellOverlap(doc2, [
+        [0, 0],
+        [5, 5],
+      ]);
+      expect(overlap?.ownerId).toBe('first');
     });
   });
 

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -1798,7 +1798,24 @@ export class RegionValidationError extends Error {}
  * whole-pending-set check at Create time) either passes a single cell or
  * a pending set that, by construction, never straddles two owners in a
  * way worth reporting simultaneously — see this function's own callers
- * for why. `null` when `cells` doesn't collide with anything. */
+ * for why. `null` when `cells` doesn't collide with anything.
+ *
+ * **Single-cell fast path** (Copilot review, PR #714): the region brush's
+ * own per-cell paint check — the hot path, called once per cell touched
+ * during a drag, many times a second — always passes exactly one cell.
+ * Building a `Set` of an entire region's cells just to test ONE
+ * membership is allocation churn for no benefit at that shape, so
+ * `cells.length === 1` scans `region.cells` directly with `.some()`
+ * instead — no Set, no array allocation, short-circuits on the first
+ * hit. Deliberately NOT a precomputed whole-doc ownership index: this
+ * concept's regions top out at a handful-to-dozens of cells each
+ * (CONTRACT.md), so a per-call linear scan is already cheap; an index
+ * would trade a real allocation cost for a bookkeeping cost (keeping it
+ * in sync with every region mutation) to solve a problem that doesn't
+ * exist yet at this scale. The multi-cell path (`createRegion`'s
+ * whole-pending-set check at Create time) keeps the `Set`-based approach
+ * below — there, the candidate set can be large enough that a Set
+ * actually pays for itself. */
 export function findRegionCellOverlap(
   doc: DungeonDoc,
   cells: readonly Cell[],
@@ -1809,6 +1826,21 @@ export function findRegionCellOverlap(
   cells: Cell[];
   cellCount: number;
 } | null {
+  if (cells.length === 1) {
+    const [only] = cells;
+    for (const region of doc.regions) {
+      if (region.id === excludeRegionId) continue;
+      if (region.cells.some((c) => c[0] === only[0] && c[1] === only[1])) {
+        return {
+          ownerId: region.id,
+          ownerName: region.name,
+          cells: [only],
+          cellCount: 1,
+        };
+      }
+    }
+    return null;
+  }
   for (const region of doc.regions) {
     if (region.id === excludeRegionId) continue;
     const owned = new Set(region.cells.map((c) => `${c[0]},${c[1]}`));

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -58,6 +58,7 @@ import {
   sharedBoundaryEdges,
   type Cell,
 } from './regionGeometry';
+import { OVERLAP_SAMPLE_CELLS } from './regionTree';
 
 function parseFacing(raw: unknown): number | null {
   if (typeof raw !== 'string') return null;
@@ -1782,21 +1783,61 @@ export function setLightingAmbient(
 
 export class RegionValidationError extends Error {}
 
+/** The evidence a plain "already belongs to another region" rejection
+ * lacked — Kirk, live authoring (region-brush honesty round, 2026-08-06):
+ * "it says 'one or more cells already belong to another region'... with
+ * NO indication which cells or whose." Finds the FIRST existing region
+ * (other than `excludeRegionId`) that owns any of `cells`, and returns
+ * exactly which of `cells` collide with it — capped to
+ * `OVERLAP_SAMPLE_CELLS`, the same "representative handful, not a full
+ * accounting" convention `regionTree.ts`'s own `RegionOverlapWarning`
+ * uses for the sibling case (two EXISTING regions overlapping in a
+ * hand-pasted document, rather than a CANDIDATE cell set colliding with
+ * one). Only the first colliding region is reported: every caller today
+ * (the region-brush's own per-cell paint check, and `createRegion`'s
+ * whole-pending-set check at Create time) either passes a single cell or
+ * a pending set that, by construction, never straddles two owners in a
+ * way worth reporting simultaneously — see this function's own callers
+ * for why. `null` when `cells` doesn't collide with anything. */
+export function findRegionCellOverlap(
+  doc: DungeonDoc,
+  cells: readonly Cell[],
+  excludeRegionId?: string
+): {
+  ownerId: string;
+  ownerName?: string;
+  cells: Cell[];
+  cellCount: number;
+} | null {
+  for (const region of doc.regions) {
+    if (region.id === excludeRegionId) continue;
+    const owned = new Set(region.cells.map((c) => `${c[0]},${c[1]}`));
+    const hits = cells.filter((c) => owned.has(`${c[0]},${c[1]}`));
+    if (hits.length > 0) {
+      return {
+        ownerId: region.id,
+        ownerName: region.name,
+        cells: hits.slice(0, OVERLAP_SAMPLE_CELLS),
+        cellCount: hits.length,
+      };
+    }
+  }
+  return null;
+}
+
 /** Whether `cells` shares any member with an EXISTING region OTHER than
  * `excludeRegionId` (the region currently being edited, if any) —
  * rpg-project#180's own "Overlapping... cell sets fail" acceptance
- * criterion. */
+ * criterion. A thin boolean wrapper over `findRegionCellOverlap` — kept
+ * as its own export since most callers (`validateRegionCells` below)
+ * only ever needed the yes/no answer before this unit gave the overlap
+ * itself a shape worth returning. */
 export function cellsOverlapAnotherRegion(
   doc: DungeonDoc,
   cells: readonly Cell[],
   excludeRegionId?: string
 ): boolean {
-  const claimed = new Set<string>();
-  for (const region of doc.regions) {
-    if (region.id === excludeRegionId) continue;
-    for (const c of region.cells) claimed.add(`${c[0]},${c[1]}`);
-  }
-  return cells.some((c) => claimed.has(`${c[0]},${c[1]}`));
+  return findRegionCellOverlap(doc, cells, excludeRegionId) !== null;
 }
 
 /** Validate a candidate cell set for `createRegion`/membership edits —
@@ -1824,8 +1865,16 @@ export function validateRegionCells(
   if (!cellsAreContiguous(cells)) {
     return 'cells must be hex-contiguous (rpg-project#180)';
   }
-  if (cellsOverlapAnotherRegion(doc, cells, excludeRegionId)) {
-    return 'one or more cells already belong to another region';
+  const overlap = findRegionCellOverlap(doc, cells, excludeRegionId);
+  if (overlap) {
+    const label = overlap.ownerName ?? overlap.ownerId;
+    // Named region + exact count — the evidence the old generic message
+    // lacked (this function's own doc comment on `findRegionCellOverlap`
+    // above has the full "why"). `cellCount` (the TRUE count) drives the
+    // number, not `overlap.cells.length` (the capped sample) — a stroke
+    // that collides on 9 cells should say "9", not silently cap the
+    // reported count to 6 just because the cell LIST itself is capped.
+    return `${pluralCount(overlap.cellCount, 'cell')} already belong${overlap.cellCount === 1 ? 's' : ''} to '${label}'`;
   }
   return null;
 }
@@ -2290,7 +2339,11 @@ export interface V1SubsetResult {
   compilableBlockers: string[];
 }
 
-function pluralCount(n: number, noun: string): string {
+/** Exported so `useRegionEditing.ts`'s brush-stroke skip summary (region-
+ * brush honesty round, 2026-08-06 — "painted 12, skipped 4 owned by
+ * 'entrance'") uses the SAME pluralization this file's own compile-badge
+ * strip does, instead of a second hand-rolled copy. */
+export function pluralCount(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? '' : 's'}`;
 }
 
@@ -2686,20 +2739,50 @@ export function stripToV1Subset(
 
   const strippedDoc = toDungeonDoc(cst);
   const compilableBlockers: string[] = [];
-  if (strippedDoc.rooms.length < 2) {
-    compilableBlockers.push(
-      `needs at least 2 rooms (has ${strippedDoc.rooms.length})`
-    );
-  }
-  const bossRooms = strippedDoc.rooms.filter((r) => r.archetype === 'boss');
-  if (bossRooms.length !== 1 || !bossRooms[0]?.boss) {
-    compilableBlockers.push(
-      bossRooms.length === 0
-        ? 'needs exactly one boss-archetype room with a declared boss (has none)'
-        : bossRooms.length > 1
-          ? `needs exactly one boss-archetype room (has ${bossRooms.length})`
-          : 'the boss-archetype room needs a declared boss'
-    );
+  // `doc` (the ORIGINAL parse, before this function's own `cst.delete`
+  // calls above) — not `strippedDoc` — is what says whether this is a
+  // from-scratch canvas document: when `canvas` isn't accepted, the block
+  // above already deleted `canvas:` from `cst`, so `strippedDoc.canvas`
+  // would read `null` here regardless, losing exactly the signal this
+  // branch needs. A canvas document has no `rooms:`/`boss:` chain AT ALL
+  // (TARGET-YAML.md's "top-level placement" section — `emptyCanvasDoc.ts`:
+  // "a from-scratch canvas has nothing... no fictional room standing in
+  // for one"), so the room-count/boss-archetype checks below are
+  // chain-mode's own real server minimums (validate.go) reinterpreted
+  // against a document shape they were never written for. Kirk hit this
+  // live (region-brush honesty round, 2026-08-06): added a whole boss
+  // region trying to satisfy "needs exactly one boss-archetype room" on a
+  // canvas doc — which can never unblock it, since the server rejects
+  // `canvas:` itself before validation ever reaches boss cardinality. The
+  // only HONEST blocker for a canvas doc today is that fact, driven by
+  // the live probe (`accepted('canvas')`), not a hardcoded guess: the
+  // moment `canvas` graduates to accepted, this blocker disappears and
+  // nothing invented takes its place — whatever the server's real canvas
+  // validation turns out to require will surface through the actual save
+  // attempt's own error path once it exists, not a client-side prediction
+  // of rules nobody has written yet.
+  if (doc.canvas) {
+    if (!accepted('canvas')) {
+      compilableBlockers.push(
+        "from-scratch canvas documents aren't accepted by this server yet (platform Wave 0 — rpg-project#192)"
+      );
+    }
+  } else {
+    if (strippedDoc.rooms.length < 2) {
+      compilableBlockers.push(
+        `needs at least 2 rooms (has ${strippedDoc.rooms.length})`
+      );
+    }
+    const bossRooms = strippedDoc.rooms.filter((r) => r.archetype === 'boss');
+    if (bossRooms.length !== 1 || !bossRooms[0]?.boss) {
+      compilableBlockers.push(
+        bossRooms.length === 0
+          ? 'needs exactly one boss-archetype room with a declared boss (has none)'
+          : bossRooms.length > 1
+            ? `needs exactly one boss-archetype room (has ${bossRooms.length})`
+            : 'the boss-archetype room needs a declared boss'
+      );
+    }
   }
 
   return {

--- a/src/concepts/dungeon-builder/regionTree.ts
+++ b/src/concepts/dungeon-builder/regionTree.ts
@@ -103,7 +103,12 @@ export interface RegionTree<T extends RegionLike = RegionLike> {
   overlaps: RegionOverlapWarning[];
 }
 
-const OVERLAP_SAMPLE_CELLS = 6;
+/** Exported so `dungeonYaml.ts`'s own overlap-evidence helper
+ * (`findRegionCellOverlap`, region-brush honesty round, 2026-08-06) caps
+ * its sample the same way — one "representative handful" convention for
+ * every region-overlap surface in this concept, not two independently
+ * chosen numbers. */
+export const OVERLAP_SAMPLE_CELLS = 6;
 
 /** How two regions' cell sets relate, given their sizes and shared-cell
  * count — the one comparison every pairwise check in this module reduces


### PR DESCRIPTION
## Summary

Three fixes for live authoring friction Kirk hit brushing two regions across a straight wall, plus a Save & Play tooltip that misled him into a dead end (rpg-project#180 region work; the canvas blocker references rpg-project#192, platform Wave 0).

Kirk's own diagnosis, verbatim: (a) "it says 'one or more cells already belong to another region'" — no indication which cells or whose; (b) "the shared hexes look like the unplayable piece the wall goes through" — his first region's brush swept up a straight wall's footprint cells (they read as "the wall," not "claimed floor"), so painting a second region up to the same wall from the other side collided on that band and the generic message sent him hunting blind; (c) he added a boss region trying to satisfy "needs exactly one boss-archetype room" on a from-scratch canvas doc — which can never unblock it (the server rejects `canvas:` entirely until platform Wave 0), so the message sent him chasing a ghost.

1. **Overlap rejection shows its evidence** — `dungeonYaml.ts`'s new `findRegionCellOverlap` names which cells collide and which region owns them; `validateRegionCells`'s message is now `"3 cells already belong to 'entrance'"` instead of a generic "another region."
2. **The brush paints what it can and reports what it skips** — both region-paint paths now pre-check overlap per cell during a stroke, skip (never apply) an owned cell, and flush ONE end-of-stroke summary toast — `"painted 12, skipped 4 cells owned by 'entrance'"` — instead of the old all-or-nothing whole-set rejection (pending-region path) or a per-cell toast flood (selected-region path). A pulsing white flash-highlight marks the exact skipped cells. Region membership on a wall's footprint band now tints OVER the crimson hatch (was silently buried under it — a real render-order bug, not new data) so a region's claim is unmistakable; footprint cells remain fully paintable members throughout.
3. **Probe-aware canvas save blocker** — a from-scratch canvas document's Save & Play tooltip now says the truth ("from-scratch canvas documents aren't accepted by this server yet (platform Wave 0 — rpg-project#192)") instead of dungeonspec's chain-mode room/boss rules, which a canvas doc can never satisfy. Real room-chain documents are unaffected. Written against the live capability probe, not hardcoded — the blocker disappears the moment `canvas` graduates to accepted, no invented guess takes its place.

## Test plan

- [x] 14 new tests: 6 for `findRegionCellOverlap`, 4 for the canvas-mode `compilableBlockers` gate (`dungeonYaml.test.ts`), 1 updated expectation for the new evidence-bearing message, and a new `creation/useRegionEditing.test.ts` (10 tests) covering the stroke accumulator including Kirk's own two-regions-across-a-wall-band scenario end to end.
- [x] Full `src/concepts/dungeon-builder` suite: 460 tests passing.
- [x] `tsc -b --noEmit`, `eslint`, `npm run build` all clean; `./scripts/ci-check.sh` green.
- [x] Live-verified against a real dev server via Playwright (native pointer events, same `getScreenCTM()` coordinate transform the app itself uses): drew a straight wall, painted "Entrance Hall" across its real footprint band, created it, brushed "Hallway" from the far side into the shared band. Toast read exactly `painted 8, skipped 4 cells owned by 'Entrance Hall'`. Screenshots in `docs/evidence/region-brush-honesty-*.png` (gitignored per this repo's existing convention, referenced from CONTRACT.md).
- [ ] Canvas-mode Wave 0/#192 tooltip specifically wasn't captured live (no rpg-api/envoy container running this session — `serverState` stayed `unreachable`, confirmed showing the *other*, also-correct branch of the same tooltip). Covered by the 4 dedicated `stripToV1Subset` canvas-blocker tests plus `YamlPane.test.tsx`'s existing tests proving the button renders whatever blockers it's given verbatim.

— asset-pipeline agent, on behalf of KirkDiggler