### PR TITLE
unit: game walls from truth — zones are not rooms

### DIFF
--- a/src/components/game/EncounterMap.test.tsx
+++ b/src/components/game/EncounterMap.test.tsx
@@ -20,6 +20,7 @@ import {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cubeAtColRow } from '../../hooks/wallRuns';
 import type { HexGridProps } from '../hex-grid';
 
 const hoisted = vi.hoisted(() => ({
@@ -48,6 +49,33 @@ function revealedHex(x: number, y: number, z: number, zoneId = ''): HexRecord {
   return create(HexRecordSchema, {
     position: create(PositionSchema, { x, y, z }),
     zoneId,
+  });
+}
+
+/** A small 2-column x 2-row zone's worth of revealed hexes, tagged with
+ * `zoneId` — geometrically identical whether that zone represents a real
+ * chain-generated room or a canvas dungeon's purely semantic painted
+ * region (the wire can't tell the two apart from hex membership alone;
+ * that's exactly the bug this file's "wall truth" describe block covers). */
+function zoneHexes(zoneId: string): HexRecord[] {
+  return [
+    cubeAtColRow(0, 0),
+    cubeAtColRow(1, 0),
+    cubeAtColRow(0, 1),
+    cubeAtColRow(1, 1),
+  ].map((c) => revealedHex(c.x, c.y, c.z, zoneId));
+}
+
+/** A non-door SOLID wall entry — the shape a real chain dungeon's
+ * perimeter/connector walls take on the wire (WallKind.SOLID = 1),
+ * standing in for "the server actually emitted wall data for this
+ * space" regardless of this particular entry's own position. */
+function solidWall(id: string): Wall {
+  return create(WallSchema, {
+    from: create(PositionSchema, { x: 0, y: 0, z: 0 }),
+    to: create(PositionSchema, { x: 0, y: 0, z: 0 }),
+    kind: WallKind.SOLID,
+    id,
   });
 }
 
@@ -211,5 +239,62 @@ describe('EncounterMap look-lab lighting experiment dials (?floorPools=1/?litSur
     const props = hoisted.lastHexGridProps.current!;
     expect(props.floorPoolLights).toBeUndefined();
     expect(props.litSurfaces).toBe(false);
+  });
+});
+
+describe('EncounterMap wall truth gate (game walls from truth — zones are not rooms)', () => {
+  it('a zone with ZERO server wall data renders NO envelope/connector walls — canvas regions are semantic-only, not rooms (the untitled-creation bug: walls: [], 3 painted regions, fictional envelope walls in the real game route)', () => {
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={
+          new Map(
+            zoneHexes('region-1').map((h) => [
+              `${h.position!.x},${h.position!.y},${h.position!.z}`,
+              h,
+            ])
+          )
+        }
+        walls={new Map()}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.envelopeRuns).toEqual([]);
+    expect(props.envelopeCorners).toEqual([]);
+    expect(props.connectorRuns).toEqual([]);
+  });
+
+  it('a zone WITH real server wall data (chain dungeons) still produces envelope walls — regression guard, this fix must not strip real room walls', () => {
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={
+          new Map(
+            zoneHexes('room-a').map((h) => [
+              `${h.position!.x},${h.position!.y},${h.position!.z}`,
+              h,
+            ])
+          )
+        }
+        walls={new Map([['wall-1', solidWall('wall-1')]])}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.envelopeRuns!.length).toBe(4); // left/right/top/bottom
+    expect(props.envelopeCorners!.length).toBe(4);
+  });
+
+  it('an entirely empty encounter (no zones, no walls) still renders with no envelope walls, not a crash', () => {
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={new Map()}
+        walls={new Map()}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.envelopeRuns).toEqual([]);
+    expect(props.envelopeCorners).toEqual([]);
+    expect(props.connectorRuns).toEqual([]);
   });
 });

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -200,13 +200,15 @@ export function EncounterMap({
   }, [entities, myEntityId]);
 
   // Dungeon-walls redesign (rpg-project#133 design.md/plan.md's W2 slice):
