### PR TITLE
Combat Presentation Slice 2: synchronize movement and outcome reveals

### DIFF
--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -115,11 +115,11 @@ an attack waits only for its own actor's current in-flight movement and ignores
 stale completions. `CombatPresentation` exposes `onResultRelease(id)` plus its
 existing `onComplete(id)`; it remains unaware of Three.js, the combat log, HP,
 or terminal rendering. Snapshot replacement and leaving turn-based mode
-cancel the held projection. Encounter end is different: when it belongs to one
-unambiguous already-terminal attack story, that story drains through its own
-result beat even when queued behind an earlier attack (holding banner, dock,
-tombstone, and terminal log together) before cleanup; an encounter end with no
-staged terminal story still flushes immediately. Empty/reused correlations are
+cancel the held projection. Encounter end is different: it follows the most
+recent terminal story in observed FIFO stream order, and all queued stories
+drain through their own result beats (holding banner, dock, tombstones, and
+terminal log together) before cleanup; an encounter end with no staged terminal
+story still flushes immediately. Empty/reused correlations are
 fail-safe: outcome association always requires actor/target identity, and
 same-target terminal events follow observed stream causality (the most recent
 matching damage, then explicit death for removal), never inferred HP rules.

--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -101,13 +101,17 @@ changing with no story.
 
 `EncounterView` keeps `useEncounterState` canonical as stream envelopes arrive,
 but holds a small presentation-only projection for the active attack story:
-visible HP and correlated outcome log entries release on the existing theater's
-semantic result beat (Verdict for a miss, Impact for a hit). A canonically
+visible HP, statuses, and correlated outcome log entries release on the existing
+theater's semantic result beat (Verdict for a miss, Impact for a hit).
+Correlated `StatusApplied` envelopes use the same entity/correlation and
+observed-order association: their badge, model projection, and log wait for the
+result, while uncorrelated statuses remain immediate. Command safety remains on
+canonical turn state; presentation never re-enables an action. A canonically
 removed, already-known entity is retained as a render tombstone through that
 result and then follows the existing removal path when the theater completes.
-No death, hit, damage, or HP value is inferred; every displayed value is copied
-from `AttackResolved`, `EntityDamaged.hp_after`, `EntityDied`, or
-`EntityRemoved`.
+No status, death, hit, damage, or HP value is inferred; every displayed value is
+copied from `AttackResolved`, `EntityDamaged.hp_after`, `StatusApplied`,
+`EntityDied`, or `EntityRemoved`.
 
 Two narrow lifecycle seams coordinate the story. `useHexMovePath` reports the
 exact completed `moveSeq` through `HexEntity` → `HexGrid` → `EncounterMap`, so

--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -103,10 +103,14 @@ changing with no story.
 but holds a small presentation-only projection for the active attack story:
 visible HP, statuses, and correlated outcome log entries release on the existing
 theater's semantic result beat (Verdict for a miss, Impact for a hit).
-Correlated `StatusApplied` envelopes use the same entity/correlation and
-observed-order association: their badge, model projection, and log wait for the
-result, while uncorrelated statuses remain immediate. Command safety remains on
-canonical turn state; presentation never re-enables an action. A canonically
+`StatusApplied` envelopes use entity/source identity, correlation when present,
+and observed damage order: today's empty-correlation attack statuses bind the
+most recent matching damage story. Their badge, model projection, and log wait
+for the result; a status with no causally matching damage story remains
+immediate. Command safety remains canonical: while local control labels are
+held, every combat dispatch surface (movement, targeting/actions, reactions,
+and end turn) is disabled, and presentation never re-enables an unavailable
+command. A canonically
 removed, already-known entity is retained as a render tombstone through that
 result and then follows the existing removal path when the theater completes.
 No status, death, hit, damage, or HP value is inferred; every displayed value is

--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -112,7 +112,10 @@ from `AttackResolved`, `EntityDamaged.hp_after`, `EntityDied`, or
 Two narrow lifecycle seams coordinate the story. `useHexMovePath` reports the
 exact completed `moveSeq` through `HexEntity` → `HexGrid` → `EncounterMap`, so
 an attack waits only for its own actor's current in-flight movement and ignores
-stale completions. `CombatPresentation` exposes `onResultRelease(id)` plus its
+stale completions. A same-sequence canonical/knowledge prop refresh preserves
+the active frame loop rather than snapping and losing its completion; player
+and NPC actors use this identical handshake. `CombatPresentation` exposes
+`onResultRelease(id)` plus its
 existing `onComplete(id)`; it remains unaware of Three.js, the combat log, HP,
 or terminal rendering. Snapshot replacement and leaving turn-based mode
 cancel the held projection. Encounter end is different: it follows the most

--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -1,8 +1,8 @@
 ---
 name: GameView
 description: The live game path's successor to LobbyView — party assembly (LobbyFlow) then a live encounter (EncounterView), built entirely on the shared harness stack
-updated: 2026-07-12
-confidence: high — verified by reading every new file in full, running the full vitest suite (675 passing), and cross-checking rpg-api's start_encounter.go entity-id claim
+updated: 2026-08-07
+confidence: high — verified by focused real-path tests plus the repository CI suite; server-owned entity-id behavior remains cross-checked against rpg-api start_encounter.go
 ---
 
 # GameView
