### PR TITLE
feat(camera): zoom-coupled pitch — the battle map camera flattens as you zoom in

### DIFF
--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -40,6 +40,7 @@ import { Canvas } from '@react-three/fiber';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { ErrorBoundary } from '../ui/Feedback/ErrorBoundary';
+import { readCameraDials } from './cameraDials';
 import { FrontierGroundHint } from './FrontierGroundHint';
 import { HexEntity } from './HexEntity';
 import {
@@ -603,6 +604,11 @@ function Scene({
     return new THREE.Vector3(worldPos.x, 0, worldPos.z);
   }, [myPosX, myPosY, myPosZ]);
 
+  // Camera-feel dials (`?camera=persp`, `?pitchCurve=1`, ...) — read once,
+  // all-off by default, so with no query params this call is exactly the
+  // fixed-angle orthographic rig it has always been. See cameraDials.ts.
+  const cameraDials = useMemo(() => readCameraDials(), []);
+
   // Custom camera controls: WASD pan, Q/E rotate, scroll zoom
   useCameraControls({
     target: stableTarget,
@@ -610,8 +616,12 @@ function Scene({
     panSpeed: 0.3,
     rotateSpeed: 0.02,
     minZoom: 30,
-    maxZoom: 150,
+    maxZoom: cameraDials.zoomMax ?? 150,
     focusTarget,
+    curve: cameraDials.curve,
+    perspective: cameraDials.perspective,
+    minDistance: cameraDials.minDistance,
+    maxDistance: cameraDials.maxDistance,
   });
 
   // Build entity map for interaction hook (excludes dead entities so they
@@ -1066,6 +1076,13 @@ export function HexGrid(props: HexGridProps) {
   const [isContextLost, setIsContextLost] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
+  // Camera-feel dials again out here: Scene reads them for the CONTROLS, but
+  // the projection itself is a `<Canvas>` prop and Scene lives inside it.
+  // Both call the same read-once parser rather than sharing state, so there
+  // is nothing to keep in sync. Default (no query params) is unchanged:
+  // orthographic, zoom 80.
+  const canvasDials = useMemo(() => readCameraDials(), []);
+
   // Handle WebGL context loss/restore for GPU protection
   const handleCanvasCreated = useCallback(
     ({ gl }: { gl: THREE.WebGLRenderer }) => {
@@ -1160,7 +1177,12 @@ export function HexGrid(props: HexGridProps) {
         </div>
       ) : (
         <Canvas
-          orthographic
+          // Projection is fixed at mount — R3F does not swap camera type on a
+          // prop change — so the dial rides a `key` to force a clean remount.
+          // The dials are read once from the URL, so this key is stable and
+          // nothing remounts in practice.
+          key={canvasDials.perspective ? 'persp' : 'ortho'}
+          orthographic={!canvasDials.perspective}
           frameloop="demand"
           onCreated={handleCanvasCreated}
           camera={{
@@ -1170,9 +1192,14 @@ export function HexGrid(props: HexGridProps) {
             // facing against CAMERA_WARD_XZ, derived from this same value)
             // can never drift out of sync with the actual camera.
             position: CAMERA_OFFSET,
-            zoom: 80,
             near: 0.1,
             far: 1000,
+            // `zoom` drives an orthographic camera, `fov` a perspective one.
+            // Both are spelled here because useCameraControls immediately
+            // takes over placement either way; only the projection differs.
+            ...(canvasDials.perspective
+              ? { fov: canvasDials.fovDeg }
+              : { zoom: 80 }),
           }}
           style={{ width: '100%', height: '100%' }}
         >

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -615,8 +615,8 @@ function Scene({
     polarAngle: Math.PI / 3.5, // ~51 degrees from vertical - slightly lower tactical angle
     panSpeed: 0.3,
     rotateSpeed: 0.02,
-    minZoom: 30,
-    maxZoom: cameraDials.zoomMax ?? 150,
+    minZoom: cameraDials.zoomMin,
+    maxZoom: cameraDials.zoomMax,
     focusTarget,
     curve: cameraDials.curve,
     perspective: cameraDials.perspective,
@@ -1199,7 +1199,7 @@ export function HexGrid(props: HexGridProps) {
             // takes over placement either way; only the projection differs.
             ...(canvasDials.perspective
               ? { fov: canvasDials.fovDeg }
-              : { zoom: 80 }),
+              : { zoom: canvasDials.zoomStart }),
           }}
           style={{ width: '100%', height: '100%' }}
         >

--- a/src/components/hex-grid/cameraDials.test.ts
+++ b/src/components/hex-grid/cameraDials.test.ts
@@ -5,28 +5,47 @@ import {
   DEFAULT_PERSP_FOV_DEG,
   DEFAULT_PITCH_FAR_DEG,
   DEFAULT_PITCH_NEAR_DEG,
+  DEFAULT_ZOOM_MAX,
+  DEFAULT_ZOOM_MIN,
   parseCameraDials,
 } from './cameraDials';
 
 const rad = (d: number) => (d * Math.PI) / 180;
 
 describe('parseCameraDials', () => {
-  it('with no query params is entirely off — the grid keeps its fixed-angle orthographic rig', () => {
+  it('with no query params leaves projection and pitch alone — orthographic, single fixed angle', () => {
     const dials = parseCameraDials('');
     expect(dials.perspective).toBe(false);
     expect(dials.curve).toBeNull();
-    expect(dials.zoomMax).toBeNull();
+  });
+
+  it('ships a zoom range that fits a 6-hex move without losing the room in black', () => {
+    const dials = parseCameraDials('');
+    expect(dials.zoomMin).toBe(DEFAULT_ZOOM_MIN);
+    expect(dials.zoomMax).toBe(DEFAULT_ZOOM_MAX);
+    // Adjacent hex centres are sqrt(3) apart at HEX_SIZE=1, so a 6-hex move
+    // is a ~20.8-world-unit disc. Orthographic world-width is canvasPx/zoom,
+    // so the zoomed-OUT floor has to keep at least that much on a normal
+    // canvas — otherwise you cannot see where you are allowed to walk.
+    const sixHexMoveWidth = 12 * Math.sqrt(3);
+    expect(1600 / dials.zoomMin).toBeGreaterThan(sixHexMoveWidth);
+  });
+
+  it('starts partway up the range, so the landing view is neither extreme of the curve', () => {
+    const dials = parseCameraDials('');
+    expect(dials.zoomStart).toBeGreaterThan(dials.zoomMin);
+    expect(dials.zoomStart).toBeLessThan(dials.zoomMax);
   });
 
   it('?pitchCurve=1 alone yields a curve wide enough to actually see', () => {
     // The ?wallCutaway=1 papercut: a flag whose defaults composed into
-    // something barely distinguishable from off. A 25-degree swing is not
-    // subtle, which is the point.
+    // something barely distinguishable from off. Kirk drove the first
+    // 32->57 pass and asked for more, so the swing is now >30 degrees.
     const { curve } = parseCameraDials('?pitchCurve=1');
     expect(curve).not.toBeNull();
     expect(curve?.polarFar).toBeCloseTo(rad(DEFAULT_PITCH_FAR_DEG));
     expect(curve?.polarNear).toBeCloseTo(rad(DEFAULT_PITCH_NEAR_DEG));
-    expect(DEFAULT_PITCH_NEAR_DEG - DEFAULT_PITCH_FAR_DEG).toBeGreaterThan(20);
+    expect(DEFAULT_PITCH_NEAR_DEG - DEFAULT_PITCH_FAR_DEG).toBeGreaterThan(30);
   });
 
   it('flattens as you zoom IN: the near (zoomed-in) angle is further from vertical than the far one', () => {
@@ -71,18 +90,22 @@ describe('parseCameraDials', () => {
     expect(DEFAULT_PERSP_FOV_DEG).toBeLessThan(30);
   });
 
-  it('carries dolly range and zoom ceiling overrides', () => {
-    const dials = parseCameraDials('?minDist=3&maxDist=64&zoomMax=260');
+  it('carries dolly range and zoom overrides', () => {
+    const dials = parseCameraDials(
+      '?minDist=3&maxDist=64&zoomMin=20&zoomMax=300&zoomStart=90'
+    );
     expect(dials.minDistance).toBe(3);
     expect(dials.maxDistance).toBe(64);
-    expect(dials.zoomMax).toBe(260);
+    expect(dials.zoomMin).toBe(20);
+    expect(dials.zoomMax).toBe(300);
+    expect(dials.zoomStart).toBe(90);
   });
 
   it('ignores non-numeric and empty values instead of poisoning the camera with NaN', () => {
     const dials = parseCameraDials('?pitchFar=&fov=abc&zoomMax=');
     expect(dials.curve).toBeNull();
     expect(dials.fovDeg).toBe(DEFAULT_PERSP_FOV_DEG);
-    expect(dials.zoomMax).toBeNull();
+    expect(dials.zoomMax).toBe(DEFAULT_ZOOM_MAX);
     expect(dials.minDistance).toBe(DEFAULT_MIN_DISTANCE);
     expect(dials.maxDistance).toBe(DEFAULT_MAX_DISTANCE);
   });

--- a/src/components/hex-grid/cameraDials.test.ts
+++ b/src/components/hex-grid/cameraDials.test.ts
@@ -13,10 +13,30 @@ import {
 const rad = (d: number) => (d * Math.PI) / 180;
 
 describe('parseCameraDials', () => {
-  it('with no query params leaves projection and pitch alone — orthographic, single fixed angle', () => {
+  it('curves the pitch with NO query params — this is the battle map camera now', () => {
+    // Promoted from `?pitchCurve=1` after Kirk walked it live ("ok. i like
+    // this angle a lot"). A camera nobody sees without a query param is not
+    // a camera.
     const dials = parseCameraDials('');
-    expect(dials.perspective).toBe(false);
-    expect(dials.curve).toBeNull();
+    expect(dials.curve).not.toBeNull();
+    expect(dials.curve?.polarFar).toBeCloseTo(rad(DEFAULT_PITCH_FAR_DEG));
+    expect(dials.curve?.polarNear).toBeCloseTo(rad(DEFAULT_PITCH_NEAR_DEG));
+  });
+
+  it('leaves PROJECTION alone by default — ortho vs perspective is still open', () => {
+    expect(parseCameraDials('').perspective).toBe(false);
+    expect(parseCameraDials('?pitchCurve=0').perspective).toBe(false);
+  });
+
+  it('?pitchCurve=0 is the escape hatch back to the old single fixed angle', () => {
+    expect(parseCameraDials('?pitchCurve=0').curve).toBeNull();
+  });
+
+  it('an explicit angle beats a stale ?pitchCurve=0 rather than being swallowed by it', () => {
+    // A bookmarked opt-out must not silently discard an angle you just typed.
+    const dials = parseCameraDials('?pitchCurve=0&pitchNear=70');
+    expect(dials.curve).not.toBeNull();
+    expect(dials.curve?.polarNear).toBeCloseTo(rad(70));
   });
 
   it('ships a zoom range that fits a 6-hex move without losing the room in black', () => {
@@ -71,14 +91,16 @@ describe('parseCameraDials', () => {
     expect(nearOnly.curve?.polarFar).toBeCloseTo(rad(DEFAULT_PITCH_FAR_DEG));
   });
 
-  it('?camera=persp is independent of the pitch curve — either alone is a legible experiment', () => {
+  it('?camera=persp is independent of the pitch curve — each is its own decision', () => {
+    // Perspective composes ON TOP of the shipped curve; turning the curve
+    // off must not drag the projection with it, or vice versa.
     const perspOnly = parseCameraDials('?camera=persp');
     expect(perspOnly.perspective).toBe(true);
-    expect(perspOnly.curve).toBeNull();
+    expect(perspOnly.curve).not.toBeNull();
 
-    const curveOnly = parseCameraDials('?pitchCurve=1');
-    expect(curveOnly.perspective).toBe(false);
-    expect(curveOnly.curve).not.toBeNull();
+    const perspNoCurve = parseCameraDials('?camera=persp&pitchCurve=0');
+    expect(perspNoCurve.perspective).toBe(true);
+    expect(perspNoCurve.curve).toBeNull();
   });
 
   it('reports fov in degrees, matching what <Canvas camera={{ fov }}> consumes', () => {
@@ -103,7 +125,9 @@ describe('parseCameraDials', () => {
 
   it('ignores non-numeric and empty values instead of poisoning the camera with NaN', () => {
     const dials = parseCameraDials('?pitchFar=&fov=abc&zoomMax=');
-    expect(dials.curve).toBeNull();
+    // A blank angle falls back to the shipped default rather than to NaN —
+    // one empty query param must never tilt the camera to an undefined pitch.
+    expect(dials.curve?.polarFar).toBeCloseTo(rad(DEFAULT_PITCH_FAR_DEG));
     expect(dials.fovDeg).toBe(DEFAULT_PERSP_FOV_DEG);
     expect(dials.zoomMax).toBe(DEFAULT_ZOOM_MAX);
     expect(dials.minDistance).toBe(DEFAULT_MIN_DISTANCE);

--- a/src/components/hex-grid/cameraDials.test.ts
+++ b/src/components/hex-grid/cameraDials.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MAX_DISTANCE,
+  DEFAULT_MIN_DISTANCE,
+  DEFAULT_PERSP_FOV_DEG,
+  DEFAULT_PITCH_FAR_DEG,
+  DEFAULT_PITCH_NEAR_DEG,
+  parseCameraDials,
+} from './cameraDials';
+
+const rad = (d: number) => (d * Math.PI) / 180;
+
+describe('parseCameraDials', () => {
+  it('with no query params is entirely off — the grid keeps its fixed-angle orthographic rig', () => {
+    const dials = parseCameraDials('');
+    expect(dials.perspective).toBe(false);
+    expect(dials.curve).toBeNull();
+    expect(dials.zoomMax).toBeNull();
+  });
+
+  it('?pitchCurve=1 alone yields a curve wide enough to actually see', () => {
+    // The ?wallCutaway=1 papercut: a flag whose defaults composed into
+    // something barely distinguishable from off. A 25-degree swing is not
+    // subtle, which is the point.
+    const { curve } = parseCameraDials('?pitchCurve=1');
+    expect(curve).not.toBeNull();
+    expect(curve?.polarFar).toBeCloseTo(rad(DEFAULT_PITCH_FAR_DEG));
+    expect(curve?.polarNear).toBeCloseTo(rad(DEFAULT_PITCH_NEAR_DEG));
+    expect(DEFAULT_PITCH_NEAR_DEG - DEFAULT_PITCH_FAR_DEG).toBeGreaterThan(20);
+  });
+
+  it('flattens as you zoom IN: the near (zoomed-in) angle is further from vertical than the far one', () => {
+    const { curve } = parseCameraDials('?pitchCurve=1');
+    expect(curve!.polarNear).toBeGreaterThan(curve!.polarFar);
+  });
+
+  it('keeps the close end shy of the angle that would make wall cutaway mandatory', () => {
+    // Occlusion behind a WALL_HEIGHT=2.4 wall is 2.4*tan(polar); at 70deg
+    // that is ~6.6 world units (~3.8 hexes) and a near wall eats the room.
+    // The reference close-up sits around 57deg (~2.1 hexes), which is only
+    // modestly worse than today's fixed 51.4deg (~1.7 hexes).
+    expect(DEFAULT_PITCH_NEAR_DEG).toBeLessThan(65);
+  });
+
+  it('an explicit endpoint implies the curve without also needing ?pitchCurve=1', () => {
+    const farOnly = parseCameraDials('?pitchFar=20');
+    expect(farOnly.curve?.polarFar).toBeCloseTo(rad(20));
+    expect(farOnly.curve?.polarNear).toBeCloseTo(rad(DEFAULT_PITCH_NEAR_DEG));
+
+    const nearOnly = parseCameraDials('?pitchNear=70');
+    expect(nearOnly.curve?.polarNear).toBeCloseTo(rad(70));
+    expect(nearOnly.curve?.polarFar).toBeCloseTo(rad(DEFAULT_PITCH_FAR_DEG));
+  });
+
+  it('?camera=persp is independent of the pitch curve — either alone is a legible experiment', () => {
+    const perspOnly = parseCameraDials('?camera=persp');
+    expect(perspOnly.perspective).toBe(true);
+    expect(perspOnly.curve).toBeNull();
+
+    const curveOnly = parseCameraDials('?pitchCurve=1');
+    expect(curveOnly.perspective).toBe(false);
+    expect(curveOnly.curve).not.toBeNull();
+  });
+
+  it('reports fov in degrees, matching what <Canvas camera={{ fov }}> consumes', () => {
+    expect(parseCameraDials('?camera=persp').fovDeg).toBe(
+      DEFAULT_PERSP_FOV_DEG
+    );
+    expect(parseCameraDials('?camera=persp&fov=35').fovDeg).toBe(35);
+    // Narrow by default so the pulled-back view still reads as near-ortho.
+    expect(DEFAULT_PERSP_FOV_DEG).toBeLessThan(30);
+  });
+
+  it('carries dolly range and zoom ceiling overrides', () => {
+    const dials = parseCameraDials('?minDist=3&maxDist=64&zoomMax=260');
+    expect(dials.minDistance).toBe(3);
+    expect(dials.maxDistance).toBe(64);
+    expect(dials.zoomMax).toBe(260);
+  });
+
+  it('ignores non-numeric and empty values instead of poisoning the camera with NaN', () => {
+    const dials = parseCameraDials('?pitchFar=&fov=abc&zoomMax=');
+    expect(dials.curve).toBeNull();
+    expect(dials.fovDeg).toBe(DEFAULT_PERSP_FOV_DEG);
+    expect(dials.zoomMax).toBeNull();
+    expect(dials.minDistance).toBe(DEFAULT_MIN_DISTANCE);
+    expect(dials.maxDistance).toBe(DEFAULT_MAX_DISTANCE);
+  });
+});

--- a/src/components/hex-grid/cameraDials.ts
+++ b/src/components/hex-grid/cameraDials.ts
@@ -1,15 +1,19 @@
 /**
- * Camera-feel dials for the hex-grid battle map — the live-judgment surface
- * for the "flatten the camera when you zoom in" work (Gloomhaven's board
- * camera, which Kirk called out from play).
+ * The hex-grid battle map's camera: it flattens as you zoom in and stands up
+ * as you pull out (Gloomhaven's board camera, which Kirk called out from
+ * play), plus the dials for tuning that live.
  *
- * Same "read the query string once, default off" convention as
- * `?syntyDungeon=` / `?wallCutaway=` / `?wallHeight=` (EncounterMap.tsx), but
- * parsed HERE rather than in EncounterMap so the concepts surfaces that mount
- * `<HexGrid>` directly (`?concept=fog-of-war`) get the same dials without
- * threading props through every caller. Camera feel is exactly the thing
- * that's pointless to argue about in review and has to be driven — every
- * surface that renders the grid should be able to show it.
+ * The curve is ON by default — this is the camera now, not an experiment.
+ * `?pitchCurve=0` restores the old fixed angle; `?camera=persp` remains
+ * opt-in, because orthographic-vs-perspective is a separate open question.
+ *
+ * Same "read the query string once" convention as `?syntyDungeon=` /
+ * `?wallCutaway=` / `?wallHeight=` (EncounterMap.tsx), but parsed HERE rather
+ * than in EncounterMap so the concepts surfaces that mount `<HexGrid>`
+ * directly (`?concept=fog-of-war`) get the same camera and the same dials
+ * without threading props through every caller. Camera feel is exactly the
+ * thing that's pointless to argue about in review and has to be driven —
+ * every surface that renders the grid should show the same one.
  *
  * WHY THESE DEFAULTS. Measured off Gloomhaven reference shots:
  *  - zoomed out, their camera is near TOP-DOWN (~30° from vertical)
@@ -105,8 +109,9 @@ export interface CameraDials {
   minDistance: number;
   maxDistance: number;
   /**
-   * Zoom-coupled pitch. `null` keeps the single fixed angle the grid has
-   * always used — the untouched default path.
+   * Zoom-coupled pitch — ON by default, since this is the battle map's
+   * camera now rather than an experiment. `null` (only via `?pitchCurve=0`)
+   * restores the single fixed angle the grid used before this feature.
    */
   curve: { polarFar: number; polarNear: number } | null;
   /** Orthographic zoom range and starting point. */
@@ -127,23 +132,30 @@ function num(params: URLSearchParams, key: string): number | null {
  * Pure parser over a query string — the whole point of splitting this out of
  * HexGrid is that the dial resolution is testable without a Canvas.
  *
- * `?camera=persp` and `?pitchCurve=1` are independent: either alone is a
- * legible experiment, and both together is the full proposal. Each implies
- * usable defaults on its own, deliberately — the `?wallCutaway=1` papercut
- * (a flag that composed into something barely distinguishable from off) is
- * the failure mode being avoided here.
+ * The pitch curve is ON with no query params at all. It shipped behind
+ * `?pitchCurve=1` while it was being judged live; Kirk's verdict walking it
+ * ("ok. i like this angle a lot") is what promoted it, so the flag inverted
+ * rather than lingering as a permanently-off experiment nobody would see.
+ * `?pitchCurve=0` is the escape hatch back to the old fixed angle.
+ *
+ * `?camera=persp` is deliberately NOT promoted with it — orthographic vs
+ * perspective is a separate, still-open call, and it stays opt-in until it
+ * gets the same live judgment the curve just had.
  */
 export function parseCameraDials(search: string): CameraDials {
   const params = new URLSearchParams(search);
 
   const perspective = params.get('camera') === 'persp';
 
-  // An explicit endpoint override implies the curve, so you can dial one end
-  // without also remembering `?pitchCurve=1`.
   const pitchFarDeg = num(params, 'pitchFar');
   const pitchNearDeg = num(params, 'pitchNear');
+  // Only an explicit `0` turns the curve off. An endpoint override still
+  // implies ON, so `?pitchFar=20` alone tunes one end without also having to
+  // remember to re-enable the thing you are tuning — and it beats `=0`, so a
+  // stale `?pitchCurve=0` in a bookmarked URL cannot silently swallow a
+  // deliberate angle you just typed.
   const curveOn =
-    params.get('pitchCurve') === '1' ||
+    params.get('pitchCurve') !== '0' ||
     pitchFarDeg !== null ||
     pitchNearDeg !== null;
 

--- a/src/components/hex-grid/cameraDials.ts
+++ b/src/components/hex-grid/cameraDials.ts
@@ -34,16 +34,19 @@ const deg = (d: number): number => (d * Math.PI) / 180;
  * top-down: this is the planning view, where a full 6-hex move and the room's
  * true shape need to read without wall occlusion eating the far side.
  */
-export const DEFAULT_PITCH_FAR_DEG = 32;
+export const DEFAULT_PITCH_FAR_DEG = 28;
 
 /**
  * Polar angle (degrees from vertical) at the zoomed-IN extreme — the
- * "up close and personal" end. ~57° matches the reference close-up and is
- * only modestly flatter than today's fixed 51.4°, so wall occlusion grows
- * from ~1.7 to ~2.1 hexes: noticeable, not disqualifying. Deliberately NOT
- * the 70°+ that would make `?wallCutaway=1` a hard prerequisite.
+ * "up close and personal" end. 62° is past the ~57° measured off the
+ * reference: Kirk drove the 32→57 version and asked for more swing.
+ *
+ * Wall occlusion is the thing this trades against — 2.4 * tan(62°) hides
+ * ~3.4 world units, ~2.6 hexes, against ~1.7 at today's fixed 51.4°. Still
+ * deliberately short of the 70°+ that hides ~3.8 hexes and would make
+ * `?wallCutaway=1` a hard prerequisite rather than an opt-in experiment.
  */
-export const DEFAULT_PITCH_NEAR_DEG = 57;
+export const DEFAULT_PITCH_NEAR_DEG = 62;
 
 /**
  * Vertical FOV for `?camera=persp`. Narrow on purpose: at the zoomed-out end
@@ -55,9 +58,39 @@ export const DEFAULT_PITCH_NEAR_DEG = 57;
  */
 export const DEFAULT_PERSP_FOV_DEG = 24;
 
-/** Perspective dolly range, world units from the orbit target. */
+/**
+ * Perspective dolly range, world units from the orbit target. The far end is
+ * 28 rather than 40 for the same reason the ortho floor moved up to
+ * DEFAULT_ZOOM_MIN — pulled all the way back, the room shrank into the middle
+ * of a lot of black.
+ */
 export const DEFAULT_MIN_DISTANCE = 6;
-export const DEFAULT_MAX_DISTANCE = 40;
+export const DEFAULT_MAX_DISTANCE = 28;
+
+/**
+ * Orthographic zoom floor — how far OUT you may go. Was 30, which showed
+ * ~31 hexes across a 1600px canvas: far more board than a 6-hex move needs
+ * (a ~20.8-world-unit disc, ~12 hexes) and the dungeon read as a small
+ * object in a black frame. 50 still frames ~18 hexes, so a full move plus
+ * margin fits, without the room getting lost.
+ */
+export const DEFAULT_ZOOM_MIN = 50;
+
+/**
+ * Orthographic zoom ceiling — how far IN you may go. The stock 150 topped
+ * out around 6 hexes across, short of the reference close-up's ~4; 220 gets
+ * there. Raised as a DEFAULT (not just a dial) so `?pitchCurve=1` on its own
+ * reaches the close end the curve exists to serve.
+ */
+export const DEFAULT_ZOOM_MAX = 220;
+
+/**
+ * Starting orthographic zoom. Sits partway up the [MIN, MAX] range so the
+ * landing view is moderately close and moderately steep rather than pinned
+ * at either extreme of the pitch curve — at 110 the curve resolves to ~40°
+ * from vertical, between the 28° planning angle and the 62° close angle.
+ */
+export const DEFAULT_ZOOM_START = 110;
 
 export interface CameraDials {
   /** Perspective projection instead of the default orthographic. */
@@ -76,12 +109,10 @@ export interface CameraDials {
    * always used — the untouched default path.
    */
   curve: { polarFar: number; polarNear: number } | null;
-  /**
-   * Orthographic max zoom override. The stock 150 tops out around 6 hexes
-   * across; the reference close-up frames roughly 4, so getting there needs
-   * ~230-260. Left alone by default.
-   */
-  zoomMax: number | null;
+  /** Orthographic zoom range and starting point. */
+  zoomMin: number;
+  zoomMax: number;
+  zoomStart: number;
 }
 
 /** Finite-number query param, or null when absent/garbage. */
@@ -127,7 +158,9 @@ export function parseCameraDials(search: string): CameraDials {
           polarNear: deg(pitchNearDeg ?? DEFAULT_PITCH_NEAR_DEG),
         }
       : null,
-    zoomMax: num(params, 'zoomMax'),
+    zoomMin: num(params, 'zoomMin') ?? DEFAULT_ZOOM_MIN,
+    zoomMax: num(params, 'zoomMax') ?? DEFAULT_ZOOM_MAX,
+    zoomStart: num(params, 'zoomStart') ?? DEFAULT_ZOOM_START,
   };
 }
 

--- a/src/components/hex-grid/cameraDials.ts
+++ b/src/components/hex-grid/cameraDials.ts
@@ -1,0 +1,138 @@
+/**
+ * Camera-feel dials for the hex-grid battle map — the live-judgment surface
+ * for the "flatten the camera when you zoom in" work (Gloomhaven's board
+ * camera, which Kirk called out from play).
+ *
+ * Same "read the query string once, default off" convention as
+ * `?syntyDungeon=` / `?wallCutaway=` / `?wallHeight=` (EncounterMap.tsx), but
+ * parsed HERE rather than in EncounterMap so the concepts surfaces that mount
+ * `<HexGrid>` directly (`?concept=fog-of-war`) get the same dials without
+ * threading props through every caller. Camera feel is exactly the thing
+ * that's pointless to argue about in review and has to be driven — every
+ * surface that renders the grid should be able to show it.
+ *
+ * WHY THESE DEFAULTS. Measured off Gloomhaven reference shots:
+ *  - zoomed out, their camera is near TOP-DOWN (~30° from vertical)
+ *  - zoomed in, it flattens to roughly eye-level-ish (~57° from vertical)
+ * Ours is pinned at 51.4° (`Math.PI / 3.5`, HexGrid.tsx) at every zoom — i.e.
+ * parked permanently at their CLOSE end, never reaching their planning angle.
+ * So the curve is bidirectional: steeper when out, flatter when in.
+ *
+ * The steep end is not just cosmetic. A 6-hex move (our normal budget, vs
+ * Gloomhaven's 2-4) is a ~20.8-world-unit disc at HEX_SIZE=1, and wall
+ * occlusion scales with `tan(polar)`: a WALL_HEIGHT=2.4 wall hides ~1.7 hexes
+ * at today's 51.4° but only ~0.8 hexes at 32°. Zooming out to plan therefore
+ * gets a BETTER read on the move range than we have now, which is what makes
+ * the close end affordable at all.
+ */
+
+/** Degrees → radians. Dials are authored in degrees; the camera wants radians. */
+const deg = (d: number): number => (d * Math.PI) / 180;
+
+/**
+ * Polar angle (degrees FROM VERTICAL) at the zoomed-OUT extreme. Near
+ * top-down: this is the planning view, where a full 6-hex move and the room's
+ * true shape need to read without wall occlusion eating the far side.
+ */
+export const DEFAULT_PITCH_FAR_DEG = 32;
+
+/**
+ * Polar angle (degrees from vertical) at the zoomed-IN extreme — the
+ * "up close and personal" end. ~57° matches the reference close-up and is
+ * only modestly flatter than today's fixed 51.4°, so wall occlusion grows
+ * from ~1.7 to ~2.1 hexes: noticeable, not disqualifying. Deliberately NOT
+ * the 70°+ that would make `?wallCutaway=1` a hard prerequisite.
+ */
+export const DEFAULT_PITCH_NEAR_DEG = 57;
+
+/**
+ * Vertical FOV for `?camera=persp`. Narrow on purpose: at the zoomed-out end
+ * a ~24° perspective camera is nearly indistinguishable from orthographic, so
+ * the tactical read (hexes the same size across the screen) survives — while
+ * dollying in still buys real convergence, which is what actually sells
+ * "these minis are standing in a place" and what ortho can never give at any
+ * pitch.
+ */
+export const DEFAULT_PERSP_FOV_DEG = 24;
+
+/** Perspective dolly range, world units from the orbit target. */
+export const DEFAULT_MIN_DISTANCE = 6;
+export const DEFAULT_MAX_DISTANCE = 40;
+
+export interface CameraDials {
+  /** Perspective projection instead of the default orthographic. */
+  perspective: boolean;
+  /**
+   * Vertical FOV in DEGREES (perspective only) — degrees, not radians,
+   * because that is what `<Canvas camera={{ fov }}>` wants; keeping the unit
+   * matched to the consumer avoids a silent conversion bug at the call site.
+   */
+  fovDeg: number;
+  /** Dolly range in world units (perspective only). */
+  minDistance: number;
+  maxDistance: number;
+  /**
+   * Zoom-coupled pitch. `null` keeps the single fixed angle the grid has
+   * always used — the untouched default path.
+   */
+  curve: { polarFar: number; polarNear: number } | null;
+  /**
+   * Orthographic max zoom override. The stock 150 tops out around 6 hexes
+   * across; the reference close-up frames roughly 4, so getting there needs
+   * ~230-260. Left alone by default.
+   */
+  zoomMax: number | null;
+}
+
+/** Finite-number query param, or null when absent/garbage. */
+function num(params: URLSearchParams, key: string): number | null {
+  const raw = params.get(key);
+  if (raw === null || raw.trim() === '') return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Pure parser over a query string — the whole point of splitting this out of
+ * HexGrid is that the dial resolution is testable without a Canvas.
+ *
+ * `?camera=persp` and `?pitchCurve=1` are independent: either alone is a
+ * legible experiment, and both together is the full proposal. Each implies
+ * usable defaults on its own, deliberately — the `?wallCutaway=1` papercut
+ * (a flag that composed into something barely distinguishable from off) is
+ * the failure mode being avoided here.
+ */
+export function parseCameraDials(search: string): CameraDials {
+  const params = new URLSearchParams(search);
+
+  const perspective = params.get('camera') === 'persp';
+
+  // An explicit endpoint override implies the curve, so you can dial one end
+  // without also remembering `?pitchCurve=1`.
+  const pitchFarDeg = num(params, 'pitchFar');
+  const pitchNearDeg = num(params, 'pitchNear');
+  const curveOn =
+    params.get('pitchCurve') === '1' ||
+    pitchFarDeg !== null ||
+    pitchNearDeg !== null;
+
+  return {
+    perspective,
+    fovDeg: num(params, 'fov') ?? DEFAULT_PERSP_FOV_DEG,
+    minDistance: num(params, 'minDist') ?? DEFAULT_MIN_DISTANCE,
+    maxDistance: num(params, 'maxDist') ?? DEFAULT_MAX_DISTANCE,
+    curve: curveOn
+      ? {
+          polarFar: deg(pitchFarDeg ?? DEFAULT_PITCH_FAR_DEG),
+          polarNear: deg(pitchNearDeg ?? DEFAULT_PITCH_NEAR_DEG),
+        }
+      : null,
+    zoomMax: num(params, 'zoomMax'),
+  };
+}
+
+/** Read the dials once from the live URL. */
+export function readCameraDials(): CameraDials {
+  if (typeof window === 'undefined') return parseCameraDials('');
+  return parseCameraDials(window.location.search);
+}

--- a/src/components/hex-grid/useCameraControls.ts
+++ b/src/components/hex-grid/useCameraControls.ts
@@ -2,9 +2,11 @@
  * Custom camera controls for HexGrid
  *
  * - WASD to pan
- * - Q/E to rotate (Y-axis only)
+ * - Q/E to rotate (Y-axis only) — the ONLY way to rotate
  * - Mouse wheel to zoom
- * - Right-click drag to rotate
+ * - Right-click drag to pan ("grab the board"). This used to rotate; Kirk
+ *   moved it to panning so rotation lives on Q/E alone and the mouse does
+ *   the thing a mouse on a map is expected to do.
  * - Tilt is never under direct player control: it is either a fixed angle
  *   (the default, unchanged) or a function of zoom via the `curve` option
  *   (`?pitchCurve=1`, see cameraDials.ts). There is deliberately no free-look.
@@ -76,10 +78,13 @@ export function useCameraControls({
     e: false,
   });
 
-  // Track mouse state for right-click drag
+  // Track mouse state for right-click drag (pans the board — rotation is
+  // Q/E only, per Kirk: "use Q and E to rotate and rt click could move the
+  // board"). Y is tracked too now that the drag moves in both axes.
   const mouse = useRef({
     isRightDown: false,
     lastX: 0,
+    lastY: 0,
   });
 
   // Reusable vectors for camera movement (avoid allocations in useFrame)
@@ -129,6 +134,23 @@ export function useCameraControls({
     if (!curve) return polarAngle;
     return THREE.MathUtils.lerp(curve.polarFar, curve.polarNear, zoomT());
   }, [curve, polarAngle, zoomT]);
+
+  /**
+   * World units spanned by one screen pixel at the current zoom. Right-drag
+   * panning multiplies by this so the board tracks the cursor 1:1 instead of
+   * moving at a fixed speed that feels sluggish zoomed out and twitchy in.
+   */
+  const worldPerPixel = useCallback((): number => {
+    // R3F sizes the orthographic frustum in PIXELS and then divides by zoom,
+    // so world-per-pixel is exactly 1/zoom.
+    if (camera instanceof THREE.OrthographicCamera) return 1 / camera.zoom;
+    if (camera instanceof THREE.PerspectiveCamera) {
+      const heightPx = gl.domElement.clientHeight || 1;
+      const vFov = (camera.fov * Math.PI) / 180;
+      return (2 * distance.current * Math.tan(vFov / 2)) / heightPx;
+    }
+    return 1 / 80;
+  }, [camera, gl]);
 
   // Update camera position based on spherical coordinates
   const updateCamera = useCallback(() => {
@@ -188,6 +210,7 @@ export function useCameraControls({
         // Right click
         mouse.current.isRightDown = true;
         mouse.current.lastX = e.clientX;
+        mouse.current.lastY = e.clientY;
       }
     };
 
@@ -198,13 +221,42 @@ export function useCameraControls({
     };
 
     const handleMouseMove = (e: MouseEvent) => {
-      if (mouse.current.isRightDown) {
-        const deltaX = e.clientX - mouse.current.lastX;
-        azimuth.current -= deltaX * 0.01;
-        mouse.current.lastX = e.clientX;
-        updateCamera();
-        invalidate(); // Request re-render for on-demand frameloop
-      }
+      if (!mouse.current.isRightDown) return;
+
+      const dx = e.clientX - mouse.current.lastX;
+      const dy = e.clientY - mouse.current.lastY;
+      mouse.current.lastX = e.clientX;
+      mouse.current.lastY = e.clientY;
+
+      // Ground-plane basis for the current heading — same convention as the
+      // WASD block in useFrame below, reusing the same scratch vectors.
+      const az = azimuth.current;
+      forward.current.set(-Math.cos(az), 0, -Math.sin(az));
+      right.current.set(Math.sin(az), 0, -Math.cos(az));
+
+      // Screen-vertical covers MORE ground than screen-horizontal once the
+      // camera tilts (a ground plane compresses by cos(polar) on screen), so
+      // undo that to keep the board tracking the cursor in both axes. Clamped
+      // because the correction runs away as the camera nears the horizon —
+      // and with the pitch curve on, the close end really does get flat.
+      const perPx = worldPerPixel();
+      const depthScale = Math.min(
+        4,
+        1 / Math.max(0.25, Math.cos(currentPolar()))
+      );
+
+      // Grab-the-board: content follows the cursor, so the orbit target moves
+      // against the drag horizontally, and with it into depth (pulling down
+      // brings far ground toward you).
+      target.addScaledVector(right.current, -dx * perPx);
+      target.addScaledVector(forward.current, dy * perPx * depthScale);
+
+      // A manual pan owns the framing from here, exactly like WASD — without
+      // this the auto-follow lerp yanks the board straight back to the player.
+      lerpTarget.current = null;
+
+      updateCamera();
+      invalidate(); // Request re-render for on-demand frameloop
     };
 
     const handleWheel = (e: WheelEvent) => {
@@ -263,6 +315,8 @@ export function useCameraControls({
     curve,
     minDistance,
     maxDistance,
+    worldPerPixel,
+    currentPolar,
   ]);
 
   // Update each frame based on key state

--- a/src/components/hex-grid/useCameraControls.ts
+++ b/src/components/hex-grid/useCameraControls.ts
@@ -5,7 +5,9 @@
  * - Q/E to rotate (Y-axis only)
  * - Mouse wheel to zoom
  * - Right-click drag to rotate
- * - Fixed tilt angle (no tilting up/down)
+ * - Tilt is never under direct player control: it is either a fixed angle
+ *   (the default, unchanged) or a function of zoom via the `curve` option
+ *   (`?pitchCurve=1`, see cameraDials.ts). There is deliberately no free-look.
  */
 
 import { useFrame, useThree } from '@react-three/fiber';
@@ -27,6 +29,26 @@ interface CameraControlsOptions {
   maxZoom?: number;
   /** When set, camera lerps target to this position. Cleared on manual pan. */
   focusTarget?: THREE.Vector3 | null;
+  /**
+   * Zoom-coupled pitch (`?pitchCurve=1`, see cameraDials.ts). When set, the
+   * polar angle interpolates between `polarFar` at the zoomed-OUT extreme and
+   * `polarNear` at the zoomed-IN extreme instead of staying at the single
+   * fixed `polarAngle` — the camera goes near top-down for planning and
+   * flattens out as you lean in, which is the Gloomhaven behaviour.
+   *
+   * `undefined`/`null` keeps `polarAngle` fixed: the untouched default path.
+   */
+  curve?: { polarFar: number; polarNear: number } | null;
+  /**
+   * Drive a PerspectiveCamera by dollying `distance` instead of driving an
+   * OrthographicCamera's `zoom` (`?camera=persp`). Orthographic stays the
+   * default — the tactical read depends on hexes being the same size across
+   * the whole screen.
+   */
+  perspective?: boolean;
+  /** Perspective dolly range in world units (ignored when orthographic). */
+  minDistance?: number;
+  maxDistance?: number;
 }
 
 export function useCameraControls({
@@ -37,6 +59,10 @@ export function useCameraControls({
   minZoom = 20,
   maxZoom = 200,
   focusTarget,
+  curve = null,
+  perspective = false,
+  minDistance = 5,
+  maxDistance = 100,
 }: CameraControlsOptions) {
   const { camera, gl, invalidate } = useThree();
 
@@ -76,19 +102,46 @@ export function useCameraControls({
     }
   }, [focusTarget]);
 
+  /**
+   * How far "zoomed in" we currently are, normalised to 0 (furthest out) → 1
+   * (closest in), so one pitch curve can serve both projections. Read out of
+   * whichever quantity actually drives zoom for this camera — ortho `zoom`
+   * grows as you close in, perspective `distance` shrinks — rather than being
+   * stored separately, so it can never drift from what's on screen.
+   */
+  const zoomT = useCallback((): number => {
+    if (perspective) {
+      const span = maxDistance - minDistance;
+      if (span <= 0) return 0;
+      return THREE.MathUtils.clamp(
+        (maxDistance - distance.current) / span,
+        0,
+        1
+      );
+    }
+    const span = maxZoom - minZoom;
+    if (span <= 0 || !(camera instanceof THREE.OrthographicCamera)) return 0;
+    return THREE.MathUtils.clamp((camera.zoom - minZoom) / span, 0, 1);
+  }, [perspective, maxDistance, minDistance, maxZoom, minZoom, camera]);
+
+  /** Polar angle for the current zoom — constant unless a curve is supplied. */
+  const currentPolar = useCallback((): number => {
+    if (!curve) return polarAngle;
+    return THREE.MathUtils.lerp(curve.polarFar, curve.polarNear, zoomT());
+  }, [curve, polarAngle, zoomT]);
+
   // Update camera position based on spherical coordinates
   const updateCamera = useCallback(() => {
+    const polar = currentPolar();
     const x =
-      target.x +
-      distance.current * Math.sin(polarAngle) * Math.cos(azimuth.current);
-    const y = target.y + distance.current * Math.cos(polarAngle);
+      target.x + distance.current * Math.sin(polar) * Math.cos(azimuth.current);
+    const y = target.y + distance.current * Math.cos(polar);
     const z =
-      target.z +
-      distance.current * Math.sin(polarAngle) * Math.sin(azimuth.current);
+      target.z + distance.current * Math.sin(polar) * Math.sin(azimuth.current);
 
     camera.position.set(x, y, z);
     camera.lookAt(target);
-  }, [target, polarAngle, camera]);
+  }, [target, currentPolar, camera]);
 
   // Handle keyboard events
   useEffect(() => {
@@ -163,12 +216,17 @@ export function useCameraControls({
           Math.min(maxZoom, camera.zoom - e.deltaY * 0.1)
         );
         camera.updateProjectionMatrix();
+        // Ortho zoom normally leaves the camera's POSITION alone — but with a
+        // pitch curve the polar angle is a function of zoom, so the rig has to
+        // be re-placed on every wheel tick. Skipped entirely when no curve is
+        // active, keeping the default path's work identical to before.
+        if (curve) updateCamera();
         invalidate(); // Request re-render for on-demand frameloop
       } else {
         // For perspective camera, adjust distance
         distance.current = Math.max(
-          5,
-          Math.min(100, distance.current + e.deltaY * 0.05)
+          minDistance,
+          Math.min(maxDistance, distance.current + e.deltaY * 0.05)
         );
         updateCamera();
         invalidate(); // Request re-render for on-demand frameloop
@@ -202,6 +260,9 @@ export function useCameraControls({
     polarAngle,
     updateCamera,
     invalidate,
+    curve,
+    minDistance,
+    maxDistance,
   ]);
 
   // Update each frame based on key state


### PR DESCRIPTION
Kirk was playing Gloomhaven and noticed their camera flattens out when you get close: "I would like to get up close and personal like this."

Ours couldn't. It was pinned at a single fixed angle (`Math.PI / 3.5`, ~51.4° from vertical) at every zoom level. Measured off the reference shots, Gloomhaven sits near top-down (~30°) when pulled out and flattens to roughly eye-level (~57°) up close — so our one fixed angle was parked permanently at *their close end*, and never reached their planning angle at all.

## What this does

The pitch is now coupled to zoom, bidirectionally:

- **Pulled out → ~28° from vertical.** The planning view. A full 6-hex move and the room's true shape read without wall occlusion eating the far side.
- **Zoomed in → ~62°.** The "up close and personal" end.

Plus two things that fell out of driving it live:

- **Zoom-out floor raised** (30 → 50). The old floor showed ~31 hexes across a 1600px canvas — far more board than a 6-hex move needs, and the dungeon read as a small object in a black frame. Zoom ceiling raised 150 → 220 so the close end is actually reachable, and the start moved to 110 so you land mid-curve rather than pinned at an extreme.
- **Right-drag now pans** instead of rotating. Rotation is Q/E. Panning scales with zoom so the board tracks the cursor 1:1 at any distance, with a correction on the depth axis since a tilted ground plane compresses on screen.

## The 6-hex question

Kirk raised the obvious worry: Gloomhaven characters move 2–4 hexes, we normally move 6 — does a close camera fight our longer range?

It doesn't, because the curve is bidirectional. Wall occlusion scales with `tan(polar)`: a `WALL_HEIGHT = 2.4` wall hides ~1.7 hexes at the old fixed 51.4°, but only ~0.8 hexes at 28°. **Zooming out to plan now reads better than it did before this change**, which is exactly what makes spending the close end affordable.

The close end costs ~2.6 hexes of occlusion, up from ~1.7. That is deliberately short of the ~70° that would hide ~3.8 hexes and make a wall-cutaway mechanism a hard prerequisite rather than an option.

## Shipping it on

The curve rode behind `?pitchCurve=1` while it was being judged. Kirk's verdict walking it live — "ok. i like this angle a lot" — is what promotes it here, so the flag inverts to `?pitchCurve=0` as an escape hatch rather than lingering as a permanently-off experiment nobody sees.

An explicit `?pitchFar=` / `?pitchNear=` still implies the curve is on and deliberately **beats** `?pitchCurve=0` — otherwise a stale opt-out in a bookmarked URL would silently swallow an angle you just typed.

**`?camera=persp` is NOT promoted.** Orthographic vs perspective is a separate, still-open call — the one genuinely irreversible fork here — and it stays opt-in until it gets the same live judgment the curve just had.

## Dials

`?pitchCurve=0` `?pitchFar=` `?pitchNear=` `?camera=persp` `?fov=` `?minDist=` `?maxDist=` `?zoomMin=` `?zoomMax=` `?zoomStart=`

Parsed in `cameraDials.ts` rather than `EncounterMap` so the concept surfaces that mount `<HexGrid>` directly get the same camera and the same dials without threading props through every caller.

## Verification

`npm run ci-check` green. Driven live against a real encounter, not just unit-tested: both ends of the curve confirmed with **no query params at all**, `?pitchCurve=0` confirmed to restore the old fixed angle, right-drag confirmed to translate the scene with orientation unchanged (pillars keep the same faces), and Q confirmed to orbit around a stationary player.

## Known rough edge

At maximum zoom in TURN_BASED, a character's head can pass behind the turn-order HUD — the camera centres the *hex*, but the model stands well above it, so a flat angle pushes the head high on screen. The fix is to bias the look-at target upward as the pitch flattens; left out of this PR deliberately, since it changes the framing that was just judged and approved. Happy to follow up.

## Related

Split out of the see-through-walls prototype branch (`camera/pitch-curve-prototype`) so it can land on its own while wall-transparency work continues on top of it.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FU8uNAkALrewp8je4F1yyZ
