### PR TITLE
unit: local drafts + versioned full-fidelity save/load

### DIFF
--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -6459,3 +6459,125 @@ exactly 5/17 with the mode-combo/decode-unknown/accept rules modeled — this
 last one is the test that would have failed (reporting 3/17) against the
 pre-fix `buildProbeDoc`. Full `src/concepts/dungeon-builder` suite: 449 tests
 passing (up from 440), `tsc --noEmit` clean.
+
+## Local drafts + versioned full-fidelity save/load (2026-08-06)
+
+Kirk's two rulings, verbatim: saved artifacts are ALWAYS full dialect —
+"compatibility stripping should happen at load time not save"; files target a
+spec version — "we could have 0.4 able to load in the concept page and want to
+run the v0.3 version of it if possible. maybe we can check compatibility."
+
+**What shipped, four pieces:**
+
+1. **Refresh-proof local drafts** (`draftStorage.ts`) — the working document's
+   full-dialect YAML TEXT (the CST source `YamlPane`/`ProposedYamlPane` show,
+   never a stripped projection) autosaves to `localStorage`, debounced 500ms,
+   keyed per mode (`edit`/`create` — the same "remembered per mode" precedent
+   the palette/YAML collapse-state pairs already set, so switching tabs never
+   collides one mode's draft with the other's). Restored on mount via each
+   mode's lazy `useState` initializer (`DungeonBuilderConcept.tsx`'s
+   `initial`/`creationInitial`) — a corrupt/unparseable stored draft is
+   discarded rather than kept re-offering broken content. `DraftRestoredBanner`
+   (new component, rendered above the board, not inside the YAML pane — a
+   board-level fact) shows "Draft restored from `<timestamp>` (local,
+   unsaved)" with two independent actions: dismiss (keep editing, hide the
+   banner) and Discard draft (throw it away, reload the mode's default seed).
+   Best-effort throughout — `localStorage` failures (quota, private
+   browsing) are swallowed, never crash authoring.
+2. **Download .yaml** (`fileIO.ts`'s `downloadYamlFile`, `YamlPane.tsx`'s
+   `DownloadYamlButton`) — the standard Blob + object-URL + synthetic-click
+   pattern, always the CURRENT, complete, unstripped `yamlText`. No server
+   involvement, no transformation — this is the concrete enforcement point for
+   Kirk's "stripping happens at load, not save" ruling; `stripToV1Subset`
+   remains exactly where it already lived (the transient send-time projection
+   Save & Play uses), untouched by this unit.
+3. **Load .yaml** (`YamlPane.tsx`'s `LoadYamlButton`) — a hidden file input
+   behind a styled button; reads the file via `File.text()` and feeds it
+   straight into the SAME `applyText`/`applyCreationText` parse pipeline the
+   Apply button and debounced typing already use (`handleLoadYamlFile`/
+   `handleLoadCreationYamlFile` in `DungeonBuilderConcept.tsx` — no forked
+   pipeline). A malformed file surfaces exactly like a bad paste-and-Apply:
+   the same parse-error banner, same place.
+4. **`spec:` version marker + load-time compat check** (`dungeonYaml.ts`'s
+   new `DungeonDoc.spec` field, `specCompat.ts`, `YamlPane.tsx`'s
+   `SpecCompatBanner`) — see TARGET-YAML.md's new "`spec:` — the
+   authoring-dialect spec-cut marker" section for the full value-scheme
+   writeup (`"0.3"` / `"draft"`, and why it's a genuinely different axis from
+   `version:`). Two independent checks, neither reimplementing the other:
+   `inferSpecCut(doc)` derives the minimum spec cut a document's own
+   constructs require, offline, from spec.md §1/§2's construct table;
+   `buildSpecCompatReport` combines that with `stripToV1Subset`'s own
+   `dropped` list VERBATIM (never recomputed) for what the currently
+   connected server would drop today. `stripToV1Subset` deletes `spec:`
+   UNCONDITIONALLY before any real request — same "key presence alone is
+   rejected by the server's strict decode" lesson as `holes:`/`end:`
+   (`spec:` is never counted in `dropped`/`compiling` either, same treatment
+   as `version:` itself — pure client metadata, not a dialect capability).
+   "New Dungeon"'s seed (`emptyCanvasDoc.ts`) stamps `spec: "0.3"` directly
+   into its template — honest by construction, since a fresh canvas only
+   populates v0.3-ratified constructs.
+
+### Live-verified, 2026-08-06, against the Wave-0 server (`rpg-api:dev-wave0`, `localhost:8092`)
+
+A throwaway Playwright script (this file's own established pattern — own dev
+server, port 3041, `VITE_API_HOST` pointed at `localhost:8092`, never touching
+the shared port-3001 view or any other in-flight unit's port) drove the real
+concept page through the full acceptance loop:
+
+1. Switched to New Dungeon (creation mode). Hand-edited the YAML pane to add a
+   `wallLines:` entry — a draft-only construct — on top of the seed's declared
+   `spec: "0.3"`, creating a genuine, intentional mismatch. Apply succeeded
+   (no parse error).
+2. **`SpecCompatBanner` correctly flagged it, live**: `⚠ spec: "0.3" declared,
+but this document uses draft-only constructs: 1 straight wall — needs
+"draft", not "0.3".` — screenshot at the PR. The pre-existing
+   `CompileBadgeStrip` right above it, unchanged, independently showed `Uses:
+1 straight wall — not yet accepted by this server` alongside `Compiles on
+this server: canvas` (5/17 capabilities live today) — both halves of the
+   compat report visible together, neither one faked.
+3. **Refresh-proof autosave, real browser reload**: `page.reload()`, switched
+   back to New Dungeon — `DraftRestoredBanner` reads "Draft restored from
+   8/6/2026, 10:50:42 PM (local, unsaved)" with the wall geometry intact on
+   the board. Restored text matched the pre-reload text exactly modulo the
+   PRE-EXISTING, already-documented `yaml` package flow-sequence
+   bracket-padding quirk (this file's own top-of-file doc comment on
+   `dungeonYaml.ts`: `[ 1, 1 ]` vs `[1, 1]`) — confirmed by normalizing
+   whitespace inside brackets before comparing; genuinely a pre-existing gap
+   surfacing on a new code path (draft-restore reparses+reserializes on
+   mount, same as every board click's `syncFromCst` already does), not a
+   regression this unit introduces.
+4. **Download .yaml**: the downloaded file byte-matched the pane text exactly
+   — full `spec: "0.3"` and the hand-typed `wallLines:` entry both present,
+   confirming nothing strips on save.
+5. **Discard draft**: board reset to the fresh "New Dungeon" seed — no
+   `wallLines:`, `spec: "0.3"` still present (from the seed template itself).
+6. **Load the downloaded file back in**: loaded text byte-matched the
+   downloaded file exactly (no reparse/reserialize happens on Load until the
+   debounced Apply fires, and Apply never touches the raw text state) — a
+   real, verified round trip. The compat report (both mismatch banner and
+   compile badges) reappeared immediately, unprompted, reading the reloaded
+   document live.
+
+No unexpected console errors either side — only the same benign
+`[invalid_argument] key "" must match ...` noise from
+`usePutDungeonPreview`'s own deliberately-invalid liveness probe every prior
+live-verification round in this file documents.
+
+### Tests
+
+42 new: 11 in `draftStorage.test.ts` (round-trip, per-mode independence,
+overwrite, corrupt/malformed-JSON handling, `localStorage` failure
+best-effort), 5 in `fileIO.test.ts` (Blob content/type, anchor
+href/download/click, object-URL revoke including on a thrown click, no
+leaked DOM node), 20 in `specCompat.test.ts` (every spec.md §1/§2 construct
+individually — `walls:`/`start:`/`canvas:`/`regions:`/top-level `place:`
+correctly do NOT require draft, `wallLines:`/`holes:`/`end:`/`lighting:`/
+`defaults:`/per-placement `mount: wall`/`height`/`rotate_degrees`/`targeting`
+all correctly DO, `facing` correctly does NOT regardless of entry type,
+`buildSpecCompatReport`'s mismatch/conservative/verbatim-passthrough cases),
+6 in `dungeonYaml.test.ts` (parse, `setSpecVersion` round-trip and removal,
+the seed template's honest-by-construction `spec: "0.3"`,
+`stripToV1Subset`'s unconditional delete both when set and when absent).
+Full `src/concepts/dungeon-builder` suite: 514 tests passing, `npm run
+ci-check` (format + lint + typecheck + build + full repo test suite, 2247
+tests) clean.

--- a/src/concepts/dungeon-builder/CONTRACT.md
+++ b/src/concepts/dungeon-builder/CONTRACT.md
@@ -6581,3 +6581,61 @@ the seed template's honest-by-construction `spec: "0.3"`,
 Full `src/concepts/dungeon-builder` suite: 514 tests passing, `npm run
 ci-check` (format + lint + typecheck + build + full repo test suite, 2247
 tests) clean.
+
+### Copilot review round: a real bug, not a nit (PR #717)
+
+One of Copilot's four comments was load-bearing, not cosmetic: the edit/create
+autosave `useEffect`s fired on `yamlText`'s FIRST change too — the one React
+runs right after initial mount — so the pristine default seed itself got
+autosaved 500ms after every fresh load. A refresh would then ALWAYS show
+"Draft restored" for content nobody had touched, and `handleDiscardEditDraft`/
+`handleDiscardCreateDraft`'s own `setYamlText` reset triggered the exact same
+effect again, silently re-autosaving the fresh seed and undoing the discard
+the very next tick.
+
+**Fixed with two independent layers**, per the review's own suggestion:
+
+1. **Skip the mount tick and the tick immediately after an explicit discard.**
+   Extracted the (previously duplicated, once per mode) inline effect into
+   `useDraftAutosave.ts` — a small hook owning a `skipNextRef` that starts
+   `true` (skips the mount tick) and exposes `skipNextTick()` for a discard
+   handler to arm again right before its own `setYamlText` reset. Extracting
+   it also fixed the untestability problem: the original inline effects
+   couldn't be unit-tested without mounting the whole 900+ line composition
+   root (never done anywhere in this concept); the hook can be driven
+   directly with `renderHook` + fake timers.
+2. **Belt-and-suspenders on the restore side.** `draftStorage.ts`'s new
+   `draftDiffersFromFreshSeed(draftText, freshSeedText, canonicalize)` — both
+   texts canonicalized through the SAME `dungeonYaml.ts` parse+serialize round
+   trip before comparing (which washes out the `yaml` package's own
+   pre-existing flow-padding quirk symmetrically on both sides), plus an
+   explicit bracket-padding normalization pass as a second, independent
+   safety net. A stored "draft" indistinguishable from the mode's own fresh
+   seed is never restored or announced, regardless of how it got saved —
+   independent of fix 1 holding, not reliant on it alone.
+
+The other three comments were real but smaller: `LoadYamlButton`'s
+`file.text().then(onLoad)` had no rejection handler (added `.catch`, wired
+through a new `onLoadFileError` prop straight to the same `parseError`/
+`creationParseError` state a bad paste-and-Apply already surfaces through —
+one error affordance, not a second silent one); `SpecCompatBanner`'s doc
+comment claimed it rendered `serverWouldDrop` when only `CompileBadgeStrip`
+does (comment corrected to describe actual behavior); `fileIO.test.ts`
+mutated `URL.createObjectURL`/`revokeObjectURL` directly, which
+`vi.restoreAllMocks()` can't revert since jsdom never defines those
+properties as spyable — captured the originals and restored them by hand in
+`afterEach`, plus a regression test asserting no leak.
+
+**Live-verified again, same Wave-0 server, same throwaway-script pattern**:
+pristine mount → real refresh → no banner (both modes); a real hand-edit →
+refresh → banner correctly appears; Discard → refresh → no banner, confirmed
+stays gone across a SECOND refresh too (not just a one-tick fluke).
+Screenshots: `local-drafts-fix-banner-after-real-edit.png`,
+`local-drafts-fix-no-banner-after-discard.png`.
+
+11 new tests (5 in `useDraftAutosave.test.ts` — mount-skip, real-edit
+autosave, discard-tick-skip, skip-consumed-then-resumes, edit/create
+independence; 5 in `draftStorage.test.ts` for `draftDiffersFromFreshSeed`; 1
+regression test in `fileIO.test.ts`). Full `src/concepts/dungeon-builder`
+suite: 525 tests passing. Full repo `npm run ci-check` and `vitest run`
+(2258 tests) clean.

--- a/src/concepts/dungeon-builder/DraftRestoredBanner.tsx
+++ b/src/concepts/dungeon-builder/DraftRestoredBanner.tsx
@@ -1,0 +1,77 @@
+/**
+ * DraftRestoredBanner — the "draft restored" affordance (local-drafts
+ * unit). Shown once per mount when `DungeonBuilderConcept.tsx` found a
+ * local draft (`draftStorage.ts`) for the current mode and loaded it
+ * instead of the mode's default seed (`SHOWCASE_YAML`/`emptyCanvasYaml`).
+ * Rendered above the board (sibling to the mode tabs), not inside
+ * `YamlPane`/`ProposedYamlPane` — it's a board-level fact (the whole
+ * working document came from a draft, not just the text pane), same
+ * reasoning `ToastBanner` in `DungeonBuilderConcept.tsx` already applies
+ * to page-level, not pane-level, notices.
+ *
+ * Two independent actions, deliberately not conflated:
+ * - **Dismiss** (`onDismiss`) — keep the restored draft as the working
+ *   document, just stop showing the banner. The author's edits.
+ * - **Discard draft** (`onDiscard`) — throw the local draft away and
+ *   reload the mode's default seed instead, for when the restored
+ *   content isn't wanted at all.
+ */
+export function DraftRestoredBanner({
+  savedAt,
+  onDismiss,
+  onDiscard,
+}: {
+  savedAt: number;
+  onDismiss: () => void;
+  onDiscard: () => void;
+}) {
+  const when = new Date(savedAt).toLocaleString();
+  return (
+    <div
+      role="status"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '6px 16px',
+        background: '#1c2233',
+        borderBottom: '1px solid #3a4a6a',
+        color: '#9ac2ff',
+        fontSize: 12,
+      }}
+    >
+      <span>Draft restored from {when} (local, unsaved).</span>
+      <button
+        onClick={onDiscard}
+        style={{
+          background: 'transparent',
+          color: '#9ac2ff',
+          border: '1px solid #3a4a6a',
+          borderRadius: 3,
+          padding: '2px 8px',
+          fontSize: 11,
+          cursor: 'pointer',
+        }}
+      >
+        Discard draft
+      </button>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss draft-restored notice"
+        title="Keep the restored draft, just hide this notice"
+        style={{
+          marginLeft: 'auto',
+          background: 'transparent',
+          color: '#9ac2ff',
+          border: 'none',
+          fontSize: 14,
+          lineHeight: 1,
+          cursor: 'pointer',
+          padding: '0 4px',
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -15,6 +15,8 @@ import type { DemoActions } from './creation/demoScript';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import type { CornerRef } from './creation/hexCorner';
 import { useRegionEditing } from './creation/useRegionEditing';
+import { DraftRestoredBanner } from './DraftRestoredBanner';
+import { discardDraft, loadDraft, saveDraft } from './draftStorage';
 import './DungeonBuilderConcept.css';
 import {
   addWallLine,
@@ -48,6 +50,7 @@ import { Palette } from './Palette';
 import { PALETTE_PROPS } from './paletteData';
 import { DungeonPreview3D } from './preview3d/DungeonPreview3D';
 import { RolledContentPanel } from './RolledContentPanel';
+import { buildSpecCompatReport } from './specCompat';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
 import {
@@ -59,6 +62,11 @@ import { WallGashExplainer } from './WallGashExplainer';
 import { YamlPane } from './YamlPane';
 
 const APPLY_DEBOUNCE_MS = 700;
+// Local drafts (this unit) — a separate, shorter debounce from Apply's:
+// autosave should catch a refresh mid-typing even before the text has
+// finished re-parsing into a valid board, since the whole point is never
+// losing keystrokes, not just never losing compiled state.
+const DRAFT_AUTOSAVE_DEBOUNCE_MS = 500;
 
 type BuilderMode = 'edit' | 'create';
 
@@ -68,7 +76,35 @@ export function DungeonBuilderConcept() {
   // serializeDungeon both do real parsing/stringification work, and a
   // bare `useState(parseDungeon(...))` evaluates that argument on EVERY
   // render (React only USES it on the first), not just once on mount.
-  const [initial] = useState(() => parseDungeon(SHOWCASE_YAML));
+  //
+  // Local drafts (this unit): before falling back to SHOWCASE_YAML, check
+  // for a locally-saved edit-mode draft (`draftStorage.ts`) and restore it
+  // instead — the author never loses a board to a refresh/crash. A
+  // corrupt/unparseable draft is discarded rather than left to keep
+  // failing on every future mount (`editRestoredDraftAt` stays null in
+  // that case, so `DraftRestoredBanner` never appears for content that
+  // was never actually loaded).
+  const [{ parsed: initial, restoredAt: editRestoredDraftAt }] = useState(
+    () => {
+      const draft = loadDraft('edit');
+      if (draft) {
+        try {
+          return {
+            parsed: parseDungeon(draft.yamlText),
+            restoredAt: draft.savedAt,
+          };
+        } catch {
+          discardDraft('edit');
+        }
+      }
+      return {
+        parsed: parseDungeon(SHOWCASE_YAML),
+        restoredAt: null as number | null,
+      };
+    }
+  );
+  const [editDraftBannerDismissed, setEditDraftBannerDismissed] =
+    useState(false);
   const [cst, setCst] = useState(initial.cst);
   const [doc, setDoc] = useState<DungeonDoc>(initial.doc);
   const [yamlText, setYamlText] = useState(() => serializeDungeon(initial.cst));
@@ -140,6 +176,16 @@ export function DungeonBuilderConcept() {
       return null;
     }
   }, [yamlText, preview.capabilities]);
+
+  // Local drafts + versioned save/load (this unit) — the load-time
+  // spec-compatibility report. Reads `v1Subset.dropped` verbatim (see
+  // `specCompat.ts`'s own doc comment); recomputed only when `doc`/
+  // `v1Subset` actually change, same memoization discipline `v1Subset`
+  // itself already follows.
+  const specCompat = useMemo(
+    () => buildSpecCompatReport(doc, v1Subset),
+    [doc, v1Subset]
+  );
 
   const handleWalkIt = () => {
     const walkKey = `${doc.key}-walk`;
@@ -231,6 +277,19 @@ export function DungeonBuilderConcept() {
     );
   };
 
+  // Load .yaml (this unit) — feeds the file's text straight into the SAME
+  // parse/Apply pipeline `applyText`/`handleChangeText` already use
+  // (`applyText(text)` directly, not via the debounce) so a malformed
+  // file surfaces exactly like a bad paste-and-Apply does. Also updates
+  // `yamlText` immediately so the pane reflects the loaded file even if
+  // `applyText` throws.
+  const handleLoadYamlFile = (text: string) => {
+    setYamlText(text);
+    applyText(text);
+  };
+
+  const downloadFilename = `${doc.key || 'dungeon'}.yaml`;
+
   useEffect(
     () => () => {
       if (applyDebounce.current) clearTimeout(applyDebounce.current);
@@ -238,6 +297,32 @@ export function DungeonBuilderConcept() {
     },
     []
   );
+
+  // Local drafts (this unit): debounced autosave of the edit-mode working
+  // text — watches `yamlText`, which board-driven mutations (syncFromCst)
+  // and direct typing (handleChangeText) both already keep current, so
+  // this one effect covers both edit paths without a second write site.
+  // Deliberately saves the RAW text on every debounce tick, not just
+  // successfully-parsed text — the point is never losing keystrokes to a
+  // refresh, including mid-typo.
+  useEffect(() => {
+    const t = setTimeout(
+      () => saveDraft('edit', yamlText),
+      DRAFT_AUTOSAVE_DEBOUNCE_MS
+    );
+    return () => clearTimeout(t);
+  }, [yamlText]);
+
+  const handleDiscardEditDraft = () => {
+    discardDraft('edit');
+    const fresh = parseDungeon(SHOWCASE_YAML);
+    setCst(fresh.cst);
+    setDoc(fresh.doc);
+    setYamlText(serializeDungeon(fresh.cst));
+    setParseError(null);
+    edit.setSelectedPlacement(null);
+    setEditDraftBannerDismissed(true);
+  };
 
   // After any board-driven CST mutation: re-derive doc, re-serialize text.
   const syncFromCst = (nextCst: typeof cst) => {
@@ -267,10 +352,32 @@ export function DungeonBuilderConcept() {
   // placement selection is independent of edit mode's (same "remembered
   // per mode" precedent the collapse-state pairs above already set). See
   // CONTRACT.md's "unifying New Dungeon onto the shared CST" section.
-  // Same lazy-initializer fix as `initial` above.
-  const [creationInitial] = useState(() =>
-    parseDungeon(emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height))
-  );
+  // Same lazy-initializer fix as `initial` above — and the same local-
+  // drafts restore-or-seed check, keyed to the 'create' mode slot so it
+  // never collides with edit mode's own draft (`draftStorage.ts`'s own
+  // doc comment on why the two modes are independent keys).
+  const [{ parsed: creationInitial, restoredAt: createRestoredDraftAt }] =
+    useState(() => {
+      const draft = loadDraft('create');
+      if (draft) {
+        try {
+          return {
+            parsed: parseDungeon(draft.yamlText),
+            restoredAt: draft.savedAt,
+          };
+        } catch {
+          discardDraft('create');
+        }
+      }
+      return {
+        parsed: parseDungeon(
+          emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
+        ),
+        restoredAt: null as number | null,
+      };
+    });
+  const [createDraftBannerDismissed, setCreateDraftBannerDismissed] =
+    useState(false);
   const [creationCst, setCreationCst] = useState(creationInitial.cst);
   const [creationDoc, setCreationDoc] = useState<DungeonDoc>(
     creationInitial.doc
@@ -328,6 +435,15 @@ export function DungeonBuilderConcept() {
       creationV1Subset?.yaml ?? creationYamlText
     );
   };
+
+  // Local drafts + versioned save/load (this unit) — creation mode's own
+  // spec-compat report, same reasoning as edit mode's `specCompat` above.
+  const creationSpecCompat = useMemo(
+    () => buildSpecCompatReport(creationDoc, creationV1Subset),
+    [creationDoc, creationV1Subset]
+  );
+
+  const creationDownloadFilename = `${creationDoc.key || 'dungeon'}.yaml`;
 
   const syncFromCreationCst = (nextCst: typeof creationCst) => {
     setCreationCst(nextCst);
@@ -461,6 +577,14 @@ export function DungeonBuilderConcept() {
     );
   };
 
+  // Load .yaml (this unit) — creation mode's own version of edit mode's
+  // handleLoadYamlFile, same reasoning: feeds the EXISTING parse/Apply
+  // pipeline directly rather than forking it.
+  const handleLoadCreationYamlFile = (text: string) => {
+    setCreationYamlText(text);
+    applyCreationText(text);
+  };
+
   useEffect(
     () => () => {
       if (creationApplyDebounce.current)
@@ -468,6 +592,29 @@ export function DungeonBuilderConcept() {
     },
     []
   );
+
+  // Local drafts (this unit) — creation mode's own autosave, same
+  // reasoning as edit mode's above, keyed to the 'create' slot.
+  useEffect(() => {
+    const t = setTimeout(
+      () => saveDraft('create', creationYamlText),
+      DRAFT_AUTOSAVE_DEBOUNCE_MS
+    );
+    return () => clearTimeout(t);
+  }, [creationYamlText]);
+
+  const handleDiscardCreateDraft = () => {
+    discardDraft('create');
+    const fresh = parseDungeon(
+      emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
+    );
+    setCreationCst(fresh.cst);
+    setCreationDoc(fresh.doc);
+    setCreationYamlText(serializeDungeon(fresh.cst));
+    setCreationParseError(null);
+    creationEdit.setSelectedPlacement(null);
+    setCreateDraftBannerDismissed(true);
+  };
 
   // "Play the pitch" (Kirk's own demo script) drives these same mutators
   // a manual click would — see demoScript.ts's own doc comment. Rebuilt
@@ -594,6 +741,13 @@ export function DungeonBuilderConcept() {
     return (
       <div>
         {modeTabs}
+        {createRestoredDraftAt !== null && !createDraftBannerDismissed && (
+          <DraftRestoredBanner
+            savedAt={createRestoredDraftAt}
+            onDismiss={() => setCreateDraftBannerDismissed(true)}
+            onDiscard={handleDiscardCreateDraft}
+          />
+        )}
         <CreationConcept
           doc={creationDoc}
           yamlText={creationYamlText}
@@ -629,6 +783,9 @@ export function DungeonBuilderConcept() {
           saveErrorMessage={creationSave.errorMessage}
           boardDim={createBoardDim}
           onSetBoardDim={setCreateBoardDim}
+          yamlDownloadFilename={creationDownloadFilename}
+          onLoadYamlFile={handleLoadCreationYamlFile}
+          specCompat={creationSpecCompat}
         />
         {toast && <ToastBanner message={toast} />}
       </div>
@@ -647,6 +804,13 @@ export function DungeonBuilderConcept() {
   return (
     <div>
       {modeTabs}
+      {editRestoredDraftAt !== null && !editDraftBannerDismissed && (
+        <DraftRestoredBanner
+          savedAt={editRestoredDraftAt}
+          onDismiss={() => setEditDraftBannerDismissed(true)}
+          onDiscard={handleDiscardEditDraft}
+        />
+      )}
       <div
         style={{
           display: 'flex',
@@ -860,6 +1024,9 @@ export function DungeonBuilderConcept() {
               v1CompilableBlockers={v1Subset?.compilableBlockers ?? []}
               capabilities={preview.capabilities}
               onRefreshCapabilities={preview.refreshCapabilities}
+              downloadFilename={downloadFilename}
+              onLoadFile={handleLoadYamlFile}
+              specCompat={specCompat}
             />
           </CollapsibleSidePanel>
         </div>

--- a/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
+++ b/src/concepts/dungeon-builder/DungeonBuilderConcept.tsx
@@ -16,7 +16,11 @@ import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import type { CornerRef } from './creation/hexCorner';
 import { useRegionEditing } from './creation/useRegionEditing';
 import { DraftRestoredBanner } from './DraftRestoredBanner';
-import { discardDraft, loadDraft, saveDraft } from './draftStorage';
+import {
+  discardDraft,
+  draftDiffersFromFreshSeed,
+  loadDraft,
+} from './draftStorage';
 import './DungeonBuilderConcept.css';
 import {
   addWallLine,
@@ -53,6 +57,7 @@ import { RolledContentPanel } from './RolledContentPanel';
 import { buildSpecCompatReport } from './specCompat';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
+import { useDraftAutosave } from './useDraftAutosave';
 import {
   useCreationFloorPlanPreview,
   usePutDungeonPreview,
@@ -62,11 +67,12 @@ import { WallGashExplainer } from './WallGashExplainer';
 import { YamlPane } from './YamlPane';
 
 const APPLY_DEBOUNCE_MS = 700;
-// Local drafts (this unit) — a separate, shorter debounce from Apply's:
-// autosave should catch a refresh mid-typing even before the text has
-// finished re-parsing into a valid board, since the whole point is never
-// losing keystrokes, not just never losing compiled state.
-const DRAFT_AUTOSAVE_DEBOUNCE_MS = 500;
+
+/** `draftDiffersFromFreshSeed`'s canonicalize function — the real
+ * parse+serialize round trip, module-level since it needs nothing from
+ * component state. */
+const canonicalizeYaml = (yamlText: string): string =>
+  serializeDungeon(parseDungeon(yamlText).cst);
 
 type BuilderMode = 'edit' | 'create';
 
@@ -84,16 +90,34 @@ export function DungeonBuilderConcept() {
   // failing on every future mount (`editRestoredDraftAt` stays null in
   // that case, so `DraftRestoredBanner` never appears for content that
   // was never actually loaded).
+  //
+  // Honesty guard (Copilot review, PR #717): a stored draft that's
+  // canonically indistinguishable from the fresh SHOWCASE_YAML seed is
+  // NOT a real authored draft — announcing it as one would be dishonest.
+  // This can only happen from a stale localStorage entry today (the
+  // autosave effect below now skips its own mount/discard ticks), but
+  // this check is independent belt-and-suspenders, not reliant on that
+  // fix alone.
   const [{ parsed: initial, restoredAt: editRestoredDraftAt }] = useState(
     () => {
       const draft = loadDraft('edit');
       if (draft) {
-        try {
-          return {
-            parsed: parseDungeon(draft.yamlText),
-            restoredAt: draft.savedAt,
-          };
-        } catch {
+        if (
+          draftDiffersFromFreshSeed(
+            draft.yamlText,
+            SHOWCASE_YAML,
+            canonicalizeYaml
+          )
+        ) {
+          try {
+            return {
+              parsed: parseDungeon(draft.yamlText),
+              restoredAt: draft.savedAt,
+            };
+          } catch {
+            discardDraft('edit');
+          }
+        } else {
           discardDraft('edit');
         }
       }
@@ -288,6 +312,15 @@ export function DungeonBuilderConcept() {
     applyText(text);
   };
 
+  // A real file-READ failure (not a YAML parse error — `applyText` above
+  // already owns that via `parseError`) — `LoadYamlButton`'s own doc
+  // comment (Copilot review, PR #717). Reuses the SAME `parseError` state/
+  // banner rather than a second, silent-except-for-the-console failure
+  // mode.
+  const handleLoadYamlFileError = (message: string) => {
+    setParseError(message);
+  };
+
   const downloadFilename = `${doc.key || 'dungeon'}.yaml`;
 
   useEffect(
@@ -301,20 +334,14 @@ export function DungeonBuilderConcept() {
   // Local drafts (this unit): debounced autosave of the edit-mode working
   // text — watches `yamlText`, which board-driven mutations (syncFromCst)
   // and direct typing (handleChangeText) both already keep current, so
-  // this one effect covers both edit paths without a second write site.
-  // Deliberately saves the RAW text on every debounce tick, not just
-  // successfully-parsed text — the point is never losing keystrokes to a
-  // refresh, including mid-typo.
-  useEffect(() => {
-    const t = setTimeout(
-      () => saveDraft('edit', yamlText),
-      DRAFT_AUTOSAVE_DEBOUNCE_MS
-    );
-    return () => clearTimeout(t);
-  }, [yamlText]);
+  // this one hook call covers both edit paths without a second write
+  // site. See `useDraftAutosave.ts`'s own doc comment for the mount/
+  // discard-tick skip logic it owns (Copilot review, PR #717).
+  const editAutosave = useDraftAutosave('edit', yamlText);
 
   const handleDiscardEditDraft = () => {
     discardDraft('edit');
+    editAutosave.skipNextTick();
     const fresh = parseDungeon(SHOWCASE_YAML);
     setCst(fresh.cst);
     setDoc(fresh.doc);
@@ -355,24 +382,38 @@ export function DungeonBuilderConcept() {
   // Same lazy-initializer fix as `initial` above — and the same local-
   // drafts restore-or-seed check, keyed to the 'create' mode slot so it
   // never collides with edit mode's own draft (`draftStorage.ts`'s own
-  // doc comment on why the two modes are independent keys).
+  // doc comment on why the two modes are independent keys). Same honesty
+  // guard too (Copilot review, PR #717) — a stored draft indistinguishable
+  // from the fresh "New Dungeon" seed is not a real authored draft.
   const [{ parsed: creationInitial, restoredAt: createRestoredDraftAt }] =
     useState(() => {
+      const freshCreationSeed = emptyCanvasYaml(
+        DEFAULT_CANVAS.width,
+        DEFAULT_CANVAS.height
+      );
       const draft = loadDraft('create');
       if (draft) {
-        try {
-          return {
-            parsed: parseDungeon(draft.yamlText),
-            restoredAt: draft.savedAt,
-          };
-        } catch {
+        if (
+          draftDiffersFromFreshSeed(
+            draft.yamlText,
+            freshCreationSeed,
+            canonicalizeYaml
+          )
+        ) {
+          try {
+            return {
+              parsed: parseDungeon(draft.yamlText),
+              restoredAt: draft.savedAt,
+            };
+          } catch {
+            discardDraft('create');
+          }
+        } else {
           discardDraft('create');
         }
       }
       return {
-        parsed: parseDungeon(
-          emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
-        ),
+        parsed: parseDungeon(freshCreationSeed),
         restoredAt: null as number | null,
       };
     });
@@ -585,6 +626,11 @@ export function DungeonBuilderConcept() {
     applyCreationText(text);
   };
 
+  // Creation mode's own version of `handleLoadYamlFileError` above.
+  const handleLoadCreationYamlFileError = (message: string) => {
+    setCreationParseError(message);
+  };
+
   useEffect(
     () => () => {
       if (creationApplyDebounce.current)
@@ -595,16 +641,11 @@ export function DungeonBuilderConcept() {
 
   // Local drafts (this unit) — creation mode's own autosave, same
   // reasoning as edit mode's above, keyed to the 'create' slot.
-  useEffect(() => {
-    const t = setTimeout(
-      () => saveDraft('create', creationYamlText),
-      DRAFT_AUTOSAVE_DEBOUNCE_MS
-    );
-    return () => clearTimeout(t);
-  }, [creationYamlText]);
+  const createAutosave = useDraftAutosave('create', creationYamlText);
 
   const handleDiscardCreateDraft = () => {
     discardDraft('create');
+    createAutosave.skipNextTick();
     const fresh = parseDungeon(
       emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
     );
@@ -785,6 +826,7 @@ export function DungeonBuilderConcept() {
           onSetBoardDim={setCreateBoardDim}
           yamlDownloadFilename={creationDownloadFilename}
           onLoadYamlFile={handleLoadCreationYamlFile}
+          onLoadYamlFileError={handleLoadCreationYamlFileError}
           specCompat={creationSpecCompat}
         />
         {toast && <ToastBanner message={toast} />}
@@ -1026,6 +1068,7 @@ export function DungeonBuilderConcept() {
               onRefreshCapabilities={preview.refreshCapabilities}
               downloadFilename={downloadFilename}
               onLoadFile={handleLoadYamlFile}
+              onLoadFileError={handleLoadYamlFileError}
               specCompat={specCompat}
             />
           </CollapsibleSidePanel>

--- a/src/concepts/dungeon-builder/TARGET-YAML.md
+++ b/src/concepts/dungeon-builder/TARGET-YAML.md
@@ -1821,6 +1821,91 @@ section for the live verification and the one named follow-up (growing
 makes distant content _reachable_, not yet _discoverable_ — no minimap
 or auto-scroll).
 
+## `spec:` — the authoring-dialect spec-cut marker (local-drafts unit)
+
+Kirk's ask, verbatim: "we could have 0.4 able to load in the concept page
+and want to run the v0.3 version of it if possible. maybe we can check
+compatibility." That's two separate needs — a way for a document to SAY
+which spec cut it was authored against, and a way for the builder to
+check that claim against both the document's own structure and whatever
+server it's currently talking to — and `spec:` plus `specCompat.ts`
+(this unit) are the answer to both.
+
+**Two independent version axes — do not conflate them:**
+
+|                     | `version:`                                                             | `spec:`                                                                                                             |
+| ------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| What it names       | The YAML SCHEMA line dungeonspec's own decoder checks                  | Which ratified SPEC CUT (`ideas/dungeon-builder/spec/v0.3/spec.md`) the document's constructs were authored against |
+| Who enforces it     | The real server — `dungeonspec.Validate` hard-rejects anything but `1` | Nobody server-side, ever — pure client-side authoring metadata                                                      |
+| Bump trigger        | An incompatible room/topology change (none has ever happened)          | A new ratified spec level shipping (v0.4, whenever that's real)                                                     |
+| Sent to the server? | Yes, forced to `1` unconditionally (`stripToV1Subset`)                 | Never — deleted unconditionally, same field-presence-alone-is-rejected lesson as `holes:`/`end:`                    |
+
+Growing the target dialect (adding `walls:`, `canvas:`, `regions:`, …)
+has never bumped `version:` and still doesn't — see "Settled early
+model" above. `spec:` is the field that actually answers "how far past
+v1 does this document reach," which `version:` was never designed to
+answer at all.
+
+**Value scheme.** `spec:` is a STRING (`spec: "0.3"`, not a bare
+`spec: 0.3`) — a bare YAML float would round-trip `0.30`/`0.3` ambiguity
+for no reason, and a string leaves room for a non-numeric or suffixed
+value later without a shape change. Two values exist today:
+
+- `"0.3"` — the document uses only constructs in the ratified v0.3 level
+  cut (spec.md §1's four groups: (a) the already-v1 chain, (b) already-
+  compiling `walls:`/`start:`/room-scoped `facing:`, (c) Wave 0 `canvas:`/
+  top-level `place:`, (d) Wave 1 `regions:`). Note groups (c)/(d) count as
+  `"0.3"` even though no server compiles them yet — "not started
+  server-side" and "not part of v0.3" are different facts; the spec
+  itself ratifies the CONSTRUCT, delivery is a separate, later question
+  `capabilityProbe.ts`/`stripToV1Subset` already answer honestly.
+- `"draft"` — the document uses at least one construct spec.md §2
+  explicitly places ABOVE v0.3 (`wallLines:`, `defaults:`, `holes:`,
+  `end:`, `lighting:`, or a placement's `mount: wall`/`height:`/
+  `rotate_degrees:`/`targeting:`). No numbered value exists for "how far
+  above" — `"draft"` is the honest label until whichever construct is
+  itself ratified into a numbered cut, at which point that value (e.g.
+  `"0.4"`) becomes a new valid `spec:` value alongside `"0.3"`, same
+  shape, no migration needed on this field.
+
+**Who writes it.** "New Dungeon" stamps `spec: "0.3"` directly into its
+seed template (`emptyCanvasDoc.ts`) — honest by construction, since the
+only things a fresh canvas populates (`canvas:`, top-level `place:`) are
+both in the v0.3 cut. Nothing else in the builder auto-stamps or
+auto-corrects the field on every edit — the same "don't silently rewrite
+content nothing has explicitly mutated" discipline this file already
+applies to comment preservation. A hand-editor can declare (or change)
+`spec:` directly in the YAML pane like any other field; the load-time
+check below is what keeps that declaration honest without needing the
+builder to police it on every keystroke.
+
+**The load-time check (`specCompat.ts`).** On every load (file, paste,
+board edit — it's a live-derived value, not a one-shot event, same
+"badges can't drift because they ARE the answer, re-asked every time"
+principle `capabilityProbe.ts` already established), two independent
+questions get answered, neither reimplementing the other:
+
+1. **Does the declared `spec:` value match what the document's own
+   constructs actually require?** — `inferSpecCut(doc)`, pure and
+   offline, nothing to do with any server. Flags ONLY the dishonest
+   direction: declaring `"0.3"` while using a draft-only construct.
+   Declaring `"draft"` for an actually-clean document is conservative,
+   not dishonest, and is deliberately not flagged.
+2. **What would the CURRENTLY CONNECTED server actually drop from this
+   document today?** — read verbatim from `stripToV1Subset`'s own
+   `dropped` list (`capabilityProbe.ts`'s live probe), never recomputed.
+   This is the existing compile-badge machinery (`CompileBadgeStrip`),
+   unchanged by this unit — `specCompat.ts`'s `buildSpecCompatReport`
+   just reads its output rather than re-deriving it.
+
+A document can be spec-clean (`"0.3"`, nothing flagged) and still have
+real server drops today (any from-scratch canvas doc, until platform
+Wave 0 ships) — the two questions are genuinely independent axes, not
+the same fact asked twice. `YamlPane.tsx`'s `SpecCompatBanner` renders
+axis 1; the pre-existing `CompileBadgeStrip` right above it renders axis
+2 — see CONTRACT.md's "local drafts + versioned save/load" ledger entry
+for the live-verified screenshot of both together.
+
 ## What this file is not
 
 Not a request. Not Kirk-approved as a server-side commitment. Not a

--- a/src/concepts/dungeon-builder/YamlPane.tsx
+++ b/src/concepts/dungeon-builder/YamlPane.tsx
@@ -38,9 +38,26 @@
  * now" instead of silently omitting them. `capabilities`/
  * `onRefreshCapabilities` drive the small "server capabilities" readout
  * beside the LIVE badge — the same probe result, surfaced honestly rather
- * than only acted on invisibly. */
+ * than only acted on invisibly.
+ *
+ * **Local drafts + versioned save/load (this unit)**: `DownloadYamlButton`/
+ * `LoadYamlButton`/`SpecCompatBanner` below are the three new pieces,
+ * exported the same way `CompileBadgeStrip`/`SaveAndPlayButton` already
+ * are so `creation/ProposedYamlPane.tsx` reuses them instead of growing a
+ * second copy. Download/Load never touch the server or `stripToV1Subset`
+ * — Kirk's ruling, verbatim: "compatibility stripping should happen at
+ * load time not save," so a downloaded/loaded file is always the complete
+ * authoring dialect (`fileIO.ts`'s own doc comment has the full
+ * reasoning). `SpecCompatBanner` renders the other half of "load time":
+ * `specCompat.ts`'s spec-cut inference/mismatch, computed by the parent
+ * and handed down as one plain-data prop — this component still never
+ * imports `DungeonDoc` itself, same "don't deep-couple" bar CONTRACT.md's
+ * Operating Bar section sets. */
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
+import { useRef } from 'react';
 import { capabilitySummary, type ServerCapabilities } from './capabilityProbe';
+import { downloadYamlFile } from './fileIO';
+import type { SpecCompatReport } from './specCompat';
 import type { ServerState } from './usePutDungeonPreview';
 import type { SaveState } from './useSaveDungeon';
 
@@ -86,6 +103,18 @@ interface YamlPaneProps {
    * drives the "server capabilities" readout beside the LIVE badge. */
   capabilities: ServerCapabilities | null;
   onRefreshCapabilities: () => void;
+  /** Filename the Download button writes — computed by the parent
+   * (`${doc.key || 'dungeon'}.yaml`) so this component still never needs
+   * `doc` itself. */
+  downloadFilename: string;
+  /** Wired by the parent straight to `applyText` (edit mode) /
+   * `applyCreationText` (creation mode) — the SAME parse/Apply pipeline
+   * the Apply button and debounced typing already use. See
+   * `LoadYamlButton`'s own doc comment. */
+  onLoadFile: (text: string) => void;
+  /** The load-time spec-compatibility report (`specCompat.ts`) — see
+   * `SpecCompatBanner`'s own doc comment. */
+  specCompat: SpecCompatReport;
 }
 
 function ServerBadge({
@@ -324,6 +353,127 @@ export function SaveAndPlayButton({
   );
 }
 
+/** Downloads the CURRENT, full-fidelity dialect YAML text — never
+ * stripped, no server round trip (`fileIO.ts`'s `downloadYamlFile`). See
+ * this file's own doc comment for Kirk's "stripping happens at load, not
+ * save" ruling this button exists to satisfy. */
+export function DownloadYamlButton({
+  yamlText,
+  filename,
+}: {
+  yamlText: string;
+  filename: string;
+}) {
+  return (
+    <button
+      onClick={() => downloadYamlFile(filename, yamlText)}
+      title="Download the complete authoring-dialect YAML — never stripped, no server round trip."
+      style={{
+        background: 'transparent',
+        color: '#8a7a5a',
+        border: '1px solid var(--border-primary)',
+        borderRadius: 4,
+        padding: '5px 10px',
+        fontSize: 12,
+        fontWeight: 600,
+        cursor: 'pointer',
+      }}
+    >
+      Download .yaml
+    </button>
+  );
+}
+
+/** Loads a `.yaml` file from disk into the SAME parse/Apply path the
+ * Apply button and debounced typing already use (`onLoad`, wired by the
+ * parent to `applyText`/`applyCreationText` directly — see
+ * `DungeonBuilderConcept.tsx`'s `handleLoadYamlFile`) — no separate
+ * pipeline, so a parse error surfaces exactly like Apply's already does.
+ * A hidden file input behind a styled button, the standard pattern for a
+ * button-triggered file picker. Resets its own value after each pick so
+ * selecting the SAME file twice in a row still fires `onChange` (browsers
+ * dedupe on unchanged `<input>` value otherwise). */
+export function LoadYamlButton({ onLoad }: { onLoad: (text: string) => void }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <button
+        onClick={() => inputRef.current?.click()}
+        title="Load a .yaml file — replaces the current document, same as pasting + Apply."
+        style={{
+          background: 'transparent',
+          color: '#8a7a5a',
+          border: '1px solid var(--border-primary)',
+          borderRadius: 4,
+          padding: '5px 10px',
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: 'pointer',
+        }}
+      >
+        Load .yaml
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".yaml,.yml,text/yaml"
+        aria-label="Load dungeon YAML file"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = '';
+          if (!file) return;
+          void file.text().then(onLoad);
+        }}
+      />
+    </>
+  );
+}
+
+/** The load-time spec-compatibility report (`specCompat.ts`, local-drafts
+ * unit) — Kirk's ask: "we could have 0.4 able to load in the concept page
+ * and want to run the v0.3 version of it if possible. maybe we can check
+ * compatibility." Two lines, each independently honest: the declared-vs-
+ * inferred spec CUT (a document-structure fact, nothing to do with any
+ * live server), and — reusing `stripToV1Subset`'s own `dropped` list
+ * verbatim, never recomputed — what the CONNECTED server would actually
+ * drop from this document today (a live-capability fact). Renders nothing
+ * when there is truly nothing to say: no `spec:` declared, the document
+ * is 0.3-clean, and the server would drop nothing — the same "only appear
+ * when there's something real to report" discipline `CompileBadgeStrip`
+ * already follows. */
+export function SpecCompatBanner({ report }: { report: SpecCompatReport }) {
+  const { declaredSpec, inferredCut, inferredReasons, specMismatch } = report;
+  const hasSpecLine =
+    declaredSpec !== null || inferredCut === 'draft' || specMismatch;
+  if (!hasSpecLine) return null;
+
+  const specLine = specMismatch
+    ? `spec: "${declaredSpec}" declared, but this document uses draft-only constructs: ${inferredReasons.join(', ')} — needs "draft", not "0.3".`
+    : declaredSpec !== null
+      ? `spec: "${declaredSpec}" — ${inferredCut === declaredSpec ? 'matches' : 'declared conservatively; inferred'} ${inferredCut === declaredSpec ? 'what this document actually uses.' : `"${inferredCut}" would also be accurate.`}`
+      : inferredCut === 'draft'
+        ? `No spec: declared — this document requires "draft" (uses: ${inferredReasons.join(', ')}).`
+        : `No spec: declared — inferred "0.3" (only ratified constructs used).`;
+
+  return (
+    <div
+      style={{
+        fontSize: 11,
+        color: specMismatch ? '#ff9a8a' : '#8fc9e8',
+        background: specMismatch ? '#2a1512' : '#101f26',
+        border: `1px solid ${specMismatch ? '#5a2a20' : '#2a4a5a'}`,
+        borderRadius: 4,
+        padding: '5px 8px',
+        lineHeight: 1.4,
+      }}
+    >
+      {specMismatch ? '⚠ ' : ''}
+      {specLine}
+    </div>
+  );
+}
+
 /** Shared by both Save & Play and Walk it — `honestyNote`, when given, is
  * appended to the success message (Walk it's one real caveat: the boss
  * pin survives). */
@@ -429,6 +579,9 @@ export function YamlPane({
   v1CompilableBlockers,
   capabilities,
   onRefreshCapabilities,
+  downloadFilename,
+  onLoadFile,
+  specCompat,
 }: YamlPaneProps) {
   const hasDialectFields = dialectDropped.length > 0;
   const canWalk = serverState === 'live' && walkState !== 'saving';
@@ -475,6 +628,10 @@ export function YamlPane({
           </span>
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <DownloadYamlButton yamlText={yamlText} filename={downloadFilename} />
+          <LoadYamlButton onLoad={onLoadFile} />
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <ServerBadge serverState={serverState} onRetryProbe={onRetryProbe} />
         </div>
         <CapabilitiesLine
@@ -486,6 +643,7 @@ export function YamlPane({
           dropped={dialectDropped}
           compiling={dialectCompiling}
         />
+        <SpecCompatBanner report={specCompat} />
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <SaveAndPlayButton
             serverState={serverState}

--- a/src/concepts/dungeon-builder/YamlPane.tsx
+++ b/src/concepts/dungeon-builder/YamlPane.tsx
@@ -112,6 +112,11 @@ interface YamlPaneProps {
    * the Apply button and debounced typing already use. See
    * `LoadYamlButton`'s own doc comment. */
   onLoadFile: (text: string) => void;
+  /** A real file-read failure (not a YAML parse error — see
+   * `LoadYamlButton`'s own doc comment) — wired by the parent to the same
+   * `parseError`/`creationParseError` state a bad paste-and-Apply already
+   * surfaces through. */
+  onLoadFileError: (message: string) => void;
   /** The load-time spec-compatibility report (`specCompat.ts`) — see
    * `SpecCompatBanner`'s own doc comment. */
   specCompat: SpecCompatReport;
@@ -393,7 +398,20 @@ export function DownloadYamlButton({
  * button-triggered file picker. Resets its own value after each pick so
  * selecting the SAME file twice in a row still fires `onChange` (browsers
  * dedupe on unchanged `<input>` value otherwise). */
-export function LoadYamlButton({ onLoad }: { onLoad: (text: string) => void }) {
+export function LoadYamlButton({
+  onLoad,
+  onLoadError,
+}: {
+  onLoad: (text: string) => void;
+  /** Called when `File.text()` itself rejects (a real read failure — file
+   * became inaccessible, permission revoked mid-pick, etc., NOT a YAML
+   * parse error, which `onLoad`'s own `applyText`/`applyCreationText`
+   * already catches and reports through `parseError`). Wired by the
+   * parent to the SAME `parseError`/`creationParseError` state a bad
+   * paste-and-Apply already surfaces through — one error affordance, not
+   * a second, silent-except-for-the-console one. */
+  onLoadError: (message: string) => void;
+}) {
   const inputRef = useRef<HTMLInputElement>(null);
   return (
     <>
@@ -423,7 +441,16 @@ export function LoadYamlButton({ onLoad }: { onLoad: (text: string) => void }) {
           const file = e.target.files?.[0];
           e.target.value = '';
           if (!file) return;
-          void file.text().then(onLoad);
+          void file
+            .text()
+            .then(onLoad)
+            .catch((err: unknown) => {
+              onLoadError(
+                err instanceof Error
+                  ? `Could not read file: ${err.message}`
+                  : 'Could not read the selected file.'
+              );
+            });
         }}
       />
     </>
@@ -433,15 +460,18 @@ export function LoadYamlButton({ onLoad }: { onLoad: (text: string) => void }) {
 /** The load-time spec-compatibility report (`specCompat.ts`, local-drafts
  * unit) — Kirk's ask: "we could have 0.4 able to load in the concept page
  * and want to run the v0.3 version of it if possible. maybe we can check
- * compatibility." Two lines, each independently honest: the declared-vs-
- * inferred spec CUT (a document-structure fact, nothing to do with any
- * live server), and — reusing `stripToV1Subset`'s own `dropped` list
- * verbatim, never recomputed — what the CONNECTED server would actually
- * drop from this document today (a live-capability fact). Renders nothing
- * when there is truly nothing to say: no `spec:` declared, the document
- * is 0.3-clean, and the server would drop nothing — the same "only appear
+ * compatibility." Renders ONLY the declared-vs-inferred spec CUT (a
+ * document-structure fact, nothing to do with any live server) — the
+ * OTHER half of that compatibility question, what the CONNECTED server
+ * would actually drop from this document today, is `report.serverWouldDrop`
+ * (reusing `stripToV1Subset`'s own `dropped` list verbatim, never
+ * recomputed) and is already rendered by the pre-existing
+ * `CompileBadgeStrip` right above this component in both `YamlPane`/
+ * `ProposedYamlPane` — this component doesn't re-render that half, just
+ * sits next to it. Renders nothing when there is truly nothing to say: no
+ * `spec:` declared and the document is 0.3-clean — the same "only appear
  * when there's something real to report" discipline `CompileBadgeStrip`
- * already follows. */
+ * itself follows. */
 export function SpecCompatBanner({ report }: { report: SpecCompatReport }) {
   const { declaredSpec, inferredCut, inferredReasons, specMismatch } = report;
   const hasSpecLine =
@@ -581,6 +611,7 @@ export function YamlPane({
   onRefreshCapabilities,
   downloadFilename,
   onLoadFile,
+  onLoadFileError,
   specCompat,
 }: YamlPaneProps) {
   const hasDialectFields = dialectDropped.length > 0;
@@ -629,7 +660,7 @@ export function YamlPane({
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <DownloadYamlButton yamlText={yamlText} filename={downloadFilename} />
-          <LoadYamlButton onLoad={onLoadFile} />
+          <LoadYamlButton onLoad={onLoadFile} onLoadError={onLoadFileError} />
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <ServerBadge serverState={serverState} onRetryProbe={onRetryProbe} />

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -117,6 +117,7 @@ interface CreationConceptProps {
    * matching edit-mode props. */
   yamlDownloadFilename: string;
   onLoadYamlFile: (text: string) => void;
+  onLoadYamlFileError: (message: string) => void;
   specCompat: SpecCompatReport;
 }
 
@@ -157,6 +158,7 @@ export function CreationConcept({
   onSetBoardDim,
   yamlDownloadFilename,
   onLoadYamlFile,
+  onLoadYamlFileError,
   specCompat,
 }: CreationConceptProps) {
   const [dims, setDims] = useState(DEFAULT_CANVAS);
@@ -545,6 +547,7 @@ export function CreationConcept({
             saveErrorMessage={saveErrorMessage}
             downloadFilename={yamlDownloadFilename}
             onLoadFile={onLoadYamlFile}
+            onLoadFileError={onLoadYamlFileError}
             specCompat={specCompat}
           />
         </CollapsibleSidePanel>

--- a/src/concepts/dungeon-builder/creation/CreationConcept.tsx
+++ b/src/concepts/dungeon-builder/creation/CreationConcept.tsx
@@ -16,6 +16,7 @@ import type { DungeonDoc, V1SubsetResult, WallKind } from '../dungeonYaml';
 import { Inspector } from '../Inspector';
 import { Palette } from '../Palette';
 import { DungeonPreview3D } from '../preview3d/DungeonPreview3D';
+import type { SpecCompatReport } from '../specCompat';
 import type { BoardTool } from '../types';
 import type { BoardEditing } from '../useBoardEditing';
 import type { ServerState } from '../usePutDungeonPreview';
@@ -111,6 +112,12 @@ interface CreationConceptProps {
    * this is owned by the parent rather than local `useState` here. */
   boardDim: BoardDim;
   onSetBoardDim: (dim: BoardDim) => void;
+  /** Local drafts + versioned save/load (this unit) — threaded straight
+   * to `ProposedYamlPane`. See `YamlPane.tsx`'s own doc comment on the
+   * matching edit-mode props. */
+  yamlDownloadFilename: string;
+  onLoadYamlFile: (text: string) => void;
+  specCompat: SpecCompatReport;
 }
 
 export function CreationConcept({
@@ -148,6 +155,9 @@ export function CreationConcept({
   saveErrorMessage,
   boardDim,
   onSetBoardDim,
+  yamlDownloadFilename,
+  onLoadYamlFile,
+  specCompat,
 }: CreationConceptProps) {
   const [dims, setDims] = useState(DEFAULT_CANVAS);
 
@@ -533,6 +543,9 @@ export function CreationConcept({
             savedKey={savedKey}
             saveFieldErrors={saveFieldErrors}
             saveErrorMessage={saveErrorMessage}
+            downloadFilename={yamlDownloadFilename}
+            onLoadFile={onLoadYamlFile}
+            specCompat={specCompat}
           />
         </CollapsibleSidePanel>
       </div>

--- a/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
+++ b/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
@@ -42,13 +42,17 @@
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import type { ServerCapabilities } from '../capabilityProbe';
 import type { V1SubsetResult } from '../dungeonYaml';
+import type { SpecCompatReport } from '../specCompat';
 import type { ServerState } from '../usePutDungeonPreview';
 import type { SaveState } from '../useSaveDungeon';
 import {
   CapabilitiesLine,
   CompileBadgeStrip,
+  DownloadYamlButton,
+  LoadYamlButton,
   SaveAndPlayButton,
   SaveResultPanel,
+  SpecCompatBanner,
 } from '../YamlPane';
 
 interface ProposedYamlPaneProps {
@@ -64,6 +68,12 @@ interface ProposedYamlPaneProps {
   savedKey: string | null;
   saveFieldErrors: ValidationError[];
   saveErrorMessage: string | null;
+  /** Local drafts + versioned save/load (this unit) — see
+   * `YamlPane.tsx`'s own doc comment on these three props; same shape,
+   * reused directly rather than re-specified. */
+  downloadFilename: string;
+  onLoadFile: (text: string) => void;
+  specCompat: SpecCompatReport;
 }
 
 export function ProposedYamlPane({
@@ -79,6 +89,9 @@ export function ProposedYamlPane({
   savedKey,
   saveFieldErrors,
   saveErrorMessage,
+  downloadFilename,
+  onLoadFile,
+  specCompat,
 }: ProposedYamlPaneProps) {
   const dropped = v1Subset?.dropped ?? [];
   const compiling = v1Subset?.compiling ?? [];
@@ -119,12 +132,17 @@ export function ProposedYamlPane({
           gap: 4,
         }}
       >
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <DownloadYamlButton yamlText={yamlText} filename={downloadFilename} />
+          <LoadYamlButton onLoad={onLoadFile} />
+        </div>
         <CapabilitiesLine
           serverState={serverState}
           capabilities={capabilities}
           onRefresh={onRefreshCapabilities}
         />
         <CompileBadgeStrip dropped={dropped} compiling={compiling} />
+        <SpecCompatBanner report={specCompat} />
         <SaveAndPlayButton
           serverState={serverState}
           saveState={saveState}

--- a/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
+++ b/src/concepts/dungeon-builder/creation/ProposedYamlPane.tsx
@@ -69,10 +69,11 @@ interface ProposedYamlPaneProps {
   saveFieldErrors: ValidationError[];
   saveErrorMessage: string | null;
   /** Local drafts + versioned save/load (this unit) — see
-   * `YamlPane.tsx`'s own doc comment on these three props; same shape,
-   * reused directly rather than re-specified. */
+   * `YamlPane.tsx`'s own doc comment on these props; same shape, reused
+   * directly rather than re-specified. */
   downloadFilename: string;
   onLoadFile: (text: string) => void;
+  onLoadFileError: (message: string) => void;
   specCompat: SpecCompatReport;
 }
 
@@ -91,6 +92,7 @@ export function ProposedYamlPane({
   saveErrorMessage,
   downloadFilename,
   onLoadFile,
+  onLoadFileError,
   specCompat,
 }: ProposedYamlPaneProps) {
   const dropped = v1Subset?.dropped ?? [];
@@ -134,7 +136,7 @@ export function ProposedYamlPane({
       >
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
           <DownloadYamlButton yamlText={yamlText} filename={downloadFilename} />
-          <LoadYamlButton onLoad={onLoadFile} />
+          <LoadYamlButton onLoad={onLoadFile} onLoadError={onLoadFileError} />
         </div>
         <CapabilitiesLine
           serverState={serverState}

--- a/src/concepts/dungeon-builder/creation/emptyCanvasDoc.ts
+++ b/src/concepts/dungeon-builder/creation/emptyCanvasDoc.ts
@@ -27,11 +27,21 @@
  * version." Additive target-dialect capabilities stay on `version: 1`; a
  * real version bump is reserved for an incompatible room/topology change,
  * which this from-scratch canvas is not.
+ *
+ * `spec: "0.3"` (local-drafts unit) is stamped here, not injected by a
+ * runtime mutator, because it's honest BY CONSTRUCTION: every field this
+ * template writes (`canvas:`, top-level `place:`) is in the ratified
+ * v0.3 level cut (spec.md §1 group c) and nothing else is populated, so
+ * "New Dungeon" starting life declaring `0.3` needs no inference — see
+ * `specCompat.ts`'s `inferSpecCut` for what happens the moment an author
+ * adds a draft-only construct (the declared value stops matching the
+ * inferred one, and the compat report says so).
  */
 export const DEFAULT_CANVAS = { width: 20, height: 30 };
 
 export function emptyCanvasYaml(width: number, height: number): string {
   return `version: 1
+spec: "0.3"
 key: untitled-creation
 name: "Untitled Dungeon"
 height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads

--- a/src/concepts/dungeon-builder/draftStorage.test.ts
+++ b/src/concepts/dungeon-builder/draftStorage.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { discardDraft, loadDraft, saveDraft } from './draftStorage';
+import {
+  discardDraft,
+  draftDiffersFromFreshSeed,
+  loadDraft,
+  saveDraft,
+} from './draftStorage';
 
 describe('draftStorage', () => {
   beforeEach(() => {
@@ -83,6 +88,48 @@ describe('draftStorage', () => {
         throw new Error('storage unavailable');
       });
       expect(() => discardDraft('edit')).not.toThrow();
+    });
+  });
+
+  describe('draftDiffersFromFreshSeed (honesty guard, Copilot review PR #717)', () => {
+    // An identity canonicalizer is enough to test THIS function's own
+    // comparison/normalization logic in isolation — the real
+    // `dungeonYaml.ts` parse+serialize round trip is exercised instead by
+    // `DungeonBuilderConcept.tsx`'s own live-verified call site (see
+    // CONTRACT.md).
+    const identity = (s: string) => s;
+
+    it('identical text is NOT meaningfully different', () => {
+      expect(draftDiffersFromFreshSeed('same', 'same', identity)).toBe(false);
+    });
+
+    it('different text IS meaningfully different', () => {
+      expect(draftDiffersFromFreshSeed('edited', 'fresh-seed', identity)).toBe(
+        true
+      );
+    });
+
+    it('normalizes flow-sequence bracket padding before comparing — the pre-existing yaml package quirk does not count as a real difference', () => {
+      const padded = 'wallLines: [ { from: [ 2, 2 ] } ]';
+      const unpadded = 'wallLines: [{ from: [2, 2] }]';
+      expect(draftDiffersFromFreshSeed(padded, unpadded, identity)).toBe(false);
+    });
+
+    it('falls back to true (meaningful) when canonicalize throws for either input — the safe failure direction', () => {
+      const throwing = () => {
+        throw new Error('parse failure');
+      };
+      expect(draftDiffersFromFreshSeed('a', 'b', throwing)).toBe(true);
+    });
+
+    it('calls canonicalize on both the draft and the fresh seed, not just one', () => {
+      const seen: string[] = [];
+      const canonicalize = (s: string) => {
+        seen.push(s);
+        return s;
+      };
+      draftDiffersFromFreshSeed('draft-text', 'seed-text', canonicalize);
+      expect(seen).toEqual(['draft-text', 'seed-text']);
     });
   });
 });

--- a/src/concepts/dungeon-builder/draftStorage.test.ts
+++ b/src/concepts/dungeon-builder/draftStorage.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { discardDraft, loadDraft, saveDraft } from './draftStorage';
+
+describe('draftStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips a saved draft', () => {
+    saveDraft('edit', 'version: 1\nkey: foo\n');
+    const loaded = loadDraft('edit');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.yamlText).toBe('version: 1\nkey: foo\n');
+    expect(typeof loaded!.savedAt).toBe('number');
+  });
+
+  it('returns null when nothing has been saved for that mode', () => {
+    expect(loadDraft('edit')).toBeNull();
+  });
+
+  it('keeps edit and create drafts independent', () => {
+    saveDraft('edit', 'edit-doc');
+    saveDraft('create', 'create-doc');
+    expect(loadDraft('edit')!.yamlText).toBe('edit-doc');
+    expect(loadDraft('create')!.yamlText).toBe('create-doc');
+  });
+
+  it('a later save for the same mode overwrites the earlier one', () => {
+    saveDraft('edit', 'first');
+    saveDraft('edit', 'second');
+    expect(loadDraft('edit')!.yamlText).toBe('second');
+  });
+
+  it('discardDraft removes the stored draft', () => {
+    saveDraft('edit', 'doomed');
+    discardDraft('edit');
+    expect(loadDraft('edit')).toBeNull();
+  });
+
+  it('discarding one mode does not touch the other', () => {
+    saveDraft('edit', 'edit-doc');
+    saveDraft('create', 'create-doc');
+    discardDraft('edit');
+    expect(loadDraft('edit')).toBeNull();
+    expect(loadDraft('create')!.yamlText).toBe('create-doc');
+  });
+
+  it('treats corrupt JSON under the key as no draft, not a crash', () => {
+    localStorage.setItem('dungeon-builder:draft:edit', 'not json{{{');
+    expect(loadDraft('edit')).toBeNull();
+  });
+
+  it('treats a foreign/malformed value (missing fields) as no draft', () => {
+    localStorage.setItem(
+      'dungeon-builder:draft:edit',
+      JSON.stringify({ somethingElse: true })
+    );
+    expect(loadDraft('edit')).toBeNull();
+  });
+
+  describe('storage failures are best-effort, never thrown', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('saveDraft swallows a setItem failure (quota/private-mode)', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('quota exceeded');
+      });
+      expect(() => saveDraft('edit', 'anything')).not.toThrow();
+    });
+
+    it('loadDraft swallows a getItem failure', () => {
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+      expect(() => loadDraft('edit')).not.toThrow();
+      expect(loadDraft('edit')).toBeNull();
+    });
+
+    it('discardDraft swallows a removeItem failure', () => {
+      vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+      expect(() => discardDraft('edit')).not.toThrow();
+    });
+  });
+});

--- a/src/concepts/dungeon-builder/draftStorage.ts
+++ b/src/concepts/dungeon-builder/draftStorage.ts
@@ -1,0 +1,84 @@
+/**
+ * draftStorage — refresh-proof local drafts for the Dungeon Builder
+ * (local-drafts unit, Kirk's ask verbatim: "the author never loses a
+ * board to a refresh/crash"). Persists the WORKING doc's full-dialect
+ * YAML TEXT — the CST source `YamlPane`/`ProposedYamlPane` show, comments
+ * and formatting included, never a stripped/parsed projection — to
+ * `localStorage`, keyed per mode/tab so edit mode and creation mode
+ * ("New Dungeon") each keep their own, independent draft. Same
+ * "remembered per mode" precedent `DungeonBuilderConcept.tsx`'s
+ * palette/YAML collapse-state pairs already set (state that would
+ * otherwise reset on an edit<->create tab switch has to live keyed by
+ * mode, not as one shared slot).
+ *
+ * Deliberately NOT the same thing as a real save: this is a client-only,
+ * best-effort safety net against an accidental refresh/tab-close, not a
+ * server persistence mechanism (Save & Play / Download own that). Every
+ * function here is best-effort — `localStorage` can throw (private
+ * browsing quota, disabled storage, a corrupted/foreign value under this
+ * key) — and swallows that rather than crashing the author's session
+ * over an autosave failure.
+ */
+
+export type DraftMode = 'edit' | 'create';
+
+const DRAFT_KEY_PREFIX = 'dungeon-builder:draft:';
+
+export interface StoredDraft {
+  /** Full-fidelity YAML text — the CST source, exactly as the pane last
+   * showed it, never stripped (Kirk's ruling: "compatibility stripping
+   * should happen at load time not save"). */
+  yamlText: string;
+  /** `Date.now()` at the moment this draft was written — drives the
+   * "draft restored from ..." affordance's timestamp. */
+  savedAt: number;
+}
+
+function draftKey(mode: DraftMode): string {
+  return `${DRAFT_KEY_PREFIX}${mode}`;
+}
+
+/** Best-effort read — `null` on no stored draft, corrupt/foreign JSON, a
+ * value missing either field, or `localStorage` throwing outright. Never
+ * throws. */
+export function loadDraft(mode: DraftMode): StoredDraft | null {
+  try {
+    const raw = localStorage.getItem(draftKey(mode));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredDraft>;
+    if (
+      typeof parsed.yamlText !== 'string' ||
+      typeof parsed.savedAt !== 'number'
+    ) {
+      return null;
+    }
+    return { yamlText: parsed.yamlText, savedAt: parsed.savedAt };
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort write — silently no-ops on a storage failure (quota,
+ * private-mode restrictions, `localStorage` unavailable entirely). Never
+ * blocks or interrupts authoring; callers debounce their own calls to
+ * this (see `DungeonBuilderConcept.tsx`'s autosave `useEffect`s) — this
+ * function itself does no debouncing of its own. */
+export function saveDraft(mode: DraftMode, yamlText: string): void {
+  try {
+    const entry: StoredDraft = { yamlText, savedAt: Date.now() };
+    localStorage.setItem(draftKey(mode), JSON.stringify(entry));
+  } catch {
+    // best-effort — see this file's own doc comment.
+  }
+}
+
+/** Clears the stored draft for `mode` — the "discard draft" control's own
+ * action (reload the mode's default seed and stop offering this draft
+ * back). Best-effort, same as `saveDraft`/`loadDraft`. */
+export function discardDraft(mode: DraftMode): void {
+  try {
+    localStorage.removeItem(draftKey(mode));
+  } catch {
+    // best-effort — see this file's own doc comment.
+  }
+}

--- a/src/concepts/dungeon-builder/draftStorage.ts
+++ b/src/concepts/dungeon-builder/draftStorage.ts
@@ -18,6 +18,19 @@
  * browsing quota, disabled storage, a corrupted/foreign value under this
  * key) — and swallows that rather than crashing the author's session
  * over an autosave failure.
+ *
+ * **Honesty guard (Copilot review, PR #717)**: the autosave effect in
+ * `DungeonBuilderConcept.tsx` fires on every `yamlText` change, INCLUDING
+ * the one React runs after initial mount — so without a guard, the
+ * pristine default seed itself gets autosaved 500ms after every fresh
+ * load, and the very next refresh would show a "draft restored" banner
+ * for a document nobody actually touched. Two independent layers fix
+ * this: `DungeonBuilderConcept.tsx` skips the mount-triggered and
+ * discard-triggered autosave ticks explicitly (a ref flag, not this
+ * module's concern), and — as a second, independent safety net this
+ * module DOES own — `draftDiffersFromFreshSeed` below lets the restore
+ * path refuse to announce a "draft" that's indistinguishable from the
+ * mode's own fresh seed, regardless of how it got saved.
  */
 
 export type DraftMode = 'edit' | 'create';
@@ -80,5 +93,45 @@ export function discardDraft(mode: DraftMode): void {
     localStorage.removeItem(draftKey(mode));
   } catch {
     // best-effort — see this file's own doc comment.
+  }
+}
+
+/** True when `draftYamlText` is MEANINGFULLY different from
+ * `freshSeedYamlText` — the restore path's honesty guard (see this
+ * file's own doc comment). Both sides are canonicalized through the same
+ * `dungeonYaml.ts` parse+serialize round trip before comparing, which
+ * already washes out the `yaml` package's own pre-existing flow-sequence
+ * bracket-padding quirk (`dungeonYaml.ts`'s top-of-file doc comment) —
+ * BOTH strings pass through the identical serializer, so any padding it
+ * introduces applies symmetrically. An explicit bracket-padding
+ * normalization pass runs on top as a second, independent safety net
+ * against any other asymmetry between the two round trips.
+ *
+ * Falls back to `true` (treat as meaningful — the safe direction) if
+ * EITHER text fails to parse: a genuinely corrupt stored draft is the
+ * caller's job to detect and discard separately (`parseDungeon` throwing
+ * on `draftYamlText` there is a real, different failure mode, not this
+ * function's concern); showing an honest "restored" banner for content
+ * this function can't confidently prove is a no-op is the safer failure
+ * mode than silently hiding something real.
+ *
+ * Takes plain YAML strings, not a `DungeonDoc`/CST — deliberately not
+ * async, deliberately synchronous and pure, so `DungeonBuilderConcept.tsx`
+ * can call it straight from a `useState` lazy initializer. */
+export function draftDiffersFromFreshSeed(
+  draftYamlText: string,
+  freshSeedYamlText: string,
+  canonicalize: (yamlText: string) => string
+): boolean {
+  const normalizeFlowPadding = (s: string) =>
+    s.replace(/\[\s+/g, '[').replace(/\s+\]/g, ']');
+  try {
+    const draftCanonical = normalizeFlowPadding(canonicalize(draftYamlText));
+    const freshCanonical = normalizeFlowPadding(
+      canonicalize(freshSeedYamlText)
+    );
+    return draftCanonical !== freshCanonical;
+  } catch {
+    return true;
   }
 }

--- a/src/concepts/dungeon-builder/dungeonYaml.test.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.test.ts
@@ -43,6 +43,7 @@ import {
   setPlacementTargeting,
   setRefDefault,
   setRegionArchetype,
+  setSpecVersion,
   setStart,
   setWallEdge,
   setWallLineEndpoint,
@@ -960,6 +961,61 @@ describe('target-dialect fields (TARGET-YAML.md, rpg-dnd5e-web#667)', () => {
 
     setPlacementTargeting(cst, 'antechamber', 0, null);
     expect(toDungeonDoc(cst).rooms[0].place[0].targeting).toBeNull();
+  });
+
+  describe('spec: version marker (local-drafts unit)', () => {
+    it('parses a declared spec: value', () => {
+      const yaml = `version: 1
+spec: "0.3"
+key: foo
+name: "Foo"
+height: 8
+rooms: []
+connectors: []
+`;
+      expect(parseDungeon(yaml).doc.spec).toBe('0.3');
+    });
+
+    it('is null when undeclared — not an error', () => {
+      const { doc } = parseDungeon(SHOWCASE_YAML);
+      expect(doc.spec).toBeNull();
+    });
+
+    it('setSpecVersion writes the key, round-tripping through serialize/parse', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setSpecVersion(cst, '0.3');
+      const { doc } = parseDungeon(serializeDungeon(cst));
+      expect(doc.spec).toBe('0.3');
+    });
+
+    it('setSpecVersion(cst, null) removes a previously-set key', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setSpecVersion(cst, '0.3');
+      setSpecVersion(cst, null);
+      const { doc } = parseDungeon(serializeDungeon(cst));
+      expect(doc.spec).toBeNull();
+    });
+
+    it("New Dungeon's seed template declares spec: 0.3 — honest by construction (only canvas:/top-level place: populated)", () => {
+      const { doc } = parseDungeon(emptyCanvasYaml(20, 30));
+      expect(doc.spec).toBe('0.3');
+    });
+
+    it('stripToV1Subset deletes spec: unconditionally — pure client metadata, never sent to the real server', () => {
+      const { cst } = parseDungeon(SHOWCASE_YAML);
+      setSpecVersion(cst, '0.3');
+      const result = stripToV1Subset(serializeDungeon(cst));
+      expect(result.yaml).not.toMatch(/^spec:/m);
+      // Never counted in dropped/compiling — same treatment as version:
+      // itself (see stripToV1Subset's own comment on this field).
+      expect(result.dropped).toEqual([]);
+      expect(result.compiling).toEqual([]);
+    });
+
+    it('stripToV1Subset deletes an undeclared spec: the same way — nothing to delete is a no-op, not an error', () => {
+      const result = stripToV1Subset(SHOWCASE_YAML);
+      expect(result.yaml).not.toMatch(/^spec:/m);
+    });
   });
 
   describe('stripToV1Subset', () => {

--- a/src/concepts/dungeon-builder/dungeonYaml.ts
+++ b/src/concepts/dungeon-builder/dungeonYaml.ts
@@ -498,6 +498,23 @@ export type DefaultsDoc = Record<string, RefDefaultsDoc>;
 
 export interface DungeonDoc {
   version: number;
+  /** Authoring-dialect spec-cut marker — local-drafts unit, Kirk's ask:
+   * "we could have 0.4 able to load in the concept page and want to run
+   * the v0.3 version of it if possible. maybe we can check
+   * compatibility." A DIFFERENT axis from `version` above: `version` is
+   * the YAML SCHEMA line (additive forever, never bumped by target-dialect
+   * growth — see this file's own doc comment on `version`'s handling in
+   * `stripToV1Subset`); `spec` names which ratified SPEC CUT
+   * (`ideas/dungeon-builder/spec/v0.3/spec.md`) the document's constructs
+   * were authored against — `'0.3'` today, `'draft'` for anything using a
+   * construct spec.md §2 places above it. `null` when undeclared (not an
+   * error — `specCompat.ts`'s `inferSpecCut` derives the honest minimum
+   * from structure alone; TARGET-YAML.md's "spec: version marker" section
+   * has the full value-scheme writeup). Purely client-side authoring
+   * metadata, same tier as `wallLines:` — never sent to the real server in
+   * any form; `stripToV1Subset` deletes the key unconditionally, same
+   * "key presence alone is rejected" lesson as `holes:`/`end:`. */
+  spec: string | null;
   key: string;
   name: string;
   theme?: string;
@@ -773,6 +790,7 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
 
   return {
     version: (raw.version as number) ?? 1,
+    spec: typeof raw.spec === 'string' ? raw.spec : null,
     key: raw.key as string,
     name: raw.name as string,
     theme: raw.theme as string | undefined,
@@ -1775,6 +1793,19 @@ export function setLightingAmbient(
   cst.set('lighting', node);
 }
 
+/** Authoring-dialect spec-cut marker — local-drafts unit. See
+ * `DungeonDoc.spec`'s own doc comment for the full two-axis distinction
+ * from `version:`. `null` removes the key entirely — an undeclared
+ * document is not an error, `specCompat.ts`'s `inferSpecCut` derives the
+ * honest minimum from structure alone regardless. */
+export function setSpecVersion(cst: Document, spec: string | null): void {
+  if (spec === null) {
+    cst.delete('spec');
+    return;
+  }
+  cst.set('spec', spec);
+}
+
 // ============================================================
 // regions: — cell-authored semantic room regions, target dialect,
 // proposed (rpg-project#180). See RegionDoc's own doc comment and
@@ -2440,6 +2471,15 @@ export function stripToV1Subset(
     capabilities?.[field]?.accepted === true;
 
   cst.set('version', 1);
+
+  // spec: is pure client-side authoring metadata (local-drafts unit) —
+  // never a server construct in any form, so unlike every field below it
+  // is never counted in dropped/compiling (same treatment as version:
+  // itself, which also never appears in either list). Deleted
+  // UNCONDITIONALLY, not gated on a truthy value — same "key presence
+  // alone gets rejected by a strict decode-unknown check" lesson as
+  // holes:/end: above (see their own comments, a few lines down).
+  cst.delete('spec');
 
   if (doc.canvas) {
     if (accepted('canvas')) {

--- a/src/concepts/dungeon-builder/fileIO.test.ts
+++ b/src/concepts/dungeon-builder/fileIO.test.ts
@@ -1,28 +1,42 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadYamlFile } from './fileIO';
 
-// jsdom implements neither `URL.createObjectURL`/`revokeObjectURL` nor a
-// real navigating `HTMLAnchorElement.prototype.click` — stub both so this
-// test exercises the real DOM orchestration (anchor href/download/click,
-// object-URL create+revoke) without needing an actual browser.
+// jsdom implements neither `URL.createObjectURL`/`revokeObjectURL` (the
+// property doesn't exist at all — `vi.spyOn` can't wrap something that
+// isn't there) nor a real navigating `HTMLAnchorElement.prototype.click`
+// (a real function jsdom DOES define, just one that logs "not
+// implemented" for anchor navigation — `vi.spyOn` works fine on it).
 describe('downloadYamlFile', () => {
   let createObjectURL: ReturnType<typeof vi.fn>;
   let revokeObjectURL: ReturnType<typeof vi.fn>;
   let clickSpy: ReturnType<typeof vi.fn>;
+  // `vi.restoreAllMocks()` only reverts `vi.spyOn`-based mocks — it has
+  // no idea these two were ever assigned, since jsdom never defined them
+  // as spyable properties in the first place (Copilot review, PR #717:
+  // a raw `URL.createObjectURL = ...` assignment leaks across the whole
+  // suite otherwise). Captured and restored by hand instead.
+  let originalCreateObjectURL: typeof URL.createObjectURL | undefined;
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined;
 
   beforeEach(() => {
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
     createObjectURL = vi.fn(() => 'blob:mock-url');
     revokeObjectURL = vi.fn();
     URL.createObjectURL =
       createObjectURL as unknown as typeof URL.createObjectURL;
     URL.revokeObjectURL =
       revokeObjectURL as unknown as typeof URL.revokeObjectURL;
-    clickSpy = vi.fn();
-    HTMLAnchorElement.prototype.click =
-      clickSpy as unknown as typeof HTMLAnchorElement.prototype.click;
+    // A real `vi.spyOn` — jsdom DOES define this one, so `restoreAllMocks`
+    // below correctly puts the original back (unlike the two above).
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL as typeof URL.createObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL as typeof URL.revokeObjectURL;
     vi.restoreAllMocks();
   });
 
@@ -57,5 +71,17 @@ describe('downloadYamlFile', () => {
     });
     expect(() => downloadYamlFile('dungeon.yaml', 'version: 1\n')).toThrow();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});
+
+describe('downloadYamlFile global cleanup (Copilot review, PR #717)', () => {
+  it('does not leak URL.createObjectURL/revokeObjectURL stubs into a later test file/suite', () => {
+    // The describe block above always restores in its own afterEach —
+    // this is the regression test: if that restore were missing/broken,
+    // these would still be the `vi.fn()` stubs from the last test above.
+    // `vi.isMockFunction` handles `undefined` (jsdom's real, un-stubbed
+    // state) without throwing, unlike probing `.mock` directly.
+    expect(vi.isMockFunction(URL.createObjectURL)).toBe(false);
+    expect(vi.isMockFunction(URL.revokeObjectURL)).toBe(false);
   });
 });

--- a/src/concepts/dungeon-builder/fileIO.test.ts
+++ b/src/concepts/dungeon-builder/fileIO.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadYamlFile } from './fileIO';
+
+// jsdom implements neither `URL.createObjectURL`/`revokeObjectURL` nor a
+// real navigating `HTMLAnchorElement.prototype.click` — stub both so this
+// test exercises the real DOM orchestration (anchor href/download/click,
+// object-URL create+revoke) without needing an actual browser.
+describe('downloadYamlFile', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let clickSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    createObjectURL = vi.fn(() => 'blob:mock-url');
+    revokeObjectURL = vi.fn();
+    URL.createObjectURL =
+      createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL =
+      revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+    clickSpy = vi.fn();
+    HTMLAnchorElement.prototype.click =
+      clickSpy as unknown as typeof HTMLAnchorElement.prototype.click;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds a Blob from the exact text passed, untransformed', () => {
+    downloadYamlFile('dungeon.yaml', 'version: 1\nkey: foo\n');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0][0] as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('application/x-yaml');
+  });
+
+  it('sets the anchor href/download and clicks it', () => {
+    downloadYamlFile('my-dungeon.yaml', 'version: 1\n');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('revokes the object URL after triggering the download', () => {
+    downloadYamlFile('dungeon.yaml', 'version: 1\n');
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('does not leave the synthetic anchor attached to the document', () => {
+    const before = document.querySelectorAll('a').length;
+    downloadYamlFile('dungeon.yaml', 'version: 1\n');
+    const after = document.querySelectorAll('a').length;
+    expect(after).toBe(before);
+  });
+
+  it('still revokes the object URL even if the click throws', () => {
+    clickSpy.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(() => downloadYamlFile('dungeon.yaml', 'version: 1\n')).toThrow();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+});

--- a/src/concepts/dungeon-builder/fileIO.ts
+++ b/src/concepts/dungeon-builder/fileIO.ts
@@ -1,0 +1,36 @@
+/**
+ * fileIO — the browser-native "download this text as a file" primitive
+ * behind the Download .yaml button (`YamlPane.tsx`'s `DownloadYamlButton`,
+ * local-drafts unit). No server involvement, no transformation of the
+ * text: Kirk's ruling is that a saved/downloaded artifact is ALWAYS the
+ * complete authoring dialect — "compatibility stripping should happen at
+ * load time not save" — so this function exists purely to hand the
+ * browser a string and a filename; stripping stays exactly where it
+ * already lived (`dungeonYaml.ts`'s `stripToV1Subset`, the transient
+ * send-time projection Save & Play already uses, unchanged by this unit).
+ *
+ * The Load side has no matching helper here — reading a `File`'s text is
+ * already a browser one-liner (`file.text()`), called directly from
+ * `YamlPane.tsx`'s `LoadYamlButton`; the only genuinely fiddly DOM
+ * orchestration is on the download side (Blob + object URL + a synthetic
+ * anchor click), which is what's worth isolating and unit-testing here.
+ */
+
+/** Triggers a browser download of `text` as `filename` — the standard
+ * Blob + temporary object-URL + synthetic-click pattern. Revokes the
+ * object URL immediately after the click so this doesn't leak one per
+ * download. */
+export function downloadYamlFile(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'application/x-yaml' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/concepts/dungeon-builder/specCompat.test.ts
+++ b/src/concepts/dungeon-builder/specCompat.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import { emptyCanvasYaml } from './creation/emptyCanvasDoc';
+import { canonicalCorner } from './creation/hexCorner';
+import {
+  addWallLine,
+  parseDungeon,
+  setBossTargeting,
+  setEnd,
+  setLightingAmbient,
+  setPlacementFacing,
+  setPlacementHeight,
+  setPlacementMount,
+  setPlacementRotationDegrees,
+  setPlacementTargeting,
+  setRefDefault,
+  setStart,
+  toggleHole,
+  toggleWall,
+  type V1SubsetResult,
+} from './dungeonYaml';
+import { SHOWCASE_YAML } from './fixtures';
+import { buildSpecCompatReport, inferSpecCut } from './specCompat';
+
+describe('inferSpecCut', () => {
+  it('a pure showcase.yaml (rooms/connectors/room-scoped place — spec group a) is 0.3, no reasons', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    expect(inferSpecCut(doc)).toEqual({ inferredCut: '0.3', reasons: [] });
+  });
+
+  it('walls: and start: (spec group b, already-compiling) do not require draft', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    toggleWall(cst, 7, 0);
+    setStart(cst, [0, 4]);
+    const { doc } = parseDungeon(cst.toString());
+    expect(inferSpecCut(doc).inferredCut).toBe('0.3');
+  });
+
+  it('a from-scratch canvas doc (canvas: + top-level place:, spec group c) is 0.3', () => {
+    const { doc } = parseDungeon(emptyCanvasYaml(20, 30));
+    expect(inferSpecCut(doc).inferredCut).toBe('0.3');
+  });
+
+  it('wallLines: (spec §2, above v0.3) requires draft, named in reasons', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    const from = canonicalCorner({ cell: [1, 1], corner: 0 });
+    const to = canonicalCorner({ cell: [3, 1], corner: 0 });
+    addWallLine(cst, from, to);
+    const { doc } = parseDungeon(cst.toString());
+    const result = inferSpecCut(doc);
+    expect(result.inferredCut).toBe('draft');
+    expect(result.reasons).toEqual(['1 straight wall']);
+  });
+
+  it('holes: requires draft', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    toggleHole(cst, 2, 2);
+    const { doc } = parseDungeon(cst.toString());
+    expect(inferSpecCut(doc)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['1 hole'],
+    });
+  });
+
+  it('end: requires draft', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setEnd(cst, [19, 25]);
+    const { doc } = parseDungeon(cst.toString());
+    expect(inferSpecCut(doc)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['end'],
+    });
+  });
+
+  it('lighting: requires draft', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setLightingAmbient(cst, 0.5);
+    const { doc } = parseDungeon(cst.toString());
+    expect(inferSpecCut(doc)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['lighting'],
+    });
+  });
+
+  it('defaults: requires draft', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    setRefDefault(cst, 'dnd5e:props:brazier', 'blocksMovement', true);
+    const { doc } = parseDungeon(cst.toString());
+    expect(inferSpecCut(doc)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['1 default ref'],
+    });
+  });
+
+  it('mount: wall on a placement requires draft, tallied by count', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    setPlacementMount(cst, doc.rooms[0].id, 0, 'wall');
+    const { doc: after } = parseDungeon(cst.toString());
+    expect(inferSpecCut(after)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['mount: wall (1 placement)'],
+    });
+  });
+
+  it('a placement height requires draft', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    setPlacementHeight(cst, doc.rooms[0].id, 0, 2.0);
+    const { doc: after } = parseDungeon(cst.toString());
+    expect(inferSpecCut(after)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['height (1 placement)'],
+    });
+  });
+
+  it('a placement rotate_degrees requires draft', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    setPlacementRotationDegrees(cst, doc.rooms[0].id, 0, 15);
+    const { doc: after } = parseDungeon(cst.toString());
+    expect(inferSpecCut(after)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['rotate_degrees (1 placement)'],
+    });
+  });
+
+  it('a placement targeting requires draft', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    setPlacementTargeting(cst, doc.rooms[0].id, 0, 'lowest-health');
+    const { doc: after } = parseDungeon(cst.toString());
+    expect(inferSpecCut(after)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['targeting (1 placement)'],
+    });
+  });
+
+  it('a boss targeting also requires draft, tallied into the same "targeting" bucket', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    setBossTargeting(cst, doc.rooms[2].id, 'closest');
+    const { doc: after } = parseDungeon(cst.toString());
+    expect(inferSpecCut(after)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['targeting (1 placement)'],
+    });
+  });
+
+  it('facing does NOT require draft — it is a v0.3 construct (spec.md §4.9) regardless of who uses it', () => {
+    const { cst, doc } = parseDungeon(SHOWCASE_YAML);
+    const room = doc.rooms[0];
+    setPlacementFacing(cst, room.id, 0, 2);
+    const { doc: after } = parseDungeon(cst.toString());
+    expect(inferSpecCut(after).inferredCut).toBe('0.3');
+  });
+
+  it('multiple above-v0.3 constructs are all named, in field order', () => {
+    const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+    toggleHole(cst, 2, 2);
+    setEnd(cst, [5, 5]);
+    const { doc } = parseDungeon(cst.toString());
+    expect(inferSpecCut(doc)).toEqual({
+      inferredCut: 'draft',
+      reasons: ['1 hole', 'end'],
+    });
+  });
+});
+
+describe('buildSpecCompatReport', () => {
+  it('undeclared spec: + a 0.3-clean document — no mismatch, empty reasons', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const report = buildSpecCompatReport(doc, null);
+    expect(report).toEqual({
+      declaredSpec: null,
+      inferredCut: '0.3',
+      inferredReasons: [],
+      specMismatch: false,
+      serverWouldDrop: [],
+    });
+  });
+
+  it('declared "0.3" but the document actually uses a draft construct — flagged as a mismatch', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    cst.set('spec', '0.3');
+    toggleHole(cst, 2, 2);
+    const { doc } = parseDungeon(cst.toString());
+    const report = buildSpecCompatReport(doc, null);
+    expect(report.specMismatch).toBe(true);
+    expect(report.declaredSpec).toBe('0.3');
+    expect(report.inferredCut).toBe('draft');
+    expect(report.inferredReasons).toEqual(['1 hole']);
+  });
+
+  it('declared "draft" for an actually-0.3-clean document is conservative, not a mismatch', () => {
+    const { cst } = parseDungeon(SHOWCASE_YAML);
+    cst.set('spec', 'draft');
+    const { doc } = parseDungeon(cst.toString());
+    const report = buildSpecCompatReport(doc, null);
+    expect(report.specMismatch).toBe(false);
+    expect(report.inferredCut).toBe('0.3');
+  });
+
+  it("reads v1Subset.dropped verbatim as serverWouldDrop — doesn't recompute anything", () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const fakeV1Subset = {
+      yaml: '',
+      dropped: ['2 walls', 'start'],
+      compiling: [],
+      compilable: true,
+      compilableBlockers: [],
+    } satisfies V1SubsetResult;
+    const report = buildSpecCompatReport(doc, fakeV1Subset);
+    expect(report.serverWouldDrop).toEqual(['2 walls', 'start']);
+  });
+
+  it('null v1Subset (mid-edit/unparseable) reports an empty serverWouldDrop, not an error', () => {
+    const { doc } = parseDungeon(SHOWCASE_YAML);
+    const report = buildSpecCompatReport(doc, null);
+    expect(report.serverWouldDrop).toEqual([]);
+  });
+});

--- a/src/concepts/dungeon-builder/specCompat.ts
+++ b/src/concepts/dungeon-builder/specCompat.ts
@@ -1,0 +1,162 @@
+/**
+ * specCompat — the load-time spec-version compatibility check
+ * (local-drafts unit). Kirk's ask, verbatim: "we could have 0.4 able to
+ * load in the concept page and want to run the v0.3 version of it if
+ * possible. maybe we can check compatibility."
+ *
+ * Two genuinely different questions, both answered here, neither
+ * reimplementing the other's machinery:
+ *
+ * 1. **Which spec CUT does this document's own construct usage require?**
+ *    (`inferSpecCut`) — a pure, structural read of the parsed `DungeonDoc`
+ *    against the ratified level cut
+ *    (`ideas/dungeon-builder/spec/v0.3/spec.md` §1/§2): every construct in
+ *    §1's four groups (a–d) is "0.3"; anything in §2 ("Explicitly ABOVE
+ *    v0.3" — `wallLines:`, `defaults:`, `holes:`, `end:`, `lighting:`,
+ *    `mount:`/`height:`/`rotate_degrees:`/`targeting:` on a placement) is
+ *    "draft." This has nothing to do with any live server — it's a
+ *    property of the DOCUMENT, derivable offline. Note `canvas:`/
+ *    `regions:`/top-level `place:` (spec groups c/d, Wave 0/1) ARE "0.3"
+ *    by this reckoning even though no server compiles them yet — they're
+ *    ratified constructs, just not-yet-IMPLEMENTED ones. "Not started
+ *    server-side" and "not part of v0.3" are different facts; conflating
+ *    them would make every from-scratch canvas doc read as "draft" when
+ *    the spec itself says otherwise.
+ * 2. **What would THIS connected server actually drop from this document
+ *    today?** — server capability, not document classification, and
+ *    already fully solved by `dungeonYaml.ts`'s `stripToV1Subset` /
+ *    `capabilityProbe.ts`'s live probe. `buildSpecCompatReport` below
+ *    reads `V1SubsetResult.dropped` verbatim rather than recomputing
+ *    anything — the explicit instruction this unit was given ("REUSE the
+ *    existing stripToV1Subset dropped-list machinery, do not
+ *    reimplement").
+ *
+ * A document can be spec-clean ("0.3", nothing in `reasons`) and STILL
+ * have server drops (e.g. a from-scratch canvas today, before platform
+ * Wave 0 ships `canvas:` support) — the two questions are independent
+ * axes, not the same fact asked twice.
+ */
+import type { DungeonDoc, PlacementDoc, V1SubsetResult } from './dungeonYaml';
+import { pluralCount } from './dungeonYaml';
+
+/** The two spec-cut values this concept currently knows about. `'0.3'` —
+ * the document uses only constructs in the ratified v0.3 level cut.
+ * `'draft'` — it uses at least one construct spec.md §2 explicitly places
+ * ABOVE v0.3 (no ratified number for "how far" above; `'draft'` is the
+ * honest label until whichever of those constructs is itself ratified
+ * into a numbered cut, at which point THAT value — e.g. `'0.4'` — becomes
+ * a new valid `spec:` value alongside `'0.3'`, unchanged shape). */
+export type SpecCut = '0.3' | 'draft';
+
+export interface SpecInference {
+  /** The minimum spec cut this document's constructs actually require. */
+  inferredCut: SpecCut;
+  /** Human-readable, which above-v0.3 constructs are in use
+   * ("2 straight walls", "mount: wall (1 placement)") — empty when
+   * `inferredCut === '0.3'`. */
+  reasons: string[];
+}
+
+/** Which above-v0.3 (spec.md §2) constructs a single placement uses —
+ * `facing` is deliberately excluded: it's a v0.3 construct (§4.9) on
+ * every entry type, including the ones the SERVER currently rejects it
+ * on (monster/boss/`mount:wall`) — that's a live-capability gap
+ * (`stripToV1Subset`'s job), not a spec-cut one. */
+function placementAboveV03Reasons(p: PlacementDoc): string[] {
+  const reasons: string[] = [];
+  if (p.mount === 'wall') reasons.push('mount: wall');
+  if (p.height !== null) reasons.push('height');
+  if (p.rotationDegrees !== null) reasons.push('rotate_degrees');
+  if (p.targeting !== null) reasons.push('targeting');
+  return reasons;
+}
+
+/** Structural, offline inference — no server involved. See this file's
+ * own doc comment for the full reasoning and the spec.md §1/§2 mapping. */
+export function inferSpecCut(doc: DungeonDoc): SpecInference {
+  const reasons: string[] = [];
+
+  if (doc.wallLines.length > 0) {
+    reasons.push(pluralCount(doc.wallLines.length, 'straight wall'));
+  }
+  if (doc.holes.length > 0) {
+    reasons.push(pluralCount(doc.holes.length, 'hole'));
+  }
+  if (doc.end) {
+    reasons.push('end');
+  }
+  if (doc.lighting) {
+    reasons.push('lighting');
+  }
+  const defaultRefCount = Object.keys(doc.defaults).length;
+  if (defaultRefCount > 0) {
+    reasons.push(pluralCount(defaultRefCount, 'default ref'));
+  }
+
+  // Per-placement above-v0.3 fields (mount: wall / height / rotate_degrees
+  // / targeting), tallied by reason across every placement — room-scoped,
+  // top-level, and boss — the same way stripToV1Subset's own dropped-list
+  // bookkeeping counts per-field, not per-placement.
+  const counts = new Map<string, number>();
+  const allPlacements: PlacementDoc[] = [
+    ...doc.place,
+    ...doc.rooms.flatMap((r) => r.place),
+  ];
+  for (const p of allPlacements) {
+    for (const reason of placementAboveV03Reasons(p)) {
+      counts.set(reason, (counts.get(reason) ?? 0) + 1);
+    }
+  }
+  // A boss is always a monster and never gates blocks_movement/blocks_los/
+  // mount/height/rotate_degrees (BossDoc doesn't carry those fields at
+  // all — only ref/at/facing/targeting), so `targeting` is the one
+  // above-v0.3 construct a boss entry can use.
+  for (const room of doc.rooms) {
+    if (room.boss?.targeting) {
+      counts.set('targeting', (counts.get('targeting') ?? 0) + 1);
+    }
+  }
+  for (const [reason, count] of counts) {
+    reasons.push(`${reason} (${pluralCount(count, 'placement')})`);
+  }
+
+  return { inferredCut: reasons.length === 0 ? '0.3' : 'draft', reasons };
+}
+
+export interface SpecCompatReport {
+  /** The document's own declared `spec:` value, verbatim — `null` when
+   * undeclared (not an error; `inferredCut` below is the honest fallback). */
+  declaredSpec: string | null;
+  /** The minimum spec cut this document's constructs actually require,
+   * per `inferSpecCut` — independent of `declaredSpec`. */
+  inferredCut: SpecCut;
+  /** Mirrors `SpecInference.reasons` — empty when `inferredCut === '0.3'`. */
+  inferredReasons: string[];
+  /** True only in the DISHONEST direction: `declaredSpec === '0.3'` but
+   * the document actually uses a draft-only construct. Declaring
+   * `'draft'` for an actually-0.3-clean document is conservative, not
+   * dishonest, and is deliberately NOT flagged. */
+  specMismatch: boolean;
+  /** What the CURRENTLY CONNECTED server (per its live-probed
+   * capabilities) would drop from this document today —
+   * `V1SubsetResult.dropped` verbatim, never recomputed here. Empty when
+   * `v1Subset` is `null` (mid-edit, unparseable) or nothing would drop. */
+  serverWouldDrop: string[];
+}
+
+/** Combines the two axes above into one report — see this file's own doc
+ * comment for why they're independent and why `serverWouldDrop` is read,
+ * not recomputed. */
+export function buildSpecCompatReport(
+  doc: DungeonDoc,
+  v1Subset: V1SubsetResult | null
+): SpecCompatReport {
+  const { inferredCut, reasons } = inferSpecCut(doc);
+  return {
+    declaredSpec: doc.spec,
+    inferredCut,
+    inferredReasons: reasons,
+    specMismatch: doc.spec === '0.3' && inferredCut === 'draft',
+    serverWouldDrop: v1Subset?.dropped ?? [],
+  };
+}

--- a/src/concepts/dungeon-builder/useDraftAutosave.test.ts
+++ b/src/concepts/dungeon-builder/useDraftAutosave.test.ts
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { discardDraft, loadDraft } from './draftStorage';
+import { useDraftAutosave } from './useDraftAutosave';
+
+// These three tests are the direct regression coverage for the Copilot
+// review finding on PR #717: pristine mount must never look like a
+// restored draft, and an explicit discard must survive the very next
+// autosave tick instead of being silently undone by it.
+describe('useDraftAutosave', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT autosave on initial mount, even after the debounce delay elapses (no false "draft restored")', () => {
+    renderHook(() => useDraftAutosave('edit', 'version: 1\nkey: pristine\n'));
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')).toBeNull();
+  });
+
+  it('DOES autosave a real subsequent edit, after the debounce delay', () => {
+    const { rerender } = renderHook(
+      ({ yamlText }) => useDraftAutosave('edit', yamlText),
+      { initialProps: { yamlText: 'version: 1\nkey: pristine\n' } }
+    );
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')).toBeNull(); // mount tick still skipped
+
+    rerender({ yamlText: 'version: 1\nkey: edited\n' });
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')?.yamlText).toBe('version: 1\nkey: edited\n');
+  });
+
+  it('skipNextTick() makes a programmatic reset (e.g. Discard draft) stick — the very next tick does not re-save', () => {
+    const { result, rerender } = renderHook(
+      ({ yamlText }) => useDraftAutosave('edit', yamlText),
+      { initialProps: { yamlText: 'version: 1\nkey: edited\n' } }
+    );
+    // A real edit autosaves normally (establishes there WAS a draft to
+    // discard, mirroring the real "user edited, then discarded" flow).
+    rerender({ yamlText: 'version: 1\nkey: edited-again\n' });
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')?.yamlText).toBe('version: 1\nkey: edited-again\n');
+
+    // Mirrors handleDiscardEditDraft exactly: discardDraft() clears
+    // storage, skipNextTick() arms the skip, THEN yamlText resets to the
+    // fresh seed — all synchronous, skipNextTick before the state change
+    // that follows it, same order the real handler uses.
+    discardDraft('edit');
+    result.current.skipNextTick();
+    rerender({ yamlText: 'version: 1\nkey: fresh-seed\n' });
+    vi.advanceTimersByTime(1000);
+
+    // The fresh-seed reset must NOT have been silently re-autosaved —
+    // discard stays discarded.
+    expect(loadDraft('edit')).toBeNull();
+  });
+
+  it('after skipNextTick() consumes its one skip, the tick AFTER that resumes normal autosaving', () => {
+    const { result, rerender } = renderHook(
+      ({ yamlText }) => useDraftAutosave('edit', yamlText),
+      { initialProps: { yamlText: 'version: 1\nkey: a\n' } }
+    );
+    vi.advanceTimersByTime(1000); // consume the mount skip
+
+    result.current.skipNextTick();
+    rerender({ yamlText: 'version: 1\nkey: b\n' }); // this tick is skipped
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')).toBeNull();
+
+    rerender({ yamlText: 'version: 1\nkey: c\n' }); // a REAL subsequent edit
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')?.yamlText).toBe('version: 1\nkey: c\n');
+  });
+
+  it('edit and create modes autosave independently', () => {
+    const { rerender: rerenderEdit } = renderHook(
+      ({ yamlText }) => useDraftAutosave('edit', yamlText),
+      { initialProps: { yamlText: 'edit-v0' } }
+    );
+    const { rerender: rerenderCreate } = renderHook(
+      ({ yamlText }) => useDraftAutosave('create', yamlText),
+      { initialProps: { yamlText: 'create-v0' } }
+    );
+    vi.advanceTimersByTime(1000);
+
+    rerenderEdit({ yamlText: 'edit-v1' });
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('edit')?.yamlText).toBe('edit-v1');
+    expect(loadDraft('create')).toBeNull();
+
+    rerenderCreate({ yamlText: 'create-v1' });
+    vi.advanceTimersByTime(1000);
+    expect(loadDraft('create')?.yamlText).toBe('create-v1');
+  });
+});

--- a/src/concepts/dungeon-builder/useDraftAutosave.ts
+++ b/src/concepts/dungeon-builder/useDraftAutosave.ts
@@ -1,0 +1,66 @@
+/**
+ * useDraftAutosave — debounced localStorage autosave for one draft mode's
+ * working YAML text (`draftStorage.ts`'s `saveDraft`). Extracted from
+ * `DungeonBuilderConcept.tsx`, which previously inlined this same effect
+ * twice, once per mode (Copilot review, PR #717).
+ *
+ * **The bug this fixes.** The original inline `useEffect` fired on every
+ * `yamlText` change, INCLUDING the one React runs right after initial
+ * mount — so it autosaved the pristine default seed 500ms after every
+ * fresh load. A subsequent refresh would then ALWAYS show "draft
+ * restored" for content nobody actually touched, and a programmatic
+ * `setYamlText` reset (Discard draft, New Canvas) got immediately
+ * re-autosaved by the very next tick as if it were real content, silently
+ * undoing the reset it was supposed to make stick.
+ *
+ * **The fix.** The hook's first tick is pre-skipped (the mount tick,
+ * `skipNextRef` starts `true`), and `skipNextTick()` lets a caller arm
+ * that same skip again immediately before any programmatic `yamlText`
+ * reset, so that reset's own resulting tick is skipped too. Everything
+ * else is exactly the original inline effect: save the RAW text on every
+ * debounce tick, not just successfully-parsed text — the point is never
+ * losing keystrokes to a refresh, including mid-typo — debounced,
+ * cleared on unmount/next change.
+ *
+ * See `draftStorage.ts`'s own doc comment for the second, independent
+ * safety net (`draftDiffersFromFreshSeed`) that catches the same class of
+ * dishonest-banner bug from the RESTORE side, in case a no-op draft ever
+ * makes it into storage some other way.
+ */
+import { useEffect, useRef } from 'react';
+import { saveDraft, type DraftMode } from './draftStorage';
+
+const DRAFT_AUTOSAVE_DEBOUNCE_MS = 500;
+
+export interface DraftAutosave {
+  /** Marks the NEXT `yamlText` change as not a real edit — skips exactly
+   * one autosave tick. Call this synchronously, immediately before a
+   * programmatic `setYamlText` reset, so that reset doesn't get silently
+   * autosaved as if it were authored content. */
+  skipNextTick: () => void;
+}
+
+export function useDraftAutosave(
+  mode: DraftMode,
+  yamlText: string
+): DraftAutosave {
+  const skipNextRef = useRef(true);
+
+  useEffect(() => {
+    if (skipNextRef.current) {
+      skipNextRef.current = false;
+      return;
+    }
+    const t = setTimeout(
+      () => saveDraft(mode, yamlText),
+      DRAFT_AUTOSAVE_DEBOUNCE_MS
+    );
+    return () => clearTimeout(t);
+  }, [mode, yamlText]);
+
+  return {
+    skipNextTick: () => {
+      skipNextRef.current = true;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Dungeon Builder concept (rpg-project#170), local-drafts unit. Kirk's two rulings, verbatim:

- Saved artifacts are ALWAYS full dialect — "compatibility stripping should happen at load time not save."
- Files target a spec version — "we could have 0.4 able to load in the concept page and want to run the v0.3 version of it if possible. maybe we can check compatibility."

**Four pieces:**

1. **Refresh-proof local drafts** (`draftStorage.ts`) — the working document's full-dialect YAML text autosaves to `localStorage`, debounced 500ms, keyed per mode (edit/create — independent drafts, same "remembered per mode" precedent the palette/YAML collapse-state pairs already set). Restored on mount with a `DraftRestoredBanner` (dismiss / discard). Best-effort throughout — storage failures never crash authoring.
2. **Download .yaml** (`fileIO.ts`) — always the current, complete, unstripped document. No server round trip. This is the concrete enforcement point for Kirk's "stripping happens at load, not save" ruling; `stripToV1Subset` stays exactly where it already lived.
3. **Load .yaml** — a file-input button feeding the *existing* `applyText`/`applyCreationText` parse/Apply pipeline directly, not a forked one. A malformed file surfaces exactly like a bad paste-and-Apply.
4. **`spec:` version marker + load-time compat check** (`dungeonYaml.ts`'s new `DungeonDoc.spec`, `specCompat.ts`, `YamlPane.tsx`'s `SpecCompatBanner`) — `"0.3"` when a document uses only ratified v0.3 constructs, `"draft"` the moment it uses anything spec.md §2 places above that cut. Two independent checks: `inferSpecCut` (offline, structural) and a live server-drop report that reuses `stripToV1Subset`'s own `dropped` list verbatim rather than reimplementing it. `stripToV1Subset` deletes `spec:` unconditionally before any real request — same "key presence alone is rejected" lesson as `holes:`/`end:`. Full value-scheme writeup in `TARGET-YAML.md`'s new `spec:` section.

## Live verification

Real browser session (Playwright) against the live Wave-0 server (`localhost:8092`): declared `spec: "0.3"` + hand-added `wallLines:` → `SpecCompatBanner` correctly flags the mismatch live, alongside the pre-existing (unchanged) compile-badge strip. Real page reload → `DraftRestoredBanner` restores the board with wall geometry intact. Download byte-matches the pane. Discard resets to the fresh seed. Loading the downloaded file back in byte-matches exactly. Full writeup + reasoning for the one cosmetic (pre-existing, already-documented `yaml`-package flow-array-padding) diff found along the way is in `CONTRACT.md`'s new ledger entry.

## Test plan

- [x] 42 new unit tests (`draftStorage.test.ts`, `fileIO.test.ts`, `specCompat.test.ts`, plus 6 added to `dungeonYaml.test.ts`)
- [x] Full `src/concepts/dungeon-builder` suite: 514 passing
- [x] `npm run ci-check` (format, lint, typecheck, build, full repo suite — 2247 tests) clean
- [x] Live verification against the Wave-0 server (`localhost:8092`) — see `CONTRACT.md`

— asset-pipeline agent, on behalf of KirkDiggler