@@ -96,6 +96,26 @@ changing with no story.
   renders its entityId-derived fallback name/emoji for every combatant
   (same as `EncounterMap`'s existing renderable-entity naming) rather than
   portraits/class icons — a follow-up, not a proto gap.
+
+### Ordered combat presentation (#721)
+
+`EncounterView` keeps `useEncounterState` canonical as stream envelopes arrive,
+but holds a small presentation-only projection for the active attack story:
+visible HP and correlated outcome log entries release on the existing theater's
+semantic result beat (Verdict for a miss, Impact for a hit). A canonically
+removed, already-known entity is retained as a render tombstone through that
+result and then follows the existing removal path when the theater completes.
+No death, hit, damage, or HP value is inferred; every displayed value is copied
+from `AttackResolved`, `EntityDamaged.hp_after`, `EntityDied`, or
+`EntityRemoved`.
+
+Two narrow lifecycle seams coordinate the story. `useHexMovePath` reports the
+exact completed `moveSeq` through `HexEntity` → `HexGrid` → `EncounterMap`, so
+an attack waits only for its own actor's current in-flight movement and ignores
+stale completions. `CombatPresentation` exposes `onResultRelease(id)` plus its
+existing `onComplete(id)`; it remains unaware of Three.js, the combat log, HP,
+or terminal rendering. Snapshot replacement, encounter end, and leaving
+turn-based mode flush the held projection instead of replaying it.
 
 ## Related references
 

--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -114,8 +114,11 @@ exact completed `moveSeq` through `HexEntity` → `HexGrid` → `EncounterMap`, 
 an attack waits only for its own actor's current in-flight movement and ignores
 stale completions. `CombatPresentation` exposes `onResultRelease(id)` plus its
 existing `onComplete(id)`; it remains unaware of Three.js, the combat log, HP,
-or terminal rendering. Snapshot replacement, encounter end, and leaving
-turn-based mode flush the held projection instead of replaying it.
+or terminal rendering. Snapshot replacement and leaving turn-based mode
+cancel the held projection. Encounter end is different: when it belongs to one
+unambiguous already-terminal attack story, that story drains through its result
+beat (including tombstone and terminal log) before cleanup; an encounter end
+with no staged terminal story still flushes immediately.
 
 ## Related references
 

--- a/docs/architecture/components/game-view.md
+++ b/docs/architecture/components/game-view.md
@@ -116,9 +116,13 @@ stale completions. `CombatPresentation` exposes `onResultRelease(id)` plus its
 existing `onComplete(id)`; it remains unaware of Three.js, the combat log, HP,
 or terminal rendering. Snapshot replacement and leaving turn-based mode
 cancel the held projection. Encounter end is different: when it belongs to one
-unambiguous already-terminal attack story, that story drains through its result
-beat (including tombstone and terminal log) before cleanup; an encounter end
-with no staged terminal story still flushes immediately.
+unambiguous already-terminal attack story, that story drains through its own
+result beat even when queued behind an earlier attack (holding banner, dock,
+tombstone, and terminal log together) before cleanup; an encounter end with no
+staged terminal story still flushes immediately. Empty/reused correlations are
+fail-safe: outcome association always requires actor/target identity, and
+same-target terminal events follow observed stream causality (the most recent
+matching damage, then explicit death for removal), never inferred HP rules.
 
 ## Related references
 

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -134,6 +134,11 @@ export interface EncounterMapProps {
   openDoorIds?: string[];
   /** Full computed path (start + intermediates + end) when a hex click lands a move. */
   onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
+  /** Presentation-only completion of an entity's exact rendered move. */
+  onEntityMovementPresentationComplete?: (
+    entityId: string,
+    moveSeq: number
+  ) => void;
   /** Clicked entity id — caller dispatches attack for monsters or selects for characters. */
   onEntityClick: (entityId: string) => void;
   /** Fired with the door's Wall.id (rpg-api-protos#186) when a DOOR_* wall
@@ -159,6 +164,7 @@ export function EncounterMap({
   movementRemaining = DEFAULT_MOVEMENT_FEET,
   openDoorIds = [],
   onMove,
+  onEntityMovementPresentationComplete,
   onEntityClick,
   onDoorClick,
 }: EncounterMapProps) {
@@ -583,6 +589,9 @@ export function EncounterMap({
         onMoveComplete={(path: CubeCoord[]) => {
           onMove(path.map((c) => ({ x: c.x, y: c.y, z: c.z })));
         }}
+        onEntityMovementPresentationComplete={
+          onEntityMovementPresentationComplete
+        }
         onEntityClick={(targetId: string) => {
           onEntityClick(targetId);
         }}

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -2388,6 +2388,252 @@ describe('EncounterView combat pacing', () => {
     }
   );
 
+  it('binds same-entity uncorrelated death/removal to the most recent damage story in stream order', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = {
+      sequence: 1n,
+      timestamp: undefined,
+      correlationId: 'corr-shared',
+    } as EncounterEventMetadata;
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                {
+                  id: 'goblin-1',
+                  type: EntityType.MONSTER,
+                  hp: { current: 10, max: 10, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 1, y: -1, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        metadata
+      );
+      for (const attackRoll of [14, 19]) {
+        callbacks.onAttackResolved?.(
+          {
+            attackerEntityId: 'char-alice',
+            targetEntityId: 'goblin-1',
+            hit: true,
+            critical: false,
+            attackRoll,
+          } as never,
+          metadata
+        );
+      }
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'goblin-1',
+          sourceEntityId: 'char-alice',
+          amount: 3,
+          damageBreakdown: [],
+          hpAfter: { current: 7, max: 10, temp: 0 },
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'goblin-1',
+          sourceEntityId: 'char-alice',
+          amount: 7,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 10, temp: 0 },
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDied?.(
+        { entityId: 'goblin-1', killerEntityId: 'char-alice' } as never,
+        { ...metadata, correlationId: '' }
+      );
+      callbacks.onEntityRemoved?.(
+        { entityId: 'goblin-1', reason: 'dead' } as never,
+        { ...metadata, correlationId: '' }
+      );
+    });
+
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000 + 1600));
+    expect(screen.getByTestId('beat-damage').textContent).toContain('3 damage');
+    expect(screen.queryByTestId('combat-log-entry-died-2')).toBeNull();
+    expect(screen.queryByTestId('combat-log-entry-removed-3')).toBeNull();
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).toContain('goblin-1');
+
+    act(() => vi.advanceTimersByTime(900));
+    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000 + 1600));
+    expect(screen.getByTestId('beat-damage').textContent).toContain('7 damage');
+    expect(screen.getByTestId('combat-log-entry-died-4')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-removed-5')).toBeTruthy();
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).toContain('goblin-1');
+
+    act(() => vi.advanceTimersByTime(900));
+    act(() => vi.advanceTimersByTime(300));
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).not.toContain('goblin-1');
+  });
+
+  it('holds queued terminal-story banner, dock, log, and tombstone until that story result', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const firstMetadata = {
+      sequence: 1n,
+      timestamp: undefined,
+      correlationId: 'corr-first',
+    } as EncounterEventMetadata;
+    const terminalMetadata = {
+      sequence: 2n,
+      timestamp: undefined,
+      correlationId: 'corr-terminal',
+    } as EncounterEventMetadata;
+    const emptyTerminalMetadata = {
+      sequence: 3n,
+      timestamp: undefined,
+      correlationId: '',
+    } as EncounterEventMetadata;
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                {
+                  id: 'goblin-2',
+                  type: EntityType.MONSTER,
+                  hp: { current: 5, max: 5, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 2, y: -2, z: 0 },
+                  contents: [{ entityId: 'goblin-2' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        firstMetadata
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'char-alice',
+          targetEntityId: 'goblin-1',
+          hit: false,
+          critical: false,
+          attackRoll: 4,
+        } as never,
+        firstMetadata
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'char-alice',
+          targetEntityId: 'goblin-2',
+          hit: true,
+          critical: false,
+          attackRoll: 18,
+        } as never,
+        terminalMetadata
+      );
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'goblin-2',
+          sourceEntityId: 'char-alice',
+          amount: 5,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 5, temp: 0 },
+        } as never,
+        terminalMetadata
+      );
+      callbacks.onEntityDied?.(
+        { entityId: 'goblin-2', killerEntityId: 'char-alice' } as never,
+        emptyTerminalMetadata
+      );
+      callbacks.onEntityRemoved?.(
+        { entityId: 'goblin-2', reason: 'dead' } as never,
+        emptyTerminalMetadata
+      );
+      callbacks.onEncounterEnded?.(
+        { reason: 'all hostiles defeated' } as never,
+        emptyTerminalMetadata
+      );
+    });
+
+    expect(screen.queryByText(/Encounter ended/)).toBeNull();
+    expect(
+      screen.queryByTestId('combat-log-entry-encounterEnded-5')
+    ).toBeNull();
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.getByTestId('beat-verdict').textContent).toContain('MISS');
+    expect(screen.queryByText(/Encounter ended/)).toBeNull();
+    act(() => vi.advanceTimersByTime(1600));
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.queryByText(/Encounter ended/)).toBeNull();
+
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => vi.advanceTimersByTime(1600));
+    expect(screen.getByTestId('encounter-ended-banner')).toBeTruthy();
+    expect(
+      screen.getByTestId('combat-log-entry-encounterEnded-5')
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).toContain('goblin-2');
+    act(() => vi.advanceTimersByTime(900));
+    act(() => vi.advanceTimersByTime(300));
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).not.toContain('goblin-2');
+  });
+
   it.each([
     ['snapshotDelivered', {}],
     [

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -104,9 +104,14 @@ vi.mock('./EncounterMap', () => ({
     openDoorIds?: string[];
     theme?: string;
     entities: Map<string, { position?: { x: number; y: number; z: number } }>;
+    entityHP: Map<string, { current: number; max: number }>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (entityId: string) => void;
     onDoorClick?: (doorId: string) => void;
+    onEntityMovementPresentationComplete?: (
+      entityId: string,
+      moveSeq: number
+    ) => void;
   }) => (
     <div
       data-testid="encounter-map-stub"
@@ -121,6 +126,7 @@ vi.mock('./EncounterMap', () => ({
       data-entity-positions={JSON.stringify(
         [...props.entities.entries()].map(([id, e]) => [id, e.position])
       )}
+      data-entity-hp={JSON.stringify([...props.entityHP.entries()])}
     >
       <button
         data-testid="stub-move"
@@ -139,6 +145,22 @@ vi.mock('./EncounterMap', () => ({
         onClick={() => props.onDoorClick?.('door-1')}
       >
         click door
+      </button>
+      <button
+        data-testid="stub-finish-stale-goblin-move"
+        onClick={() =>
+          props.onEntityMovementPresentationComplete?.('goblin-1', 0)
+        }
+      >
+        finish stale goblin move
+      </button>
+      <button
+        data-testid="stub-finish-goblin-move"
+        onClick={() =>
+          props.onEntityMovementPresentationComplete?.('goblin-1', 1)
+        }
+      >
+        finish goblin move
       </button>
     </div>
   ),
@@ -1715,7 +1737,7 @@ describe('EncounterView combat pacing', () => {
     expect(screen.getByRole('button', { name: 'Roll d20' })).toBeTruthy();
   });
 
-  it('queues callback arrivals, records each attack immediately, and advances from viewer to autoplay attack', async () => {
+  it('keeps queued attack outcomes FIFO and advances from viewer to autoplay attack without later-log leakage', async () => {
     render(
       <EncounterView
         encounterId="enc-1"
@@ -1732,22 +1754,177 @@ describe('EncounterView combat pacing', () => {
       );
       await Promise.resolve();
     });
-    expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
-    expect(screen.getByTestId('combat-log-entry-attack-1')).toBeTruthy();
+    expect(screen.queryByTestId('combat-log-entry-attack-0')).toBeNull();
+    expect(screen.queryByTestId('combat-log-entry-attack-1')).toBeNull();
     act(() => vi.advanceTimersByTime(300));
     fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
     act(() => vi.advanceTimersByTime(2000 + 1600 + 900 + 300));
     expect(screen.queryByRole('button', { name: 'Roll d20' })).toBeNull();
+    expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
+    expect(screen.queryByTestId('combat-log-entry-attack-1')).toBeNull();
     expect(
       screen.getByTestId('combat-presentation').getAttribute('data-beat')
     ).toBe('cue');
     act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(2000));
     expect(
       screen.getByTestId('combat-presentation').getAttribute('data-beat')
-    ).toBe('throw');
+    ).toBe('verdict');
+    expect(screen.getByTestId('combat-log-entry-attack-1')).toBeTruthy();
   });
 
-  it('applies HP, shows the exact damage result, and records the damage log immediately while theater is active', async () => {
+  it('waits for the attacking actor current move instance and ignores stale movement completion', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [{ id: 'goblin-1', type: EntityType.MONSTER }],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        {} as never
+      );
+      callbacks.onEntityMoved?.(
+        {
+          entityId: 'goblin-1',
+          actualPath: [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: -1, z: 0 },
+          ],
+        } as never,
+        {} as never
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
+          attackRoll: 12,
+          attackBonus: 4,
+          targetAc: 14,
+          hit: true,
+          critical: false,
+        } as never,
+        {} as never
+      );
+    });
+
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+    fireEvent.click(screen.getByTestId('stub-finish-stale-goblin-move'));
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+    fireEvent.click(screen.getByTestId('stub-finish-goblin-move'));
+    expect(screen.getByTestId('combat-presentation')).toBeTruthy();
+  });
+
+  it('keeps an already-known removed monster as a tombstone through lethal impact, then releases current removal behavior', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = {
+      sequence: 2n,
+      timestamp: undefined,
+      correlationId: 'corr-lethal',
+    } as EncounterEventMetadata;
+
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                {
+                  id: 'goblin-1',
+                  type: EntityType.MONSTER,
+                  hp: { current: 5, max: 5, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 2, y: -2, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        {} as never
+      );
+    });
+    act(() => {
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'char-alice',
+          targetEntityId: 'goblin-1',
+          attackRoll: 18,
+          attackBonus: 5,
+          targetAc: 12,
+          hit: true,
+          critical: false,
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'goblin-1',
+          sourceEntityId: 'char-alice',
+          amount: 5,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 5, temp: 0 },
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDied?.(
+        { entityId: 'goblin-1', killerEntityId: 'char-alice' } as never,
+        metadata
+      );
+      callbacks.onEntityRemoved?.(
+        { entityId: 'goblin-1', reason: 'dead' } as never,
+        metadata
+      );
+    });
+
+    const map = screen.getByTestId('encounter-map-stub');
+    expect(map.getAttribute('data-entity-positions')).toContain('goblin-1');
+    expect(map.getAttribute('data-entity-hp')).toContain('"current":5');
+
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000 + 1600));
+    expect(map.getAttribute('data-entity-positions')).toContain('goblin-1');
+    expect(map.getAttribute('data-entity-hp')).toContain('"current":0');
+    expect(screen.getByTestId('combat-log-entry-removed-3')).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(900 + 300));
+    expect(map.getAttribute('data-entity-positions')).not.toContain('goblin-1');
+  });
+
+  it('keeps canonical HP current while releasing visible HP, damage, and correlated logs together at impact', async () => {
     hoisted.captureStreamCallbacks = true;
     render(
       <EncounterView
@@ -1827,11 +2004,11 @@ describe('EncounterView combat pacing', () => {
       );
     });
 
-    expect(screen.getByTitle('HP 13/20')).toBeTruthy();
-    expect(screen.getByTestId('combat-log-entry-damage-1')).toBeTruthy();
-    // HP and the combat log apply immediately (server-owned facts), but
-    // the presented damage number must not leak before the roll theater
-    // reaches Impact -- this is the bug this test now proves fixed.
+    // Canonical hp_after has already reached useEncounterState, while the
+    // visible projection and correlated log remain at the pre-impact story.
+    expect(screen.getByTitle('HP 20/20')).toBeTruthy();
+    expect(screen.queryByTestId('combat-log-entry-attack-0')).toBeNull();
+    expect(screen.queryByTestId('combat-log-entry-damage-1')).toBeNull();
     expect(screen.queryByTestId('beat-damage')).toBeNull();
 
     act(() => vi.advanceTimersByTime(300));
@@ -1842,6 +2019,9 @@ describe('EncounterView combat pacing', () => {
       screen.getByTestId('combat-presentation').getAttribute('data-beat')
     ).toBe('impact');
     expect(screen.getByTestId('beat-damage').textContent).toContain('7 damage');
+    expect(screen.getByTitle('HP 13/20')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-damage-1')).toBeTruthy();
   });
 
   it.each([
@@ -1856,7 +2036,7 @@ describe('EncounterView combat pacing', () => {
     ],
     ['encounterEnded', { reason: 'complete' }],
   ])(
-    'flushes only on %s and retains the immediate attack log',
+    'flushes staged outcome exactly once on %s without leaking its log',
     async (caseName, value) => {
       render(
         <EncounterView
@@ -1877,7 +2057,7 @@ describe('EncounterView combat pacing', () => {
       });
       act(() => vi.runAllTimers());
       expect(screen.queryByTestId('combat-presentation')).toBeNull();
-      expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
+      expect(screen.queryByTestId('combat-log-entry-attack-0')).toBeNull();
     }
   );
 

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -162,6 +162,14 @@ vi.mock('./EncounterMap', () => ({
       >
         finish goblin move
       </button>
+      <button
+        data-testid="stub-finish-goblin-move-2"
+        onClick={() =>
+          props.onEntityMovementPresentationComplete?.('goblin-1', 2)
+        }
+      >
+        finish goblin move 2
+      </button>
     </div>
   ),
 }));
@@ -1834,6 +1842,81 @@ describe('EncounterView combat pacing', () => {
     expect(screen.getByTestId('combat-presentation')).toBeTruthy();
   });
 
+  it('accepts the production moveSeq after a presentation flush instead of restarting a local generation', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [{ id: 'goblin-1', type: EntityType.MONSTER }],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        {} as never
+      );
+      callbacks.onEntityMoved?.(
+        {
+          entityId: 'goblin-1',
+          actualPath: [{ x: 1, y: -1, z: 0 }],
+        } as never,
+        {} as never
+      );
+    });
+    fireEvent.click(screen.getByTestId('stub-finish-goblin-move'));
+    act(() => {
+      callbacks.onModeChanged?.(
+        {
+          from: EncounterMode.TURN_BASED,
+          to: EncounterMode.FREE_ROAM,
+        } as never,
+        {} as never
+      );
+      callbacks.onEntityMoved?.(
+        {
+          entityId: 'goblin-1',
+          actualPath: [{ x: 2, y: -2, z: 0 }],
+        } as never,
+        {} as never
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
+          hit: false,
+          critical: false,
+          attackRoll: 7,
+          attackBonus: 4,
+          targetAc: 14,
+        } as never,
+        {} as never
+      );
+    });
+
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+    fireEvent.click(screen.getByTestId('stub-finish-goblin-move'));
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+    fireEvent.click(screen.getByTestId('stub-finish-goblin-move-2'));
+    expect(screen.getByTestId('combat-presentation')).toBeTruthy();
+  });
+
   it('keeps an already-known removed monster as a tombstone through lethal impact, then releases current removal behavior', () => {
     hoisted.captureStreamCallbacks = true;
     render(
@@ -1981,8 +2064,8 @@ describe('EncounterView combat pacing', () => {
       );
       callbacks.onAttackResolved?.(
         {
-          attackerEntityId: 'char-alice',
-          targetEntityId: 'goblin-1',
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
           attackRoll: 14,
           attackBonus: 5,
           targetAc: 16,
@@ -2012,7 +2095,6 @@ describe('EncounterView combat pacing', () => {
     expect(screen.queryByTestId('beat-damage')).toBeNull();
 
     act(() => vi.advanceTimersByTime(300));
-    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
     expect(screen.queryByTestId('beat-damage')).toBeNull();
     act(() => vi.advanceTimersByTime(2000 + 1600));
     expect(
@@ -2023,6 +2105,174 @@ describe('EncounterView combat pacing', () => {
     expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
     expect(screen.getByTestId('combat-log-entry-damage-1')).toBeTruthy();
   });
+
+  it('releases delayed correlated damage and terminal envelopes when they arrive after the result beat without double-releasing the lifecycle', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = {
+      sequence: 2n,
+      timestamp: undefined,
+      correlationId: 'corr-delayed',
+    } as EncounterEventMetadata;
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                {
+                  id: 'char-alice',
+                  type: EntityType.CHARACTER,
+                  hp: { current: 20, max: 20, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-alice' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        {} as never
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
+          hit: true,
+          critical: false,
+          attackRoll: 17,
+          attackBonus: 4,
+          targetAc: 14,
+        } as never,
+        metadata
+      );
+    });
+    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(2000));
+    act(() => vi.advanceTimersByTime(1600));
+    expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
+
+    act(() => {
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'char-alice',
+          sourceEntityId: 'goblin-1',
+          amount: 20,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 20, temp: 0 },
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDied?.(
+        { entityId: 'char-alice', killerEntityId: 'goblin-1' } as never,
+        metadata
+      );
+      callbacks.onEntityRemoved?.(
+        { entityId: 'char-alice', reason: 'dead' } as never,
+        metadata
+      );
+    });
+
+    expect(screen.getByTestId('combat-log-entry-damage-1')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-died-2')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-removed-3')).toBeTruthy();
+    expect(screen.getByTitle('HP 0/20')).toBeTruthy();
+    act(() => vi.advanceTimersByTime(900 + 300));
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+  });
+
+  it.each(['', 'corr-reused'])(
+    'uses entity identity when correlation %j cannot distinguish queued attacks',
+    (correlationId) => {
+      hoisted.captureStreamCallbacks = true;
+      render(
+        <EncounterView
+          encounterId="enc-1"
+          characterId="char-alice"
+          playerId="alice"
+          onBack={() => {}}
+        />
+      );
+      const callbacks = hoisted.streamCallbacks;
+      if (!callbacks) throw new Error('stream callbacks not captured');
+      const emptyMetadata = {
+        sequence: 1n,
+        timestamp: undefined,
+        correlationId,
+      } as EncounterEventMetadata;
+      act(() => {
+        callbacks.onAttackResolved?.(
+          {
+            attackerEntityId: 'char-alice',
+            targetEntityId: 'goblin-1',
+            hit: true,
+            critical: false,
+            attackRoll: 16,
+          } as never,
+          emptyMetadata
+        );
+        callbacks.onAttackResolved?.(
+          {
+            attackerEntityId: 'char-alice',
+            targetEntityId: 'goblin-2',
+            hit: true,
+            critical: false,
+            attackRoll: 18,
+          } as never,
+          emptyMetadata
+        );
+        // Reverse outcome arrival makes correlation-only first-unfilled matching
+        // attach goblin-2's damage to goblin-1's theater.
+        callbacks.onEntityDamaged?.(
+          {
+            entityId: 'goblin-2',
+            sourceEntityId: 'char-alice',
+            amount: 8,
+            damageBreakdown: [],
+            hpAfter: { current: 2, max: 10, temp: 0 },
+          } as never,
+          emptyMetadata
+        );
+        callbacks.onEntityDamaged?.(
+          {
+            entityId: 'goblin-1',
+            sourceEntityId: 'char-alice',
+            amount: 3,
+            damageBreakdown: [],
+            hpAfter: { current: 7, max: 10, temp: 0 },
+          } as never,
+          emptyMetadata
+        );
+      });
+      act(() => vi.advanceTimersByTime(300));
+      fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+      act(() => vi.advanceTimersByTime(2000 + 1600));
+      expect(screen.getByTestId('beat-damage').textContent).toContain(
+        '3 damage'
+      );
+      act(() => vi.advanceTimersByTime(900));
+      act(() => vi.advanceTimersByTime(300));
+      act(() => vi.advanceTimersByTime(300));
+      fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+      act(() => vi.advanceTimersByTime(2000));
+      act(() => vi.advanceTimersByTime(1600));
+      expect(screen.getByTestId('beat-damage').textContent).toContain(
+        '8 damage'
+      );
+    }
+  );
 
   it.each([
     ['snapshotDelivered', {}],

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -108,6 +108,7 @@ vi.mock('./EncounterMap', () => ({
       { position?: { x: number; y: number; z: number }; moveSeq?: number }
     >;
     entityHP: Map<string, { current: number; max: number }>;
+    entityStatuses: Map<string, Array<{ displayName: string }>>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (entityId: string) => void;
     onDoorClick?: (doorId: string) => void;
@@ -130,6 +131,7 @@ vi.mock('./EncounterMap', () => ({
         [...props.entities.entries()].map(([id, e]) => [id, e.position])
       )}
       data-entity-hp={JSON.stringify([...props.entityHP.entries()])}
+      data-entity-statuses={JSON.stringify([...props.entityStatuses.entries()])}
     >
       <button
         data-testid="stub-move"
@@ -2026,6 +2028,288 @@ describe('EncounterView combat pacing', () => {
     expect(screen.queryByTestId('combat-presentation')).toBeNull();
     fireEvent.click(screen.getByTestId('stub-finish-goblin-move-2'));
     expect(screen.getByTestId('combat-presentation')).toBeTruthy();
+  });
+
+  it('holds correlated authoritative status badges, logs, and model projection until hit Impact', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = {
+      sequence: 1n,
+      timestamp: undefined,
+      correlationId: 'corr-player-down',
+    } as EncounterEventMetadata;
+    const unconscious = {
+      entityId: 'char-alice',
+      sourceEntityId: 'goblin-1',
+      status: {
+        source: { module: 'dnd5e', type: 'conditions', id: 'unconscious' },
+        displayName: 'Unconscious',
+      },
+    } as never;
+
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                {
+                  id: 'char-alice',
+                  type: EntityType.CHARACTER,
+                  hp: { current: 2, max: 10, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-alice' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        metadata
+      );
+    });
+    act(() => {
+      callbacks.onModeChanged?.(
+        {
+          from: EncounterMode.FREE_ROAM,
+          to: EncounterMode.TURN_BASED,
+        } as never,
+        metadata
+      );
+      callbacks.onTurnStarted?.(
+        { entityId: 'char-alice', round: 1 } as never,
+        metadata
+      );
+      callbacks.onTurnStateChanged?.(
+        {
+          turnState: {
+            economy: { movementRemaining: 30 },
+            availableActions: [],
+          },
+        } as never,
+        metadata
+      );
+    });
+    act(() => {
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
+          attackRoll: 18,
+          attackBonus: 4,
+          targetAc: 13,
+          hit: true,
+          critical: false,
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'char-alice',
+          sourceEntityId: 'goblin-1',
+          amount: 4,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 10, temp: 0 },
+        } as never,
+        metadata
+      );
+      callbacks.onStatusApplied?.(unconscious, metadata);
+      callbacks.onStatusApplied?.(unconscious, metadata);
+      callbacks.onTurnStateChanged?.(
+        {
+          turnState: {
+            economy: { movementRemaining: 0 },
+            availableActions: [],
+          },
+        } as never,
+        metadata
+      );
+    });
+
+    const map = screen.getByTestId('encounter-map-stub');
+    expect(map.getAttribute('data-entity-hp')).toContain('"current":2');
+    expect(map.getAttribute('data-entity-statuses')).not.toContain(
+      'Unconscious'
+    );
+    expect(screen.queryByTestId('my-status-badges')).toBeNull();
+    expect(screen.queryByTestId('combat-log-entry-statusApplied-3')).toBeNull();
+    expect(screen.queryByTestId('combat-log-entry-statusApplied-4')).toBeNull();
+    expect(screen.getByTestId('encounter-dock-movement').textContent).toContain(
+      '30 ft'
+    );
+    expect(
+      (screen.getByRole('button', { name: 'End Turn' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+
+    act(() => vi.advanceTimersByTime(300 + 2000));
+    expect(screen.getByTestId('beat-verdict')).toBeTruthy();
+    expect(map.getAttribute('data-entity-statuses')).not.toContain(
+      'Unconscious'
+    );
+    act(() => vi.advanceTimersByTime(1600));
+
+    expect(map.getAttribute('data-entity-hp')).toContain('"current":0');
+    expect(screen.getByTestId('encounter-dock-movement').textContent).toContain(
+      '0 ft'
+    );
+    expect(map.getAttribute('data-entity-statuses')).toContain('Unconscious');
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Unconscious'
+    );
+    expect(screen.getByTestId('combat-log-entry-statusApplied-3')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-statusApplied-4')).toBeTruthy();
+
+    // A correlated envelope arriving after semantic release reveals only its
+    // new payload and does not re-fire the attack lifecycle.
+    act(() => {
+      callbacks.onStatusApplied?.(
+        {
+          entityId: 'char-alice',
+          sourceEntityId: 'goblin-1',
+          status: {
+            source: { module: 'dnd5e', type: 'conditions', id: 'prone' },
+            displayName: 'Prone',
+          },
+        } as never,
+        metadata
+      );
+    });
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Prone'
+    );
+    expect(screen.getByTestId('combat-log-entry-statusApplied-5')).toBeTruthy();
+    expect(screen.getAllByTestId('combat-log-entry-attack-1')).toHaveLength(1);
+    act(() => vi.advanceTimersByTime(900 + 300));
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Unconscious'
+    );
+  });
+
+  it('binds a reused-correlation same-target status to the most recent damage story', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = { correlationId: 'corr-reused-status' } as never;
+    act(() => {
+      for (const attackRoll of [14, 18]) {
+        callbacks.onAttackResolved?.(
+          {
+            attackerEntityId: 'goblin-1',
+            targetEntityId: 'char-alice',
+            attackRoll,
+            hit: true,
+            critical: false,
+          } as never,
+          metadata
+        );
+      }
+      for (const amount of [2, 4]) {
+        callbacks.onEntityDamaged?.(
+          {
+            entityId: 'char-alice',
+            sourceEntityId: 'goblin-1',
+            amount,
+            damageBreakdown: [],
+            hpAfter: { current: 10 - amount, max: 10, temp: 0 },
+          } as never,
+          metadata
+        );
+      }
+      callbacks.onStatusApplied?.(
+        {
+          entityId: 'char-alice',
+          sourceEntityId: 'goblin-1',
+          status: {
+            source: { module: 'dnd5e', type: 'conditions', id: 'prone' },
+            displayName: 'Prone',
+          },
+        } as never,
+        metadata
+      );
+    });
+
+    act(() => vi.advanceTimersByTime(300 + 2000 + 1600));
+    expect(screen.getByTestId('beat-damage').textContent).toContain('2 damage');
+    expect(screen.queryByTestId('my-status-badges')).toBeNull();
+    act(() => vi.advanceTimersByTime(900 + 300));
+    act(() => vi.advanceTimersByTime(300 + 2000 + 1600));
+    expect(screen.getByTestId('beat-damage').textContent).toContain('4 damage');
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Prone'
+    );
+    expect(screen.getByTestId('combat-log-entry-statusApplied-4')).toBeTruthy();
+  });
+
+  it('keeps an uncorrelated status immediate while an attack story is staged', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    act(() => {
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
+          hit: true,
+          critical: false,
+          attackRoll: 18,
+        } as never,
+        { correlationId: 'corr-attack' } as never
+      );
+      callbacks.onStatusApplied?.(
+        {
+          entityId: 'char-alice',
+          status: {
+            source: { module: 'dnd5e', type: 'conditions', id: 'blessed' },
+            displayName: 'Blessed',
+          },
+        } as never,
+        { correlationId: '' } as never
+      );
+    });
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Blessed'
+    );
+    expect(screen.getByTestId('combat-log-entry-statusApplied-0')).toBeTruthy();
+    act(() => {
+      callbacks.onStatusRemoved?.(
+        {
+          entityId: 'char-alice',
+          statusSource: { module: 'dnd5e', type: 'conditions', id: 'blessed' },
+        } as never,
+        { correlationId: '' } as never
+      );
+    });
+    expect(screen.queryByTestId('my-status-badges')).toBeNull();
+    expect(screen.getByTestId('combat-log-entry-statusRemoved-1')).toBeTruthy();
   });
 
   it('keeps an already-known removed monster as a tombstone through lethal impact, then releases current removal behavior', () => {

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -2634,6 +2634,136 @@ describe('EncounterView combat pacing', () => {
     ).not.toContain('goblin-2');
   });
 
+  it.each(['', 'corr-reused-terminal'])(
+    'drains two queued terminal stories FIFO before encounter end for correlation %j',
+    (correlationId) => {
+      hoisted.captureStreamCallbacks = true;
+      render(
+        <EncounterView
+          encounterId="enc-1"
+          characterId="char-alice"
+          playerId="alice"
+          onBack={() => {}}
+        />
+      );
+      const callbacks = hoisted.streamCallbacks;
+      if (!callbacks) throw new Error('stream callbacks not captured');
+      const metadata = {
+        sequence: 1n,
+        timestamp: undefined,
+        correlationId,
+      } as EncounterEventMetadata;
+      act(() => {
+        callbacks.onSnapshotDelivered?.(
+          {
+            encounter: {
+              space: {
+                entities: [
+                  {
+                    id: 'goblin-1',
+                    type: EntityType.MONSTER,
+                    hp: { current: 3, max: 3, temp: 0 },
+                  },
+                  {
+                    id: 'goblin-2',
+                    type: EntityType.MONSTER,
+                    hp: { current: 4, max: 4, temp: 0 },
+                  },
+                ],
+                hexes: [
+                  {
+                    position: { x: 1, y: -1, z: 0 },
+                    contents: [{ entityId: 'goblin-1' }],
+                  },
+                  {
+                    position: { x: 2, y: -2, z: 0 },
+                    contents: [{ entityId: 'goblin-2' }],
+                  },
+                ],
+              },
+            },
+          } as never,
+          metadata
+        );
+        for (const [targetEntityId, amount] of [
+          ['goblin-1', 3],
+          ['goblin-2', 4],
+        ] as const) {
+          callbacks.onAttackResolved?.(
+            {
+              attackerEntityId: 'char-alice',
+              targetEntityId,
+              hit: true,
+              critical: false,
+              attackRoll: 18,
+            } as never,
+            metadata
+          );
+          callbacks.onEntityDamaged?.(
+            {
+              entityId: targetEntityId,
+              sourceEntityId: 'char-alice',
+              amount,
+              damageBreakdown: [],
+              hpAfter: { current: 0, max: amount, temp: 0 },
+            } as never,
+            metadata
+          );
+          callbacks.onEntityDied?.(
+            { entityId: targetEntityId, killerEntityId: 'char-alice' } as never,
+            metadata
+          );
+          callbacks.onEntityRemoved?.(
+            { entityId: targetEntityId, reason: 'dead' } as never,
+            metadata
+          );
+        }
+        callbacks.onEncounterEnded?.(
+          { reason: 'all hostiles defeated' } as never,
+          metadata
+        );
+      });
+
+      expect(screen.getByTestId('combat-presentation')).toBeTruthy();
+      expect(screen.queryByText(/Encounter ended/)).toBeNull();
+      const map = screen.getByTestId('encounter-map-stub');
+      expect(map.getAttribute('data-entity-positions')).toContain('goblin-1');
+      expect(map.getAttribute('data-entity-positions')).toContain('goblin-2');
+
+      act(() => vi.advanceTimersByTime(300));
+      fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+      act(() => vi.advanceTimersByTime(2000 + 1600));
+      expect(screen.getByTestId('beat-damage').textContent).toContain(
+        '3 damage'
+      );
+      expect(screen.queryByText(/Encounter ended/)).toBeNull();
+      act(() => vi.advanceTimersByTime(900));
+      act(() => vi.advanceTimersByTime(300));
+      expect(map.getAttribute('data-entity-positions')).not.toContain(
+        'goblin-1'
+      );
+      expect(map.getAttribute('data-entity-positions')).toContain('goblin-2');
+
+      act(() => vi.advanceTimersByTime(300));
+      fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+      act(() => vi.advanceTimersByTime(2000));
+      act(() => vi.advanceTimersByTime(1600));
+      expect(screen.getByTestId('beat-damage').textContent).toContain(
+        '4 damage'
+      );
+      expect(screen.getByTestId('encounter-ended-banner')).toBeTruthy();
+      expect(
+        screen.getByTestId('combat-log-entry-encounterEnded-8')
+      ).toBeTruthy();
+      expect(map.getAttribute('data-entity-positions')).toContain('goblin-2');
+      act(() => vi.advanceTimersByTime(900));
+      act(() => vi.advanceTimersByTime(300));
+      expect(map.getAttribute('data-entity-positions')).not.toContain(
+        'goblin-2'
+      );
+    }
+  );
+
   it.each([
     ['snapshotDelivered', {}],
     [

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -2106,6 +2106,120 @@ describe('EncounterView combat pacing', () => {
     expect(screen.getByTestId('combat-log-entry-damage-1')).toBeTruthy();
   });
 
+  it('drains a final-enemy terminal burst through its result beat instead of flushing on EncounterEnded', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = {
+      sequence: 10n,
+      timestamp: undefined,
+      correlationId: 'corr-final-enemy',
+    } as EncounterEventMetadata;
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                {
+                  id: 'goblin-1',
+                  type: EntityType.MONSTER,
+                  hp: { current: 4, max: 4, temp: 0 },
+                },
+              ],
+              hexes: [
+                {
+                  position: { x: 1, y: -1, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        {} as never
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'char-alice',
+          targetEntityId: 'goblin-1',
+          hit: true,
+          critical: false,
+          attackRoll: 19,
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'goblin-1',
+          sourceEntityId: 'char-alice',
+          amount: 4,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 4, temp: 0 },
+        } as never,
+        metadata
+      );
+      callbacks.onEntityDied?.(
+        { entityId: 'goblin-1', killerEntityId: 'char-alice' } as never,
+        metadata
+      );
+      callbacks.onEntityRemoved?.(
+        { entityId: 'goblin-1', reason: 'dead' } as never,
+        metadata
+      );
+      callbacks.onEncounterEnded?.(
+        { reason: 'all hostiles defeated' } as never,
+        { ...metadata, correlationId: '' }
+      );
+    });
+
+    expect(screen.getByTestId('combat-presentation')).toBeTruthy();
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).toContain('goblin-1');
+    expect(screen.queryByTestId('encounter-ended-banner')).toBeNull();
+    expect(screen.queryByText('Encounter ended')).toBeNull();
+    expect(screen.queryByTestId('combat-log-entry-attack-0')).toBeNull();
+    expect(
+      screen.queryByTestId('combat-log-entry-encounterEnded-4')
+    ).toBeNull();
+
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000 + 1600));
+    expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-damage-1')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-died-2')).toBeTruthy();
+    expect(screen.getByTestId('combat-log-entry-removed-3')).toBeTruthy();
+    expect(
+      screen.getByTestId('combat-log-entry-encounterEnded-4')
+    ).toBeTruthy();
+    expect(screen.getByTestId('encounter-ended-banner')).toBeTruthy();
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).toContain('goblin-1');
+
+    act(() => vi.advanceTimersByTime(900));
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+    expect(
+      screen
+        .getByTestId('encounter-map-stub')
+        .getAttribute('data-entity-positions')
+    ).not.toContain('goblin-1');
+  });
+
   it('releases delayed correlated damage and terminal envelopes when they arrive after the result beat without double-releasing the lifecycle', () => {
     hoisted.captureStreamCallbacks = true;
     render(

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -103,7 +103,10 @@ vi.mock('./EncounterMap', () => ({
     myEntityId: string;
     openDoorIds?: string[];
     theme?: string;
-    entities: Map<string, { position?: { x: number; y: number; z: number } }>;
+    entities: Map<
+      string,
+      { position?: { x: number; y: number; z: number }; moveSeq?: number }
+    >;
     entityHP: Map<string, { current: number; max: number }>;
     onMove: (path: Array<{ x: number; y: number; z: number }>) => void;
     onEntityClick: (entityId: string) => void;
@@ -145,6 +148,20 @@ vi.mock('./EncounterMap', () => ({
         onClick={() => props.onDoorClick?.('door-1')}
       >
         click door
+      </button>
+      <button
+        data-testid="stub-finish-player-move"
+        onClick={() => {
+          const moveSeq = props.entities.get(props.myEntityId)?.moveSeq;
+          if (moveSeq !== undefined) {
+            props.onEntityMovementPresentationComplete?.(
+              props.myEntityId,
+              moveSeq
+            );
+          }
+        }}
+      >
+        finish player move
       </button>
       <button
         data-testid="stub-finish-stale-goblin-move"
@@ -1741,6 +1758,100 @@ describe('EncounterView combat pacing', () => {
       );
     });
 
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getByRole('button', { name: 'Roll d20' })).toBeTruthy();
+  });
+
+  it('releases player movement into viewer Armed/Roll and does not re-wait that move for a second attack', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const metadata = {
+      sequence: 1n,
+      timestamp: undefined,
+      correlationId: 'corr-viewer',
+    } as EncounterEventMetadata;
+
+    act(() => {
+      callbacks.onSnapshotDelivered?.(
+        {
+          encounter: {
+            space: {
+              entities: [
+                { id: 'char-alice', type: EntityType.CHARACTER },
+                { id: 'goblin-1', type: EntityType.MONSTER },
+              ],
+              hexes: [
+                {
+                  position: { x: 0, y: 0, z: 0 },
+                  contents: [{ entityId: 'char-alice' }],
+                },
+                {
+                  position: { x: 2, y: -2, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
+                },
+              ],
+            },
+          },
+        } as never,
+        metadata
+      );
+      callbacks.onEntityMoved?.(
+        {
+          entityId: 'char-alice',
+          actualPath: [
+            { x: 0, y: 0, z: 0 },
+            { x: 1, y: -1, z: 0 },
+            { x: 2, y: -2, z: 0 },
+          ],
+        } as never,
+        metadata
+      );
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'char-alice',
+          targetEntityId: 'goblin-1',
+          attackRoll: 18,
+          attackBonus: 5,
+          targetAc: 13,
+          hit: true,
+          critical: false,
+        } as never,
+        metadata
+      );
+    });
+
+    expect(screen.queryByTestId('combat-presentation')).toBeNull();
+    fireEvent.click(screen.getByTestId('stub-finish-player-move'));
+    expect(screen.getByTestId('combat-presentation')).toBeTruthy();
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
+    act(() => vi.advanceTimersByTime(2000 + 1600 + 900 + 300));
+    expect(screen.getByTestId('combat-log-entry-attack-0')).toBeTruthy();
+
+    act(() => {
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'char-alice',
+          targetEntityId: 'goblin-1',
+          attackRoll: 7,
+          attackBonus: 5,
+          targetAc: 13,
+          hit: false,
+          critical: false,
+        } as never,
+        { ...metadata, sequence: 2n, correlationId: 'corr-viewer-2' }
+      );
+    });
+    expect(screen.getByTestId('combat-presentation')).toBeTruthy();
     act(() => vi.advanceTimersByTime(300));
     expect(screen.getByRole('button', { name: 'Roll d20' })).toBeTruthy();
   });

--- a/src/components/game/EncounterView.test.tsx
+++ b/src/components/game/EncounterView.test.tsx
@@ -2030,7 +2030,7 @@ describe('EncounterView combat pacing', () => {
     expect(screen.getByTestId('combat-presentation')).toBeTruthy();
   });
 
-  it('holds correlated authoritative status badges, logs, and model projection until hit Impact', () => {
+  it('holds correlated authoritative status badges, logs, and model projection until hit Impact', async () => {
     hoisted.captureStreamCallbacks = true;
     render(
       <EncounterView
@@ -2067,11 +2067,16 @@ describe('EncounterView combat pacing', () => {
                   type: EntityType.CHARACTER,
                   hp: { current: 2, max: 10, temp: 0 },
                 },
+                { id: 'goblin-1', type: EntityType.MONSTER },
               ],
               hexes: [
                 {
                   position: { x: 0, y: 0, z: 0 },
                   contents: [{ entityId: 'char-alice' }],
+                },
+                {
+                  position: { x: 1, y: -1, z: 0 },
+                  contents: [{ entityId: 'goblin-1' }],
                 },
               ],
             },
@@ -2096,7 +2101,15 @@ describe('EncounterView combat pacing', () => {
         {
           turnState: {
             economy: { movementRemaining: 30 },
-            availableActions: [],
+            availableActions: [
+              {
+                ref: { module: 'dnd5e', type: 'action', id: 'attack' },
+                displayName: 'Attack',
+                available: true,
+                economySlot: EconomySlot.ACTION,
+                targetKind: TargetKind.SINGLE_ENTITY,
+              },
+            ],
           },
         } as never,
         metadata
@@ -2125,8 +2138,14 @@ describe('EncounterView combat pacing', () => {
         } as never,
         metadata
       );
-      callbacks.onStatusApplied?.(unconscious, metadata);
-      callbacks.onStatusApplied?.(unconscious, metadata);
+      callbacks.onStatusApplied?.(unconscious, {
+        ...metadata,
+        correlationId: '',
+      });
+      callbacks.onStatusApplied?.(unconscious, {
+        ...metadata,
+        correlationId: '',
+      });
       callbacks.onTurnStateChanged?.(
         {
           turnState: {
@@ -2149,10 +2168,24 @@ describe('EncounterView combat pacing', () => {
     expect(screen.getByTestId('encounter-dock-movement').textContent).toContain(
       '30 ft'
     );
-    expect(
-      (screen.getByRole('button', { name: 'End Turn' }) as HTMLButtonElement)
-        .disabled
-    ).toBe(true);
+    const endTurnButton = screen.getByRole('button', { name: 'End Turn' });
+    const attackButton = screen.getByRole('button', { name: 'Attack' });
+    fireEvent.click(screen.getByLabelText('Combat settings'));
+    const reactionToggle = screen.getByTestId(
+      'reaction-toggle-dnd5e:conditions:opportunity_attack'
+    );
+    expect((endTurnButton as HTMLButtonElement).disabled).toBe(true);
+    expect((attackButton as HTMLButtonElement).disabled).toBe(true);
+    expect((reactionToggle as HTMLInputElement).disabled).toBe(true);
+    fireEvent.click(screen.getByTestId('stub-move'));
+    fireEvent.click(screen.getByTestId('stub-click-goblin'));
+    fireEvent.click(attackButton);
+    fireEvent.click(endTurnButton);
+    fireEvent.click(reactionToggle);
+    expect(hoisted.moveEntityFn).not.toHaveBeenCalled();
+    expect(hoisted.takeActionFn).not.toHaveBeenCalled();
+    expect(hoisted.endTurnFn).not.toHaveBeenCalled();
+    expect(hoisted.setReactionReadyFn).not.toHaveBeenCalled();
 
     act(() => vi.advanceTimersByTime(300 + 2000));
     expect(screen.getByTestId('beat-verdict')).toBeTruthy();
@@ -2171,6 +2204,35 @@ describe('EncounterView combat pacing', () => {
     );
     expect(screen.getByTestId('combat-log-entry-statusApplied-3')).toBeTruthy();
     expect(screen.getByTestId('combat-log-entry-statusApplied-4')).toBeTruthy();
+    expect((reactionToggle as HTMLInputElement).disabled).toBe(false);
+    act(() => {
+      callbacks.onTurnStateChanged?.(
+        {
+          turnState: {
+            economy: { movementRemaining: 30 },
+            availableActions: [
+              {
+                ref: { module: 'dnd5e', type: 'action', id: 'attack' },
+                displayName: 'Attack',
+                available: true,
+                economySlot: EconomySlot.ACTION,
+                targetKind: TargetKind.SINGLE_ENTITY,
+              },
+            ],
+          },
+        } as never,
+        metadata
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('stub-move'));
+      fireEvent.click(screen.getByTestId('stub-click-goblin'));
+      fireEvent.click(reactionToggle);
+      await Promise.resolve();
+    });
+    expect(hoisted.moveEntityFn).toHaveBeenCalledOnce();
+    expect(hoisted.takeActionFn).toHaveBeenCalledOnce();
+    expect(hoisted.setReactionReadyFn).toHaveBeenCalledOnce();
 
     // A correlated envelope arriving after semantic release reveals only its
     // new payload and does not re-fire the attack lifecycle.
@@ -2245,7 +2307,7 @@ describe('EncounterView combat pacing', () => {
             displayName: 'Prone',
           },
         } as never,
-        metadata
+        { correlationId: '' } as never
       );
     });
 
@@ -2260,6 +2322,177 @@ describe('EncounterView combat pacing', () => {
     );
     expect(screen.getByTestId('combat-log-entry-statusApplied-4')).toBeTruthy();
   });
+
+  it('keeps newer immediate status apply/remove truth when releasing an earlier held status', () => {
+    hoisted.captureStreamCallbacks = true;
+    render(
+      <EncounterView
+        encounterId="enc-1"
+        characterId="char-alice"
+        playerId="alice"
+        onBack={() => {}}
+      />
+    );
+    const callbacks = hoisted.streamCallbacks;
+    if (!callbacks) throw new Error('stream callbacks not captured');
+    const attackMetadata = { correlationId: 'corr-status-order' } as never;
+    act(() => {
+      callbacks.onAttackResolved?.(
+        {
+          attackerEntityId: 'goblin-1',
+          targetEntityId: 'char-alice',
+          hit: true,
+          critical: false,
+          attackRoll: 18,
+        } as never,
+        attackMetadata
+      );
+      callbacks.onEntityDamaged?.(
+        {
+          entityId: 'char-alice',
+          sourceEntityId: 'goblin-1',
+          amount: 4,
+          damageBreakdown: [],
+          hpAfter: { current: 0, max: 10, temp: 0 },
+        } as never,
+        attackMetadata
+      );
+      callbacks.onStatusApplied?.(
+        {
+          entityId: 'char-alice',
+          sourceEntityId: 'goblin-1',
+          status: {
+            source: { module: 'dnd5e', type: 'conditions', id: 'prone' },
+            displayName: 'Prone',
+          },
+        } as never,
+        { correlationId: '' } as never
+      );
+      callbacks.onStatusApplied?.(
+        {
+          entityId: 'char-alice',
+          status: {
+            source: { module: 'dnd5e', type: 'conditions', id: 'blessed' },
+            displayName: 'Blessed',
+          },
+        } as never,
+        { correlationId: 'unrelated-status' } as never
+      );
+      callbacks.onStatusRemoved?.(
+        {
+          entityId: 'char-alice',
+          statusSource: { module: 'dnd5e', type: 'conditions', id: 'prone' },
+        } as never,
+        { correlationId: '' } as never
+      );
+    });
+
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Blessed'
+    );
+    expect(screen.getByTestId('my-status-badges').textContent).not.toContain(
+      'Prone'
+    );
+    act(() => vi.advanceTimersByTime(300 + 2000 + 1600));
+    expect(screen.getByTestId('my-status-badges').textContent).toContain(
+      'Blessed'
+    );
+    expect(screen.getByTestId('my-status-badges').textContent).not.toContain(
+      'Prone'
+    );
+  });
+
+  it.each(['snapshot', 'knowledge'] as const)(
+    'uses batched %s status hydration as the held pre-attack baseline',
+    (hydration) => {
+      hoisted.captureStreamCallbacks = true;
+      render(
+        <EncounterView
+          encounterId="enc-1"
+          characterId="char-alice"
+          playerId="alice"
+          onBack={() => {}}
+        />
+      );
+      const callbacks = hoisted.streamCallbacks;
+      if (!callbacks) throw new Error('stream callbacks not captured');
+      const entity = {
+        id: 'char-alice',
+        type: EntityType.CHARACTER,
+        statusEffects: [
+          {
+            source: { module: 'dnd5e', type: 'conditions', id: 'raging' },
+            displayName: 'Raging',
+          },
+        ],
+      };
+      const hex = {
+        position: { x: 0, y: 0, z: 0 },
+        contents: [{ entityId: 'char-alice' }],
+      };
+      const metadata = { correlationId: 'corr-hydrated-status' } as never;
+      act(() => {
+        if (hydration === 'snapshot') {
+          callbacks.onSnapshotDelivered?.(
+            {
+              encounter: { space: { entities: [entity], hexes: [hex] } },
+            } as never,
+            metadata
+          );
+        } else {
+          callbacks.onHexKnowledgeChanged?.(
+            { entities: [entity], hexes: [hex] } as never,
+            metadata
+          );
+        }
+        callbacks.onAttackResolved?.(
+          {
+            attackerEntityId: 'goblin-1',
+            targetEntityId: 'char-alice',
+            hit: true,
+            critical: false,
+            attackRoll: 18,
+          } as never,
+          metadata
+        );
+        callbacks.onEntityDamaged?.(
+          {
+            entityId: 'char-alice',
+            sourceEntityId: 'goblin-1',
+            amount: 2,
+            damageBreakdown: [],
+            hpAfter: { current: 8, max: 10, temp: 0 },
+          } as never,
+          metadata
+        );
+        callbacks.onStatusApplied?.(
+          {
+            entityId: 'char-alice',
+            sourceEntityId: 'goblin-1',
+            status: {
+              source: { module: 'dnd5e', type: 'conditions', id: 'prone' },
+              displayName: 'Prone',
+            },
+          } as never,
+          { correlationId: '' } as never
+        );
+      });
+
+      expect(screen.getByTestId('my-status-badges').textContent).toContain(
+        'Raging'
+      );
+      expect(screen.getByTestId('my-status-badges').textContent).not.toContain(
+        'Prone'
+      );
+      act(() => vi.advanceTimersByTime(300 + 2000 + 1600));
+      expect(screen.getByTestId('my-status-badges').textContent).toContain(
+        'Raging'
+      );
+      expect(screen.getByTestId('my-status-badges').textContent).toContain(
+        'Prone'
+      );
+    }
+  );
 
   it('keeps an uncorrelated status immediate while an attack story is staged', () => {
     hoisted.captureStreamCallbacks = true;

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -41,12 +41,14 @@ import type {
   EntityDamaged,
   EntityDied,
   EntityRemoved,
+  StatusApplied,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 import type {
   AvailableAction,
   CharacterData,
   Entity,
+  TurnState,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import {
   EncounterMode,
@@ -65,8 +67,13 @@ import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useTakeAction } from '../../api/useTakeAction';
 import { useUnequipItem } from '../../api/useUnequipItem';
 import { useCombatLog } from '../../hooks/useCombatLog';
-import type { CharacterEquipment } from '../../hooks/useEncounterState';
+import type {
+  CharacterEquipment,
+  EntityStatus,
+} from '../../hooks/useEncounterState';
 import {
+  applyStatusApplied,
+  applyStatusRemoved,
   positionByEntityIdFromHexes,
   useEncounterState,
 } from '../../hooks/useEncounterState';
@@ -181,10 +188,18 @@ function characterEquipmentFrom(
 interface PresentationStoryItem extends CombatPresentationAttack {
   /** Per-attacker movement generation observed before this attack event. */
   waitForMovementGeneration?: number;
+  /** Pre-story dock labels for a local target. Commands remain canonically gated. */
+  targetControlSnapshot?: { turnState: TurnState | null };
+}
+
+interface PresentationStatusOutcome {
+  event: StatusApplied;
+  statusesAfter: EntityStatus[];
 }
 
 interface PresentationStoryOutcome {
   damage?: EntityDamaged;
+  statuses?: PresentationStatusOutcome[];
   died?: EntityDied;
   removed?: EntityRemoved;
   encounterEnded?: EncounterEnded;
@@ -228,6 +243,30 @@ function findPresentationStory(
   );
   if (withDamage.length > 0) return withDamage[withDamage.length - 1];
   return candidates[candidates.length - 1];
+}
+
+/** StatusApplied is multi-valued and correlation-bearing. Empty correlation
+ * remains immediate; a reused correlation follows the most recent matching
+ * damage story in observed stream order. */
+function findPresentationStatusStory(
+  queue: PresentationStoryItem[],
+  outcomes: ReadonlyMap<number, PresentationStoryOutcome>,
+  correlationId: string,
+  targetEntityId: string,
+  sourceEntityId?: string
+): PresentationStoryItem | undefined {
+  if (correlationId === '') return undefined;
+  const candidates = queue.filter(
+    (item) =>
+      item.correlationId === correlationId &&
+      item.attack.targetEntityId === targetEntityId &&
+      (!sourceEntityId || item.attack.attackerEntityId === sourceEntityId)
+  );
+  const withDamage = candidates.filter(
+    (item) => outcomes.get(item.id)?.damage !== undefined
+  );
+  const preferred = withDamage.length > 0 ? withDamage : candidates;
+  return preferred[preferred.length - 1];
 }
 
 function findTerminalPresentationStory(
@@ -274,6 +313,10 @@ export function EncounterView({
   canonicalHPRef.current = encounterState.state.entityHP;
   const canonicalEntitiesRef = useRef(encounterState.state.entities);
   canonicalEntitiesRef.current = encounterState.state.entities;
+  const canonicalStatusesRef = useRef(encounterState.state.entityStatuses);
+  canonicalStatusesRef.current = encounterState.state.entityStatuses;
+  const canonicalTurnStateRef = useRef(encounterState.state.turnState);
+  canonicalTurnStateRef.current = encounterState.state.turnState;
   // #445: game-grade combat narrative — the same dispatched events, rendered
   // as a scrolling log instead of PlaytestHarness's raw dev-log text.
   const combatLog = useCombatLog();
@@ -314,6 +357,10 @@ export function EncounterView({
   const heldVisibleHPRef = useRef(
     new Map<string, { current: number; max: number }>()
   );
+  const [heldVisibleStatuses, setHeldVisibleStatuses] = useState<
+    Map<string, EntityStatus[]>
+  >(new Map());
+  const heldVisibleStatusesRef = useRef(new Map<string, EntityStatus[]>());
   const [presentationTombstones, setPresentationTombstones] = useState<
     typeof encounterState.state.entities
   >(new Map());
@@ -330,6 +377,8 @@ export function EncounterView({
     setPresentationOutcomes(new Map());
     heldVisibleHPRef.current = new Map();
     setHeldVisibleHP(new Map());
+    heldVisibleStatusesRef.current = new Map();
+    setHeldVisibleStatuses(new Map());
     setPresentationTombstones(new Map());
     movementGenerationRef.current.clear();
     completedMovementGenerationRef.current.clear();
@@ -354,6 +403,15 @@ export function EncounterView({
         heldVisibleHPRef.current = next;
         setHeldVisibleHP(next);
       }
+    }
+    if (outcome.statuses) {
+      const next = new Map(heldVisibleStatusesRef.current);
+      for (const status of outcome.statuses) {
+        combatLog.recordStatusApplied(status.event);
+        next.set(status.event.entityId, status.statusesAfter);
+      }
+      heldVisibleStatusesRef.current = next;
+      setHeldVisibleStatuses(next);
     }
     if (outcome.died) combatLog.recordEntityDied(outcome.died);
     if (outcome.removed) combatLog.recordEntityRemoved(outcome.removed);
@@ -389,6 +447,22 @@ export function EncounterView({
         heldVisibleHPRef.current = next;
         setHeldVisibleHP(next);
       }
+    }
+    if (outcome.statuses) {
+      const targetIds = new Set(
+        outcome.statuses.map((status) => status.event.entityId)
+      );
+      const next = new Map(heldVisibleStatusesRef.current);
+      for (const targetId of targetIds) {
+        const laterStatusPending = remaining.some((item) =>
+          presentationOutcomesRef.current
+            .get(item.id)
+            ?.statuses?.some((status) => status.event.entityId === targetId)
+        );
+        if (!laterStatusPending) next.delete(targetId);
+      }
+      heldVisibleStatusesRef.current = next;
+      setHeldVisibleStatuses(next);
     }
     releasedPresentationIdsRef.current.delete(id);
     const remainingOutcomes = new Map(presentationOutcomesRef.current);
@@ -495,6 +569,7 @@ export function EncounterView({
             setResolvedEntityId(resolved);
           }
         }
+        canonicalTurnStateRef.current = e.encounter.turnState ?? null;
         encounterState.applySnapshotTurnState(
           e.encounter.mode,
           e.encounter.turnState
@@ -689,13 +764,113 @@ export function EncounterView({
         encounterState.applyWallsRevealed(liveWalls);
       }
     },
-    onStatusApplied: (e) => {
+    onStatusApplied: (e, metadata) => {
+      const canonicalBefore = canonicalStatusesRef.current;
+      const canonicalNextState = applyStatusApplied(
+        { ...encounterState.state, entityStatuses: canonicalBefore },
+        e
+      );
+      canonicalStatusesRef.current = canonicalNextState.entityStatuses;
       encounterState.applyStatusApplied(e);
-      combatLog.recordStatusApplied(e);
+
+      const stagedAttack = findPresentationStatusStory(
+        presentationQueueRef.current,
+        presentationOutcomesRef.current,
+        metadata.correlationId,
+        e.entityId,
+        e.sourceEntityId
+      );
+      const heldBefore = heldVisibleStatusesRef.current.get(e.entityId);
+      if (!stagedAttack) {
+        combatLog.recordStatusApplied(e);
+        // An honest, unrelated status stays immediate even while another
+        // attack story holds this entity's correlated status projection.
+        if (heldBefore) {
+          const visibleBase = new Map(heldVisibleStatusesRef.current);
+          visibleBase.set(e.entityId, heldBefore);
+          const visibleNext = applyStatusApplied(
+            { ...encounterState.state, entityStatuses: visibleBase },
+            e
+          ).entityStatuses;
+          const next = new Map(heldVisibleStatusesRef.current);
+          next.set(e.entityId, visibleNext.get(e.entityId) ?? []);
+          heldVisibleStatusesRef.current = next;
+          setHeldVisibleStatuses(next);
+        }
+        return;
+      }
+
+      const stagedIndex = presentationQueueRef.current.findIndex(
+        (item) => item.id === stagedAttack.id
+      );
+      let priorStagedStatuses: PresentationStatusOutcome | undefined;
+      for (const item of presentationQueueRef.current.slice(
+        0,
+        stagedIndex + 1
+      )) {
+        const statuses = presentationOutcomesRef.current.get(item.id)?.statuses;
+        for (const status of statuses ?? []) {
+          if (status.event.entityId === e.entityId)
+            priorStagedStatuses = status;
+        }
+      }
+      const visibleBefore =
+        priorStagedStatuses?.statusesAfter ??
+        heldBefore ??
+        canonicalBefore.get(e.entityId) ??
+        [];
+      if (!heldVisibleStatusesRef.current.has(e.entityId)) {
+        const next = new Map(heldVisibleStatusesRef.current);
+        next.set(e.entityId, visibleBefore);
+        heldVisibleStatusesRef.current = next;
+        setHeldVisibleStatuses(next);
+      }
+      const projectionBase = new Map(canonicalBefore);
+      projectionBase.set(e.entityId, visibleBefore);
+      const statusesAfter =
+        applyStatusApplied(
+          { ...encounterState.state, entityStatuses: projectionBase },
+          e
+        ).entityStatuses.get(e.entityId) ?? [];
+      updatePresentationOutcome(stagedAttack.id, (outcome) => ({
+        ...outcome,
+        statuses: [...(outcome.statuses ?? []), { event: e, statusesAfter }],
+      }));
+      if (releasedPresentationIdsRef.current.has(stagedAttack.id)) {
+        combatLog.recordStatusApplied(e);
+        const next = new Map(heldVisibleStatusesRef.current);
+        next.set(e.entityId, statusesAfter);
+        heldVisibleStatusesRef.current = next;
+        setHeldVisibleStatuses(next);
+      }
     },
     onStatusRemoved: (e) => {
+      const canonicalNext = applyStatusRemoved(
+        {
+          ...encounterState.state,
+          entityStatuses: canonicalStatusesRef.current,
+        },
+        e
+      ).entityStatuses;
+      canonicalStatusesRef.current = canonicalNext;
       encounterState.applyStatusRemoved(e);
       combatLog.recordStatusRemoved(e);
+      // StatusRemoved is not an attack outcome in this slice. Preserve its
+      // existing immediate behavior even if another story is holding this
+      // entity's correlated StatusApplied projection.
+      const held = heldVisibleStatusesRef.current.get(e.entityId);
+      if (held) {
+        const visibleBase = new Map(heldVisibleStatusesRef.current);
+        visibleBase.set(e.entityId, held);
+        const visibleNext = applyStatusRemoved(
+          { ...encounterState.state, entityStatuses: visibleBase },
+          e
+        ).entityStatuses;
+        const next = new Map(heldVisibleStatusesRef.current);
+        next.set(e.entityId, visibleNext.get(e.entityId) ?? []);
+        heldVisibleStatusesRef.current = next;
+        setHeldVisibleStatuses(next);
+      }
     },
     onModeChanged: (e) => {
       encounterState.applyModeChanged(e);
@@ -724,6 +899,7 @@ export function EncounterView({
       combatLog.recordTurnEnded(e);
     },
     onTurnStateChanged: (e) => {
+      canonicalTurnStateRef.current = e.turnState ?? null;
       encounterState.applyTurnStateChanged(e.turnState);
     },
     // TakeAction wave (#426): umbrella resolution beat for any action. The
@@ -746,6 +922,10 @@ export function EncounterView({
           waitForMovementGeneration: movementGenerationRef.current.get(
             e.attackerEntityId
           ),
+          targetControlSnapshot:
+            e.targetEntityId === entityIdRef.current
+              ? { turnState: canonicalTurnStateRef.current }
+              : undefined,
         },
       ]);
     },
@@ -911,13 +1091,17 @@ export function EncounterView({
   }
   const presentedEntityHP = new Map(encounterState.state.entityHP);
   for (const [id, hp] of heldVisibleHP) presentedEntityHP.set(id, hp);
+  const presentedEntityStatuses = new Map(encounterState.state.entityStatuses);
+  for (const [id, statuses] of heldVisibleStatuses) {
+    presentedEntityStatuses.set(id, statuses);
+  }
 
   const myPosition = presentedEntities.get(entityId)?.position;
   const myHP = presentedEntityHP.get(entityId);
   const myAC = encounterState.state.entityAC.get(entityId);
   const myMeta = encounterState.state.entityMeta.get(entityId);
   const myEquipment = encounterState.state.characterEquipment.get(entityId);
-  const myStatuses = encounterState.state.entityStatuses.get(entityId) ?? [];
+  const myStatuses = presentedEntityStatuses.get(entityId) ?? [];
   const encounterEnded = encounterState.state.encounterStatus === 'ended';
   const terminalResultHeld = Boolean(
     encounterEnded &&
@@ -959,9 +1143,21 @@ export function EncounterView({
       setArmedState(null);
   }, [armedState, currentTurnKey, combatEnabled]);
 
-  const turnState = encounterState.state.turnState;
-  const availableActions = turnState?.availableActions ?? [];
-  const economy = turnState?.economy ?? null;
+  const canonicalTurnState = encounterState.state.turnState;
+  const heldControlStory = presentationQueue.find(
+    (item) =>
+      item.targetControlSnapshot !== undefined &&
+      presentationOutcomes
+        .get(item.id)
+        ?.statuses?.some((status) => status.event.entityId === entityId) &&
+      !releasedPresentationIdsRef.current.has(item.id)
+  );
+  const controlsHeld = heldControlStory !== undefined;
+  const presentedTurnState = controlsHeld
+    ? heldControlStory.targetControlSnapshot!.turnState
+    : canonicalTurnState;
+  const availableActions = presentedTurnState?.availableActions ?? [];
+  const economy = presentedTurnState?.economy ?? null;
 
   // Returns whether the dispatch succeeded — rpg-dnd5e-web#511's armed-
   // action state clears only on a successful dispatch (a rejected target
@@ -1280,7 +1476,7 @@ export function EncounterView({
           revealedHexes={encounterState.state.revealedHexes}
           walls={encounterState.state.walls}
           entityHP={presentedEntityHP}
-          entityStatuses={encounterState.state.entityStatuses}
+          entityStatuses={presentedEntityStatuses}
           theme={encounterState.state.theme}
           // Gate by mode: applyModeChanged only flips `mode`, it doesn't
           // clear initiativeOrder/activeEntityId (only the next snapshot's
@@ -1484,7 +1680,7 @@ export function EncounterView({
               )
             : undefined
         }
-        actionsEnabled={combatEnabled}
+        actionsEnabled={combatEnabled && !controlsHeld}
         actionsLoading={takeActionLoading}
         onSelectAction={(a) => void handleSelectAction(a)}
         armedActionKey={armedAction ? actionKey(armedAction) : undefined}
@@ -1501,7 +1697,7 @@ export function EncounterView({
           void handleToggleReactionReady(ref, ready)
         }
         onEndTurn={() => void handleEndTurn()}
-        endTurnDisabled={!combatEnabled || endTurnLoading}
+        endTurnDisabled={!combatEnabled || controlsHeld || endTurnLoading}
         endTurnLoading={endTurnLoading}
         combatLogEntries={combatLog.entries}
         equipment={myEquipment}

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -37,6 +37,7 @@
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
 import type {
+  EncounterEnded,
   EntityDamaged,
   EntityDied,
   EntityRemoved,
@@ -186,6 +187,7 @@ interface PresentationStoryOutcome {
   damage?: EntityDamaged;
   died?: EntityDied;
   removed?: EntityRemoved;
+  encounterEnded?: EncounterEnded;
 }
 
 type PresentationOutcomeKind = keyof PresentationStoryOutcome;
@@ -211,6 +213,28 @@ function findPresentationStory(
       return false;
     return outcomes.get(item.id)?.[kind] === undefined;
   });
+}
+
+function findTerminalPresentationStory(
+  queue: PresentationStoryItem[],
+  outcomes: ReadonlyMap<number, PresentationStoryOutcome>,
+  correlationId: string
+): PresentationStoryItem | undefined {
+  const terminal = queue.filter((item) => {
+    const outcome = outcomes.get(item.id);
+    return (
+      outcome?.encounterEnded === undefined &&
+      (outcome?.removed !== undefined || outcome?.died !== undefined)
+    );
+  });
+  const correlated = correlationId
+    ? terminal.filter((item) => item.correlationId === correlationId)
+    : [];
+  if (correlated.length === 1) return correlated[0];
+  // EncounterEnded is encounter-global and may carry no attack correlation.
+  // A single already-terminal story is unambiguous; multiple candidates fail
+  // closed rather than guessing which attack ended the encounter.
+  return terminal.length === 1 ? terminal[0] : undefined;
 }
 
 export function EncounterView({
@@ -317,6 +341,8 @@ export function EncounterView({
     }
     if (outcome.died) combatLog.recordEntityDied(outcome.died);
     if (outcome.removed) combatLog.recordEntityRemoved(outcome.removed);
+    if (outcome.encounterEnded)
+      combatLog.recordEncounterEnded(outcome.encounterEnded);
   };
 
   const completePresentation = (id: number) => {
@@ -822,12 +848,29 @@ export function EncounterView({
         combatLog.recordEntityRemoved(e);
       }
     },
-    onEncounterEnded: (e) => {
+    onEncounterEnded: (e, metadata) => {
       encounterState.applyEncounterEnded(e);
-      combatLog.recordEncounterEnded(e);
-      // rpg-dnd5e-web#544: an ended encounter has no turns to be armed in.
+      // rpg-dnd5e-web#544: canonical encounter end disables actions now, but
+      // a terminal attack story already on stage must drain rather than be
+      // cancelled like an explicit snapshot/view transition.
       setArmedState(null);
-      flushPresentation();
+      const terminalStory = findTerminalPresentationStory(
+        presentationQueueRef.current,
+        presentationOutcomesRef.current,
+        metadata.correlationId
+      );
+      if (!terminalStory) {
+        combatLog.recordEncounterEnded(e);
+        flushPresentation();
+        return;
+      }
+      updatePresentationOutcome(terminalStory.id, (outcome) => ({
+        ...outcome,
+        encounterEnded: e,
+      }));
+      if (releasedPresentationIdsRef.current.has(terminalStory.id)) {
+        combatLog.recordEncounterEnded(e);
+      }
     },
     // Death-save arc (rpg-toolkit#742, wave KirkDiggler/rpg-project#75):
     // PlaytestHarness has logged these since that wave landed; EncounterView
@@ -860,6 +903,13 @@ export function EncounterView({
   const myEquipment = encounterState.state.characterEquipment.get(entityId);
   const myStatuses = encounterState.state.entityStatuses.get(entityId) ?? [];
   const encounterEnded = encounterState.state.encounterStatus === 'ended';
+  const terminalResultHeld = Boolean(
+    encounterEnded &&
+    activePresentation &&
+    activePresentationOutcome?.encounterEnded &&
+    !releasedPresentationIdsRef.current.has(activePresentation.id)
+  );
+  const showEncounterEnded = encounterEnded && !terminalResultHeld;
   const isMyTurn =
     encounterState.state.mode === EncounterMode.TURN_BASED &&
     encounterState.state.activeEntityId === entityId;
@@ -1170,7 +1220,7 @@ export function EncounterView({
         </button>
       </div>
 
-      {encounterEnded && (
+      {showEncounterEnded && (
         <div
           data-testid="encounter-ended-banner"
           className="rounded-lg px-4 py-3 font-bold"
@@ -1400,7 +1450,7 @@ export function EncounterView({
         economy={economy}
         actions={availableActions}
         mode={encounterState.state.mode}
-        encounterEnded={encounterEnded}
+        encounterEnded={showEncounterEnded}
         isMyTurn={isMyTurn}
         // Spectator strip (#458): whose turn it is, resolved the same way
         // the dock resolves the local player's own name.

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -36,7 +36,11 @@
 
 import { create } from '@bufbuild/protobuf';
 import { EntityStateSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/encounter_pb';
-import type { EntityDamaged } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import type {
+  EntityDamaged,
+  EntityDied,
+  EntityRemoved,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import type { ActionTarget } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/service_pb';
 import type {
   AvailableAction,
@@ -173,6 +177,17 @@ function characterEquipmentFrom(
   };
 }
 
+interface PresentationStoryItem extends CombatPresentationAttack {
+  /** Per-attacker movement generation observed before this attack event. */
+  waitForMovementGeneration?: number;
+}
+
+interface PresentationStoryOutcome {
+  damage?: EntityDamaged;
+  died?: EntityDied;
+  removed?: EntityRemoved;
+}
+
 export function EncounterView({
   encounterId,
   characterId,
@@ -187,40 +202,144 @@ export function EncounterView({
   const entityIdRef = useRef(entityId);
   entityIdRef.current = entityId;
   const encounterState = useEncounterState();
+  // Callback-time mirror of authoritative HP. Stream events can batch before
+  // React commits; this ref preserves the exact last server value for the
+  // presentation hold without deriving/subtracting anything.
+  const canonicalHPRef = useRef(encounterState.state.entityHP);
+  canonicalHPRef.current = encounterState.state.entityHP;
+  const canonicalEntitiesRef = useRef(encounterState.state.entities);
+  canonicalEntitiesRef.current = encounterState.state.entities;
   // #445: game-grade combat narrative — the same dispatched events, rendered
   // as a scrolling log instead of PlaytestHarness's raw dev-log text.
   const combatLog = useCombatLog();
   const [presentationQueue, setPresentationQueue] = useState<
-    CombatPresentationAttack[]
+    PresentationStoryItem[]
   >([]);
-  // Observed server contract for this path: one EntityDamaged payload per
-  // attack correlation. If the stream ever starts emitting multiple damage
-  // envelopes for one correlation, this last-write map stays a residual
-  // and will need a list model — we are not expanding scope without proof.
-  const [damageByCorrelationId, setDamageByCorrelationId] = useState<
-    Record<string, EntityDamaged>
-  >({});
-  const presentationIdRef = useRef(0);
-  const flushPresentation = () => {
-    setPresentationQueue([]);
-    setDamageByCorrelationId({});
+  const presentationQueueRef = useRef<PresentationStoryItem[]>([]);
+  const [presentationOutcomes, setPresentationOutcomes] = useState<
+    Map<number, PresentationStoryOutcome>
+  >(new Map());
+  const presentationOutcomesRef = useRef(
+    new Map<number, PresentationStoryOutcome>()
+  );
+  const updatePresentationOutcome = (
+    id: number,
+    update: (outcome: PresentationStoryOutcome) => PresentationStoryOutcome
+  ) => {
+    const next = new Map(presentationOutcomesRef.current);
+    next.set(id, update(next.get(id) ?? {}));
+    presentationOutcomesRef.current = next;
+    setPresentationOutcomes(next);
   };
-  const completePresentation = (id: number) => {
-    const current = presentationQueue[0];
+  const updatePresentationQueue = (
+    update: (queue: PresentationStoryItem[]) => PresentationStoryItem[]
+  ) => {
+    // Stream callbacks may arrive in one React batch. Advance the ref
+    // synchronously so later envelopes correlate against earlier envelopes
+    // without waiting for a render commit.
+    const next = update(presentationQueueRef.current);
+    presentationQueueRef.current = next;
+    setPresentationQueue(next);
+  };
+  // Canonical reducers always update immediately. These two maps are only the
+  // visible projection held back while an authoritative outcome is staged.
+  const [heldVisibleHP, setHeldVisibleHP] = useState<
+    Map<string, { current: number; max: number }>
+  >(new Map());
+  const heldVisibleHPRef = useRef(
+    new Map<string, { current: number; max: number }>()
+  );
+  const [presentationTombstones, setPresentationTombstones] = useState<
+    typeof encounterState.state.entities
+  >(new Map());
+  const movementGenerationRef = useRef(new Map<string, number>());
+  const completedMovementGenerationRef = useRef(new Map<string, number>());
+  const [, setMovementCompletionVersion] = useState(0);
+  const presentationIdRef = useRef(0);
+  const releasedPresentationIdsRef = useRef(new Set<number>());
+
+  const flushPresentation = () => {
+    presentationQueueRef.current = [];
+    setPresentationQueue([]);
+    presentationOutcomesRef.current = new Map();
+    setPresentationOutcomes(new Map());
+    heldVisibleHPRef.current = new Map();
+    setHeldVisibleHP(new Map());
+    setPresentationTombstones(new Map());
+    movementGenerationRef.current.clear();
+    completedMovementGenerationRef.current.clear();
+    releasedPresentationIdsRef.current.clear();
+  };
+
+  const releasePresentationResult = (id: number) => {
+    if (releasedPresentationIdsRef.current.has(id)) return;
+    const current = presentationQueueRef.current[0];
     if (current?.id !== id) return;
-    if (current.correlationId) {
-      setDamageByCorrelationId((currentDamage) => {
-        if (!(current.correlationId in currentDamage)) return currentDamage;
-        const next = { ...currentDamage };
-        delete next[current.correlationId];
+    releasedPresentationIdsRef.current.add(id);
+    const outcome = presentationOutcomesRef.current.get(id) ?? {};
+    combatLog.recordAttackResolved(current.attack);
+    if (outcome.damage) {
+      combatLog.recordEntityDamaged(outcome.damage);
+      if (outcome.damage.hpAfter) {
+        const next = new Map(heldVisibleHPRef.current);
+        next.set(outcome.damage.entityId, {
+          current: outcome.damage.hpAfter.current,
+          max: outcome.damage.hpAfter.max,
+        });
+        heldVisibleHPRef.current = next;
+        setHeldVisibleHP(next);
+      }
+    }
+    if (outcome.died) combatLog.recordEntityDied(outcome.died);
+    if (outcome.removed) combatLog.recordEntityRemoved(outcome.removed);
+  };
+
+  const completePresentation = (id: number) => {
+    const current = presentationQueueRef.current[0];
+    if (current?.id !== id) return;
+    // Defensive for instant/skip policy changes: completion cannot bypass the
+    // semantic outcome release, and the id set keeps it exactly-once.
+    releasePresentationResult(id);
+    const outcome = presentationOutcomesRef.current.get(id) ?? {};
+    const remaining = presentationQueueRef.current.slice(1);
+    if (outcome.removed) {
+      setPresentationTombstones((tombstones) => {
+        const next = new Map(tombstones);
+        next.delete(outcome.removed!.entityId);
         return next;
       });
     }
-    setPresentationQueue((queue) =>
-      queue[0]?.id === id ? queue.slice(1) : queue
-    );
+    if (outcome.damage) {
+      const targetId = outcome.damage.entityId;
+      const laterDamagePending = remaining.some(
+        (item) =>
+          presentationOutcomesRef.current.get(item.id)?.damage?.entityId ===
+          targetId
+      );
+      if (!laterDamagePending) {
+        const next = new Map(heldVisibleHPRef.current);
+        next.delete(targetId);
+        heldVisibleHPRef.current = next;
+        setHeldVisibleHP(next);
+      }
+    }
+    releasedPresentationIdsRef.current.delete(id);
+    const remainingOutcomes = new Map(presentationOutcomesRef.current);
+    remainingOutcomes.delete(id);
+    presentationOutcomesRef.current = remainingOutcomes;
+    setPresentationOutcomes(remainingOutcomes);
+    presentationQueueRef.current = remaining;
+    setPresentationQueue(remaining);
   };
   const activePresentation = presentationQueue[0];
+  const activePresentationOutcome = activePresentation
+    ? presentationOutcomes.get(activePresentation.id)
+    : undefined;
+  const activeMovementComplete = activePresentation
+    ? (completedMovementGenerationRef.current.get(
+        activePresentation.attack.attackerEntityId
+      ) ?? 0) >= (activePresentation.waitForMovementGeneration ?? 0)
+    : true;
   // rpg-dnd5e-web#511: the action-selection interaction state. Set by
   // clicking a SINGLE_ENTITY/POSITION/AREA-targeted menu action ("arming"
   // it) — survives exploratory clicks (hover/inspect/camera, an empty-hex
@@ -385,6 +504,17 @@ export function EncounterView({
           }));
         if (entityEntries.length > 0) {
           encounterState.applyEntityAppearedBatch(entityEntries);
+          const nextEntities = new Map(canonicalEntitiesRef.current);
+          for (const entry of entityEntries) {
+            nextEntities.set(entry.entity.entityId, entry.entity);
+          }
+          canonicalEntitiesRef.current = nextEntities;
+          const nextHP = new Map(canonicalHPRef.current);
+          for (const entry of entityEntries) {
+            if (entry.initialHP)
+              nextHP.set(entry.entity.entityId, entry.initialHP);
+          }
+          canonicalHPRef.current = nextHP;
         }
         // v1alpha2 hex-knowledge contract: walls no longer ride a flat
         // Space.walls list — each hex carries its own boundary segments as
@@ -399,16 +529,33 @@ export function EncounterView({
     onEntityMoved: (e) => {
       const last = e.actualPath[e.actualPath.length - 1];
       if (last) {
+        movementGenerationRef.current.set(
+          e.entityId,
+          (movementGenerationRef.current.get(e.entityId) ?? 0) + 1
+        );
         // rpg-dnd5e-web#542: pass the WHOLE actualPath (not just its last
         // element) so HexEntity can step through the real hex-by-hex route
         // instead of teleporting straight to the destination. actualPath is
         // real, backend-populated per-viewer-visible route data (confirmed
         // directly against rpg-api's translateMoveEvent), not a stub.
+        const position = v2PositionToV1(last);
+        const movePath = e.actualPath.map(v2PositionToV1);
         encounterState.applyEntityPositionUpdate(
           e.entityId,
-          v2PositionToV1(last),
-          e.actualPath.map(v2PositionToV1)
+          position,
+          movePath
         );
+        const existing = canonicalEntitiesRef.current.get(e.entityId);
+        if (existing) {
+          const nextEntities = new Map(canonicalEntitiesRef.current);
+          nextEntities.set(e.entityId, {
+            ...existing,
+            position,
+            movePath,
+            moveSeq: movementGenerationRef.current.get(e.entityId),
+          });
+          canonicalEntitiesRef.current = nextEntities;
+        }
       }
     },
     // DoorOpened is a pure notification now (door identity only,
@@ -520,34 +667,104 @@ export function EncounterView({
     // too (hit=false) — rendered as-is in the combat log so a whiff isn't
     // silent. Damage rides the correlated EntityDamaged above.
     onAttackResolved: (e, metadata) => {
-      combatLog.recordAttackResolved(e);
-      setPresentationQueue((queue) => [
+      updatePresentationQueue((queue) => [
         ...queue,
         {
           id: ++presentationIdRef.current,
           correlationId: metadata.correlationId,
           attack: e,
           isViewerAttack: e.attackerEntityId === entityIdRef.current,
+          waitForMovementGeneration: movementGenerationRef.current.get(
+            e.attackerEntityId
+          ),
         },
       ]);
     },
     onEntityDamaged: (e, metadata) => {
-      encounterState.applyEntityDamaged(e);
-      combatLog.recordEntityDamaged(e);
-      if (metadata.correlationId) {
-        setDamageByCorrelationId((current) => ({
-          ...current,
-          [metadata.correlationId]: e,
-        }));
+      const stagedAttack = presentationQueueRef.current.find(
+        (item) =>
+          item.correlationId === metadata.correlationId &&
+          !presentationOutcomesRef.current.get(item.id)?.damage
+      );
+      if (!stagedAttack) {
+        if (e.hpAfter) {
+          const nextHP = new Map(canonicalHPRef.current);
+          nextHP.set(e.entityId, {
+            current: e.hpAfter.current,
+            max: e.hpAfter.max,
+          });
+          canonicalHPRef.current = nextHP;
+        }
+        encounterState.applyEntityDamaged(e);
+        combatLog.recordEntityDamaged(e);
+        return;
       }
+      // Freeze the last-painted HP before applying authoritative hp_after.
+      // A later queued attack against the same target keeps this hold and
+      // advances it only as each earlier story reaches its result beat.
+      const beforeHP = canonicalHPRef.current.get(e.entityId);
+      if (!heldVisibleHPRef.current.has(e.entityId) && beforeHP) {
+        const next = new Map(heldVisibleHPRef.current);
+        next.set(e.entityId, beforeHP);
+        heldVisibleHPRef.current = next;
+        setHeldVisibleHP(next);
+      }
+      if (e.hpAfter) {
+        const nextHP = new Map(canonicalHPRef.current);
+        nextHP.set(e.entityId, {
+          current: e.hpAfter.current,
+          max: e.hpAfter.max,
+        });
+        canonicalHPRef.current = nextHP;
+      }
+      encounterState.applyEntityDamaged(e);
+      updatePresentationOutcome(stagedAttack.id, (outcome) => ({
+        ...outcome,
+        damage: e,
+      }));
     },
-    onEntityDied: (e) => {
+    onEntityDied: (e, metadata) => {
       encounterState.applyEntityDied(e);
-      combatLog.recordEntityDied(e);
+      const stagedAttack = presentationQueueRef.current.find(
+        (item) =>
+          item.correlationId === metadata.correlationId &&
+          !presentationOutcomesRef.current.get(item.id)?.died
+      );
+      if (!stagedAttack) {
+        combatLog.recordEntityDied(e);
+        return;
+      }
+      updatePresentationOutcome(stagedAttack.id, (outcome) => ({
+        ...outcome,
+        died: e,
+      }));
     },
-    onEntityRemoved: (e) => {
+    onEntityRemoved: (e, metadata) => {
+      const stagedAttack = presentationQueueRef.current.find(
+        (item) =>
+          item.correlationId === metadata.correlationId &&
+          !presentationOutcomesRef.current.get(item.id)?.removed
+      );
+      const knownEntity = canonicalEntitiesRef.current.get(e.entityId);
+      if (stagedAttack && knownEntity) {
+        setPresentationTombstones((tombstones) => {
+          const next = new Map(tombstones);
+          next.set(e.entityId, knownEntity);
+          return next;
+        });
+      }
       encounterState.applyEntityRemoved(e);
-      combatLog.recordEntityRemoved(e);
+      const remainingEntities = new Map(canonicalEntitiesRef.current);
+      remainingEntities.delete(e.entityId);
+      canonicalEntitiesRef.current = remainingEntities;
+      if (!stagedAttack) {
+        combatLog.recordEntityRemoved(e);
+        return;
+      }
+      updatePresentationOutcome(stagedAttack.id, (outcome) => ({
+        ...outcome,
+        removed: e,
+      }));
     },
     onEncounterEnded: (e) => {
       encounterState.applyEncounterEnded(e);
@@ -573,8 +790,15 @@ export function EncounterView({
     },
   });
 
-  const myPosition = encounterState.state.entities.get(entityId)?.position;
-  const myHP = encounterState.state.entityHP.get(entityId);
+  const presentedEntities = new Map(encounterState.state.entities);
+  for (const [id, entity] of presentationTombstones) {
+    if (!presentedEntities.has(id)) presentedEntities.set(id, entity);
+  }
+  const presentedEntityHP = new Map(encounterState.state.entityHP);
+  for (const [id, hp] of heldVisibleHP) presentedEntityHP.set(id, hp);
+
+  const myPosition = presentedEntities.get(entityId)?.position;
+  const myHP = presentedEntityHP.get(entityId);
   const myAC = encounterState.state.entityAC.get(entityId);
   const myMeta = encounterState.state.entityMeta.get(entityId);
   const myEquipment = encounterState.state.characterEquipment.get(entityId);
@@ -927,11 +1151,11 @@ export function EncounterView({
           renders at width/height 100% of its container. */}
       <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
         <EncounterMap
-          entities={encounterState.state.entities}
+          entities={presentedEntities}
           entityMeta={encounterState.state.entityMeta}
           revealedHexes={encounterState.state.revealedHexes}
           walls={encounterState.state.walls}
-          entityHP={encounterState.state.entityHP}
+          entityHP={presentedEntityHP}
           entityStatuses={encounterState.state.entityStatuses}
           theme={encounterState.state.theme}
           // Gate by mode: applyModeChanged only flips `mode`, it doesn't
@@ -962,11 +1186,22 @@ export function EncounterView({
           )}
           openDoorIds={Array.from(encounterState.state.openDoors)}
           onMove={(path) => void handleVisualMove(path)}
+          onEntityMovementPresentationComplete={(movedEntityId, moveSeq) => {
+            const currentGeneration =
+              movementGenerationRef.current.get(movedEntityId) ?? 0;
+            // Ignore a completion from an animation superseded by a newer move.
+            if (moveSeq !== currentGeneration) return;
+            completedMovementGenerationRef.current.set(
+              movedEntityId,
+              currentGeneration
+            );
+            setMovementCompletionVersion((version) => version + 1);
+          }}
           onEntityClick={handleVisualEntityClick}
           onDoorClick={(doorId) => void handleDoorClick(doorId)}
         />
 
-        {activePresentation && (
+        {activePresentation && activeMovementComplete && (
           <div
             data-testid="combat-presentation-overlay"
             style={{
@@ -981,7 +1216,8 @@ export function EncounterView({
             <CombatPresentation
               key={activePresentation.id}
               item={activePresentation}
-              damage={damageByCorrelationId[activePresentation.correlationId]}
+              damage={activePresentationOutcome?.damage}
+              onResultRelease={releasePresentationResult}
               onComplete={completePresentation}
             />
           </div>

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -202,17 +202,32 @@ function findPresentationStory(
   kind: PresentationOutcomeKind,
   sourceEntityId?: string
 ): PresentationStoryItem | undefined {
-  return queue.find((item) => {
-    if (
-      item.correlationId !== correlationId &&
-      (item.correlationId !== '' || correlationId !== '')
-    )
+  const candidates = queue.filter((item) => {
+    // A non-empty envelope correlation is authoritative and must match.
+    // Empty correlations fall back to the identity + stream-order rules
+    // below; they must not erase a correlated attack's story.
+    if (correlationId !== '' && item.correlationId !== correlationId)
       return false;
     if (item.attack.targetEntityId !== targetEntityId) return false;
     if (sourceEntityId && item.attack.attackerEntityId !== sourceEntityId)
       return false;
     return outcomes.get(item.id)?.[kind] === undefined;
   });
+  if (kind === 'damage') return candidates[0];
+  if (kind === 'removed') {
+    const withDeath = candidates.filter(
+      (item) => outcomes.get(item.id)?.died !== undefined
+    );
+    if (withDeath.length > 0) return withDeath[withDeath.length - 1];
+  }
+  // Died follows the most recent matching damage in observed stream order;
+  // Removed prefers that explicit Died story above, then the same damage
+  // evidence. This is event association only — no HP/lethality inference.
+  const withDamage = candidates.filter(
+    (item) => outcomes.get(item.id)?.damage !== undefined
+  );
+  if (withDamage.length > 0) return withDamage[withDamage.length - 1];
+  return candidates[candidates.length - 1];
 }
 
 function findTerminalPresentationStory(
@@ -905,9 +920,11 @@ export function EncounterView({
   const encounterEnded = encounterState.state.encounterStatus === 'ended';
   const terminalResultHeld = Boolean(
     encounterEnded &&
-    activePresentation &&
-    activePresentationOutcome?.encounterEnded &&
-    !releasedPresentationIdsRef.current.has(activePresentation.id)
+    presentationQueue.some(
+      (item) =>
+        presentationOutcomes.get(item.id)?.encounterEnded !== undefined &&
+        !releasedPresentationIdsRef.current.has(item.id)
+    )
   );
   const showEncounterEnded = encounterEnded && !terminalResultHeld;
   const isMyTurn =

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -188,6 +188,31 @@ interface PresentationStoryOutcome {
   removed?: EntityRemoved;
 }
 
+type PresentationOutcomeKind = keyof PresentationStoryOutcome;
+
+/** Correlation narrows a story when present; target/source identity is always
+ * required, so empty or reused correlations can never cross-wire actors. */
+function findPresentationStory(
+  queue: PresentationStoryItem[],
+  outcomes: ReadonlyMap<number, PresentationStoryOutcome>,
+  correlationId: string,
+  targetEntityId: string,
+  kind: PresentationOutcomeKind,
+  sourceEntityId?: string
+): PresentationStoryItem | undefined {
+  return queue.find((item) => {
+    if (
+      item.correlationId !== correlationId &&
+      (item.correlationId !== '' || correlationId !== '')
+    )
+      return false;
+    if (item.attack.targetEntityId !== targetEntityId) return false;
+    if (sourceEntityId && item.attack.attackerEntityId !== sourceEntityId)
+      return false;
+    return outcomes.get(item.id)?.[kind] === undefined;
+  });
+}
+
 export function EncounterView({
   encounterId,
   characterId,
@@ -529,10 +554,13 @@ export function EncounterView({
     onEntityMoved: (e) => {
       const last = e.actualPath[e.actualPath.length - 1];
       if (last) {
-        movementGenerationRef.current.set(
-          e.entityId,
-          (movementGenerationRef.current.get(e.entityId) ?? 0) + 1
-        );
+        const existing = canonicalEntitiesRef.current.get(e.entityId);
+        // This is the same per-entity sequence mergeEntityPosition will store.
+        // Derive from canonical presentation data, not a flushable local count:
+        // mode/snapshot cancellation clears story bookkeeping but does not
+        // necessarily clear the reducer's existing moveSeq.
+        const nextMoveSeq = (existing?.moveSeq ?? 0) + 1;
+        movementGenerationRef.current.set(e.entityId, nextMoveSeq);
         // rpg-dnd5e-web#542: pass the WHOLE actualPath (not just its last
         // element) so HexEntity can step through the real hex-by-hex route
         // instead of teleporting straight to the destination. actualPath is
@@ -545,14 +573,13 @@ export function EncounterView({
           position,
           movePath
         );
-        const existing = canonicalEntitiesRef.current.get(e.entityId);
         if (existing) {
           const nextEntities = new Map(canonicalEntitiesRef.current);
           nextEntities.set(e.entityId, {
             ...existing,
             position,
             movePath,
-            moveSeq: movementGenerationRef.current.get(e.entityId),
+            moveSeq: nextMoveSeq,
           });
           canonicalEntitiesRef.current = nextEntities;
         }
@@ -681,10 +708,13 @@ export function EncounterView({
       ]);
     },
     onEntityDamaged: (e, metadata) => {
-      const stagedAttack = presentationQueueRef.current.find(
-        (item) =>
-          item.correlationId === metadata.correlationId &&
-          !presentationOutcomesRef.current.get(item.id)?.damage
+      const stagedAttack = findPresentationStory(
+        presentationQueueRef.current,
+        presentationOutcomesRef.current,
+        metadata.correlationId,
+        e.entityId,
+        'damage',
+        e.sourceEntityId
       );
       if (!stagedAttack) {
         if (e.hpAfter) {
@@ -722,13 +752,31 @@ export function EncounterView({
         ...outcome,
         damage: e,
       }));
+      // If the semantic result beat already fired, this authoritative
+      // envelope joins the already-open result surface immediately. The
+      // lifecycle callback remains exactly-once; only this newly arrived
+      // payload is released.
+      if (releasedPresentationIdsRef.current.has(stagedAttack.id)) {
+        combatLog.recordEntityDamaged(e);
+        if (e.hpAfter) {
+          const next = new Map(heldVisibleHPRef.current);
+          next.set(e.entityId, {
+            current: e.hpAfter.current,
+            max: e.hpAfter.max,
+          });
+          heldVisibleHPRef.current = next;
+          setHeldVisibleHP(next);
+        }
+      }
     },
     onEntityDied: (e, metadata) => {
       encounterState.applyEntityDied(e);
-      const stagedAttack = presentationQueueRef.current.find(
-        (item) =>
-          item.correlationId === metadata.correlationId &&
-          !presentationOutcomesRef.current.get(item.id)?.died
+      const stagedAttack = findPresentationStory(
+        presentationQueueRef.current,
+        presentationOutcomesRef.current,
+        metadata.correlationId,
+        e.entityId,
+        'died'
       );
       if (!stagedAttack) {
         combatLog.recordEntityDied(e);
@@ -738,12 +786,17 @@ export function EncounterView({
         ...outcome,
         died: e,
       }));
+      if (releasedPresentationIdsRef.current.has(stagedAttack.id)) {
+        combatLog.recordEntityDied(e);
+      }
     },
     onEntityRemoved: (e, metadata) => {
-      const stagedAttack = presentationQueueRef.current.find(
-        (item) =>
-          item.correlationId === metadata.correlationId &&
-          !presentationOutcomesRef.current.get(item.id)?.removed
+      const stagedAttack = findPresentationStory(
+        presentationQueueRef.current,
+        presentationOutcomesRef.current,
+        metadata.correlationId,
+        e.entityId,
+        'removed'
       );
       const knownEntity = canonicalEntitiesRef.current.get(e.entityId);
       if (stagedAttack && knownEntity) {
@@ -765,6 +818,9 @@ export function EncounterView({
         ...outcome,
         removed: e,
       }));
+      if (releasedPresentationIdsRef.current.has(stagedAttack.id)) {
+        combatLog.recordEntityRemoved(e);
+      }
     },
     onEncounterEnded: (e) => {
       encounterState.applyEncounterEnded(e);

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -245,11 +245,12 @@ function findTerminalPresentationStory(
   const correlated = correlationId
     ? terminal.filter((item) => item.correlationId === correlationId)
     : [];
-  if (correlated.length === 1) return correlated[0];
+  if (correlated.length > 0) return correlated[correlated.length - 1];
   // EncounterEnded is encounter-global and may carry no attack correlation.
-  // A single already-terminal story is unambiguous; multiple candidates fail
-  // closed rather than guessing which attack ended the encounter.
-  return terminal.length === 1 ? terminal[0] : undefined;
+  // It follows the most recent terminal story in observed FIFO stream order:
+  // the final Died/Removed immediately preceding the encounter-global end.
+  // This associates events only; it does not infer which attack was lethal.
+  return terminal[terminal.length - 1];
 }
 
 export function EncounterView({

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -72,6 +72,8 @@ import type {
   EntityStatus,
 } from '../../hooks/useEncounterState';
 import {
+  applyEntityAppearedBatch,
+  applyEntityKnowledgeBatch,
   applyStatusApplied,
   applyStatusRemoved,
   positionByEntityIdFromHexes,
@@ -245,9 +247,10 @@ function findPresentationStory(
   return candidates[candidates.length - 1];
 }
 
-/** StatusApplied is multi-valued and correlation-bearing. Empty correlation
- * remains immediate; a reused correlation follows the most recent matching
- * damage story in observed stream order. */
+/** StatusApplied is multi-valued. A populated correlation narrows candidates;
+ * today's empty status correlations follow the most recent matching damage
+ * story by target/source and observed stream order. No damage story means the
+ * status remains immediate. */
 function findPresentationStatusStory(
   queue: PresentationStoryItem[],
   outcomes: ReadonlyMap<number, PresentationStoryOutcome>,
@@ -255,18 +258,14 @@ function findPresentationStatusStory(
   targetEntityId: string,
   sourceEntityId?: string
 ): PresentationStoryItem | undefined {
-  if (correlationId === '') return undefined;
   const candidates = queue.filter(
     (item) =>
-      item.correlationId === correlationId &&
+      (correlationId === '' || item.correlationId === correlationId) &&
       item.attack.targetEntityId === targetEntityId &&
-      (!sourceEntityId || item.attack.attackerEntityId === sourceEntityId)
+      (!sourceEntityId || item.attack.attackerEntityId === sourceEntityId) &&
+      outcomes.get(item.id)?.damage !== undefined
   );
-  const withDamage = candidates.filter(
-    (item) => outcomes.get(item.id)?.damage !== undefined
-  );
-  const preferred = withDamage.length > 0 ? withDamage : candidates;
-  return preferred[preferred.length - 1];
+  return candidates[candidates.length - 1];
 }
 
 function findTerminalPresentationStory(
@@ -369,6 +368,7 @@ export function EncounterView({
   const [, setMovementCompletionVersion] = useState(0);
   const presentationIdRef = useRef(0);
   const releasedPresentationIdsRef = useRef(new Set<number>());
+  const heldControlStoryIdsRef = useRef(new Set<number>());
 
   const flushPresentation = () => {
     presentationQueueRef.current = [];
@@ -383,6 +383,7 @@ export function EncounterView({
     movementGenerationRef.current.clear();
     completedMovementGenerationRef.current.clear();
     releasedPresentationIdsRef.current.clear();
+    heldControlStoryIdsRef.current.clear();
   };
 
   const releasePresentationResult = (id: number) => {
@@ -390,6 +391,7 @@ export function EncounterView({
     const current = presentationQueueRef.current[0];
     if (current?.id !== id) return;
     releasedPresentationIdsRef.current.add(id);
+    heldControlStoryIdsRef.current.delete(id);
     const outcome = presentationOutcomesRef.current.get(id) ?? {};
     combatLog.recordAttackResolved(current.attack);
     if (outcome.damage) {
@@ -408,7 +410,10 @@ export function EncounterView({
       const next = new Map(heldVisibleStatusesRef.current);
       for (const status of outcome.statuses) {
         combatLog.recordStatusApplied(status.event);
-        next.set(status.event.entityId, status.statusesAfter);
+        next.set(
+          status.event.entityId,
+          canonicalStatusesRef.current.get(status.event.entityId) ?? []
+        );
       }
       heldVisibleStatusesRef.current = next;
       setHeldVisibleStatuses(next);
@@ -645,6 +650,13 @@ export function EncounterView({
                 : undefined,
           }));
         if (entityEntries.length > 0) {
+          canonicalStatusesRef.current = applyEntityAppearedBatch(
+            {
+              ...encounterState.state,
+              entityStatuses: canonicalStatusesRef.current,
+            },
+            entityEntries
+          ).entityStatuses;
           encounterState.applyEntityAppearedBatch(entityEntries);
           const nextEntities = new Map(canonicalEntitiesRef.current);
           for (const entry of entityEntries) {
@@ -751,6 +763,13 @@ export function EncounterView({
             : undefined,
       }));
       if (knowledgeEntries.length > 0) {
+        canonicalStatusesRef.current = applyEntityKnowledgeBatch(
+          {
+            ...encounterState.state,
+            entityStatuses: canonicalStatusesRef.current,
+          },
+          knowledgeEntries
+        ).entityStatuses;
         encounterState.applyEntityKnowledgeBatch(knowledgeEntries);
       }
 
@@ -800,6 +819,13 @@ export function EncounterView({
         return;
       }
 
+      if (
+        e.entityId === entityIdRef.current &&
+        !releasedPresentationIdsRef.current.has(stagedAttack.id)
+      ) {
+        heldControlStoryIdsRef.current.add(stagedAttack.id);
+      }
+
       const stagedIndex = presentationQueueRef.current.findIndex(
         (item) => item.id === stagedAttack.id
       );
@@ -839,7 +865,10 @@ export function EncounterView({
       if (releasedPresentationIdsRef.current.has(stagedAttack.id)) {
         combatLog.recordStatusApplied(e);
         const next = new Map(heldVisibleStatusesRef.current);
-        next.set(e.entityId, statusesAfter);
+        next.set(
+          e.entityId,
+          canonicalStatusesRef.current.get(e.entityId) ?? []
+        );
         heldVisibleStatusesRef.current = next;
         setHeldVisibleStatuses(next);
       }
@@ -1173,7 +1202,7 @@ export function EncounterView({
     // completes (see resolveMyEntityId above). Never send an RPC with an
     // empty actor id — a fast click in that window would otherwise reach
     // the server as a real, malformed request (Copilot review on #461).
-    if (!entityId) return false;
+    if (!entityId || heldControlStoryIdsRef.current.size > 0) return false;
     try {
       await takeAction({
         encounterId,
@@ -1198,7 +1227,7 @@ export function EncounterView({
   // (an explicit toggle-off, one of #511's two cancel affordances — Escape
   // is the other, wired via the keydown effect below).
   const handleSelectAction = async (action: AvailableAction) => {
-    if (!action.ref) return;
+    if (heldControlStoryIdsRef.current.size > 0 || !action.ref) return;
     if (
       armedAction &&
       action.ref &&
@@ -1229,7 +1258,13 @@ export function EncounterView({
   const handleVisualMove = async (
     path: Array<{ x: number; y: number; z: number }>
   ) => {
-    if (!entityId || encounterEnded || path.length === 0) return;
+    if (
+      !entityId ||
+      encounterEnded ||
+      heldControlStoryIdsRef.current.size > 0 ||
+      path.length === 0
+    )
+      return;
     try {
       await moveEntity(encounterId, entityId, path);
     } catch {
@@ -1250,7 +1285,8 @@ export function EncounterView({
   // immediate basic attack" shortcut; any other click is a no-op (matches
   // the harness's identical primary-loop convenience).
   const handleVisualEntityClick = (targetId: string) => {
-    if (!entityId || encounterEnded) return;
+    if (!entityId || encounterEnded || heldControlStoryIdsRef.current.size > 0)
+      return;
     if (armedAction?.ref) {
       if (armedAction.targetKind === TargetKind.SINGLE_ENTITY) {
         const armedRef = armedAction.ref;
@@ -1274,6 +1310,7 @@ export function EncounterView({
   };
 
   const handleEndTurn = async () => {
+    if (heldControlStoryIdsRef.current.size > 0) return;
     // combatEnabled already can't be true while entityId is unresolved
     // (isMyTurn compares activeEntityId against entityId, and a real
     // activeEntityId never equals ''), but guard explicitly rather than
@@ -1296,7 +1333,7 @@ export function EncounterView({
     reactionRef: { module: string; type: string; id: string },
     ready: boolean
   ) => {
-    if (!entityId) return;
+    if (!entityId || heldControlStoryIdsRef.current.size > 0) return;
     try {
       await setReactionReady({
         encounterId,
@@ -1331,6 +1368,7 @@ export function EncounterView({
   // rpg-api-protos#197) plus the next snapshot's HexRecord.edges for the
   // newly-visible geometry — there is no parallel reveal event anymore.
   const handleDoorClick = async (doorId: string) => {
+    if (heldControlStoryIdsRef.current.size > 0) return;
     try {
       const response = await interact(encounterId, doorId, 'open');
       if (response.inputRequired) {
@@ -1692,7 +1730,7 @@ export function EncounterView({
         // that window was a silent no-op (handleToggleReactionReady's own
         // `if (!entityId) return` guard fires, but nothing tells the
         // player why nothing happened).
-        reactionDisabled={encounterEnded || !entityId}
+        reactionDisabled={encounterEnded || controlsHeld || !entityId}
         onToggleReaction={(ref, ready) =>
           void handleToggleReactionReady(ref, ready)
         }

--- a/src/components/game/combatPresentation/CombatPresentation.test.tsx
+++ b/src/components/game/combatPresentation/CombatPresentation.test.tsx
@@ -1,6 +1,7 @@
 import type { EntityDamaged } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useReducedMotion } from 'framer-motion';
+import { readFileSync } from 'node:fs';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -47,6 +48,15 @@ beforeEach(() => {
 afterEach(() => vi.useRealTimers());
 
 describe('CombatPresentation', () => {
+  it('uses a layout-phase lifecycle release so outcome state commits before the Impact/Verdict paint', () => {
+    const source = readFileSync(
+      'src/components/game/combatPresentation/CombatPresentation.tsx',
+      'utf8'
+    );
+    expect(source).toContain('useLayoutEffect');
+    expect(source).toMatch(/useLayoutEffect\(\(\) => \{[\s\S]*onResultRelease/);
+  });
+
   it('keeps the authoritative roll out of initial static markup', () => {
     const markup = renderToStaticMarkup(
       <CombatPresentation item={item()} onComplete={() => {}} />

--- a/src/components/game/combatPresentation/CombatPresentation.test.tsx
+++ b/src/components/game/combatPresentation/CombatPresentation.test.tsx
@@ -72,11 +72,13 @@ describe('CombatPresentation', () => {
     expect(complete).toHaveBeenCalledWith(7);
   });
 
-  it('gates the server-sent damage behind Impact so the roll is never spoiled, and announces it once in the verdict live-region', () => {
+  it('gates the server-sent damage behind Impact, emits one semantic result release, and announces it once in the verdict live-region', () => {
+    const onResultRelease = vi.fn();
     render(
       <CombatPresentation
         item={item()}
         damage={damage(16)}
+        onResultRelease={onResultRelease}
         onComplete={() => {}}
       />
     );
@@ -108,8 +110,10 @@ describe('CombatPresentation', () => {
     expect(revealed.textContent).toContain('16 damage');
     expect(screen.getByTestId('beat-verdict').contains(revealed)).toBe(true);
     expect(screen.getAllByRole('status')).toHaveLength(1);
+    expect(onResultRelease).toHaveBeenCalledExactlyOnceWith(7);
 
     act(() => vi.advanceTimersByTime(CINEMATIC.impact));
+    expect(onResultRelease).toHaveBeenCalledOnce();
     // Release: damage stays visible, doesn't flash away before the item
     // completes.
     expect(screen.getByTestId('beat-damage').textContent).toContain(
@@ -152,39 +156,42 @@ describe('CombatPresentation', () => {
     );
   });
 
-  it('does not complete a newly swapped item until its own sequence finishes', () => {
+  it('does not complete or re-release a newly swapped item until its own sequence finishes', () => {
     const complete = vi.fn();
+    const resultRelease = vi.fn();
     const firstItem = item();
     const secondItem = { ...item(), id: 8 };
     const { rerender } = render(
-      <CombatPresentation item={firstItem} onComplete={complete} />
+      <CombatPresentation
+        item={firstItem}
+        onResultRelease={resultRelease}
+        onComplete={complete}
+      />
     );
     act(() => vi.advanceTimersByTime(CINEMATIC.cue));
     fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
-    act(() =>
-      vi.advanceTimersByTime(
-        CINEMATIC.throw +
-          CINEMATIC.verdict +
-          CINEMATIC.impact +
-          CINEMATIC.release
-      )
-    );
+    act(() => vi.advanceTimersByTime(CINEMATIC.throw));
+    act(() => vi.advanceTimersByTime(CINEMATIC.verdict));
+    expect(resultRelease).toHaveBeenCalledExactlyOnceWith(7);
+    act(() => vi.advanceTimersByTime(CINEMATIC.impact + CINEMATIC.release));
     expect(complete).toHaveBeenCalledExactlyOnceWith(7);
 
-    rerender(<CombatPresentation item={secondItem} onComplete={complete} />);
+    rerender(
+      <CombatPresentation
+        item={secondItem}
+        onResultRelease={resultRelease}
+        onComplete={complete}
+      />
+    );
 
     expect(complete).toHaveBeenCalledExactlyOnceWith(7);
     act(() => vi.advanceTimersByTime(CINEMATIC.cue));
     fireEvent.click(screen.getByRole('button', { name: 'Roll d20' }));
-    act(() =>
-      vi.advanceTimersByTime(
-        CINEMATIC.throw +
-          CINEMATIC.verdict +
-          CINEMATIC.impact +
-          CINEMATIC.release
-      )
-    );
+    act(() => vi.advanceTimersByTime(CINEMATIC.throw));
+    act(() => vi.advanceTimersByTime(CINEMATIC.verdict));
+    act(() => vi.advanceTimersByTime(CINEMATIC.impact + CINEMATIC.release));
     expect(complete).toHaveBeenLastCalledWith(8);
+    expect(resultRelease.mock.calls).toEqual([[7], [8]]);
   });
 
   it('completes an item only once when onComplete changes after done', () => {
@@ -221,14 +228,16 @@ describe('CombatPresentation', () => {
     ).toBe('throw');
   });
 
-  it('autoplays and completes a non-viewer miss with no throw control and one MISS status', () => {
+  it('autoplays a non-viewer miss and releases its log seam exactly with the MISS verdict', () => {
     const complete = vi.fn();
+    const resultRelease = vi.fn();
     render(
       <CombatPresentation
         item={{
           ...item({ attackerEntityId: 'npc-1', hit: false, attackRoll: 8 }),
           isViewerAttack: false,
         }}
+        onResultRelease={resultRelease}
         onComplete={complete}
       />
     );
@@ -236,7 +245,9 @@ describe('CombatPresentation', () => {
     expect(screen.queryByRole('button', { name: 'Roll d20' })).toBeNull();
     expect(screen.getAllByRole('status')).toHaveLength(1);
     expect(screen.getByRole('status').textContent).toContain('MISS');
+    expect(resultRelease).toHaveBeenCalledExactlyOnceWith(7);
     act(() => vi.advanceTimersByTime(CINEMATIC.verdict + CINEMATIC.release));
+    expect(resultRelease).toHaveBeenCalledOnce();
     expect(complete).toHaveBeenCalledWith(7);
   });
 

--- a/src/components/game/combatPresentation/CombatPresentation.tsx
+++ b/src/components/game/combatPresentation/CombatPresentation.tsx
@@ -3,7 +3,7 @@ import type {
   EntityDamaged,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
 import { useReducedMotion } from 'framer-motion';
-import { useEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { DiceTray, type DiceTrayPhase } from '../../ui/dice/DiceTray';
 import { BeatStage } from './BeatStage';
 import { verdictLabel, type BeatSequence } from './beatStageTypes';
@@ -79,7 +79,11 @@ export function CombatPresentation({
     undefined
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    // Layout phase is deliberate: consumers release visible HP/log/tombstone
+    // state before the browser can paint the Impact/Verdict frame. A passive
+    // effect would allow one spoiler frame where the theater and surrounding
+    // outcome surfaces disagree.
     // A new item first renders with the previous sequencer beat. Wait for its
     // sequence reset before allowing that item to complete.
     if (previousItemRef.current !== item) {

--- a/src/components/game/combatPresentation/CombatPresentation.tsx
+++ b/src/components/game/combatPresentation/CombatPresentation.tsx
@@ -19,6 +19,9 @@ export interface CombatPresentationAttack {
 export interface CombatPresentationProps {
   item: CombatPresentationAttack;
   damage?: EntityDamaged;
+  /** Fires exactly once when this attack reaches its authoritative outcome beat:
+   * Verdict for a miss, Impact for a hit. Presentation coordination only. */
+  onResultRelease?: (id: number) => void;
   onComplete: (id: number) => void;
 }
 
@@ -49,6 +52,7 @@ function damageVisibleAtBeat(beat: string, hit: boolean): boolean {
 export function CombatPresentation({
   item,
   damage,
+  onResultRelease,
   onComplete,
 }: CombatPresentationProps) {
   const reducedMotion = useReducedMotion() ?? false;
@@ -71,6 +75,9 @@ export function CombatPresentation({
   const completedItemRef = useRef<CombatPresentationAttack | undefined>(
     undefined
   );
+  const releasedItemRef = useRef<CombatPresentationAttack | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     // A new item first renders with the previous sequencer beat. Wait for its
@@ -79,11 +86,16 @@ export function CombatPresentation({
       previousItemRef.current = item;
       return;
     }
+    const resultBeat = item.attack.hit ? 'impact' : 'verdict';
+    if (seq.beat === resultBeat && releasedItemRef.current !== item) {
+      releasedItemRef.current = item;
+      onResultRelease?.(item.id);
+    }
     if (seq.beat === 'done' && completedItemRef.current !== item) {
       completedItemRef.current = item;
       onComplete(item.id);
     }
-  }, [item, onComplete, seq.beat]);
+  }, [item, onComplete, onResultRelease, seq.beat]);
 
   const outcome = ['verdict', 'impact', 'release'].includes(seq.beat)
     ? verdictLabel(item.attack)

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -118,6 +118,8 @@ export interface HexEntityProps {
    * `useHexMovePath` watches this, not `position` itself, to distinguish a
    * real move from initial placement or a ghost/revive reconciliation. */
   moveSeq?: number;
+  /** Presentation-only completion for this entity's exact move sequence. */
+  onMovementPresentationComplete?: (entityId: string, moveSeq: number) => void;
 }
 
 // Visual state colors
@@ -294,6 +296,7 @@ export function HexEntity({
   propRotationY,
   movePath,
   moveSeq,
+  onMovementPresentationComplete,
 }: HexEntityProps) {
   const meshRef = useRef<THREE.Mesh>(null);
   const { invalidate } = useThree();
@@ -330,7 +333,9 @@ export function HexEntity({
     hexSize,
     CHARACTER_Y_OFFSET,
     movingGroupRef,
-    requestHeading
+    requestHeading,
+    (completedMoveSeq) =>
+      onMovementPresentationComplete?.(entityId, completedMoveSeq)
   );
 
   // Same "sticky failure keyed by url, not a bare boolean" shape as

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -110,6 +110,11 @@ export interface HexGridProps {
   /** Monster combat state for texture selection (includes monsterType) */
   monsters?: MonsterCombatState[];
   onMoveComplete?: (path: CubeCoord[]) => void;
+  /** Presentation-only completion of an entity's exact rendered move. */
+  onEntityMovementPresentationComplete?: (
+    entityId: string,
+    moveSeq: number
+  ) => void;
   onAttackComplete?: (targetId: string) => void;
   onHoverChange?: (
     entity: { id: string; type: string; name: string } | null
@@ -395,6 +400,7 @@ function Scene({
   isPlayerTurn = false,
   combatState = null,
   onMoveComplete,
+  onEntityMovementPresentationComplete,
   onAttackComplete,
   onHoverChange,
   onDoorClick,
@@ -1057,6 +1063,7 @@ function Scene({
           propRotationY={wallAdjacentRotations.get(entity.entityId)}
           movePath={entity.movePath}
           moveSeq={entity.moveSeq}
+          onMovementPresentationComplete={onEntityMovementPresentationComplete}
           knowledgeState={entity.knowledgeState}
         />
       ))}

--- a/src/components/hex-grid/useHexMovePath.test.ts
+++ b/src/components/hex-grid/useHexMovePath.test.ts
@@ -451,6 +451,40 @@ describe('useHexMovePath (hook-level regression test)', () => {
     expect(onPresentationComplete).toHaveBeenCalledExactlyOnceWith(2);
   });
 
+  it('keeps one move instance alive across same-sequence canonical prop refreshes and reports its completion', () => {
+    const onPresentationComplete = vi.fn();
+    const { result, rerender, groupRef } = renderMovePath(
+      undefined,
+      onPresentationComplete
+    );
+    act(() => {
+      groupRef.current = new THREE.Group();
+      const start = cubeToWorld(posA, HEX_SIZE);
+      groupRef.current.position.set(start.x, Y_OFFSET, start.z);
+    });
+
+    rerender({
+      entityPosition: { ...posC },
+      movePath: [posA, posB, posC],
+      moveSeq: 1,
+    });
+    expect(result.current.isMoving).toBe(true);
+
+    // The real viewer route receives a knowledge/canonical refresh for the
+    // same streamed move before its frame loop completes. Object identities
+    // change, but moveSeq still names the same presentation instance.
+    rerender({
+      entityPosition: { ...posC },
+      movePath: [{ ...posA }, { ...posB }, { ...posC }],
+      moveSeq: 1,
+    });
+    tick(SECONDS_PER_HEX_STEP);
+    tick(SECONDS_PER_HEX_STEP);
+
+    expect(onPresentationComplete).toHaveBeenCalledExactlyOnceWith(1);
+    expect(result.current.isMoving).toBe(false);
+  });
+
   it('treats the first move after a revive as a genuine move (animates), not a snap', () => {
     const { result, rerender, groupRef } = renderMovePath();
 

--- a/src/components/hex-grid/useHexMovePath.test.ts
+++ b/src/components/hex-grid/useHexMovePath.test.ts
@@ -379,7 +379,10 @@ describe('useHexMovePath (hook-level regression test)', () => {
     moveSeq: number | undefined;
   };
 
-  function renderMovePath(onHeading?: (radians: number) => void) {
+  function renderMovePath(
+    onHeading?: (radians: number) => void,
+    onPresentationComplete?: (moveSeq: number) => void
+  ) {
     // Caller-owned as of rpg-dnd5e-web#590 — the hook no longer creates and
     // returns this ref, because useEntityFacing drives rotation.y on the same
     // object. Starts null exactly like the returned ref used to, so the
@@ -394,7 +397,8 @@ describe('useHexMovePath (hook-level regression test)', () => {
           HEX_SIZE,
           Y_OFFSET,
           groupRef,
-          onHeading
+          onHeading,
+          onPresentationComplete
         ),
       {
         initialProps: {
@@ -416,6 +420,35 @@ describe('useHexMovePath (hook-level regression test)', () => {
   beforeEach(() => {
     hoisted.frameCallback = undefined;
     hoisted.invalidate.mockReset();
+  });
+
+  it('reports only the exact move instance that actually finishes after a move is superseded', () => {
+    const onPresentationComplete = vi.fn();
+    const { rerender, groupRef } = renderMovePath(
+      undefined,
+      onPresentationComplete
+    );
+    act(() => {
+      groupRef.current = new THREE.Group();
+      const start = cubeToWorld(posA, HEX_SIZE);
+      groupRef.current.position.set(start.x, Y_OFFSET, start.z);
+    });
+
+    rerender({
+      entityPosition: { ...posB },
+      movePath: [posA, posB],
+      moveSeq: 1,
+    });
+    // Supersede move 1 before its frame loop can complete.
+    rerender({
+      entityPosition: { ...posC },
+      movePath: [posA, posB, posC],
+      moveSeq: 2,
+    });
+    tick(SECONDS_PER_HEX_STEP);
+    tick(SECONDS_PER_HEX_STEP);
+
+    expect(onPresentationComplete).toHaveBeenCalledExactlyOnceWith(2);
   });
 
   it('treats the first move after a revive as a genuine move (animates), not a snap', () => {

--- a/src/components/hex-grid/useHexMovePath.ts
+++ b/src/components/hex-grid/useHexMovePath.ts
@@ -223,7 +223,10 @@ export function useHexMovePath(
   // this hook created the ref, the two hooks would be circular at the call
   // site. The two writes are disjoint by property, so they cannot fight.
   groupRef: React.RefObject<THREE.Group | null>,
-  onHeading?: (radians: number) => void
+  onHeading?: (radians: number) => void,
+  /** Reports completion of the exact move instance that finished painting.
+   * Presentation-only: callers must not treat this as game-state completion. */
+  onPresentationComplete?: (moveSeq: number) => void
 ): UseHexMovePathResult {
   const [isMoving, setIsMoving] = useState(false);
   const { invalidate } = useThree();
@@ -238,8 +241,11 @@ export function useHexMovePath(
   // first leg of every move would report through a stale callback.
   const onHeadingRef = useRef(onHeading);
   onHeadingRef.current = onHeading;
+  const onPresentationCompleteRef = useRef(onPresentationComplete);
+  onPresentationCompleteRef.current = onPresentationComplete;
 
   const seenSeqRef = useRef<number | undefined>(undefined);
+  const activeMoveSeqRef = useRef<number | undefined>(undefined);
   const stepRef = useRef<StepState>({ points: [], index: 0, elapsed: 0 });
 
   const destination = cubeToWorld(entityPosition, hexSize);
@@ -277,7 +283,11 @@ export function useHexMovePath(
     }
 
     stepRef.current = { points: result.points, index: 0, elapsed: 0 };
+    activeMoveSeqRef.current = moveSeq;
     setIsMoving(result.points.length > 1);
+    if (result.points.length <= 1 && moveSeq !== undefined) {
+      onPresentationCompleteRef.current?.(moveSeq);
+    }
     // Report the first leg's heading. `undefined` for a zero-length leg (the
     // #656 same-hex move) means "no opinion" — the entity holds whatever it
     // was already facing rather than snapping to due north.
@@ -293,6 +303,7 @@ export function useHexMovePath(
     destination.z,
     yOffset,
     invalidate,
+    groupRef,
   ]);
 
   useFrame((_state, delta) => {
@@ -313,6 +324,11 @@ export function useHexMovePath(
       if (nextHeading !== undefined) onHeadingRef.current?.(nextHeading);
       if (s.index >= s.points.length - 1) {
         setIsMoving(false);
+        const completedSeq = activeMoveSeqRef.current;
+        activeMoveSeqRef.current = undefined;
+        if (completedSeq !== undefined) {
+          onPresentationCompleteRef.current?.(completedSeq);
+        }
       }
     }
   });

--- a/src/components/hex-grid/useHexMovePath.ts
+++ b/src/components/hex-grid/useHexMovePath.ts
@@ -270,12 +270,24 @@ export function useHexMovePath(
     seenSeqRef.current = result.nextSeenSeq;
 
     if (!result.isGenuineMove) {
+      // A canonical/knowledge refresh can replace position/path objects while
+      // the same streamed moveSeq is still painting. That is the SAME move,
+      // not a snap/reset: keep its frame loop alive so its exact completion
+      // can satisfy the presentation gate. This applies identically to player
+      // and NPC actors.
+      if (
+        moveSeq !== undefined &&
+        activeMoveSeqRef.current === moveSeq &&
+        stepRef.current.points.length > 1
+      ) {
+        return;
+      }
       // Initial mount, non-move position change (initial placement,
-      // ghost/revive), or a re-render where moveSeq hasn't advanced since
-      // we last saw it — snap straight to the destination, matching
-      // pre-#542 behavior exactly. Also clears any in-flight step so a
-      // stale useFrame tick from a just-superseded move can't keep nudging
-      // the position after a non-move update resets it.
+      // ghost/revive), or a settled re-render where moveSeq hasn't advanced
+      // since we last saw it — snap straight to the destination, matching
+      // pre-#542 behavior exactly. Also clears any in-flight step so a stale
+      // useFrame tick from a reset can't keep nudging the position.
+      activeMoveSeqRef.current = undefined;
       stepRef.current = { points: [], index: 0, elapsed: 0 };
       groupRef.current.position.set(destination.x, yOffset, destination.z);
       setIsMoving(false);


### PR DESCRIPTION
## Summary

- hold queued attack theater until the attacking entity’s current rendered movement instance completes
- keep canonical encounter state current while staging visible HP and correlated combat-log outcomes until Verdict (miss) or Impact (hit)
- retain already-known removed entities as presentation tombstones through lethal impact, then release existing removal behavior
- expose only narrow presentation lifecycle seams: exact move-sequence completion and exactly-once semantic result release

## Boundaries

- no client rules or inferred hit/damage/HP/death state
- no proto, API, or toolkit changes
- no downed-asset, healing, or HP-sync changes

## Verification

- `npm run ci-check` — pass (format, lint, typecheck, build, full test suite)
- focused deterministic tests: `npx vitest run src/components/game/combatPresentation/CombatPresentation.test.tsx src/components/game/EncounterView.test.tsx src/components/hex-grid/useHexMovePath.test.ts` — 102 pass
- covers stale/current movement completion, hit and miss result beats, visible vs canonical HP, correlated log release, lethal tombstone release, FIFO, snapshot/mode/end flushes, queue swaps, cleanup, and reduced motion

## Previously accepted evidence

At prior head `3709fdb`, the independent code gate passes. The canonical App → Home → Play → LobbyFlow → GameView → EncounterView route also passes the bounded outcomes it emitted:

- miss: held through Verdict with no damage released;
- hit + single-final-enemy lethal: no result or terminal spoilers before Verdict; Impact released hit, damage, HP 0, death, removal, encounter-end log, and banner together; the tombstone remained through Release and cleaned at Done.

Evidence summary: `/tmp/pr722-3709fdb-gate-summary.md`; screenshots: `/tmp/pr722-370-lethal-attempt4/`.

## Prior movement evidence

At prior head `3709fdb`, a second canonical-route capture received a real `EntityMoved` envelope before the same-burst `AttackResolved`. Recorded browser video shows the NPC translating 62px and settling before Cue appeared; theater remained absent during movement. The capture also reconfirms visible HP stayed 10/10 through Verdict and changed to 8/10 only at Impact.

Evidence summary: `/tmp/pr722-3709fdb-movement-gate-summary.md`.

- video `/tmp/pr722-370-refmove-fast3/page@345b0d39248ff9a8be44ceaad525d486.webm` — SHA-256 `52130b382af54fb4b3304d1eef94d0a5e5dfaabf8f3c555044154ddf94c9e08a`
- event/beat trace `/tmp/pr722-370-refmove-fast3/console-and-beats.txt` — SHA-256 `c12a6d4290640fae13c60886698e4f25031bd1b945d7c94841db14266a73e1d1`
- contact sheet `/tmp/pr722-refmove-fine.jpg` — SHA-256 `8840e626ab75643e34b2121ba9f237282dccc6e1d6f1716ddad8fea9e1e715db`
- completion frames: `fine-08.00.png` `27a1275d036258de1b581d0a4d675e6220b668ff686311fd945e20b40dda4212`, `fine-08.25.png` `472a26dfc9534d50be76978481c4e4940a01ed0d05922fa4a77c05067a799cba`, `fine-08.50.png` `de42d4d382b5c3c3a81b3748ab4c77fbb3660157a918fa8ce0f11bf6ab60cb7d`, `fine-08.75.png` `4547db07ac90a5e4440c317355bae4f7695eff40267b7c5e4dc4b4dd6976f0b1`, `fine-09.00.png` `f3f6619a2df3c1b8ece77715a87933cd104f0862c75047e347c0daaeb6e631a8`, `fine-09.25.png` `88fcdf612c9eaf977b79470246bcb17607d4d38b8c17231775785960a33f176c`

## Viewer-movement regression and exact-head gate

Kirk’s real player route exposed a viewer-only FIFO stall after movement. Controlled A/B confirmed it as a PR regression: at `3709fdb`, a same-`moveSeq` canonical/knowledge prop refresh visibly snapped the actor to its destination but cancelled the active frame loop without reporting semantic completion, so viewer AttackResolved stories remained queued behind an unsatisfied movement gate. Clean `origin/dev` presented Armed/Roll normally.

Candidate `9194412b7039bc47c3f4a74d3a944347c833733e` preserves an in-flight move across same-generation prop refreshes; superseding/reset behavior and the shared player/NPC gate are unchanged. Red evidence: `/tmp/red721viewer.txt`. Focused production-wiring and movement tests pass 96/96; full `npm run ci-check` and push-hook CI pass.

The independent exact-head actual-app gate passes on the canonical Home → Play → LobbyFlow → GameView route. It naturally emitted player `EntityMoved` followed by same-generation and later `HexKnowledgeChanged` refreshes, visibly completed movement, then presented Armed/Roll for the first viewer attack. A second viewer attack after the same completed move also presented and drained, including lethal Impact, terminal banner/log release, tombstone Release, and final cleanup. NPC presentation smoke passed in the same run. Evidence: `/tmp/pr722-9194412-gate-summary.md`.

Artifacts under `/tmp/pr722-9194412-viewer-gate-freshfog/`:

- video `page@9f40461ed49f88d3d2603f4746118f6a.webm` — SHA-256 `69a4c4cee3214804c1e67b3b0471da523d0c11ce6288ef79df58296bc4f770bb`
- event/beat/DOM trace `trace.json` — SHA-256 `a4d823d70d65a33d7327dcc11c9c65357aace3e1fb52e47a8e9031110022b315`
- completed movement `02-player-move-complete.png` — SHA-256 `5d018088496e62499449cdb04e48b48f75626e32916467da7cbf1b0be00ae5b0`
- first Armed `attack1-02-armed.png` — SHA-256 `fb0ff552cf613e4b6bfc6b2a14ddb8aae6d20bf2c339cd8262ef90f452ff0469`
- first Impact `attack1-05-impact.png` — SHA-256 `8506eeff8d0f031236b94cd1c8dbbf39668349352de657a333cc853af9875978`
- first drained `attack1-07-none.png` — SHA-256 `4392abb8a0cde07540a47221c54a1e9952b3feacc15c161ea6dae88771b0ea07`
- second Armed `attack2-09-armed.png` — SHA-256 `c215934ff1e3deaa2ee903ddc08b76fac250303f750d189276cb93c1c48a4020`
- terminal Impact `attack2-12-impact.png` — SHA-256 `9d4c3beac563462f4d5e105ac4c8812ce88b58b63d936e483438feebf788b328`
- terminal Release `attack2-13-release.png` — SHA-256 `efd0033bf6d08a8d2294b08492a590814d80ff13381289255fc1179f3133db74`
- final drain `attack2-14-none.png` — SHA-256 `54e02dc6c69e6e3de2327baef6e7e42fcf561d1a8a8b8648c9d24983be7cf573`
- service health `service-identity-health.txt` — SHA-256 `77b24ca86143ae9a7c8db15640a258d53bdb6bfb357f9a40c3b161d28446395e`

The prior consolidated independent verdict passed at `9194412`; its movement/viewer evidence remains regression smoke for the new candidate but is no longer exact-head signoff.

## Player-down status reveal candidate

A real NPC lethal hit at `9194412` proved the entity was never removed: correlated `StatusApplied` envelopes updated the Unconscious badge/log and swapped the character model at Cue while HP/damage correctly waited for Impact. The final downed model exists but has a separate pre-existing placement defect (#43); this PR does not touch GLBs or placement. Classification report: `/tmp/pr722-9194412-player-lethal-report.md`.

Failure artifacts under `/tmp/pr722-9194412-player-lethal-resume/`:

- video `page@c3312038130d5bc78a20c16022057406.webm` — SHA-256 `abf4bcf63f991009ced1431a76759ab13c441d4789e396d564b297925371307d`
- trace `trace.json` — SHA-256 `a966c39e7d8a16db8284a65372c05718b7a5a748f667d3f8c5a4a8f5127d3935`
- preattack `02-pre-end-0-none.png` — SHA-256 `70b30257e584d511304ac1836cdca97eecdc4dda29273eea4d95caea9ce5bf1c`
- Cue leak `04-npc-0-cue.png` — SHA-256 `37c712001529178791eec79cade3bfe86647a8daf58805ae88293705f39442a8`
- Verdict `07-npc-0-verdict.png` — SHA-256 `217c1d2067cbe0a2b9499624d56de4572c8a9edda57362b0866e215fdfd6b1e6`
- Impact `08-npc-0-impact.png` — SHA-256 `2a946b603ece10d64990f51a9608131d613e3a8356c2ce01244f35eecb21d3bf`
- final downed/offset `10-final-none.png` — SHA-256 `3cd5dfbe64b77f58b7d179157279bcde80580168dd709809a57748bf1c05afcb`

Candidate `d2657cd` failed the exact real route because today’s two `StatusApplied` envelopes carry empty correlations even though Attack/Damage share a populated correlation; it also had independent command-safety, stale status snapshot, and hydration-ref findings. It is not accepted evidence.

Candidate `44eb684` models the real wire shape causally: empty-correlation statuses bind the most recent active/released-not-done matching damage story by target/source/order, while no matching damage remains immediate. It also:

- disables every combat dispatch surface during a held local-control story and re-enables only after release when canonically allowed;
- releases queued status logs while projecting the latest canonical status truth, preventing stale snapshot overwrite/resurrection;
- synchronizes canonical status refs during Snapshot and HexKnowledge hydration;
- covers multiple empty statuses, repeated same-target stories, mixed immediate apply/remove ordering, batched hydration, delayed/duplicate behavior, and command RPC guards.

Red evidence: `/tmp/red721emptystatus.txt`, `/tmp/red721commands.txt`, `/tmp/red721statusrace.txt`, and `/tmp/red721statushydration.txt`. Focused suite 102/102 and full `npm run ci-check` plus push-hook CI pass.

## Exact-head `44eb684` product evidence

The primary actual-app player-lethal gate passes on immutable exact-head source. A real burst delivered correlated Attack/Damage followed by two empty-correlation StatusApplied envelopes. Through Idle, Throw, and Verdict the upright model, HP 2/10, pre-story 30ft dock, badges, and correlated logs remained held and controls were disabled. Impact atomically released HP 0/10, 3 damage, both status log lines, Unconscious badge, 0ft/disabled dock state, and the downed-model swap; the story drained. Viewer movement → same-sequence refresh → Armed/real Roll → terminal drain and NPC hit/miss pacing smoke also pass. Evidence: `/tmp/pr722-44eb-gate-summary.md`.

Primary lethal resume under `/tmp/pr722-44eb-lethal-resume/`:

- video — SHA-256 `c90a80fe7c9ed9103bfa7a098b17b4faebd93e58268e794b867d690ef4f70c81`
- trace — SHA-256 `372e5ae09c697550a92f74bd3e16fa192065738a2f25d31bed10ad4cf7c590d3`
- held Idle `20-npc-2-idle.png` — SHA-256 `b76614bd9d522b12e790330e01a9271f17863b043d3e37394805012cddb8bc72`
- held Verdict `24-npc-2-verdict.png` — SHA-256 `bdf3e49ebcf44c2e1d0cd437922cb2d3beb91c2626107336d9a922f5cf3af30e`
- Impact `25-npc-2-impact.png` — SHA-256 `6868cea57a337157c6504141d583279b67589e1838fbf0c361601de28a93facd`
- final `27-final-none.png` — SHA-256 `b015c4ce8a7b3448aabd8c32079643b3d532ec0d6bb49b157604ead8474eac7b`

Full initial lethal route under `/tmp/pr722-44eb-player-lethal/`: video SHA-256 `62c344b1116230588533d04dd048bc6f0ff0d7c4b931d7eb4d2936def12c694c`; trace SHA-256 `aee94a5b56a7dd9d205b833487500c5153160d79762b22878e30d0e60cac97b5`.

Viewer/terminal artifacts under `/tmp/pr722-44eb-viewer/`:

- video — SHA-256 `cf4640fce7497f662b6035ff4c6f76a8e6296b1f9cdb92a885456b883757a624`
- console trace — SHA-256 `a391dfe86b55b562cd2ab5f79eb575212230bb6b0cafd3a6af82c68ec56efc4d`
- completed movement — SHA-256 `533d934bd86cfc38a24fc4e59b48154474e1aaadbd2694fcb9b4617854637ea6`
- Armed — SHA-256 `9ed2b9cee37278186243ad93a1df38b17d3658bb8d5acda0173832de1f458bbd`
- terminal Impact — SHA-256 `2b13d093b00e4111d5474fab43695f6e51ddaaf09ec00d8a35eb09752c8e0075`
- drained — SHA-256 `202b5f55fdfc254d3d7bb9bb6fce290e9cd8483514d7e9e37506412a122c3618`

Service capture `/tmp/pr722-44eb-service.txt` — SHA-256 `ba75d13d6234f9b01bce8c48ddfb55269a0dfdea66654b6e94e8aaa12e4263e6`.

The consolidated independent verdict is PASS at exact head `44eb684`, with no Critical or Important findings. The exact real empty-correlation player-lethal product gate and all GitHub checks pass.

Non-blocking residuals remain recorded rather than relabeled: a second viewer attack was blocked because the first naturally ended the encounter; NPC translation was blocked because the NPC was already adjacent; and an unrelated natural StatusApplied event did not occur. Deterministic tests cover those seams, while an unrelated DeathSaveRolled remained immediate. The actual-app multi-terminal case also remains fixture-unverified with deterministic production-wiring coverage. The offset downed GLB remains assets #43 and is not changed here.

Closes #721

— asset-pipeline agent, on behalf of KirkDiggler