-  // reconstruct each room's hex membership from the wire's per-hex zoneId
-  // (regions have no width/offset field on the wire at all — see
-  // wallRuns.ts's doc comment), derive each door's own cell from the walls
-  // list, and compute the straight envelope/connector runs those feed.
-  // Also builds the positive-category-filtered legacy wall list
-  // (doors + interior pattern walls only) and the per-door rotation
-  // overrides HexGrid/SyntyHexWall consume below.
+  // reconstruct each ZONE's hex membership from the wire's per-hex zoneId
+  // (zones have no width/offset field on the wire at all — see
+  // wallRuns.ts's doc comment). For a chain dungeon a zone IS a room; for a
+  // canvas dungeon a zone is a semantic-only scope with no wall truth
+  // behind it (spec §4.10.2.4) — this grouping alone does NOT mean "these
+  // hexes are enclosed by walls." Feeds the `?authorGrid=1` coordinate
+  // overlay unconditionally (labeling is honest for either dungeon kind);
+  // feeds envelope/connector wall-run computation only when gated by real
+  // wall truth below (`hasWallTruth`) — see that gate's own comment.
   const regions = useMemo(
     () => regionInputsFromHexes(revealedHexes.values()),
     [revealedHexes]
@@ -226,9 +228,36 @@ export function EncounterMap({
     () => connectorDoorInputsFromWalls(wallList),
     [wallList]
   );
+  // Wall truth gate (game-walls-truth fix, zones are not rooms):
+  // `computeWallRuns` has no notion of "openness" at all (wallRuns.ts's own
+  // doc comment on envelopeGeometryForRegion) — it synthesizes a full
+  // envelope purely from a region's bounding box, unconditionally. That's
+  // only a legitimate stand-in for a room's real walls when the server has
+  // actually emitted wall data for this space: a chain dungeon's rooms ARE
+  // its zones, and the toolkit's generator emits perimeter/connector Wall
+  // entries for every one of them, unconditionally, from the first
+  // snapshot (this file's own wallRunAdapters.wireGridBounds doc comment).
+  // A canvas dungeon's `regions:` are semantic-only zones — fog/reveal/
+  // naming scopes, spec §4.10.2.4: "region boundaries are semantic-only,
+  // MUST NOT compile to edges" — with zero server-side wall truth behind
+  // them. Feeding their bounding boxes into computeWallRuns synthesized
+  // full envelope walls around painted regions that don't exist server-side:
+  // the real bug on the `untitled-creation` dungeon (walls: [], 3 painted
+  // regions) — fictional walls in the actual game route that the server's
+  // own movement model never enforced. `wallList.length > 0` is the right
+  // signal rather than anything zone-shaped: the wall list is unconditional
+  // and whole-dungeon from wave 1, so an empty list means no wall truth
+  // exists ANYWHERE in this encounter, not merely "not revealed yet" — zero
+  // false negatives for a real walled (chain) dungeon, which always has a
+  // non-empty walls list by construction.
+  const hasWallTruth = wallList.length > 0;
   const wallRunsResult = useMemo(
-    () => computeWallRuns({ regions, doors: connectorDoors }),
-    [regions, connectorDoors]
+    () =>
+      computeWallRuns({
+        regions: hasWallTruth ? regions : [],
+        doors: connectorDoors,
+      }),
+    [regions, connectorDoors, hasWallTruth]
   );
   const legacySyntyWalls = useMemo(
     () =>


### PR DESCRIPTION
## Summary

The real game route (`EncounterMap.tsx`, mounted via `EncounterView`/`GameView` — not the `?encounterId=` dev harness, which renders through the older `PlaytestMap` and never touches this code path) rendered fictional envelope walls around a canvas dungeon's painted `regions:` even when the server authored zero walls for the space.

Root cause: `regionInputsFromHexes` groups revealed hexes by `zoneId` unconditionally, and `computeWallRuns` synthesizes a full 4-sided envelope purely from a region's bounding box, with — per its own doc comment — "no notion of openness at all." That's a legitimate stand-in for a room's real walls only when the region *is* a chain-generated room (zone == room, and the toolkit's generator always emits perimeter/connector `Wall` entries for it). A canvas dungeon's `regions:` are semantic-only zones (fog/reveal/naming — spec §4.10.2.4: "region boundaries are semantic-only, MUST NOT compile to edges"), with zero server-side wall truth behind them.

## Server-side evidence (dungeon `untitled-creation`, "Hey Stan")

Captured directly from a live `StreamEncounter` snapshot for a started encounter on this dungeon:

- `space.hexes`: 154 total — 49 tagged `zoneId: region-1`, 32 tagged `zoneId: region-2`, 73 untagged.
- `space.walls` / per-hex `edges`: **zero** wall or edge entries anywhere in the snapshot.

Zones exist on the wire; wall truth does not. Feeding the zone bounding boxes into `computeWallRuns` synthesized walls the server never authored and never enforces.

## Fix

Gate envelope/connector wall-run computation in `EncounterMap.tsx` on `wallList.length > 0` — the wall list is unconditional and whole-dungeon from wave 1, so an empty list means no wall truth exists anywhere in the encounter, not merely "not revealed yet." A chain dungeon always has a non-empty walls list (the generator emits perimeter/connector entries unconditionally), so this is byte-identical there. `regions` itself is untouched (still feeds the `?authorGrid=1` coordinate-labeling overlay, which is honest for either dungeon kind) — only what flows into `computeWallRuns` is gated.

## Verification — real `GameView` route, live server

The `?encounterId=` dev harness turned out to route through `PlaytestMap`, a pre-wall-run-redesign component that never calls `regionInputsFromHexes`/`computeWallRuns` at all — so it can't exercise this bug either way. Verified instead against the actual production route (`?playerId=<id>` with an active lobby, which `GetMyActiveLobby` auto-resumes into `GameView`).

**Canvas case (`untitled-creation`) — before:**
Fictional walls trace the region's zigzag boundary, enclosing the character and bookshelf props in a room that doesn't exist server-side.

**Canvas case — after:**
Same encounter, same camera position. Walls are gone; floor cuts off into unrevealed fog exactly where the old envelope used to stand. Bookshelf props (real server entities) are untouched.

**Chain case (`showcase`, 3-room dungeon with real walls) — before vs. after:**
Pixel-diffed the two screenshots: bounding-box diff is essentially camera/entity-animation noise (max channel delta 79/255, mean 0.82/255) — visually and structurally identical. Real room walls are unaffected by this fix.

## Tests

Added 3 tests to `EncounterMap.test.tsx` (18 total in that file, all passing):
- A zone with zero server wall data renders no envelope/connector/corner data (the exact bug).
- A zone WITH real server wall data (chain case) still produces 4 envelope runs + 4 corners — regression guard.
- An entirely empty encounter renders without crashing.

Full suite: 2292 tests passing. `npm run ci-check` clean (format, lint, typecheck, build, tests).

## Test plan
- [x] Unit tests added and passing (`EncounterMap.test.tsx`)
- [x] Full test suite green (2292 tests)
- [x] `npm run ci-check` clean
- [x] Live-verified canvas dungeon (`untitled-creation`) on the real `GameView` route: fictional walls present before, absent after
- [x] Live-verified chain dungeon (`showcase`) on the real `GameView` route: walls pixel-identical before/after

— asset-pipeline agent, on behalf of KirkDiggler