### PR TITLE
unit: drawn walls become real (wallLines→edges projection) + props on footprint cells

### DIFF
--- a/src/author/CONTRACT.md
+++ b/src/author/CONTRACT.md
@@ -7444,3 +7444,181 @@ asserted. Concepts Lab's fixtures mount re-confirmed unaffected (no
 capabilities line at all outside live mode, unchanged).
 
 — asset-pipeline agent, on behalf of KirkDiggler
+
+## Drawn walls become real: wallLines->edges projection + props on footprint cells (2026-08-07, rpg-project#169)
+
+Two halves, one meaning — "walls that are real, and things that live against
+them." Half A: `stripToV1Subset` now projects a `wallLines:` entry's
+footprint + crossed-edge geometry into wire-real `walls:` entries at send
+time, so a drawn straight wall exists in the real game (rendered AND
+enforced), not just previewed client-side. Half B: `canvasPlacementRejectReason`
+splits PLACEABLE (props — real floor is enough) from STANDABLE (monsters/
+boss — must not be footprint) so a prop can rest on a straight wall's
+footprint (Kirk's exact ask: a bookcase against the wall).
+
+### A real import cycle, found and fixed at its root
+
+Wiring the projection into `dungeonYaml.ts`'s `stripToV1Subset` needed a
+direct call into `straightWallGeometry.ts`'s `straightWallFootprint`/
+`straightWallCrossedEdges` — the SAME functions `preview3d/walkMovement.ts`
+already calls client-side. That import doesn't work as a plain top-level
+import: `straightWallGeometry.ts` (and, transitively, `creationGeometry.ts`)
+imported `neighborCell` from `boardGeometry.ts`, which itself imports
+`resolvePlacement`/`DungeonDoc` from `dungeonYaml.ts` — a real, crashing
+cycle (`dungeonYaml.ts -> straightWallGeometry.ts -> boardGeometry.ts ->
+dungeonYaml.ts`), the exact class of bug `hexCorner.ts`'s own header comment
+already documents hitting once before ("Cannot access ... before
+initialization" under Vite's ESM interop).
+
+Fix: `hexCorner.ts` already carried its own leaf-level duplicate of
+`neighborCell` (built for the identical reason, when `parseWallLineEndpoint`
+needed to call into corner math from `dungeonYaml.ts` without the same
+cycle). Exported it, and redirected both `straightWallGeometry.ts`'s and
+`creationGeometry.ts`'s own `neighborCell` imports to that copy instead of
+`boardGeometry.ts`'s — severing the cycle at its root rather than adding a
+THIRD duplicate. `boardGeometry.ts`'s own `neighborCell` (and its other
+consumers — `walkMovement.ts`, `DungeonPreview3D.tsx`) are untouched; this
+only moved which leaf copy two already-leaf-adjacent modules call.
+`npx tsc -b --noEmit` clean, all 3 affected test files (56 tests) green
+before writing a single line of new projection code.
+
+### The projection, precisely
+
+`creation/straightWallGeometry.ts` gained `projectWallLineToEdges(line,
+grid)`: for every footprint cell (door cells already excluded), seal all 6
+real neighbor edges — `kind: 'door'` toward a `doors:` cell, `'solid'`
+otherwise, `rimEdgeCount++` toward a neighbor off the canvas grid entirely
+(no cell to pair with). Unions with `straightWallCrossedEdges`'s existing
+between-two-clear-cells grazing crossings (always `'solid'` — a door only
+reverses ITS OWNING line's own footprint claim, never mechanism (b)'s
+independent test; verified directly, not assumed, with a genuinely vertical
+wallLine whose door cell has BOTH a `door`-kind flanking edge AND an
+independent `solid` grazing edge to a different neighbor at once).
+
+`stripToV1Subset` (`dungeonYaml.ts`) calls this per wallLine when
+`accepted('walls')`, merges the union across every line (a door beats a
+solid found from a different direction/line), then merges against
+`doc.walls`'s own explicit entries by an order-independent cell-pair key —
+explicit always wins on a conflict, never duplicated. Reported in
+`compiling`, not `dropped`, worded from the real projection result: "N
+straight walls (projects to M wall edges; K rim edges... could not be
+expressed)". `walls:` not accepted: unchanged prior behavior (wallLines
+drops entirely). The `wallLines:` KEY itself always strips regardless
+(dungeonspec has no such field) — this is a projection at send time, never
+a mutation of the live document; the caller's own `cst` is untouched.
+
+**Doors: `kind: door`, not a bare gap.** The real game's per-edge wall
+renderer (`syntyHexWallHelpers.ts`) only draws geometry where a `Wall`
+entry exists — an omitted edge renders as nothing, indistinguishable from a
+bug. `kind: door` gives the opening a real frame through the same rendering
+path every other door already uses. Full reasoning in TARGET-YAML.md's
+"Straight walls: stripToV1Subset" section.
+
+### Live-verified against the real server, not just unit-tested
+
+Built the actual send-time YAML by calling the real, unmodified
+`stripToV1Subset` (not a hand-typed approximation) on a canvas doc with one
+vertical wallLine (footprint `[6,4]`..`[6,9]`), a door at `[6,6]`, and a
+`dnd5e:props:bookcase` placed at `[6,5]` — a footprint cell, Half B's exact
+target. `PutDungeon` (non-`validate_only`) against the live Wave-1 server
+(`:8092`): `success: true`, zero `field_errors`, `floor_plan.floor_cells`:
+400 (20×20 canvas), `floor_plan.edges`: **exactly 31**, matching the
+projection's own count. Two `FLOOR_PLAN_EDGE_KIND_DOOR` entries at
+`[6,5]`<->`[6,6]` and `[6,6]`<->`[6,7]`, each carrying a real `doorId` — the
+server compiles the projected door edges as real doors, not decoration.
+Both the wall-footprint cell `[6,5]` and the door cell `[6,6]` confirmed
+real floor (`floor_cells` membership) — the "both endpoints are canvas
+floor cells" premise this unit's own brief named, verified, not assumed.
+
+**A real encounter, started on this exact saved dungeon** (`CreateLobby` ->
+`SetReady` -> `StartEncounter`, dungeon key `wallproj-verify`) — enforcement
+transcript, via `MoveEntity`/`GetEncounter`, cube coordinates:
+
+- Walked the player from the start hex toward the wall along a real
+  hex-adjacent path. The move landed exactly at `(6,-6,0)` [col 6, row 3] —
+  one hex short of `(6,-7,1)` [col 6, row 4], the first footprint cell —
+  even though the requested path continued past it. **The server itself
+  truncated the move at the wall boundary**, never erroring outright.
+- A second, explicit single-step `MoveEntity` from `(6,-6,0)` to
+  `(6,-7,1)` — directly across the projected `solid` edge — left the
+  entity's position UNCHANGED (re-confirmed via `GetEncounter`'s own
+  `contents` field). **Rejected in effect, verified by resulting position,
+  not just by absence of an error.**
+- Routed around via column 7 (confirmed clear of any projected edge) to
+  approach the door cell `[6,6]` from its open side, then attempted to
+  step through into `[6,5]`: **the move stopped exactly at the door cell**,
+  unchanged position. The live `GetEncounter` snapshot showed why —
+  `WALL_KIND_DOOR_CLOSED`, a real `Wall.id`
+  (`wallproj-verify-authored-door-6--9-3--6--8-2`). A genuine, honest
+  finding: **the real game's authored door starts CLOSED and blocks
+  movement until interacted with** — a real gameplay mechanic
+  `preview3d/walkMovement.ts`'s own client-side author-preview simplifies
+  away (it treats `kind: door` as always-passable, correct for its own
+  scope — a walkthrough preview with no interact affordance — but not the
+  live game's actual rule). Not a defect in this unit's projection; the
+  door compiled and rendered exactly as authored.
+- Called `Interact(encounterId, doorId, 'open')` on that same `Wall.id`.
+  Re-issued the identical single-step `MoveEntity` from the door cell into
+  `[6,5]`: **succeeded** — `GetEncounter` confirmed the entity now
+  occupies `(6,-8,2)` [col 6, row 5], the SAME hex as `canvas-prop-0` (the
+  authored bookcase) — Half B confirmed live: the prop and the player
+  genuinely share a footprint cell, exactly as authored.
+
+**Screenshot, real GameView** (`?playerId=pr692-monk-1785858891464`,
+auto-resumed, FREE_ROAM mode, character "PR692 Gate Two" HP 7/10 — the
+exact identity `CreateLobby` bound): a long straight (non-hex-zigzag) wall
+run, and a detailed bookcase model (visible shelved book spines) standing
+directly against it, floor tiles rendered beneath both. Matches Kirk's
+"bookcase against the wall" ask exactly, confirmed visually in the actual
+game route, not the author's own preview.
+
+LoS: not separately captured this round — the enforcement + rendering
+evidence above was judged sufficient and the remaining verification budget
+went to the MoveEntity transcript instead; observed-not-proven, named here
+per this file's own "flag, don't silently claim" discipline rather than
+left unmentioned.
+
+### Half B — the placement-legality split
+
+`canvasFloor.ts`'s `canvasPlacementRejectReason` gained a `requiresStandable`
+boolean: `false` skips the footprint gate entirely (a prop only needs real
+floor — every other gate, off-canvas/hole/occupied, still applies), `true`
+keeps the pre-existing hard reject. Both `CreationBoard.tsx` (2D) and
+`DungeonPreview3D.tsx` (3D `handleClickCell`) now pass
+`selectedPalette.kind !== 'prop'` — the 3D path does a FRESH check rather
+than trusting `buildPlaceableCells`'s own precomputed (necessarily
+standable-based, ref-agnostic) hover state, so a prop placement isn't
+wrongly rejected by a table built for the majority (monster) case.
+`start`/`end` deliberately left untouched: they never routed through this
+predicate at all (only a retroactive "⚠ BLOCKED!" flag exists for them
+today), so there was nothing to relax — and a start point genuinely does
+need standable ground, same as a monster. The 2D board's own retroactive
+"⚠ IN WALL FOOTPRINT" warning ring (`CreationBoard.tsx`'s `renderPlacement`)
+got the same split — scoped to `dnd5e:monsters:*` refs only, so a
+legitimately-placed prop on a footprint cell renders normally, no
+false-alarm warning, matching "keep the footprint visual unchanged; placed
+props render normally" from this unit's own brief.
+
+### Tests
+
+`straightWallGeometry.test.ts`: 6 new tests for `projectWallLineToEdges` —
+an isolated footprint cell seals all 6 real neighbors (solid, no doors);
+every real neighbor direction is either a sealed edge or a counted rim edge
+(never silently dropped, invariant: edges.length + rimEdgeCount === 6 for
+an isolated cell); a door cell's flanking footprint-neighbor edges are
+`door`; an independent mechanism-(b) grazing edge on that SAME door cell
+stays `solid` (the two mechanisms don't interfere); dedup across mechanisms
+produces no duplicate cell pairs. `dungeonYaml.test.ts`: 6 new tests under
+"wallLines -> walls: projection" — projects when accepted, counted in
+compiling; the live document is untouched (a projection, not a
+conversion); explicit `walls:` wins on a kind conflict, no duplicate;
+`doors:` projects as `kind: door`; rim edges counted honestly in the badge
+message; not accepted still drops both, unchanged prior behavior.
+`canvasFloor.test.ts`: 5 new tests under "requiresStandable: false (props)"
+— a footprint cell is legal for a prop, still rejected for anything
+requiring standable ground, holes/occupied gates stay unconditional either
+way, a real authored wallLine's footprint permits a prop via the full
+`straightWallsFootprintSet` integration path. Full suite: 139 files / 2320
+tests, `ci-check` clean (format/lint/typecheck/build/test all green).
+
+— asset-pipeline agent, on behalf of KirkDiggler

--- a/src/author/CONTRACT.md
+++ b/src/author/CONTRACT.md
@@ -7622,3 +7622,143 @@ way, a real authored wallLine's footprint permits a prop via the full
 tests, `ci-check` clean (format/lint/typecheck/build/test all green).
 
 — asset-pipeline agent, on behalf of KirkDiggler
+
+## Half B v2: coverage-based standability, replacing the binary footprint rule (2026-08-07, rpg-project#169)
+
+A live-design follow-up from Kirk mid-flight on the same unit, arriving
+AFTER the "drawn walls become real" round above had already shipped and
+been reported: "Nothing is set in stone... if you can say we won't clip
+we can go on those squares, maybe some percent is fine. the small
+triangles on the edge we could prob allow those to be placed on... like
+we can slide a bookcase to a wall." Retires the original "any hex that is
+not 100% uncovered would not be traversable" rule for STANDING purposes —
+placement legality and Walk-mode movement now read a per-cell COVERAGE
+PERCENTAGE instead of bare footprint membership. **Half A's own wire
+projection is completely untouched** — Kirk's own explicit rule 5: "the
+line blocks CROSSINGS, coverage decides STANDING," and the projected
+`walls:` edges stay exactly the line's crossings regardless of coverage.
+
+### The geometry
+
+New in `creation/straightWallGeometry.ts`: `hexCoverageFraction(from, to,
+col, row)` — clips the hex's own TRUE polygon (not the epsilon-shrunk one
+`isCellClipped` uses for the touch-vs-clip decision) against the wall
+line's half-plane (Sutherland-Hodgman, a genuinely different operation
+than this module's existing segment-vs-hex Cyrus-Beck clip), returns the
+SMALLER of the two resulting sub-polygon areas over the hex's total area.
+Smaller side, not a directionally-consistent "wall's own side" — a single
+line has no inherent material side without external context, and Kirk's
+own framing ("the small triangles on the edge") is exactly the min-area
+case, symmetric and context-free. Verified structurally (the two sides
+always sum to the hex's own full area, a corner-to-corner-two-apart
+chord always cuts off exactly 1/6 by regular-hexagon symmetry, a
+diameter always splits it exactly in half) as well as against a real,
+independently-computed spread of bench values (~1.7% to ~44.9%).
+
+`straightWallFootprintCoverage`/`straightWallsFootprintCoverage` are the
+coverage-aware siblings of the existing `straightWallFootprint`/
+`straightWallsFootprintSet` — same cell sets, richer per-cell value.
+`standableFootprintKeys(coverage, threshold)` filters down to a plain
+`Set<string>` — the exact shape `walkMovement.ts`'s `blockedCells` and
+`canvasFloor.ts`'s `canvasPlacementRejectReason` already consumed, so
+NEITHER needed a single signature or logic change: `walkMovement.ts`
+already kept mechanism (a)'s cell-blocking (the `wallLineFootprint` param
+straight into `blockedCells`) architecturally separate from mechanism
+(b)'s edge-blocking (a FRESH `straightWallFootprint` call per line,
+always the full/raw set) — exactly the separation this refinement
+needed, already there before this round. Only WHICH set callers pass in
+changed: `DungeonPreview3D.tsx`'s `buildWallLineFootprint` split into
+`buildWallLineFootprintCoverage` (full, for the dim-opacity visual) and
+`buildStandableWallLineFootprint` (coverage-filtered, for
+`buildPlaceableCells`/`buildWalkContext`/`handleClickCell`, unchanged
+code); `CreationBoard.tsx`'s palette-placement legality check and its
+`renderPlacement`'s monster-only warning ring both now pass the
+coverage-filtered set instead of the raw touch-at-all one. The 2D hatch
+and 3D `FootprintDimCell` both scale opacity by coverage (light for a
+shallow clip, full for a deep one) — every genuinely-touched cell still
+renders SOME dim, an author needs to see every real clip regardless of
+whether it also blocks standing.
+
+### The threshold — reasoned, not (yet) measured, and said so honestly
+
+`STANDABLE_COVERAGE_THRESHOLD = 0.10`. Kirk's own "measured, not guessed"
+standing-calibration principle calls for walking the first-person camera
+against a real coverage bench and observing where clipping starts to
+read as wrong. **That pass was ATTEMPTED, not completed.** A real
+two-line bench was built (`canvas: {width:50, height:30}`, lines at
+`(16,21)c0->(22,20)c0` and `(37,20)c0->(44,18)c0`, spanning
+independently-verified coverage from ~1.7% to ~44.9%), loaded live via a
+direct `localStorage` draft injection (`dungeon-builder:draft:create`) —
+no drag-draw needed, immediately reproducible — and the server-side
+projection was confirmed correct against it (`YamlPane`'s own compile
+badge: "2 straight walls (projects to 74 wall edges)" for these exact
+two lines, live against the Wave-1 server, proving Half A's own
+machinery is completely unaffected by any of this).
+
+The actual VISUAL inspection in Walk mode could not be finished: this
+session's chrome-devtools MCP browser (headless Chrome, debugging port 9222) collided live with a DIFFERENT, concurrent teammate agent's own
+active session mid-pass — a `navigate_page`/click issued from this
+session landed on a different origin/port entirely
+(`localhost:3003/?playerId=charli`, someone else's active gameplay), and
+a subsequent click (intended to leave this session's own stuck lobby
+resume) landed there too. Confirmed via `ss -tlnp`: this session's own
+Chrome was bound to `127.0.0.1:9222` (not exposed past loopback, despite
+requesting `--remote-debugging-address=0.0.0.0` — headless Chrome
+apparently ignores that flag), meaning the collision was a same-machine,
+same-default-port collision between two concurrent agents' MCP tooling,
+not a network exposure issue. Rather than push through on an actively
+shared, actively colliding resource — real risk of disrupting a
+teammate's live session — this stopped, killed this session's own Chrome
+instance immediately, and recorded the gap here instead of either
+fabricating a "measured" narrative or silently blocking without saying
+why.
+
+**The threshold is therefore reasoned from the real, independently-
+verified geometry instead**: set below the existing, already-established
+16.67% reference (`straightWallFootprint`'s own corner-to-corner-two-apart
+diagonal fixture — the smallest "clean" symmetric corner cut reachable
+via a same-cell chord, a real non-trivial triangular wedge, kept
+blocked), while treating the bench's smaller measured slivers (up to
+~10%) as standable — matching Kirk's own qualitative framing at the
+geometric level even without a completed visual confirmation. Recorded
+as a one-line constant specifically so a future session's real Walk-mode
+pass (against the exact same documented, reproducible bench) is a
+one-line change, not a rebuild. **A named, explicit follow-up, not a
+silently-accepted final answer.**
+
+### Slide-to-flush — ledgered as named next, not landed this round
+
+Kirk's own follow-on in the same message: "we can slide a bookcase to a
+wall." A sub-cell positional offset so a placement on a wall-adjacent/
+footprint cell sits flush against the wall's own face — the POSITION
+half of a pair whose ROTATION half already exists (`Inspector.tsx`'s
+"Snap flush to nearest wall" button, fine-rotation-generalization round:
+orients a prop edge-parallel to a wall, doesn't move it). Genuinely
+separate work (a computed offset, its own draft-tier dialect field,
+stripped at save, rendered in both the builder preview and the
+walkthrough) — scoped out deliberately rather than rushed alongside the
+coverage-geometry work above, which was already substantial. Named here,
+with its pairing point identified precisely, so a future session picks
+it up as a real next step instead of rediscovering the need from
+scratch. TARGET-YAML.md's own "Coverage-based standability" section
+carries the same note in the dialect-facing spec.
+
+### Tests
+
+`straightWallGeometry.test.ts`: 11 new tests — `hexCoverageFraction`'s
+own structural/symmetry proofs (corner-two-apart = 1/6, diameter = 1/2,
+the two sides always sum to the whole), the real bench's own independent
+verification (a wide spread, both above and below the threshold
+represented), `straightWallFootprintCoverage`/
+`straightWallsFootprintCoverage`/`standableFootprintKeys`'s own behavior
+(door exclusion carries through, max-wins on multi-line overlap,
+default/explicit threshold filtering), and an explicit RULE-5 REGRESSION
+GUARD: a genuinely low-coverage cell (standable) still gets fully sealed
+by `projectWallLineToEdges` — the wire projection provably doesn't know
+coverage exists. `canvasFloor.test.ts`: 2 new tests exercising the FULL
+real pipeline (not a hand-typed `Set`) — a low-coverage footprint cell
+is standable for a MONSTER too (`requiresStandable: true`), not just
+placeable for a prop; a high-coverage cell on the same real line stays
+blocked. Full suite: 139 files / 2329 tests, `ci-check` clean.
+
+— asset-pipeline agent, on behalf of KirkDiggler

--- a/src/author/TARGET-YAML.md
+++ b/src/author/TARGET-YAML.md
@@ -518,6 +518,82 @@ Two concrete cases worth naming directly, both covered by
   endpoint boundary cases" describe block, not just asserted from the
   general epsilon rule above.
 
+### Coverage-based standability (retires the binary "footprint = blocked" rule for STANDING, 2026-08-07)
+
+**"Every hex the wall's line genuinely passes through is BLOCKED," above,
+is no longer the whole story — it now describes the FOOTPRINT (what
+`straightWallFootprint`/`isCellClipped` compute, what Half A's wire
+projection seals, what mechanism (a)/(b) below still block unconditionally),
+not, by itself, who may STAND there.** Kirk, live design session, looking
+at the epsilon-gated all-or-nothing block: "Nothing is set in stone... if
+you can say we won't clip we can go on those squares, maybe some percent
+is fine. the small triangles on the edge we could prob allow those to be
+placed on... like we can slide a bookcase to a wall."
+
+**The refined model, precisely:**
+
+1. **The footprint itself — and everything this section already
+   describes about it — is UNCHANGED.** A cell the line genuinely clips
+   is still a footprint cell, at the same epsilon-gated touch-vs-clip
+   boundary as always.
+2. **What changed is what a footprint cell's membership MEANS for
+   standing.** Each footprint cell now carries a coverage FRACTION
+   (`creation/straightWallGeometry.ts`'s `hexCoverageFraction` — the
+   smaller of the two sub-polygon areas the wall's own infinite line
+   splits the hex's TRUE polygon into, over the hex's total area; see
+   that function's own doc comment for the full geometric write-up,
+   including why the SMALLER side rather than a directionally-consistent
+   "wall's own side"). A cell below `STANDABLE_COVERAGE_THRESHOLD`
+   (currently 10%) is STANDABLE — real, walkable floor again for anything
+   that needs to occupy it. At/above, blocked exactly as before.
+3. **Placeable vs. standable, restated precisely**: a PROP never needed
+   standable ground in the first place (this file's own "Interactions
+   with everything else" section) — it needs real floor, full stop,
+   coverage or not. A MONSTER/boss/start point needs standable ground —
+   now coverage-gated rather than footprint-membership-gated.
+4. **What did NOT change, deliberately (Half A stays exactly as
+   briefed)**: the wall LINE's own crossing prohibition — mechanism (b),
+   below, and Half A's wire projection
+   (`stripToV1Subset`'s `walls:` merge) — reads the FULL, unfiltered
+   footprint regardless of coverage. A standable low-coverage cell is not
+   a free pass through the wall's own line; it only means you may stand
+   there once you've reached it via an edge the line doesn't cross.
+   Server-side enforcement is completely untouched by any of this —
+   coverage is purely a client-side authoring/preview refinement of
+   "who may stand here," never a wire concept.
+5. **The threshold's own status, honestly**: `STANDABLE_COVERAGE_THRESHOLD`
+   is REASONED from real, independently-verified geometry (a documented
+   bench of wallLines spanning ~1.7%–~44.9% coverage — see the constant's
+   own doc comment for the exact fixtures), not yet CONFIRMED by a
+   completed live Walk-mode visual pass — that pass was attempted and
+   blocked by an environment-level shared-browser collision with a
+   concurrent agent session, recorded rather than silently worked around.
+   A future session without that collision should do the real visual
+   pass against the documented bench and adjust the one-line constant if
+   warranted.
+6. **Visual de-emphasis**: every genuinely-touched footprint cell still
+   renders a dim/hatch overlay (an author needs to see every cell the
+   wall clips, standable or not), but scales its opacity by coverage —
+   `DungeonPreview3D.tsx`'s `FootprintDimCell`/`CreationBoard.tsx`'s
+   hatch polygon both read the SAME `hexCoverageFraction` value, light
+   for a shallow clip, full for a deep one.
+
+**Slide-to-flush — named next, not landed this round.** Kirk's own
+follow-on ("we can slide a bookcase to a wall"): a placement on a
+wall-adjacent/footprint cell sliding flush against the wall's own face (a
+sub-cell positional offset), pairing with the EXISTING "Snap flush to
+nearest wall" button (`Inspector.tsx`'s fine-rotation-generalization
+round) — that button already solves the ROTATION half (orienting a prop
+edge-parallel to a wall); slide-to-flush is the POSITION half, genuinely
+separate work (a computed offset, its own draft-tier dialect field —
+`offset:` or a computed flush flag, TBD by whoever picks this up —
+stripped at save like every other draft field, rendered in both the
+builder preview and the walkthrough). Scoped out of this round
+deliberately rather than rushed alongside the coverage-geometry work
+above, which was already substantial on its own; recorded here so a
+future session picks it up as a real, named next step instead of
+rediscovering the need from scratch.
+
 ### Movement semantics
 
 Two distinct effects, both implemented:

--- a/src/author/TARGET-YAML.md
+++ b/src/author/TARGET-YAML.md
@@ -717,10 +717,29 @@ content is FLAGGED, not silently deleted or relocated:
 - **Placements** (`doc.place`) inside a footprint render an extra warning
   ring + "⚠ IN WALL FOOTPRINT" label, live, including while a wall is still
   being dragged (not just after release) — the placement itself is
-  untouched.
+  untouched. **PLACEABLE vs. STANDABLE split (rpg-project#169's "props on
+  footprint cells" unit, 2026-08-07):** this warning is scoped to
+  placements that actually NEED standable ground — monsters. A prop on a
+  footprint cell is no longer a warning-worthy state at all; it's the
+  intended target (Kirk's exact ask: a bookcase resting against a drawn
+  wall) — it renders normally, same as anywhere else on the floor. The
+  underlying placement-legality gate this warning mirrors
+  (`creation/canvasFloor.ts`'s `canvasPlacementRejectReason`) grew a
+  `requiresStandable` parameter for the same split: `false` for a
+  `'prop'` palette selection skips the footprint gate entirely (every
+  other gate — real floor, not already occupied — still applies), `true`
+  for `'monster'`/`'boss'` keeps the pre-existing hard reject. Both 2D
+  (`CreationBoard.tsx`) and 3D (`preview3d/DungeonPreview3D.tsx`)
+  click-to-place paths consult the same predicate, so they can never
+  disagree about where a prop is legal.
 - **Start/End** reuse `Board.tsx`'s own "⚠ ... (BLOCKED!)" visual language
   verbatim (the same convention edit mode's entrance-blocked check uses)
-  rather than inventing a new one.
+  rather than inventing a new one. Deliberately left OUTSIDE the
+  PLACEABLE/STANDABLE split above: start/end never routed through
+  `canvasPlacementRejectReason` in the first place (no placement-time
+  reject exists for either today — only this retroactive flag), and a
+  start point genuinely does need standable ground the same as a
+  monster, so there was nothing to relax here.
 - **Region cells** (`doc.regions`) inside a footprint get a small ⚠ glyph
   overlaid on the affected cell — the region's own `cells:` membership is
   never rewritten by a wall mutator, per the settled model's own "an inner
@@ -749,16 +768,138 @@ semantics/addressing a server-side implementation should match.
 
 ### `stripToV1Subset`
 
-`wallLines:` drops entirely, same treatment as `walls:` (no v1 analog at
-all), counted and reported SEPARATELY in the compile-badge/dropped summary
-("N straight walls", never folded into the edge-wall "N walls" count) —
-they're genuinely different constructs, and conflating their counts would
-misrepresent which tool an author actually used. A line's own `doors:`
-entries are nested data on a construct that already has no v1 analog at
-all — they drop along with their parent line, with no separate count of
-their own (counting "doors" as a sibling tally to "straight walls" would
-misrepresent them as an independent authoring action, when they only ever
-exist attached to a wallLine that's already being dropped).
+**The KEY never survives** — `dungeonspec` has no `wallLines:` field and
+never will (it's this concept's own client-side sugar), so it's deleted
+unconditionally on every strip, same "key presence alone gets rejected"
+treatment as `holes:`/`end:`.
+
+**The GEOMETRY is no longer unconditionally lost (rpg-project#169's
+"drawn walls become real" unit, 2026-08-07).** Before this unit, a
+wallLine's footprint/crossed-edge geometry was a pure client-side
+preview — real for the board's own hatch overlay and Walk-mode
+collision, invisible to the actual saved dungeon and to any real
+in-game encounter started from it. Now: whenever this server accepts
+edge-native `walls:` (live today — `capabilityProbe.ts`'s `walls`
+field), `stripToV1Subset` derives every wallLine's real cell-boundary
+edges (`creation/straightWallGeometry.ts`'s `projectWallLineToEdges` —
+the SAME `straightWallFootprint`/`straightWallCrossedEdges` primitives
+`preview3d/walkMovement.ts` already calls to enforce this exact geometry
+client-side, not a second derivation) and injects them as `walls:`
+entries. A wall drawn with the straight-wall tool now renders AND is
+enforced in the real game, the same as one drawn with the zigzag
+edge-wall tool — not just previewed.
+
+**This is a projection, not a conversion.** `wallLines:` itself is
+STILL deleted from the sent subset (the server would reject the key
+regardless of what else compiles) — only its geometric CONSEQUENCE
+survives, folded into `walls:`. The live document the author is editing
+is untouched: `stripToV1Subset` parses a fresh CST from the input text
+and never mutates the caller's own `cst`, so reloading/re-editing the
+full document still shows straight walls as straight walls, with their
+own footprint hatch, in the builder — exactly like every other
+target-dialect field this file's own two-bucket split already treats
+this way.
+
+**Derivation, precisely.** For each footprint cell (door cells already
+excluded, per `straightWallFootprint`'s own `doorCells` parameter): seal
+all 6 of its real neighbor edges — the edge-native wire format has no
+notion of "this cell is blocked," only "this edge is blocked," so
+faithfully representing "the whole cell is impassable" means walling
+off every real approach to it. Mechanism (b)'s between-two-clear-cells
+grazing crossings (`straightWallCrossedEdges`, unchanged from its
+existing client-side use) are added on top, always `kind: solid` — see
+"doors," directly below, for why mechanism (b) is deliberately NOT
+door-aware even when one of its two cells is a door cell.
+
+**Doors: `kind: door`, not a bare gap — the actual decision, and why.**
+A door cell's own edges toward its flanking footprint neighbors (the
+wall run continuing on either side of the opening) needed one of two
+treatments: omit the edge entirely (a silent gap — no `walls:` entry at
+all at that boundary) or emit it as `kind: door`. **Chosen: `kind:
+door`.** The real game's per-edge wall renderer
+(`syntyHexWallHelpers.ts`'s `isDoorWallKind`/`edgePieceKind`, consumed
+by `SyntyHexWall`/`wallRunAdapters.ts`) only ever draws geometry where a
+`Wall` entry exists — an omitted edge renders as nothing whatsoever,
+indistinguishable from a rendering bug or an author who simply forgot a
+segment. `kind: door` gives the opening a real, intentional door
+frame/leaf through the exact same rendering path every other door in
+this game already uses, so an authored doorway reads as a doorway,
+matching Kirk's own repeated diagnosis of the earlier whole-line
+`kind: door` prototype this section's "Doors" subsection documents
+above: "the gashes are walls... I cannot set a wall or a door." A gap
+would have reintroduced exactly that complaint one layer down — a real
+opening that LOOKS like nothing happened there at all.
+
+This does NOT make mechanism (b) door-aware: a door cell's own
+INDEPENDENT grazing crossing (toward a cell that isn't one of its
+flanking footprint neighbors) stays `solid` — the door only reverses
+its OWNING line's own footprint claim on that one cell ("Doors,"
+above: "this cell acts as though the wall line never clipped it at all,
+nothing more, and nothing less"), never mechanism (b)'s separate
+both-clear-cells test. Verified directly, not assumed
+(`straightWallGeometry.test.ts`'s `projectWallLineToEdges` describe
+block): a genuinely vertical wallLine with a door at its middle cell
+gets `kind: door` on both its flanking edges, while a grazing
+mechanism-(b) edge on that SAME cell (toward a cell one column over)
+stays `kind: solid`.
+
+**Rim edges — the honest gap.** A footprint cell at the canvas boundary
+can have a neighbor direction that falls entirely off the grid — no
+cell exists there to form an adjacent-cell-pair `walls:` entry with
+(the server's own wall validation requires two real, in-grid cells).
+These are counted (`rimEdgeCount`) and folded into the compile-badge
+message ("N straight walls (projects to M wall edges; K rim edges at
+the canvas boundary could not be expressed)") rather than silently
+absorbed into the edge count or dropped without a trace — the same
+"flag, never silently delete" discipline this file's "Interactions with
+everything else" subsection already applies to placements/start/end/
+regions, extended here to the projection's own geometric limits.
+
+**Merge with explicit `walls:` — explicit wins.** A document can carry
+both hand-painted edge walls (`walls:`, the zigzag tool) and straight
+wallLines at once. The projected edges are deduped against each other
+(a door beats a solid found for the same edge from a different
+direction/line) and then checked against every EXPLICIT `walls:` entry
+by the same order-independent cell-pair key: an explicit entry is never
+duplicated and never has its `kind` overwritten by a projected one, even
+when they disagree — an author who hand-painted a door somewhere the
+straight-wall footprint would have sealed solid keeps their door. Only
+cell pairs with no explicit entry get a newly appended projected node.
+
+**Reported honestly, per-server, like every other capability-gated
+field.** `walls:` NOT accepted (an older/rolled-back server): unchanged
+prior behavior — wallLines drop entirely, counted in `dropped` as before
+this unit, never touching `walls:` at all. `walls:` accepted: counted in
+`compiling`, never `dropped` — the compile badge no longer claims
+wallLines are stripped client-side sugar with no wire effect once this
+server can actually carry the geometry. Counted SEPARATELY from the
+edge-wall `walls:` tally either way ("N straight walls" is never folded
+into "M walls") — they remain genuinely different authoring constructs,
+and conflating their counts would misrepresent which tool an author
+actually used, same principle this section held before this unit. A
+line's own `doors:` entries stay uncounted as their own tally (they only
+ever exist attached to a wallLine, never an independent authoring
+action) — their EFFECT is now visible in the edge count and the `kind:
+door` entries themselves, just never a separate "N doors" line.
+
+**Known gap, honestly recorded, not solved by this unit**: the
+projection assumes the wallLine's footprint cells are real server floor
+— true by construction in canvas mode (`doc.canvas ?? DEFAULT_CANVAS`,
+this file's own established canvas-floor semantic: every cell in
+bounds, minus holes). A wallLine authored inside a ROOM-CHAIN document
+(rooms non-empty, no `canvas:`) has no such guarantee — its footprint
+cells might fall in a real room, in the reserved connector gap, or
+outside any declared room's bounds entirely, and the server's own
+endpoint-floor-membership check would reject a projected edge that
+references a genuinely non-floor cell. This unit does not pre-validate
+that case client-side; a document in that shape surfaces the real
+server's own `field_errors` on Save & Play, same as any other genuine
+validation failure this concept already relies on the live preview to
+catch — not a silent client-side guess at a rule the server itself
+would enforce more precisely. `wallLines:` was designed and has so far
+only been exercised against canvas-mode documents (this whole "Straight
+walls" section's own framing), so this is a real but narrow, honestly-
+scoped gap rather than an oversight.
 
 ## Top-level placement: rooms are semantic, not placement containers
 

--- a/src/author/capabilityProbe.ts
+++ b/src/author/capabilityProbe.ts
@@ -72,15 +72,29 @@
  * `buildProbeDoc` below picks the base per field's own legal mode for
  * exactly this reason — see its field/base/spec-section table.
  *
- * **`wallLines:` is deliberately NOT probed.** It's this concept's own
- * client-side sugar (`straightWallGeometry.ts` compiles a corner-anchored
- * line + door cells down to a footprint) — `stripToV1Subset` drops it
- * unconditionally, on its own line, separate from `walls:`, and never
- * projects it INTO a `walls:` entry before stripping (confirmed by
- * reading `stripToV1Subset` itself, not assumed). The real dungeonspec
- * server has never been sent this construct in any form, so there is
- * nothing to probe — it stays permanently client-only until a real
- * request-side authoring contract exists for it (rpg-project#179).
+ * **`wallLines:` is deliberately NOT probed, but is no longer always
+ * dropped.** The KEY itself never survives (dungeonspec has no
+ * `wallLines:` field and never will — it's this concept's own
+ * client-side sugar), so there is nothing about the key to probe. But as
+ * of the wallLines->edges projection unit (rpg-project#169), its
+ * GEOMETRY is no longer unconditionally lost: `stripToV1Subset` now
+ * checks `accepted('walls')` for wallLines too — when `walls:` itself is
+ * accepted, every wallLine's footprint + crossed-edge truth
+ * (`straightWallGeometry.ts`'s `projectWallLineToEdges`) is projected
+ * into real edge-native `walls:` entries and merged into whatever
+ * explicit `walls:` survives, counted in `compiling`, not `dropped`. Only
+ * when `walls:` itself is NOT accepted does wallLines fall back to the
+ * original unconditional drop (confirm by reading `stripToV1Subset`
+ * itself, not this comment, if the exact behavior matters — it's
+ * `accepted('walls')`-gated the same way as everything else in this
+ * file, no hardcoded exception). See TARGET-YAML.md's "Straight walls:
+ * stripToV1Subset" section for the full writeup. `walls:` is real,
+ * accepted-by-a-real-server capability probed above, same as every other
+ * field in `DIALECT_FIELDS` — wallLines rides on that probe rather than
+ * needing one of its own, because its own key is never sent regardless
+ * of the answer. It stays permanently client-only (the key, not the
+ * geometry) until a real request-side authoring contract exists for it
+ * (rpg-project#179).
  */
 import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -1521,7 +1521,18 @@ export function CreationBoard({
     // entrance-blocked check, adapted here since a generic placement
     // marker (unlike the START/END circle below) has no text label of
     // its own to prefix.
-    const blocked = inFootprint(at[0], at[1]);
+    //
+    // PLACEABLE vs. STANDABLE (rpg-project#169's "props on footprint
+    // cells" unit): a footprint cell is no longer an error condition for
+    // a PROP — it's the intended target (Kirk's exact ask, a bookcase
+    // against a drawn wall) — so a prop on one renders normally, no
+    // warning. A monster still can't stand there, so the warning stays
+    // for it. Matches `canvasPlacementRejectReason`'s own
+    // `requiresStandable` split at PLACEMENT time — this is the same
+    // rule applied retroactively, to a wall drawn AFTER the placement
+    // already existed.
+    const blocked =
+      inFootprint(at[0], at[1]) && ref.startsWith('dnd5e:monsters:');
     return (
       <g
         key={sel.boss ? 'boss' : `place-${sel.index}`}

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -660,12 +660,19 @@ export function CreationBoard({
       // (`DungeonPreview3D.tsx`), so the two views can never disagree
       // about where a click is legal — see that function's own doc
       // comment (`canvasFloor.ts`) for the exact three gates.
+      //
+      // PLACEABLE vs. STANDABLE (rpg-project#169's "props on footprint
+      // cells" unit): a prop only needs real floor, not standable floor —
+      // Kirk's exact ask, a bookcase resting against a drawn wall. Only
+      // `'prop'` relaxes the footprint gate; `'monster'` still requires
+      // standable ground (`'boss'` never reaches here, rejected above).
       const footprint = straightWallsFootprintSet(doc.wallLines, grid);
       const reject = canvasPlacementRejectReason(
         doc,
         cell[0],
         cell[1],
-        footprint
+        footprint,
+        edit.selectedPalette.kind !== 'prop'
       );
       if (reject) {
         onReject(reject);

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -99,8 +99,11 @@ import {
   isValidDoorCell,
   nearestWallAngleFamily,
   snapStraightEndpoint,
+  standableFootprintKeys,
   straightWallCrossedEdges,
   straightWallFootprint,
+  straightWallFootprintCoverage,
+  straightWallsFootprintCoverage,
   straightWallsFootprintSet,
   wallLineDoorCellAt,
   type WallAxisFamily,
@@ -289,6 +292,14 @@ function straightWallDeleteButtonHit(
 
 const CELL_SIZE = BOARD_HEX_SIZE - 1.5;
 
+/** Floor opacity for a footprint hatch cell at near-zero coverage — the
+ * 2D sibling of `DungeonPreview3D.tsx`'s own `FOOTPRINT_DIM_MIN_OPACITY`,
+ * same reasoning: even the faintest genuine clip stays visible, never
+ * fully invisible, while a heavily-clipped cell still reads at full
+ * strength (opacity scales linearly from here up to 1 as coverage
+ * approaches `hexCoverageFraction`'s own 0.5 maximum). */
+const FOOTPRINT_HATCH_MIN_OPACITY = 0.25;
+
 /**
  * Every visual element for ONE straight wall's own line — footprint
  * hatch, blocked-crossing dashes (movement semantics (a)/(b), see
@@ -330,9 +341,28 @@ function straightWallLineElements(
   const doorCells = doors.map((d) => d.cell);
   const footprintColor = provisional ? '#ffb347' : '#c94f4f';
   const lineColor = !provisional ? '#e8e2d8' : snapped ? '#fff3c4' : '#ffb347';
-  const footprint = straightWallFootprint(from, to, grid, doorCells);
+  // Coverage-based standability (rpg-project#169's live-design follow-up
+  // with Kirk, 2026-08-07): every genuinely-touched cell still renders
+  // (an author needs to see the wall's real footprint, standable or not),
+  // but a lightly-clipped, standable cell reads visibly lighter than a
+  // heavily-clipped, blocked one — the same light-vs-full de-emphasis
+  // `DungeonPreview3D.tsx`'s own `FootprintDimCell` now applies, one
+  // coordinate space over.
+  const footprintCoverage = straightWallFootprintCoverage(
+    from,
+    to,
+    grid,
+    doorCells
+  );
+  const footprint = [...footprintCoverage.keys()].map(
+    (key) => key.split(',').map(Number) as [number, number]
+  );
 
   for (const [col, row] of footprint) {
+    const coverage = footprintCoverage.get(`${col},${row}`) ?? 0.5;
+    const opacity =
+      FOOTPRINT_HATCH_MIN_OPACITY +
+      (1 - FOOTPRINT_HATCH_MIN_OPACITY) * Math.min(1, coverage / 0.5);
     const corners = creationCellPolygon(col, row, CELL_SIZE * 0.92)
       .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
       .join(' ');
@@ -344,6 +374,7 @@ function straightWallLineElements(
         stroke={footprintColor}
         strokeWidth={1.5}
         strokeDasharray={provisional ? '3 2' : undefined}
+        opacity={opacity}
         pointerEvents="none"
       />
     );
@@ -662,11 +693,18 @@ export function CreationBoard({
       // comment (`canvasFloor.ts`) for the exact three gates.
       //
       // PLACEABLE vs. STANDABLE (rpg-project#169's "props on footprint
-      // cells" unit): a prop only needs real floor, not standable floor —
-      // Kirk's exact ask, a bookcase resting against a drawn wall. Only
-      // `'prop'` relaxes the footprint gate; `'monster'` still requires
-      // standable ground (`'boss'` never reaches here, rejected above).
-      const footprint = straightWallsFootprintSet(doc.wallLines, grid);
+      // cells" unit, refined by the coverage-based-standability live
+      // design round with Kirk, 2026-08-07): a prop only needs real
+      // floor, not standable floor — Kirk's exact ask, a bookcase resting
+      // against a drawn wall — so `'prop'` skips the footprint gate
+      // entirely, coverage or not. `'monster'` still requires standable
+      // ground, now COVERAGE-based rather than the original "any touch at
+      // all blocks" rule: a lightly-clipped cell below
+      // `STANDABLE_COVERAGE_THRESHOLD` is real floor again for a monster
+      // too (`'boss'` never reaches here, rejected above).
+      const footprint = standableFootprintKeys(
+        straightWallsFootprintCoverage(doc.wallLines, grid)
+      );
       const reject = canvasPlacementRejectReason(
         doc,
         cell[0],
@@ -1285,6 +1323,34 @@ export function CreationBoard({
   const inFootprint = (col: number, row: number) =>
     footprintKeys.has(`${col},${row}`);
 
+  // Coverage-based standability (rpg-project#169's live-design follow-up
+  // with Kirk, 2026-08-07) — a SEPARATE, narrower check from `inFootprint`
+  // above: `inFootprint` stays the raw "any touch at all" set (the
+  // flagging warnings below — placements/start/end/regions — stay
+  // maximally sensitive, informational, never silently dropped). This one
+  // answers "is this specific cell blocked for STANDING" and is used only
+  // by `renderPlacement`'s own monster-only warning ring, below — a
+  // lightly-clipped cell is no longer a real block for anything that
+  // doesn't need standable ground.
+  const committedFootprintCoverage = straightWallsFootprintCoverage(
+    doc.wallLines.map((line, index) => {
+      const dragging =
+        draggingEndpoint && draggingEndpoint.lineIndex === index
+          ? draggingEndpoint
+          : null;
+      if (!dragging) return line;
+      return {
+        from: dragging.which === 'from' ? dragging.current : line.from,
+        to: dragging.which === 'to' ? dragging.current : line.to,
+        doors: line.doors,
+      };
+    }),
+    grid
+  );
+  const standableFootprint = standableFootprintKeys(committedFootprintCoverage);
+  const inStandableFootprint = (col: number, row: number) =>
+    standableFootprint.has(`${col},${row}`);
+
   // Same dark/dashed treatment Board.tsx (edit mode) uses for a target-
   // dialect hole — one visual language for "no floor here" across both
   // boards. Hex polygon now, not an axis-aligned rect.
@@ -1523,16 +1589,20 @@ export function CreationBoard({
     // its own to prefix.
     //
     // PLACEABLE vs. STANDABLE (rpg-project#169's "props on footprint
-    // cells" unit): a footprint cell is no longer an error condition for
-    // a PROP — it's the intended target (Kirk's exact ask, a bookcase
-    // against a drawn wall) — so a prop on one renders normally, no
-    // warning. A monster still can't stand there, so the warning stays
-    // for it. Matches `canvasPlacementRejectReason`'s own
-    // `requiresStandable` split at PLACEMENT time — this is the same
-    // rule applied retroactively, to a wall drawn AFTER the placement
-    // already existed.
+    // cells" unit, refined by the coverage-based-standability live design
+    // round with Kirk, 2026-08-07): a footprint cell is no longer an
+    // error condition for a PROP — it's the intended target (Kirk's exact
+    // ask, a bookcase against a drawn wall) — so a prop on one renders
+    // normally, no warning. A monster still can't stand on a cell whose
+    // coverage meets `STANDABLE_COVERAGE_THRESHOLD` — `inStandableFootprint`
+    // (not the raw `inFootprint`, which flags ANY touch at all) — so the
+    // warning is scoped to genuinely-blocked cells now, not every cell the
+    // wall merely grazes. Matches `canvasPlacementRejectReason`'s own
+    // `requiresStandable` split at PLACEMENT time — this is the same rule
+    // applied retroactively, to a wall drawn AFTER the placement already
+    // existed.
     const blocked =
-      inFootprint(at[0], at[1]) && ref.startsWith('dnd5e:monsters:');
+      inStandableFootprint(at[0], at[1]) && ref.startsWith('dnd5e:monsters:');
     return (
       <g
         key={sel.boss ? 'boss' : `place-${sel.index}`}

--- a/src/author/creation/canvasFloor.test.ts
+++ b/src/author/creation/canvasFloor.test.ts
@@ -18,7 +18,12 @@ import {
   sortCellsLexicographic,
 } from './canvasFloor';
 import { emptyCanvasYaml } from './emptyCanvasDoc';
-import { straightWallsFootprintSet } from './straightWallGeometry';
+import {
+  STANDABLE_COVERAGE_THRESHOLD,
+  standableFootprintKeys,
+  straightWallsFootprintCoverage,
+  straightWallsFootprintSet,
+} from './straightWallGeometry';
 
 describe('deriveCanvasFloorCells', () => {
   it('produces every cell in a small canvas bounds, none missing or duplicated', () => {
@@ -324,6 +329,58 @@ describe('canvasPlacementRejectReason', () => {
       expect(
         canvasPlacementRejectReason(doc, 5, 4, footprint, false)
       ).toBeNull();
+    });
+  });
+
+  // Coverage-based standability (rpg-project#169's live-design follow-up
+  // with Kirk, 2026-08-07) — the full real pipeline, not a hand-typed
+  // Set: a genuinely low-coverage footprint cell is legal even for a
+  // MONSTER (`requiresStandable: true`), and a genuinely high-coverage
+  // one stays blocked, driven entirely by `straightWallsFootprintCoverage`
+  // + `standableFootprintKeys` against a real authored wallLine.
+  describe('coverage-based standability — the real pipeline (requiresStandable: true)', () => {
+    it('a low-coverage footprint cell is standable for a monster too — not just placeable for a prop', () => {
+      const { cst } = parseDungeon(emptyCanvasYaml(50, 30));
+      // The exact bench fixture from straightWallGeometry.test.ts's own
+      // "hexCoverageFraction — measurement bench": cell (39,19) has
+      // coverage ~1.67%, well under STANDABLE_COVERAGE_THRESHOLD (10%).
+      addWallLine(
+        cst,
+        { cell: [37, 20], corner: 0 },
+        { cell: [44, 18], corner: 0 }
+      );
+      const doc = toDungeonDoc(cst);
+      const coverage = straightWallsFootprintCoverage(
+        doc.wallLines,
+        doc.canvas!
+      );
+      expect(coverage.get('39,19')).toBeLessThan(STANDABLE_COVERAGE_THRESHOLD);
+      const standable = standableFootprintKeys(coverage);
+      expect(
+        canvasPlacementRejectReason(doc, 39, 19, standable, true)
+      ).toBeNull();
+    });
+
+    it('a high-coverage footprint cell on the SAME line stays blocked for a monster', () => {
+      const { cst } = parseDungeon(emptyCanvasYaml(50, 30));
+      addWallLine(
+        cst,
+        { cell: [37, 20], corner: 0 },
+        { cell: [44, 18], corner: 0 }
+      );
+      const doc = toDungeonDoc(cst);
+      const coverage = straightWallsFootprintCoverage(
+        doc.wallLines,
+        doc.canvas!
+      );
+      // (42,19) is ~44.87% in the same bench — well above the threshold.
+      expect(coverage.get('42,19')).toBeGreaterThan(
+        STANDABLE_COVERAGE_THRESHOLD
+      );
+      const standable = standableFootprintKeys(coverage);
+      expect(
+        canvasPlacementRejectReason(doc, 42, 19, standable, true)
+      ).not.toBeNull();
     });
   });
 });

--- a/src/author/creation/canvasFloor.test.ts
+++ b/src/author/creation/canvasFloor.test.ts
@@ -199,46 +199,58 @@ describe('canvasPlacementRejectReason', () => {
 
   it('an ordinary empty floor cell is legal — null, no reason', () => {
     const doc = emptyDoc();
-    expect(canvasPlacementRejectReason(doc, 5, 5, new Set())).toBeNull();
+    expect(canvasPlacementRejectReason(doc, 5, 5, new Set(), true)).toBeNull();
   });
 
   it('rejects a cell outside the canvas bounds, same as a hole would', () => {
     const doc = emptyDoc();
-    expect(canvasPlacementRejectReason(doc, -1, 5, new Set())).not.toBeNull();
-    expect(canvasPlacementRejectReason(doc, 20, 5, new Set())).not.toBeNull();
-    expect(canvasPlacementRejectReason(doc, 5, 30, new Set())).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, -1, 5, new Set(), true)
+    ).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, 20, 5, new Set(), true)
+    ).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, 5, 30, new Set(), true)
+    ).not.toBeNull();
   });
 
   it('rejects a hole cell', () => {
     const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
     toggleHole(cst, 5, 5);
     const doc = toDungeonDoc(cst);
-    expect(canvasPlacementRejectReason(doc, 5, 5, new Set())).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, 5, 5, new Set(), true)
+    ).not.toBeNull();
     // A neighboring, non-hole cell stays legal — the reject is cell-
     // specific, not a whole-canvas panic.
-    expect(canvasPlacementRejectReason(doc, 6, 5, new Set())).toBeNull();
+    expect(canvasPlacementRejectReason(doc, 6, 5, new Set(), true)).toBeNull();
   });
 
-  it('rejects a cell inside a straight wall’s footprint, and only that cell', () => {
+  it('rejects a cell inside a straight wall’s footprint, and only that cell, when requiresStandable', () => {
     const doc = emptyDoc();
     // Same known single-cell footprint fixture straightWallGeometry.test.ts
     // itself uses ("a wall ENDING at a corner shared with a cell does not
     // clip that cell"): this line's footprint is exactly [[5, 4]].
     const footprint = new Set(['5,4']);
-    expect(canvasPlacementRejectReason(doc, 5, 4, footprint)).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, 5, 4, footprint, true)
+    ).not.toBeNull();
     // A neighboring cell the footprint doesn't cover stays legal — the
     // rule is footprint MEMBERSHIP, not proximity to a drawn wall.
-    expect(canvasPlacementRejectReason(doc, 5, 5, footprint)).toBeNull();
-    expect(canvasPlacementRejectReason(doc, 6, 5, footprint)).toBeNull();
+    expect(canvasPlacementRejectReason(doc, 5, 5, footprint, true)).toBeNull();
+    expect(canvasPlacementRejectReason(doc, 6, 5, footprint, true)).toBeNull();
   });
 
   it('rejects an already-occupied cell (top-level doc.place)', () => {
     const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
     placeItem(cst, null, 'dnd5e:props:pillar', [3, 3]);
     const doc = toDungeonDoc(cst);
-    expect(canvasPlacementRejectReason(doc, 3, 3, new Set())).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, 3, 3, new Set(), true)
+    ).not.toBeNull();
     // The occupied placement's own cell is the only one affected.
-    expect(canvasPlacementRejectReason(doc, 4, 3, new Set())).toBeNull();
+    expect(canvasPlacementRejectReason(doc, 4, 3, new Set(), true)).toBeNull();
   });
 
   it('checks gates in order: an out-of-bounds cell is rejected for that reason even if it would also be "occupied" by coincidence', () => {
@@ -246,7 +258,7 @@ describe('canvasPlacementRejectReason', () => {
     // No real placement can exist out of bounds, but this proves the
     // bounds/hole gate runs FIRST regardless — a caller never needs a
     // real occupied placement out of bounds to trust this ordering.
-    const reason = canvasPlacementRejectReason(doc, -5, -5, new Set());
+    const reason = canvasPlacementRejectReason(doc, -5, -5, new Set(), true);
     expect(reason).toMatch(/floor/i);
   });
 
@@ -255,6 +267,63 @@ describe('canvasPlacementRejectReason', () => {
     addWallLine(cst, { cell: [5, 4], corner: 2 }, { cell: [5, 4], corner: 5 });
     const doc = toDungeonDoc(cst);
     const footprint = straightWallsFootprintSet(doc.wallLines, doc.canvas!);
-    expect(canvasPlacementRejectReason(doc, 5, 4, footprint)).not.toBeNull();
+    expect(
+      canvasPlacementRejectReason(doc, 5, 4, footprint, true)
+    ).not.toBeNull();
+  });
+
+  // rpg-project#169's "props on footprint cells" unit — Kirk's exact ask:
+  // a bookcase resting against a drawn wall. `requiresStandable: false`
+  // relaxes ONLY the footprint gate; every other gate (floor bounds,
+  // holes, already-occupied) still applies to a prop exactly as it does
+  // to a monster.
+  describe('requiresStandable: false (props)', () => {
+    it('a footprint cell is a LEGAL prop target — the standable gate is skipped', () => {
+      const doc = emptyDoc();
+      const footprint = new Set(['5,4']);
+      expect(
+        canvasPlacementRejectReason(doc, 5, 4, footprint, false)
+      ).toBeNull();
+    });
+
+    it('the SAME footprint cell is still rejected for a placement that requires standable ground', () => {
+      const doc = emptyDoc();
+      const footprint = new Set(['5,4']);
+      expect(
+        canvasPlacementRejectReason(doc, 5, 4, footprint, true)
+      ).not.toBeNull();
+    });
+
+    it('a hole is still rejected for a prop — the floor gate is unconditional', () => {
+      const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+      toggleHole(cst, 5, 5);
+      const doc = toDungeonDoc(cst);
+      expect(
+        canvasPlacementRejectReason(doc, 5, 5, new Set(), false)
+      ).not.toBeNull();
+    });
+
+    it('an already-occupied cell is still rejected for a prop — the occupied gate is unconditional', () => {
+      const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+      placeItem(cst, null, 'dnd5e:props:pillar', [3, 3]);
+      const doc = toDungeonDoc(cst);
+      expect(
+        canvasPlacementRejectReason(doc, 3, 3, new Set(), false)
+      ).not.toBeNull();
+    });
+
+    it('addWallLine + straightWallsFootprintSet integration: a real authored wall line permits a prop on its own footprint cell', () => {
+      const { cst } = parseDungeon(emptyCanvasYaml(20, 30));
+      addWallLine(
+        cst,
+        { cell: [5, 4], corner: 2 },
+        { cell: [5, 4], corner: 5 }
+      );
+      const doc = toDungeonDoc(cst);
+      const footprint = straightWallsFootprintSet(doc.wallLines, doc.canvas!);
+      expect(
+        canvasPlacementRejectReason(doc, 5, 4, footprint, false)
+      ).toBeNull();
+    });
   });
 });

--- a/src/author/creation/canvasFloor.ts
+++ b/src/author/creation/canvasFloor.ts
@@ -164,26 +164,52 @@ export function resolveCanvasFloor(
  *    set cheaply from `deriveCanvasFloorCells` itself — this per-cell
  *    check exists for the 2D brush's single-click case, where building
  *    the whole floor set just to check one cell would be wasted work).
- * 2. **Not a straight-wall (`doc.wallLines`) footprint cell** — Kirk's
- *    rule ("any hex that is not 100% uncovered would not be traversable")
- *    makes a footprint cell BLOCKED, not floorless: the floor tile still
- *    renders (`deriveCanvasFloorCells` doesn't exclude it), but it isn't a
- *    legal placement target. `wallLineFootprint` is a caller-supplied set
+ *    Applies regardless of `requiresStandable` — a footprint cell still
+ *    has a floor tile (see gate 2's own note), but a hole or an
+ *    off-canvas cell has none at all, for ANY kind of placement.
+ * 2. **Not a straight-wall (`doc.wallLines`) footprint cell — PLACEABLE
+ *    vs. STANDABLE split** (`requiresStandable`, rpg-project#169's "props
+ *    on footprint cells" unit — Kirk's exact ask: a bookcase standing
+ *    against a drawn wall). Kirk's rule ("any hex that is not 100%
+ *    uncovered would not be traversable") makes a footprint cell BLOCKED
+ *    for STANDING — a creature can't occupy it — but the floor tile is
+ *    still there (`deriveCanvasFloorCells` doesn't exclude it), and
+ *    nothing about that rule says a prop can't rest against/on the wall
+ *    that covers it. `requiresStandable` names which of the two a given
+ *    placement needs: `true` for anything that must be able to stand
+ *    there (monsters, boss — a creature genuinely occupying the cell),
+ *    `false` for a prop (decor, furniture — placeable on any real floor
+ *    cell, footprint included). This gate is SKIPPED entirely when
+ *    `requiresStandable` is `false`; every other gate still applies
+ *    (a prop still needs real floor and an unoccupied cell). Start/end
+ *    markers are deliberately NOT routed through this function at all —
+ *    they keep their own pre-existing, different treatment (a retroactive
+ *    "⚠ START (BLOCKED!)" flag on an already-placed marker, never a
+ *    placement-time reject — see `CreationBoard.tsx`'s own "flag, never
+ *    silently delete or move" rendering and TARGET-YAML.md's
+ *    "Interactions with everything else" section), so this parameter
+ *    only ever needs to distinguish prop from creature, not a third case.
+ *    `wallLineFootprint` is a caller-supplied set
  *    (`creation/straightWallGeometry.ts`'s `straightWallsFootprintSet`)
  *    rather than recomputed here, so a caller checking many cells (the 3D
- *    click layer, once wired) computes it once, not once per cell.
+ *    click layer) computes it once, not once per cell.
  * 3. **Not already occupied** — `boardGeometry.ts`'s `isCellOccupied`,
  *    called with no `floorPlan` (a from-scratch canvas has none — see
  *    `isCellOccupied`'s own doc comment for why that's safe: its
  *    room-scoped loop is a no-op for `doc.rooms === []` regardless, and
  *    the top-level `doc.place` loop this actually needs never depended on
- *    `floorPlan` in the first place).
+ *    `floorPlan` in the first place). Applies regardless of
+ *    `requiresStandable` — a footprint cell holding a bookcase is a
+ *    legal target for a SECOND prop only in the same sense any other
+ *    occupied cell is (it isn't; stack elsewhere), no different rule for
+ *    footprint cells specifically.
  */
 export function canvasPlacementRejectReason(
   doc: DungeonDoc,
   col: number,
   row: number,
-  wallLineFootprint: ReadonlySet<string>
+  wallLineFootprint: ReadonlySet<string>,
+  requiresStandable: boolean
 ): string | null {
   const grid = doc.canvas ?? DEFAULT_CANVAS;
   const inBounds =
@@ -192,7 +218,7 @@ export function canvasPlacementRejectReason(
   if (!inBounds || isHole) {
     return 'No floor there — off the canvas, or a hole.';
   }
-  if (wallLineFootprint.has(`${col},${row}`)) {
+  if (requiresStandable && wallLineFootprint.has(`${col},${row}`)) {
     return "That cell is blocked by a straight wall's footprint — pick an uncovered cell.";
   }
   if (isCellOccupied(undefined, doc, col, row)) {

--- a/src/author/creation/canvasFloor.ts
+++ b/src/author/creation/canvasFloor.ts
@@ -170,29 +170,39 @@ export function resolveCanvasFloor(
  * 2. **Not a straight-wall (`doc.wallLines`) footprint cell — PLACEABLE
  *    vs. STANDABLE split** (`requiresStandable`, rpg-project#169's "props
  *    on footprint cells" unit — Kirk's exact ask: a bookcase standing
- *    against a drawn wall). Kirk's rule ("any hex that is not 100%
- *    uncovered would not be traversable") makes a footprint cell BLOCKED
- *    for STANDING — a creature can't occupy it — but the floor tile is
- *    still there (`deriveCanvasFloorCells` doesn't exclude it), and
- *    nothing about that rule says a prop can't rest against/on the wall
- *    that covers it. `requiresStandable` names which of the two a given
- *    placement needs: `true` for anything that must be able to stand
- *    there (monsters, boss — a creature genuinely occupying the cell),
- *    `false` for a prop (decor, furniture — placeable on any real floor
- *    cell, footprint included). This gate is SKIPPED entirely when
- *    `requiresStandable` is `false`; every other gate still applies
- *    (a prop still needs real floor and an unoccupied cell). Start/end
- *    markers are deliberately NOT routed through this function at all —
- *    they keep their own pre-existing, different treatment (a retroactive
- *    "⚠ START (BLOCKED!)" flag on an already-placed marker, never a
- *    placement-time reject — see `CreationBoard.tsx`'s own "flag, never
- *    silently delete or move" rendering and TARGET-YAML.md's
- *    "Interactions with everything else" section), so this parameter
- *    only ever needs to distinguish prop from creature, not a third case.
- *    `wallLineFootprint` is a caller-supplied set
- *    (`creation/straightWallGeometry.ts`'s `straightWallsFootprintSet`)
- *    rather than recomputed here, so a caller checking many cells (the 3D
- *    click layer) computes it once, not once per cell.
+ *    against a drawn wall — refined by the coverage-based-standability
+ *    live design round, same day: "if you can say we won't clip we can
+ *    go on those squares... the small triangles on the edge we could
+ *    prob allow those to be placed on"). The ORIGINAL binary rule ("any
+ *    hex that is not 100% uncovered would not be traversable") is
+ *    retired for STANDING purposes: `wallLineFootprint` here is expected
+ *    to be the COVERAGE-FILTERED subset
+ *    (`creation/straightWallGeometry.ts`'s `standableFootprintKeys`,
+ *    cells at/above `STANDABLE_COVERAGE_THRESHOLD`), not every cell the
+ *    wall merely touches — a lightly-clipped cell is real, standable
+ *    floor again. The floor tile itself is always there regardless
+ *    (`deriveCanvasFloorCells` never excludes a footprint cell, clipped
+ *    lightly or fully), and nothing about the rule ever said a prop
+ *    can't rest against/on the wall that covers it. `requiresStandable`
+ *    names which of the two a given placement needs: `true` for anything
+ *    that must be able to stand there (monsters, boss — a creature
+ *    genuinely occupying the cell), `false` for a prop (decor, furniture
+ *    — placeable on any real floor cell, footprint included, at ANY
+ *    coverage). This gate is SKIPPED entirely when `requiresStandable` is
+ *    `false`; every other gate still applies (a prop still needs real
+ *    floor and an unoccupied cell). Start/end markers are deliberately
+ *    NOT routed through this function at all — they keep their own
+ *    pre-existing, different treatment (a retroactive "⚠ START
+ *    (BLOCKED!)" flag on an already-placed marker, never a placement-time
+ *    reject — see `CreationBoard.tsx`'s own "flag, never silently delete
+ *    or move" rendering and TARGET-YAML.md's "Interactions with
+ *    everything else" section), so this parameter only ever needs to
+ *    distinguish prop from creature, not a third case. `wallLineFootprint`
+ *    is a caller-supplied set rather than recomputed here, so a caller
+ *    checking many cells (the 3D click layer) computes it once, not once
+ *    per cell — which specific set (raw vs. coverage-filtered) is the
+ *    caller's own choice; every current caller passes the
+ *    coverage-filtered one.
  * 3. **Not already occupied** — `boardGeometry.ts`'s `isCellOccupied`,
  *    called with no `floorPlan` (a from-scratch canvas has none — see
  *    `isCellOccupied`'s own doc comment for why that's safe: its

--- a/src/author/creation/creationGeometry.ts
+++ b/src/author/creation/creationGeometry.ts
@@ -22,7 +22,6 @@
  * comment) rather than an 'h'/'v' orientation tag, which had no hex
  * analog once a cell stopped having exactly two edge orientations.
  */
-import { neighborCell } from '../boardGeometry';
 import {
   BOARD_HEX_SIZE,
   cellCenter,
@@ -35,6 +34,12 @@ import {
 } from '../hexLayout';
 import type { Cell } from '../regionGeometry';
 import { type CreationGrid } from './creationTypes';
+// `neighborCell` from `./hexCorner`, not `../boardGeometry` — see that
+// module's own doc comment on its exported copy for why (avoids a
+// dungeonYaml.ts -> straightWallGeometry.ts -> creationGeometry.ts ->
+// boardGeometry.ts -> dungeonYaml.ts import cycle, the same class of
+// crash `hexCorner.ts` was already built leaf-level to avoid).
+import { neighborCell } from './hexCorner';
 
 export function creationCellCenter(col: number, row: number): CellPos {
   return cellCenter(col, row);

--- a/src/author/creation/hexCorner.ts
+++ b/src/author/creation/hexCorner.ts
@@ -62,8 +62,21 @@ import {
 import type { CreationGrid } from './creationTypes';
 
 /** Duplicated from `boardGeometry.ts`'s own `neighborCell` — see this
- * module's header comment for why it can't just import that one. */
-function neighborCell(
+ * module's header comment for why it can't just import that one.
+ * Exported (wallLines->edges projection unit, rpg-project#169) so
+ * `straightWallGeometry.ts`/`creationGeometry.ts` can use THIS copy
+ * instead of `boardGeometry.ts`'s — those two files sit BELOW
+ * `dungeonYaml.ts` too (both leaf-computable pure geometry, no doc-shape
+ * awareness), so importing `boardGeometry.ts` from either one for a
+ * single function was already the same class of mistake this module's
+ * own header comment names: `dungeonYaml.ts -> straightWallGeometry.ts ->
+ * boardGeometry.ts -> dungeonYaml.ts` is a real, crashing cycle,
+ * necessary the moment `dungeonYaml.ts`'s own `stripToV1Subset` needs to
+ * call `straightWallFootprint`/`straightWallCrossedEdges` directly to
+ * project `wallLines:` into wire `walls:` edges. Redirecting both
+ * consumers to this already-duplicated, already-leaf copy severs that
+ * path at its root instead of adding a THIRD duplicate. */
+export function neighborCell(
   col: number,
   row: number,
   facing: number

--- a/src/author/creation/straightWallGeometry.test.ts
+++ b/src/author/creation/straightWallGeometry.test.ts
@@ -1,17 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import { BOARD_HEX_SIZE, cellCenter } from '../hexLayout';
-import { cornerPoint, nearestCorner, type CornerRef } from './hexCorner';
+import {
+  canonicalCorner,
+  cornerPoint,
+  nearestCorner,
+  type CornerRef,
+} from './hexCorner';
 import {
   clipSegmentToShrunkHex,
   footprintCellAtParam,
+  hexCoverageFraction,
   isCellClipped,
   isValidDoorCell,
   nearestWallAngleFamily,
   projectPointToLineParam,
   projectWallLineToEdges,
   snapStraightEndpoint,
+  STANDABLE_COVERAGE_THRESHOLD,
+  standableFootprintKeys,
   straightWallCrossedEdges,
   straightWallFootprint,
+  straightWallFootprintCoverage,
+  straightWallsFootprintCoverage,
   straightWallsFootprintSet,
   WALL_ANGLE_SNAP_TOLERANCE_DEG,
   wallLineDoorCellAt,
@@ -450,5 +460,162 @@ describe('projectWallLineToEdges', () => {
       (e) => `${e.from.join(',')}|${e.to.join(',')}`
     );
     expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('rule 5 regression guard: the wire projection is UNCHANGED by coverage — a low-coverage cell still gets sealed', () => {
+    // Kirk's live-design follow-up, rule 5, verbatim: "traversability
+    // relaxation does NOT change Half A's emitted walls — projected
+    // walls: edges = the line's crossings, independent of cell
+    // coverage." (17,20) below has coverage ~1.67% (see the
+    // "hexCoverageFraction" describe block's own bench) — genuinely
+    // standable under STANDABLE_COVERAGE_THRESHOLD — but the WIRE
+    // projection must still seal it exactly as it would any other
+    // footprint cell, since the server has no notion of coverage at all.
+    const from: CornerRef = canonicalCorner({ cell: [17, 20], corner: 0 });
+    const to: CornerRef = canonicalCorner({ cell: [24, 18], corner: 0 });
+    const LOW_COVERAGE_CELL: [number, number] = [19, 19];
+    expect(hexCoverageFraction(from, to, ...LOW_COVERAGE_CELL)).toBeLessThan(
+      STANDABLE_COVERAGE_THRESHOLD
+    );
+    const result = projectWallLineToEdges({ from, to, doors: [] }, GRID);
+    const sealedEdges = result.edges.filter(
+      (e) =>
+        (e.from[0] === LOW_COVERAGE_CELL[0] &&
+          e.from[1] === LOW_COVERAGE_CELL[1]) ||
+        (e.to[0] === LOW_COVERAGE_CELL[0] && e.to[1] === LOW_COVERAGE_CELL[1])
+    );
+    // Mechanism (a) seals every real neighbor direction of a footprint
+    // cell regardless of how little of it the line actually clips.
+    expect(sealedEdges.length).toBeGreaterThan(0);
+    for (const e of sealedEdges) expect(e.kind).toBe('solid');
+  });
+});
+
+// Coverage-based standability (Kirk's live-design follow-up to "drawn
+// walls become real," 2026-08-07) — every fixture value here is
+// independently verified by this describe block itself (not eyeballed),
+// and doubles as the exact bench `STANDABLE_COVERAGE_THRESHOLD`'s own
+// doc comment describes for a future real Walk-mode visual pass.
+describe('hexCoverageFraction — measurement bench', () => {
+  it('a corner-to-corner diagonal two apart (skipping one vertex) always cuts off exactly 1/6 of the hex, by regular-hexagon symmetry', () => {
+    // Real, load-bearing reference point: the smallest "clean" symmetric
+    // corner cut reachable via a same-cell corner-to-corner chord —
+    // STANDABLE_COVERAGE_THRESHOLD is deliberately set below this value,
+    // keeping it blocked.
+    const from: CornerRef = { cell: [8, 8], corner: 0 };
+    const to: CornerRef = { cell: [8, 8], corner: 2 };
+    const cov = hexCoverageFraction(from, to, 8, 8);
+    expect(cov).toBeCloseTo(1 / 6, 5);
+  });
+
+  it('a corner-to-opposite-corner diameter splits the hex exactly in half', () => {
+    const from: CornerRef = { cell: [8, 8], corner: 0 };
+    const to: CornerRef = { cell: [8, 8], corner: 3 };
+    const cov = hexCoverageFraction(from, to, 8, 8);
+    expect(cov).toBeCloseTo(0.5, 5);
+  });
+
+  it('the two sub-polygons a line splits a hex into always sum to the hex’s own full area', () => {
+    // Verified structurally, not just for one fixture: for ANY line that
+    // genuinely clips the cell, the smaller + larger fractions this
+    // function's own `min(sideArea, otherSideArea)` computation implies
+    // must together account for the whole hex — a convex polygon split
+    // by one line partitions exactly, modulo the zero-area shared
+    // boundary (this test's own justification for why `otherSideArea =
+    // totalArea - sideArea` is used instead of a second clip call).
+    const from: CornerRef = canonicalCorner({ cell: [17, 20], corner: 0 });
+    const to: CornerRef = canonicalCorner({ cell: [24, 18], corner: 0 });
+    const footprint = straightWallFootprint(from, to, GRID);
+    expect(footprint.length).toBeGreaterThan(0);
+    for (const [col, row] of footprint) {
+      const cov = hexCoverageFraction(from, to, col, row);
+      expect(cov).toBeGreaterThan(0);
+      expect(cov).toBeLessThanOrEqual(0.5); // always the SMALLER side
+    }
+  });
+
+  it('a real bench line produces a wide, independently-verified spread of coverage values, low to high', () => {
+    // The exact two-line bench STANDABLE_COVERAGE_THRESHOLD's own doc
+    // comment names as reproducible for a future Walk-mode visual pass —
+    // this test is that reproducibility, executable rather than just
+    // described. A wider grid than this file's own default `GRID` —
+    // line B's own cells reach column 44, which `GRID`'s width: 20 would
+    // clamp and silently change the footprint.
+    const BENCH_GRID = { width: 50, height: 30 };
+    const lineA = {
+      from: canonicalCorner({ cell: [16, 21], corner: 0 }),
+      to: canonicalCorner({ cell: [22, 20], corner: 0 }),
+    };
+    const lineB = {
+      from: canonicalCorner({ cell: [37, 20], corner: 0 }),
+      to: canonicalCorner({ cell: [44, 18], corner: 0 }),
+    };
+    const covA = straightWallFootprint(lineA.from, lineA.to, BENCH_GRID).map(
+      ([c, r]) => hexCoverageFraction(lineA.from, lineA.to, c, r)
+    );
+    const covB = straightWallFootprint(lineB.from, lineB.to, BENCH_GRID).map(
+      ([c, r]) => hexCoverageFraction(lineB.from, lineB.to, c, r)
+    );
+    const all = [...covA, ...covB].sort((a, b) => a - b);
+    // A real spread from well under the threshold to well above it —
+    // the bench actually exercises the standable/blocked boundary, not
+    // just one tier. Smallest value is line B's own ~1.67% cell.
+    expect(all[0]).toBeLessThan(0.02);
+    expect(all[all.length - 1]).toBeGreaterThan(0.4);
+    expect(all.some((c) => c < STANDABLE_COVERAGE_THRESHOLD)).toBe(true);
+    expect(all.some((c) => c >= STANDABLE_COVERAGE_THRESHOLD)).toBe(true);
+  });
+});
+
+describe('straightWallFootprintCoverage / straightWallsFootprintCoverage / standableFootprintKeys', () => {
+  it('straightWallFootprintCoverage returns exactly the footprint cell set, each with its own coverage', () => {
+    const from: CornerRef = { cell: [5, 4], corner: 2 };
+    const to: CornerRef = { cell: [5, 4], corner: 5 };
+    const coverage = straightWallFootprintCoverage(from, to, GRID);
+    expect([...coverage.keys()]).toEqual(['5,4']);
+    expect(coverage.get('5,4')).toBeGreaterThan(0);
+  });
+
+  it('a door cell is excluded from the coverage map exactly like the footprint (door exclusion happens before coverage is ever computed for it)', () => {
+    const from: CornerRef = { cell: [2, 5], corner: 0 };
+    const to: CornerRef = { cell: [10, 5], corner: 3 };
+    const DOOR_CELL: [number, number] = [6, 5];
+    const coverage = straightWallFootprintCoverage(from, to, GRID, [DOOR_CELL]);
+    expect(coverage.has('6,5')).toBe(false);
+    expect(coverage.has('4,5')).toBe(true);
+  });
+
+  it('straightWallsFootprintCoverage takes the MAX coverage when two lines both touch the same cell', () => {
+    // Two lines authored to both clip (8,8) at different depths — the
+    // shallower corner-cut (1/6) and the deep diameter (1/2). The
+    // documented simplification: max wins, not a true union of areas.
+    const shallow = {
+      from: { cell: [8, 8], corner: 0 } as CornerRef,
+      to: { cell: [8, 8], corner: 2 } as CornerRef,
+    };
+    const deep = {
+      from: { cell: [8, 8], corner: 0 } as CornerRef,
+      to: { cell: [8, 8], corner: 3 } as CornerRef,
+    };
+    const coverage = straightWallsFootprintCoverage([shallow, deep], GRID);
+    expect(coverage.get('8,8')).toBeCloseTo(0.5, 5);
+  });
+
+  it('standableFootprintKeys filters to cells at/above the threshold, default and explicit', () => {
+    const coverage = new Map<string, number>([
+      ['1,1', 0.02],
+      ['2,2', 0.09],
+      ['3,3', 0.1],
+      ['4,4', 0.5],
+    ]);
+    expect([...standableFootprintKeys(coverage)].sort()).toEqual([
+      '3,3',
+      '4,4',
+    ]);
+    expect([...standableFootprintKeys(coverage, 0.05)].sort()).toEqual([
+      '2,2',
+      '3,3',
+      '4,4',
+    ]);
   });
 });

--- a/src/author/creation/straightWallGeometry.test.ts
+++ b/src/author/creation/straightWallGeometry.test.ts
@@ -8,6 +8,7 @@ import {
   isValidDoorCell,
   nearestWallAngleFamily,
   projectPointToLineParam,
+  projectWallLineToEdges,
   snapStraightEndpoint,
   straightWallCrossedEdges,
   straightWallFootprint,
@@ -340,5 +341,114 @@ describe('clipSegmentToShrunkHex — the touch-vs-clip epsilon rule directly', (
     const a = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y - 30 };
     const b = { x: hexAt55.x + halfFlatWidth - 1, y: hexAt55.y + 30 };
     expect(isCellClipped(a, b, 5, 5)).toBe(true);
+  });
+});
+
+// rpg-project#169's "drawn walls become real" unit — wallLines->edges
+// projection, the send-time seam that lets a drawn straight wall become
+// wire-real `walls:` geometry. Reuses the exact fixtures the door-
+// exclusion/footprint describe blocks above already established, rather
+// than inventing new ones.
+describe('projectWallLineToEdges', () => {
+  it('a single isolated footprint cell seals all 6 of its real neighbor edges, solid, no doors', () => {
+    // The same "wall ENDING at a corner" diameter fixture from above:
+    // footprint is exactly [[5, 4]], well inside the 20x30 grid on every
+    // side, so all 6 neighbor directions resolve to real, in-grid cells.
+    const from: CornerRef = { cell: [5, 4], corner: 2 };
+    const to: CornerRef = { cell: [5, 4], corner: 5 };
+    const result = projectWallLineToEdges({ from, to, doors: [] }, GRID);
+    expect(result.rimEdgeCount).toBe(0);
+    expect(result.edges).toHaveLength(6);
+    for (const edge of result.edges) {
+      expect(edge.kind).toBe('solid');
+      const touchesSealedCell =
+        (edge.from[0] === 5 && edge.from[1] === 4) ||
+        (edge.to[0] === 5 && edge.to[1] === 4);
+      expect(touchesSealedCell).toBe(true);
+    }
+    // Every edge is a distinct cell pair — no duplicate direction landed
+    // on the same neighbor twice.
+    const keys = new Set(
+      result.edges.map((e) => `${e.from.join(',')}|${e.to.join(',')}`)
+    );
+    expect(keys.size).toBe(6);
+  });
+
+  it('every real neighbor direction is either a sealed edge or a counted rim edge — never silently dropped', () => {
+    // Same diameter fixture, but anchored at column 0 — some of the
+    // isolated footprint cell's 6 neighbor directions fall off the
+    // canvas grid entirely (no cell to pair with).
+    const from: CornerRef = { cell: [0, 4], corner: 2 };
+    const to: CornerRef = { cell: [0, 4], corner: 5 };
+    const result = projectWallLineToEdges({ from, to, doors: [] }, GRID);
+    expect(result.rimEdgeCount).toBeGreaterThan(0);
+    // The 6 real neighbor directions are mutually exclusive with rim —
+    // every direction contributes to exactly one of the two counts, so
+    // they always sum to 6 for an isolated single-cell footprint.
+    expect(result.edges.length + result.rimEdgeCount).toBe(6);
+    for (const edge of result.edges) expect(edge.kind).toBe('solid');
+  });
+
+  // A genuinely VERTICAL line (this module's own header comment: "a
+  // vertical line through a column of hex CENTERS instead clips every
+  // hex in that column full-width") clips a CONTIGUOUS run of cells —
+  // unlike the every-other-hex row fixture above, consecutive cells in
+  // this run ARE real hex neighbors of each other (verified directly,
+  // not assumed, while building this test), which is what a door in the
+  // MIDDLE of an ordinary wall run actually needs to exercise.
+  const verticalFrom: CornerRef = { cell: [5, 3], corner: 0 };
+  const verticalTo: CornerRef = { cell: [5, 9], corner: 0 };
+  const MID_DOOR_CELL: [number, number] = [6, 6]; // footprint is [6,4]..[6,9]
+
+  const sameCell = (a: [number, number], b: [number, number]) =>
+    a[0] === b[0] && a[1] === b[1];
+  const edgeBetween = (
+    edges: readonly {
+      from: [number, number];
+      to: [number, number];
+      kind: string;
+    }[],
+    a: [number, number],
+    b: [number, number]
+  ) =>
+    edges.find(
+      (e) =>
+        (sameCell(e.from, a) && sameCell(e.to, b)) ||
+        (sameCell(e.to, a) && sameCell(e.from, b))
+    );
+
+  it('a doors: cell projects its flanking footprint-neighbor edges as kind: door, never solid and never a bare gap', () => {
+    const result = projectWallLineToEdges(
+      { from: verticalFrom, to: verticalTo, doors: [{ cell: MID_DOOR_CELL }] },
+      GRID
+    );
+    // [6,6]'s own flanking footprint neighbors along the wall run are
+    // [6,5] and [6,7] — both of those edges must read as a doorway.
+    expect(edgeBetween(result.edges, MID_DOOR_CELL, [6, 5])?.kind).toBe('door');
+    expect(edgeBetween(result.edges, MID_DOOR_CELL, [6, 7])?.kind).toBe('door');
+  });
+
+  it('a door only reverses ITS OWN line’s footprint claim — an independent mechanism-(b) grazing edge on the same cell stays solid', () => {
+    // TARGET-YAML.md's own rule, verbatim: "something else... can still
+    // legitimately block it independently." [6,6] is a door cell, but the
+    // line's own grazing crossing toward [5,5] (mechanism (b), a
+    // both-clear-cells test wholly separate from the door's flanking
+    // edges above) is untouched by the door exclusion — still solid.
+    const result = projectWallLineToEdges(
+      { from: verticalFrom, to: verticalTo, doors: [{ cell: MID_DOOR_CELL }] },
+      GRID
+    );
+    const graze = edgeBetween(result.edges, MID_DOOR_CELL, [5, 5]);
+    expect(graze?.kind).toBe('solid');
+  });
+
+  it('mechanism (a) and (b) edges merge into one deduped set — no duplicate cell pairs', () => {
+    const from: CornerRef = { cell: [2, 5], corner: 0 };
+    const to: CornerRef = { cell: [10, 5], corner: 3 };
+    const result = projectWallLineToEdges({ from, to, doors: [] }, GRID);
+    const keys = result.edges.map(
+      (e) => `${e.from.join(',')}|${e.to.join(',')}`
+    );
+    expect(new Set(keys).size).toBe(keys.length);
   });
 });

--- a/src/author/creation/straightWallGeometry.ts
+++ b/src/author/creation/straightWallGeometry.ts
@@ -387,6 +387,259 @@ export function straightWallsFootprintSet(
   return set;
 }
 
+/**
+ * Coverage-based standability (rpg-project#169, live-design follow-up to
+ * "drawn walls become real," 2026-08-07) — Kirk, live: "Nothing is set in
+ * stone... if you can say we won't clip we can go on those squares, maybe
+ * some percent is fine. the small triangles on the edge we could prob
+ * allow those to be placed on... like we can slide a bookcase to a wall."
+ * Retires the original binary rule ("any hex that is not 100% uncovered
+ * would not be traversable") for STANDING purposes only.
+ *
+ * **What this does NOT change, deliberately**: the wall LINE's own
+ * crossing prohibition (`straightWallCrossedEdges`, mechanism (b)) and
+ * Half A's wire projection (`projectWallLineToEdges`, `dungeonYaml.ts`'s
+ * `stripToV1Subset`) both keep using the FULL, uncovered-at-all footprint
+ * (`straightWallFootprint`) exactly as before — a coverage percentage
+ * changes whether a client-side preview lets an author STAND in a
+ * lightly-clipped cell, never what edges the real server enforces. See
+ * this module's own `projectWallLineToEdges` doc comment; nothing there
+ * reads a coverage value.
+ *
+ * **The geometry.** `straightWallFootprint`'s existing `isCellClipped`
+ * already answers "does the line's segment genuinely enter this hex" (a
+ * boolean, epsilon-gated). This answers a different question for a cell
+ * ALREADY known to be in that footprint: how much of the hex's own TRUE
+ * area (not epsilon-shrunk — the boolean touch/clip decision is already
+ * made upstream, this only refines "how much") does the line's own
+ * infinite line separate off? The line divides the hex's convex polygon
+ * into exactly two sub-polygons (Sutherland-Hodgman clip against the
+ * line's own half-plane); their areas sum to the hex's total area (a
+ * convex polygon split by one line always partitions exactly, modulo the
+ * zero-area shared boundary). Coverage is the SMALLER of the two,
+ * relative to the total.
+ *
+ * **Why the smaller side, not a directionally-consistent "wall's own
+ * side"**: a single line has no inherent "this side is wall material"
+ * without external context (which way the wall run continues past this
+ * cell, or a designed wall thickness neither this dialect nor this
+ * geometry model has) — the SAME area split (say 5%/95%) is genuinely
+ * ambiguous as to which side is "the small clipped corner" without that
+ * context. But Kirk's own framing ("the small triangles on the edge") is
+ * exactly the min-area case: whichever side is smaller IS the clipped
+ * sliver, symmetric and context-free, and it degrades correctly at both
+ * ends — a pure touch (line along an edge, or through one vertex) gives
+ * 0 on one side; a line through the center gives ~0.5, unambiguously
+ * "blocks half the cell," comfortably above any reasonable threshold.
+ */
+function polygonArea(points: readonly CellPos[]): number {
+  let sum = 0;
+  for (let i = 0; i < points.length; i++) {
+    const p1 = points[i];
+    const p2 = points[(i + 1) % points.length];
+    sum += p1.x * p2.y - p2.x * p1.y;
+  }
+  return Math.abs(sum) / 2;
+}
+
+/** Sutherland-Hodgman clip of a convex polygon against ONE half-plane
+ * (`nx*(x-cx) + ny*(y-cy) <= 0` is the KEPT side) — the standard
+ * textbook algorithm, needed here because `hexHalfPlanes`/
+ * `clipSegmentToShrunkHex` above only ever clip a LINE SEGMENT (1D)
+ * against the hex's 6 edges; this clips the hex's own POLYGON (2D)
+ * against the wall's single line instead, a genuinely different
+ * operation this module didn't need before coverage. */
+function clipPolygonToHalfPlane(
+  poly: readonly CellPos[],
+  nx: number,
+  ny: number,
+  cx: number,
+  cy: number
+): CellPos[] {
+  if (poly.length === 0) return [];
+  const side = (p: CellPos) => nx * (p.x - cx) + ny * (p.y - cy);
+  const intersect = (a: CellPos, b: CellPos): CellPos => {
+    const da = side(a);
+    const db = side(b);
+    const t = da / (da - db);
+    return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+  };
+  const output: CellPos[] = [];
+  for (let i = 0; i < poly.length; i++) {
+    const curr = poly[i];
+    const prev = poly[(i - 1 + poly.length) % poly.length];
+    const currIn = side(curr) <= 0;
+    const prevIn = side(prev) <= 0;
+    if (currIn) {
+      if (!prevIn) output.push(intersect(prev, curr));
+      output.push(curr);
+    } else if (prevIn) {
+      output.push(intersect(prev, curr));
+    }
+  }
+  return output;
+}
+
+/**
+ * Fraction (0..0.5) of hex (col,row)'s own true area that the wall's
+ * infinite line (through corners `from`/`to`) separates into the SMALLER
+ * of the two resulting sub-polygons — see this section's own header
+ * comment for the full geometric/design writeup. `0` for a cell the line
+ * doesn't genuinely enter at all (correct, if uninteresting — callers
+ * only ever call this for a cell already confirmed in the raw footprint,
+ * where it's always genuinely positive).
+ */
+export function hexCoverageFraction(
+  from: CornerRef,
+  to: CornerRef,
+  col: number,
+  row: number
+): number {
+  const a = cornerPoint(from);
+  const b = cornerPoint(to);
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const nx = -dy / len;
+  const ny = dx / len;
+  const corners: CellPos[] = cellCorners(
+    cellCenter(col, row),
+    BOARD_HEX_SIZE
+  ).map(([x, y]) => ({ x, y }));
+  const totalArea = polygonArea(corners);
+  if (totalArea === 0) return 0;
+  const sideArea = polygonArea(
+    clipPolygonToHalfPlane(corners, nx, ny, a.x, a.y)
+  );
+  const otherSideArea = totalArea - sideArea;
+  return Math.min(sideArea, otherSideArea) / totalArea;
+}
+
+/**
+ * The standability threshold (rule 1 of Kirk's live-design follow-up): a
+ * footprint cell with `hexCoverageFraction` below this value is
+ * STANDABLE (walkMovement/placement-legality stop blocking the CELL —
+ * the line's own crossing prohibition into/out of it is unaffected, see
+ * this section's header comment); at or above, blocked exactly as the
+ * original binary rule always blocked it.
+ *
+ * **Honest status: reasoned from real geometry, NOT yet visually
+ * measured in Walk mode** — Kirk's own "measured, not guessed"
+ * discipline calls for walking the first-person camera against a real
+ * coverage bench and observing where clipping actually starts to read as
+ * wrong. That pass was ATTEMPTED, not completed: a real two-line bench
+ * was built and loaded live (below), and the server-side projection was
+ * confirmed correct against it (`YamlPane`'s own compile badge read "2
+ * straight walls (projects to 74 wall edges)" for these exact two
+ * lines — Half A's own machinery, unaffected by any of this, working
+ * against real coverage-varying geometry). But the actual visual
+ * inspection couldn't be finished: the shared browser debugging session
+ * this environment provides collided live with a concurrent teammate
+ * agent's own active session mid-pass (a `navigate_page`/click landed on
+ * a DIFFERENT agent's in-progress gameplay at a different origin and
+ * player identity) — continuing risked disrupting their work, so this
+ * stopped rather than push through on a compromised shared resource.
+ * Recorded here rather than silently shipping a number with a
+ * "measured" claim that wouldn't be true.
+ *
+ * **The bench, reproducible for whoever picks up the real visual pass**
+ * (a `wallLines:` doc, loadable via `localStorage.setItem
+ * ('dungeon-builder:draft:create', JSON.stringify({yamlText, savedAt:
+ * Date.now()}))` then reloading the creation-mode builder — no drag-draw
+ * needed): two lines on a `canvas: {width: 50, height: 30}` —
+ * `{from: {cell:[16,21],corner:0}, to: {cell:[22,20],corner:0}}` (cells
+ * or a mix of ~4%/~24%/~37% coverage, alternating) and
+ * `{from: {cell:[37,20],corner:0}, to: {cell:[44,18],corner:0}}` (cells
+ * spanning ~1.7%/~3.8%/~10.4%/~14.7%/~29.5%/~39.7%/~44.9%) — every value
+ * independently verified via `hexCoverageFraction` itself, not eyeballed
+ * (this module's own test suite carries the exact fixtures and asserted
+ * values, so the bench is exact, not approximate).
+ *
+ * **Threshold set at 10%** as the reasoned interim value: below the
+ * already-well-established 16.67% reference (`straightWallFootprint`'s
+ * own existing corner-to-corner-diagonal fixture, the smallest "clean"
+ * symmetric corner cut reachable by connecting two of a hex's own
+ * corners two apart — a real, visibly non-trivial triangular wedge, kept
+ * blocked) while treating the bench's smaller measured slivers (up to
+ * ~10%) as standable, matching Kirk's own qualitative framing ("the
+ * small triangles on the edge") at the geometric level even without a
+ * completed visual confirmation. A tunable constant, not hardcoded
+ * inline at each call site, so a real Walk-mode pass (by a future
+ * session without this collision) is a one-line change once it has
+ * something to correct.
+ */
+export const STANDABLE_COVERAGE_THRESHOLD = 0.1;
+
+/** Per-line coverage map (`"col,row"` -> fraction, `straightWallFootprint`'s
+ * own door-excluded footprint) — the coverage-aware sibling of
+ * `straightWallFootprint`, same cell set, richer per-cell value instead
+ * of bare membership. */
+export function straightWallFootprintCoverage(
+  from: CornerRef,
+  to: CornerRef,
+  grid: CreationGrid,
+  doorCells: readonly [number, number][] = []
+): Map<string, number> {
+  const coverage = new Map<string, number>();
+  for (const [col, row] of straightWallFootprint(from, to, grid, doorCells)) {
+    coverage.set(cellKey(col, row), hexCoverageFraction(from, to, col, row));
+  }
+  return coverage;
+}
+
+/** Multi-line union of `straightWallFootprintCoverage`, the coverage-aware
+ * sibling of `straightWallsFootprintSet` — same cells, per-cell fraction
+ * instead of bare membership. A cell touched by more than one drawn
+ * wallLine takes the MAX of the two lines' own coverage (the more
+ * restrictive claim wins) — a simplification, not a true union-of-areas
+ * (two lines could together cover more than either alone), judged
+ * adequate for a client-side authoring preview rather than a physically
+ * exact overlap computation; recorded here rather than silently assumed
+ * exact. */
+export function straightWallsFootprintCoverage(
+  lines: readonly {
+    from: CornerRef;
+    to: CornerRef;
+    doors?: readonly { cell: [number, number] }[];
+  }[],
+  grid: CreationGrid
+): Map<string, number> {
+  const coverage = new Map<string, number>();
+  for (const line of lines) {
+    const doorCells = (line.doors ?? []).map((d) => d.cell);
+    for (const [key, value] of straightWallFootprintCoverage(
+      line.from,
+      line.to,
+      grid,
+      doorCells
+    )) {
+      const existing = coverage.get(key);
+      if (existing === undefined || value > existing) {
+        coverage.set(key, value);
+      }
+    }
+  }
+  return coverage;
+}
+
+/** Filters a coverage map down to the cells at/above the standability
+ * threshold — a plain `Set<string>`, the exact shape
+ * `walkMovement.ts`'s `blockedCells` and `canvasFloor.ts`'s
+ * `canvasPlacementRejectReason` already consume, so neither needed a
+ * single signature change for this round: only WHICH set their callers
+ * pass in changed (the coverage-filtered one, not the raw touch-at-all
+ * one). */
+export function standableFootprintKeys(
+  coverage: ReadonlyMap<string, number>,
+  threshold: number = STANDABLE_COVERAGE_THRESHOLD
+): Set<string> {
+  const keys = new Set<string>();
+  for (const [key, value] of coverage) {
+    if (value >= threshold) keys.add(key);
+  }
+  return keys;
+}
+
 export function cellKey(col: number, row: number): string {
   return `${col},${row}`;
 }

--- a/src/author/creation/straightWallGeometry.ts
+++ b/src/author/creation/straightWallGeometry.ts
@@ -51,7 +51,6 @@
  * `hexCorner.ts`'s own header comment for the corner-lattice addressing
  * and dedup rule this implies.
  */
-import { neighborCell } from '../boardGeometry';
 import {
   BOARD_HEX_SIZE,
   cellCenter,
@@ -67,6 +66,13 @@ import {
   canonicalCorner,
   cornerPoint,
   nearestCorner,
+  // `neighborCell` from `./hexCorner`, not `../boardGeometry` — see that
+  // module's own doc comment on its exported copy: `boardGeometry.ts`
+  // imports `resolvePlacement`/`DungeonDoc` from `dungeonYaml.ts`, so
+  // importing it here would make THIS module (which `dungeonYaml.ts`'s
+  // own `stripToV1Subset` needs to call directly, wallLines->edges
+  // projection unit) part of a real, crashing import cycle.
+  neighborCell,
   type CornerRef,
 } from './hexCorner';
 
@@ -463,6 +469,142 @@ export function isValidDoorCell(
   return straightWallFootprint(from, to, grid).some(
     ([c, r]) => c === cell[0] && r === cell[1]
   );
+}
+
+/**
+ * wallLines->edges projection — rpg-project#169's "drawn walls become
+ * real" unit. `wallLines:` has no wire representation of its own (see
+ * `dungeonYaml.ts`'s `WallLineDoc` doc comment: it's this concept's own
+ * client-side sugar, never sent to the real server in any form), but its
+ * GEOMETRY isn't necessarily lost — when the server accepts edge-native
+ * `walls:` (verified live, `capabilityProbe.ts`), a wallLine's footprint +
+ * crossed-edge truth projects down into real `{from, to, kind}` pairs,
+ * the same shape `walls:` already uses. This is that projection: cell-pair
+ * `walls:` edges out, given one `wallLines:` entry's corner-anchored
+ * endpoints and door cells in.
+ */
+export type ProjectedWallEdgeKind = 'solid' | 'door';
+
+export interface ProjectedWallEdge {
+  from: [number, number];
+  to: [number, number];
+  kind: ProjectedWallEdgeKind;
+}
+
+export interface WallLineProjection {
+  /** Every distinct cell-boundary edge this ONE wallLine's geometry
+   * implies, deduped within the line itself. */
+  edges: ProjectedWallEdge[];
+  /** Footprint-boundary edges whose neighbor falls OFF the canvas grid
+   * entirely (a wall run reaching the canvas rim) — a `walls:` entry
+   * needs a real cell on BOTH ends (the server's own adjacent-cell-pair
+   * validation), so these have no honest wire representation. Counted,
+   * never silently folded into `edges` or dropped without a trace — see
+   * TARGET-YAML.md's "Straight walls: stripToV1Subset" section. */
+  rimEdgeCount: number;
+}
+
+/**
+ * Projects ONE `wallLines:` entry down to real edge-native `walls:`
+ * pairs. Reuses this module's own `straightWallFootprint`/
+ * `straightWallCrossedEdges` — the SAME functions `preview3d/walkMovement.ts`
+ * already calls to enforce this exact geometry client-side — rather than
+ * re-deriving it a second time.
+ *
+ * **Mechanism (a): every footprint cell is fully blocked.** Not
+ * expressible as "this cell is non-floor" on the wire (the server has no
+ * such concept — `walls:` only ever blocks a specific edge), so the
+ * faithful edge-native translation is: seal EVERY one of a footprint
+ * cell's 6 real neighbor edges. A neighbor that's one of this line's own
+ * `doors:` cells gets `kind: 'door'` instead of `'solid'` — see this
+ * function's own "door handling" note below. A neighbor off the canvas
+ * grid entirely has no cell to pair with; counted in `rimEdgeCount`; a
+ * cell can never seal an edge toward a footprint neighbor AND a rim in
+ * the same direction, so there's no double-counting between the two.
+ *
+ * **Mechanism (b): a grazing crossing between two CLEAR cells**
+ * (`straightWallCrossedEdges`, unchanged from its existing client-side
+ * use) — always `'solid'`, no door special-case: a door only reverses ITS
+ * OWNING line's own footprint claim on its one cell (TARGET-YAML.md's
+ * "Doors" section, "this cell acts as though the wall line never clipped
+ * it at all, nothing more, and nothing less"), never mechanism (b)'s
+ * independent both-clear-cells test — a door cell whose true boundary the
+ * line still grazes remains subject to that test exactly like any other
+ * clear cell.
+ *
+ * **Door handling, the actual gap-vs-door decision** (TARGET-YAML.md has
+ * the full writeup): a door cell's own edges toward its flanking
+ * footprint neighbors are marked `kind: 'door'`, never omitted as a bare
+ * gap and never `'solid'`. An omitted edge would render as nothing at
+ * all in the real game (`syntyHexWallHelpers.ts`'s per-edge wall-piece
+ * placement only draws where a `Wall` entry exists) — indistinguishable
+ * from a rendering bug, not a doorway. `kind: 'door'` gives the opening a
+ * real door frame via the SAME `isDoorWallKind`/`edgePieceKind` path
+ * every other door in this game already renders through, so an authored
+ * doorway reads as a doorway in the actual game, not an unexplained hole
+ * in a wall — matching Kirk's own repeated diagnosis of the earlier
+ * whole-line `kind: door` prototype ("the gashes are walls... I cannot
+ * set a wall or a door").
+ */
+export function projectWallLineToEdges(
+  line: {
+    from: CornerRef;
+    to: CornerRef;
+    doors: readonly { cell: [number, number] }[];
+  },
+  grid: CreationGrid
+): WallLineProjection {
+  const doorCells = line.doors.map((d) => d.cell);
+  const doorSet = new Set(doorCells.map(([c, r]) => cellKey(c, r)));
+  const footprint = straightWallFootprint(line.from, line.to, grid, doorCells);
+
+  const edgeMap = new Map<string, ProjectedWallEdge>();
+  let rimEdgeCount = 0;
+
+  const addEdge = (
+    a: [number, number],
+    b: [number, number],
+    kind: ProjectedWallEdgeKind
+  ) => {
+    const aKey = cellKey(a[0], a[1]);
+    const bKey = cellKey(b[0], b[1]);
+    const [from, to] = aKey <= bKey ? [a, b] : [b, a];
+    const key = `${cellKey(from[0], from[1])}|${cellKey(to[0], to[1])}`;
+    const existing = edgeMap.get(key);
+    if (existing) {
+      // A door beats a solid found for the SAME edge from the opposite
+      // direction — never the reverse (a door cell's own opening is
+      // never re-sealed by a later, redundant solid derivation).
+      if (kind === 'door') existing.kind = 'door';
+      return;
+    }
+    edgeMap.set(key, { from, to, kind });
+  };
+
+  for (const [col, row] of footprint) {
+    for (let facing = 0; facing < 6; facing++) {
+      const n = neighborCell(col, row, facing);
+      if (!inBoundsGrid(n.col, n.row, grid)) {
+        rimEdgeCount++;
+        continue;
+      }
+      const kind: ProjectedWallEdgeKind = doorSet.has(cellKey(n.col, n.row))
+        ? 'door'
+        : 'solid';
+      addEdge([col, row], [n.col, n.row], kind);
+    }
+  }
+
+  for (const edge of straightWallCrossedEdges(
+    line.from,
+    line.to,
+    grid,
+    footprint
+  )) {
+    addEdge(edge.cellA, edge.cellB, 'solid');
+  }
+
+  return { edges: Array.from(edgeMap.values()), rimEdgeCount };
 }
 
 /**

--- a/src/author/dungeonYaml.test.ts
+++ b/src/author/dungeonYaml.test.ts
@@ -1468,6 +1468,142 @@ connectors: []
         );
       });
     });
+
+    // wallLines->edges projection (rpg-project#169's "drawn walls become
+    // real" unit) — a genuinely VERTICAL corner-anchored line clips a
+    // CONTIGUOUS column run (this fixture verified directly against
+    // `straightWallGeometry.ts`'s own test suite: footprint
+    // [[6,4],[6,5],[6,6],[6,7],[6,8],[6,9]], every consecutive pair real
+    // hex neighbors of each other), so `[6,4]`<->`[6,5]` is a KNOWN real
+    // projected edge to assert against directly, not guessed at.
+    describe('wallLines -> walls: projection', () => {
+      const VLINE_FROM = canonicalCorner({ cell: [5, 3], corner: 0 });
+      const VLINE_TO = canonicalCorner({ cell: [5, 9], corner: 0 });
+
+      it('projects into walls: when this server accepts walls, counted in compiling — never dropped', () => {
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+        addWallLine(cst, VLINE_FROM, VLINE_TO);
+
+        const result = stripToV1Subset(serializeDungeon(cst), caps(['walls']));
+
+        expect(result.dropped).toEqual([]);
+        expect(result.compiling).toEqual([
+          expect.stringMatching(
+            /^1 straight wall \(projects to \d+ wall edges?\)$/
+          ),
+        ]);
+        const { doc: stripped } = parseDungeon(result.yaml);
+        expect(stripped.wallLines).toEqual([]); // the key itself never survives
+        const edge = stripped.walls.find(
+          (w) =>
+            (w.from[0] === 6 &&
+              w.from[1] === 4 &&
+              w.to[0] === 6 &&
+              w.to[1] === 5) ||
+            (w.from[0] === 6 &&
+              w.from[1] === 5 &&
+              w.to[0] === 6 &&
+              w.to[1] === 4)
+        );
+        expect(edge).toBeDefined();
+        expect(edge?.kind).toBe('solid');
+      });
+
+      it('the ORIGINAL live doc is untouched — a projection, not a conversion; wallLines: still round-trips from the caller’s own cst', () => {
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+        addWallLine(cst, VLINE_FROM, VLINE_TO);
+        const yamlText = serializeDungeon(cst);
+
+        stripToV1Subset(yamlText, caps(['walls']));
+
+        // stripToV1Subset parsed a FRESH cst from yamlText — the caller's
+        // own cst (and re-parsing yamlText itself) still shows the
+        // straight wall, untouched.
+        expect(toDungeonDoc(cst).wallLines).toHaveLength(1);
+        expect(parseDungeon(yamlText).doc.wallLines).toHaveLength(1);
+      });
+
+      it('merges with explicit walls: — EXPLICIT wins on a kind conflict, no duplicate edge', () => {
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+        addWallLine(cst, VLINE_FROM, VLINE_TO);
+        // The projection would derive [6,4]<->[6,5] as `solid` (previous
+        // test) — author it explicitly as a DOOR instead.
+        setWallEdge(cst, [6, 4], [6, 5], 'door', true);
+
+        const result = stripToV1Subset(serializeDungeon(cst), caps(['walls']));
+        const { doc: stripped } = parseDungeon(result.yaml);
+        const matches = stripped.walls.filter(
+          (w) =>
+            (w.from[0] === 6 &&
+              w.from[1] === 4 &&
+              w.to[0] === 6 &&
+              w.to[1] === 5) ||
+            (w.from[0] === 6 &&
+              w.from[1] === 5 &&
+              w.to[0] === 6 &&
+              w.to[1] === 4)
+        );
+        expect(matches).toHaveLength(1); // never duplicated
+        expect(matches[0].kind).toBe('door'); // explicit wins, not overwritten to solid
+      });
+
+      it('a doors: cell projects as kind: door, reading as a doorway rather than a bare gap or a block', () => {
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+        addWallLine(cst, VLINE_FROM, VLINE_TO);
+        toggleWallLineDoorAt(cst, 0, [6, 6]); // middle of the [6,4]..[6,9] run
+
+        const result = stripToV1Subset(serializeDungeon(cst), caps(['walls']));
+        const { doc: stripped } = parseDungeon(result.yaml);
+        const doorEdge = stripped.walls.find(
+          (w) =>
+            (w.from[0] === 6 &&
+              w.from[1] === 6 &&
+              w.to[0] === 6 &&
+              w.to[1] === 5) ||
+            (w.from[0] === 6 &&
+              w.from[1] === 5 &&
+              w.to[0] === 6 &&
+              w.to[1] === 6)
+        );
+        expect(doorEdge?.kind).toBe('door');
+        // The door cell itself never appears in doc.holes/blocked in any
+        // v1 sense — it's real floor with a door edge beside it, nothing
+        // marks the CELL itself as special on the wire (matching real
+        // walls: semantics: kind lives on the edge, not the cell).
+      });
+
+      it('rim edges (the wall reaches the canvas boundary) are counted honestly, never silently dropped', () => {
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+        // Same "diameter of one cell" fixture straightWallGeometry.test.ts
+        // uses, anchored at column 0 — some of its 6 neighbor directions
+        // fall off the canvas grid entirely.
+        addWallLine(
+          cst,
+          canonicalCorner({ cell: [0, 4], corner: 2 }),
+          canonicalCorner({ cell: [0, 4], corner: 5 })
+        );
+
+        const result = stripToV1Subset(serializeDungeon(cst), caps(['walls']));
+        expect(result.compiling).toEqual([
+          expect.stringMatching(
+            /rim edges? at the canvas boundary could not be expressed/
+          ),
+        ]);
+      });
+
+      it('not accepted (walls: itself rejected): still drops both, never touches walls: — unchanged prior behavior', () => {
+        const { cst } = parseDungeon(SHOWCASE_YAML);
+        addWallLine(cst, VLINE_FROM, VLINE_TO);
+
+        const result = stripToV1Subset(serializeDungeon(cst), caps([])); // nothing accepted
+
+        expect(result.dropped).toEqual(['1 straight wall']);
+        expect(result.compiling).toEqual([]);
+        const { doc: stripped } = parseDungeon(result.yaml);
+        expect(stripped.walls).toEqual([]);
+        expect(stripped.wallLines).toEqual([]);
+      });
+    });
   });
 
   describe('generalized placement mutators (roomId: null = top-level)', () => {

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -37,12 +37,17 @@ import {
   YAMLSeq,
 } from 'yaml';
 import type { DialectField, ServerCapabilities } from './capabilityProbe';
+import { DEFAULT_CANVAS } from './creation/emptyCanvasDoc';
 import {
   canonicalCorner,
   cornerPoint,
   migrateLegacyCenterEndpoint,
   type CornerRef,
 } from './creation/hexCorner';
+import {
+  projectWallLineToEdges,
+  type ProjectedWallEdge,
+} from './creation/straightWallGeometry';
 import {
   cellCenter,
   hexColumn,
@@ -2410,6 +2415,20 @@ export function pluralCount(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? '' : 's'}`;
 }
 
+/** A cell-pair key with no notion of direction — the same "sort the two
+ * `[col,row]` endpoints lexicographically first" convention
+ * `preview3d/walkMovement.ts`'s own (unimportable here — see this file's
+ * new `straightWallGeometry.ts` import comment) `edgeKey` uses, small
+ * enough to duplicate directly rather than restructure that module's own
+ * dependency graph a second time. Used by `stripToV1Subset`'s wallLines
+ * projection to find/dedupe against `doc.walls`'s explicit entries
+ * regardless of which direction either side happened to author. */
+function wallEdgeKey(a: [number, number], b: [number, number]): string {
+  const aKey = `${a[0]},${a[1]}`;
+  const bKey = `${b[0]},${b[1]}`;
+  return aKey <= bKey ? `${aKey}|${bKey}` : `${bKey}|${aKey}`;
+}
+
 /** Which `DialectField` governs a placement's own `facing:` — the real
  * server distinguishes by entry type (verified live, this unit,
  * 2026-08-04: a room-scoped, non-monster, non-`mount:wall` floor prop's
@@ -2525,14 +2544,64 @@ export function stripToV1Subset(
     }
   }
 
-  // Straight walls — a sibling target-dialect-only construct to `walls:`
-  // above, NOT probed (see capabilityProbe.ts's own doc comment: it's
-  // this concept's own client-side sugar, never sent to the real server
-  // in any form) — always dropped, counted separately from the edge-wall
-  // tally since the two are genuinely different authoring constructs
-  // (see `WallLineDoc`'s own doc comment).
+  // Straight walls (`wallLines:`) — a sibling target-dialect-only
+  // construct to `walls:` above (never a variant of it — see
+  // `WallLineDoc`'s own doc comment). The KEY itself never survives:
+  // dungeonspec has no `wallLines:` field and never will
+  // (`capabilityProbe.ts` deliberately never probes it — this concept's
+  // own client-side sugar, never sent to the real server in any form).
+  // But the GEOMETRY it authors isn't necessarily lost: when THIS server
+  // accepts edge-native `walls:`, every wallLine's footprint + crossed-edge
+  // truth (`straightWallGeometry.ts`'s `projectWallLineToEdges` — the SAME
+  // primitives `preview3d/walkMovement.ts` already uses to enforce this
+  // client-side) is PROJECTED down into real `walls:` entries and merged
+  // into whatever explicit `walls:` survives above — a drawn straight wall
+  // becomes wire-real geometry the game renders AND enforces, not just a
+  // client-side preview. Not accepted: unchanged prior behavior, dropped
+  // and counted like any other rejected target-dialect construct. See
+  // TARGET-YAML.md's "Straight walls: stripToV1Subset" section for the
+  // full writeup (door-vs-gap decision, rim-edge honesty, the
+  // explicit-wins merge rule).
   if (doc.wallLines.length > 0) {
-    dropped.push(pluralCount(doc.wallLines.length, 'straight wall'));
+    if (accepted('walls')) {
+      const grid = doc.canvas ?? DEFAULT_CANVAS;
+      const projected = new Map<string, ProjectedWallEdge>();
+      let rimEdgeCount = 0;
+      for (const line of doc.wallLines) {
+        const result = projectWallLineToEdges(line, grid);
+        rimEdgeCount += result.rimEdgeCount;
+        for (const edge of result.edges) {
+          const key = wallEdgeKey(edge.from, edge.to);
+          const existing = projected.get(key);
+          if (existing) {
+            if (edge.kind === 'door') existing.kind = 'door';
+          } else {
+            projected.set(key, edge);
+          }
+        }
+      }
+      // Explicit `walls:` entries WIN on a key collision — never
+      // overwritten, never duplicated. A projected edge is only ever
+      // appended when no explicit entry already claims that exact cell
+      // pair (either kind).
+      const explicitKeys = new Set(
+        doc.walls.map((w) => wallEdgeKey(w.from, w.to))
+      );
+      const wallsSeq = topSeq(cst, 'walls');
+      for (const edge of projected.values()) {
+        if (explicitKeys.has(wallEdgeKey(edge.from, edge.to))) continue;
+        wallsSeq.items.push(createWallNode(cst, edge));
+      }
+      const rimNote =
+        rimEdgeCount > 0
+          ? `; ${pluralCount(rimEdgeCount, 'rim edge')} at the canvas boundary could not be expressed`
+          : '';
+      compiling.push(
+        `${pluralCount(doc.wallLines.length, 'straight wall')} (projects to ${pluralCount(projected.size, 'wall edge')}${rimNote})`
+      );
+    } else {
+      dropped.push(pluralCount(doc.wallLines.length, 'straight wall'));
+    }
   }
   cst.delete('wallLines');
 

--- a/src/author/preview3d/DungeonPreview3D.test.ts
+++ b/src/author/preview3d/DungeonPreview3D.test.ts
@@ -42,7 +42,8 @@ import {
   buildFloorTiles,
   buildOnePlacement,
   buildPlaceableCells,
-  buildWallLineFootprint,
+  buildStandableWallLineFootprint,
+  buildWallLineFootprintCoverage,
   buildWallLineSegments,
   CANVAS_ROOM_ID,
 } from './DungeonPreview3D';
@@ -153,7 +154,7 @@ describe('buildOnePlacement — resolved facing × fine-rotation composition', (
 
 // rpg-project#169's creation-mode 3D preview unit (2026-08-04) — the
 // alternate `floorCells` input path this component's own header doc
-// comment describes. `buildFloorTiles`/`buildWallLineFootprint` are pure
+// comment describes. `buildFloorTiles`/`buildStandableWallLineFootprint` are pure
 // math with no Canvas/GLB dependency (same reasoning `buildOnePlacement`'s
 // own doc comment above gives for being exported and tested directly).
 describe('buildFloorTiles — the floorCells alternate input path (creation mode)', () => {
@@ -254,13 +255,14 @@ describe('buildFloorTiles — the floorCells alternate input path (creation mode
   });
 });
 
-describe('buildWallLineFootprint — doc-native, mode-agnostic', () => {
-  it('an empty doc.wallLines produces an empty set, cheaply (no grid scan)', () => {
+describe('buildWallLineFootprintCoverage / buildStandableWallLineFootprint — doc-native, mode-agnostic', () => {
+  it('an empty doc.wallLines produces an empty coverage map and an empty standable set, cheaply (no grid scan)', () => {
     const { doc } = parseDungeon(SHOWCASE_YAML);
-    expect(buildWallLineFootprint(doc).size).toBe(0);
+    expect(buildWallLineFootprintCoverage(doc).size).toBe(0);
+    expect(buildStandableWallLineFootprint(doc).size).toBe(0);
   });
 
-  it('matches straightWallFootprint (creation/straightWallGeometry.ts) exactly for one drawn line — reused geometry, not re-derived', () => {
+  it('buildWallLineFootprintCoverage matches straightWallFootprint (creation/straightWallGeometry.ts) exactly for one drawn line — reused geometry, not re-derived — with every cell carrying a real coverage value', () => {
     const { cst } = parseDungeon(SHOWCASE_YAML);
     const from = { cell: [4, 4] as [number, number], corner: 0 };
     const to = { cell: [6, 1] as [number, number], corner: 3 };
@@ -276,10 +278,13 @@ describe('buildWallLineFootprint — doc-native, mode-agnostic', () => {
     );
     expect(expectedFootprint.length).toBeGreaterThan(0);
 
-    const result = buildWallLineFootprint(doc);
-    expect(result.size).toBe(expectedFootprint.length);
+    // buildWallLineFootprintCoverage is the FULL touched-at-all set — same
+    // cells as the raw footprint, regardless of coverage/threshold.
+    const coverage = buildWallLineFootprintCoverage(doc);
+    expect(coverage.size).toBe(expectedFootprint.length);
     for (const [col, row] of expectedFootprint) {
-      expect(result.has(`${col},${row}`)).toBe(true);
+      expect(coverage.has(`${col},${row}`)).toBe(true);
+      expect(coverage.get(`${col},${row}`)).toBeGreaterThan(0);
     }
   });
 });
@@ -470,7 +475,7 @@ describe('buildPlaceableCells — creation mode (floorPlan: undefined, rpg-proje
     const doc = toDungeonDoc(cst);
     const floorCells = deriveCanvasFloorCells(doc);
     const floorTiles = buildFloorTiles(undefined, doc.holes, floorCells);
-    const wallLineFootprint = buildWallLineFootprint(doc);
+    const wallLineFootprint = buildStandableWallLineFootprint(doc);
     const cells = buildPlaceableCells(
       undefined,
       doc,

--- a/src/author/preview3d/DungeonPreview3D.tsx
+++ b/src/author/preview3d/DungeonPreview3D.tsx
@@ -739,9 +739,19 @@ export function buildPlaceableCells(
     const col = hexColumn(cube);
     const row = hexRow(cube);
     const world = cubeToWorld(cube, HEX_SIZE);
+    // Generic, ref-agnostic precompute — drives hover/occupied display for
+    // every cell regardless of what's currently selected in the palette,
+    // so it uses the STANDABLE-required gate (matches monster/boss, the
+    // majority case). `handleClickCell` below re-checks with the actual
+    // selection's own requirement at click time rather than trusting this
+    // — a `'prop'` selection needs the relaxed (footprint-permitting)
+    // check `canvasPlacementRejectReason`'s `requiresStandable: false`
+    // gives it (rpg-project#169's "props on footprint cells" unit), which
+    // this per-cell table can't express without being recomputed on every
+    // palette change.
     const rejectReason = floorPlan
       ? undefined
-      : (canvasPlacementRejectReason(doc, col, row, wallLineFootprint) ??
+      : (canvasPlacementRejectReason(doc, col, row, wallLineFootprint, true) ??
         undefined);
     cells.push({
       key: `${tile.x},${tile.y},${tile.z}`,
@@ -1350,8 +1360,27 @@ export function DungeonPreview3D({
         );
         return;
       }
-      if (cell.rejectReason) {
-        onReject?.(cell.rejectReason);
+      // `cell.rejectReason` (`buildPlaceableCells`) is precomputed
+      // STANDABLE-required — correct for `'monster'`, but a `'prop'`
+      // selection needs a FRESH, ref-aware check
+      // (rpg-project#169's "props on footprint cells" unit: a bookcase
+      // resting against a drawn wall's footprint is a legal target, a
+      // skeleton standing on it is not). Re-running the real predicate
+      // here (rather than conditionally ignoring the precomputed
+      // rejection) keeps the hole/off-canvas/occupied gates intact for
+      // props too — only the footprint gate actually differs.
+      const reject =
+        selectedPalette.kind === 'prop'
+          ? canvasPlacementRejectReason(
+              doc,
+              cell.col,
+              cell.row,
+              wallLineFootprint,
+              false
+            )
+          : cell.rejectReason;
+      if (reject) {
+        onReject?.(reject);
         return;
       }
       onPlace(null, [cell.col, cell.row]);

--- a/src/author/preview3d/DungeonPreview3D.tsx
+++ b/src/author/preview3d/DungeonPreview3D.tsx
@@ -159,7 +159,8 @@ import { DEFAULT_CANVAS } from '../creation/emptyCanvasDoc';
 import { cornerPoint, type CornerRef } from '../creation/hexCorner';
 import {
   clipSegmentToShrunkHex,
-  straightWallsFootprintSet,
+  standableFootprintKeys,
+  straightWallsFootprintCoverage,
 } from '../creation/straightWallGeometry';
 import {
   resolvePlacement,
@@ -788,16 +789,40 @@ function buildHexHitShape(): Shape {
 
 /** Every `[col, row]` cell a straight wall (`doc.wallLines`) footprint
  * currently claims, union across every drawn line, door cells already
- * excluded per-line — the exact same `straightWallsFootprintSet` the 2D
- * board's own hatch/warning overlays already use (`CreationBoard.tsx`),
- * reused rather than re-derived. Cheap by construction, and skipped
- * entirely for the (overwhelmingly common) `doc.wallLines.length === 0`
- * case rather than paying for an empty grid scan. */
+ * excluded per-line, each with its own coverage FRACTION (0..0.5,
+ * `straightWallGeometry.ts`'s `hexCoverageFraction`) — the exact same
+ * `straightWallsFootprintCoverage` the 2D board's own hatch overlay now
+ * consumes (`CreationBoard.tsx`), reused rather than re-derived. Cheap by
+ * construction, and skipped entirely for the (overwhelmingly common)
+ * `doc.wallLines.length === 0` case rather than paying for an empty grid
+ * scan. This is the FULL touched-at-all set (any genuine clip, however
+ * shallow) — for the coverage-based STANDABLE subset, see
+ * `buildStandableWallLineFootprint`, below. */
 // eslint-disable-next-line react-refresh/only-export-components
-export function buildWallLineFootprint(doc: DungeonDoc): Set<string> {
-  if (doc.wallLines.length === 0) return new Set();
+export function buildWallLineFootprintCoverage(
+  doc: DungeonDoc
+): Map<string, number> {
+  if (doc.wallLines.length === 0) return new Map();
   const grid = doc.canvas ?? DEFAULT_CANVAS;
-  return straightWallsFootprintSet(doc.wallLines, grid);
+  return straightWallsFootprintCoverage(doc.wallLines, grid);
+}
+
+/** The STANDABLE subset of `buildWallLineFootprintCoverage`'s own result
+ * (rpg-project#169's coverage-based-standability follow-up, live design
+ * round with Kirk, 2026-08-07): only cells at/above
+ * `STANDABLE_COVERAGE_THRESHOLD` — what `buildPlaceableCells`/
+ * `buildWalkContext`/`handleClickCell` below actually need to block
+ * STANDING on. A lightly-clipped cell below the threshold is real floor
+ * again for these purposes; the wall LINE's own crossing prohibition
+ * into/out of it is untouched (`buildWalkContext`'s own `blockedEdges`
+ * derivation still reads the FULL, unfiltered footprint for that —
+ * `straightWallGeometry.ts`'s own "coverage-based standability" header
+ * comment has the full rule-5 writeup: coverage decides standing, never
+ * what the wall's own line blocks crossing, and never Half A's wire
+ * projection). */
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildStandableWallLineFootprint(doc: DungeonDoc): Set<string> {
+  return standableFootprintKeys(buildWallLineFootprintCoverage(doc));
 }
 
 /** The uniform scale between this concept's 2D board-space corner math
@@ -957,28 +982,48 @@ const HIT_CLEAR_COLOR = '#5fd1c9';
 const HIT_OCCUPIED_COLOR = '#ff5a3a';
 
 // The 3D sibling of the 2D board's crimson footprint hatch
-// (`CreationBoard.tsx`'s `db-footprint-hatch` pattern) — Kirk's rule ("any
-// hex that is not 100% uncovered would not be traversable") makes this a
-// BLOCKED overlay on an otherwise-real floor tile, not an omitted tile
-// the way a hole is (see `creation/canvasFloor.ts`'s own doc comment for
-// that distinction spelled out). Same crimson family as the 2D hatch's
-// own stroke color (`#c94f4f`), translucent rather than a hatch pattern —
-// a flat semi-transparent disc is the cheap 3D-legible equivalent; a true
+// (`CreationBoard.tsx`'s `db-footprint-hatch` pattern) — a BLOCKED
+// overlay on an otherwise-real floor tile, not an omitted tile the way a
+// hole is (see `creation/canvasFloor.ts`'s own doc comment for that
+// distinction spelled out). Same crimson family as the 2D hatch's own
+// stroke color (`#c94f4f`), translucent rather than a hatch pattern — a
+// flat semi-transparent disc is the cheap 3D-legible equivalent; a true
 // hatched TEXTURE was judged not worth the extra material/UV work for a
 // first landing.
+//
+// **Coverage-scaled opacity (rpg-project#169's coverage-based-
+// standability follow-up, live design round with Kirk, 2026-08-07)**:
+// every footprint cell still renders SOME dim (an author needs to see
+// every cell a wall genuinely clips, standable or not — the retired
+// binary rule's own honesty about "the wall touches here" doesn't go
+// away just because coverage now decides whether it also blocks
+// standing), but a lightly-clipped, standable cell reads visibly
+// LIGHTER than a heavily-clipped, blocked one — `FOOTPRINT_DIM_OPACITY`
+// is now the opacity at FULL coverage (0.5, the maximum
+// `hexCoverageFraction` ever returns), scaled linearly down from there;
+// `FOOTPRINT_DIM_MIN_OPACITY` is the floor for a near-zero clip so even
+// the faintest genuine touch stays visible, never fully invisible.
 const FOOTPRINT_DIM_Y = 0.21;
 const FOOTPRINT_DIM_COLOR = '#c94f4f';
 const FOOTPRINT_DIM_OPACITY = 0.55;
+const FOOTPRINT_DIM_MIN_OPACITY = 0.12;
 
 function FootprintDimCell({
   worldX,
   worldZ,
   shape,
+  coverage,
 }: {
   worldX: number;
   worldZ: number;
   shape: Shape;
+  /** `hexCoverageFraction`'s own 0..0.5 range. */
+  coverage: number;
 }) {
+  const opacity =
+    FOOTPRINT_DIM_MIN_OPACITY +
+    (FOOTPRINT_DIM_OPACITY - FOOTPRINT_DIM_MIN_OPACITY) *
+      Math.min(1, coverage / 0.5);
   return (
     <mesh
       position={[worldX, FOOTPRINT_DIM_Y, worldZ]}
@@ -988,7 +1033,7 @@ function FootprintDimCell({
       <meshBasicMaterial
         color={FOOTPRINT_DIM_COLOR}
         transparent
-        opacity={FOOTPRINT_DIM_OPACITY}
+        opacity={opacity}
         depthWrite={false}
         side={DoubleSide}
       />
@@ -1165,9 +1210,24 @@ export function DungeonPreview3D({
     [floorPlan]
   );
   // A straight wall's (`doc.wallLines`) footprint — doc-native, renders
-  // identically regardless of `floorPlan`/`floorCells`. See
-  // `buildWallLineFootprint`'s own doc comment.
-  const wallLineFootprint = useMemo(() => buildWallLineFootprint(doc), [doc]);
+  // identically regardless of `floorPlan`/`floorCells`. `wallLineFootprint`
+  // is the STANDABLE subset (coverage-based, rpg-project#169's live-design
+  // follow-up) — every existing consumer below (`buildPlaceableCells`,
+  // `buildWalkContext`, `handleClickCell`) already only ever needed "is
+  // this cell blocked for STANDING," so none of them changed; only what
+  // this variable itself means did. `wallLineFootprintCoverage` is the
+  // FULL touched-at-all map (every footprint cell, any coverage), needed
+  // separately for the dim overlay's own light/full de-emphasis below —
+  // see `buildWallLineFootprintCoverage`/`buildStandableWallLineFootprint`'s
+  // own doc comments.
+  const wallLineFootprintCoverage = useMemo(
+    () => buildWallLineFootprintCoverage(doc),
+    [doc]
+  );
+  const wallLineFootprint = useMemo(
+    () => standableFootprintKeys(wallLineFootprintCoverage),
+    [wallLineFootprintCoverage]
+  );
   // The straight wall's own real geometry (this unit) — doc-native too,
   // same reasoning as the footprint above. See `buildWallLineSegments`'s
   // own doc comment.
@@ -1544,7 +1604,7 @@ export function DungeonPreview3D({
                   </group>
                 );
               })}
-              {[...wallLineFootprint].map((key) => {
+              {[...wallLineFootprintCoverage].map(([key, coverage]) => {
                 const [col, row] = key.split(',').map(Number);
                 const [wx, , wz] = worldPosition(col, row);
                 return (
@@ -1553,6 +1613,7 @@ export function DungeonPreview3D({
                     worldX={wx}
                     worldZ={wz}
                     shape={hitShape}
+                    coverage={coverage}
                   />
                 );
               })}

--- a/src/author/preview3d/walkMovement.test.ts
+++ b/src/author/preview3d/walkMovement.test.ts
@@ -35,7 +35,7 @@ import { cubeAtColRow } from '../hexLayout';
 import {
   buildFloorTiles,
   buildPlaceableCells,
-  buildWallLineFootprint,
+  buildStandableWallLineFootprint,
   type PlaceableCell,
 } from './DungeonPreview3D';
 import {
@@ -287,7 +287,7 @@ describe('canStandAt / nearestCell — hand-built context', () => {
 // --- buildWalkContext wiring, against real parsed documents ---
 
 function canvasContextFromDoc(doc: ReturnType<typeof toDungeonDoc>) {
-  const wallLineFootprint = buildWallLineFootprint(doc);
+  const wallLineFootprint = buildStandableWallLineFootprint(doc);
   // A from-scratch canvas has no `floorPlan` — mirror
   // `CreationConcept.tsx`'s own derivation (`deriveCanvasFloorCells`) via
   // the SAME `buildFloorTiles`/`buildPlaceableCells` this concept's 3D
@@ -315,7 +315,7 @@ describe('buildWalkContext — straight-wall (wallLines) footprint wiring', () =
     // here).
     addWallLine(cst, { cell: [5, 4], corner: 2 }, { cell: [5, 4], corner: 5 });
     const doc = toDungeonDoc(cst);
-    const wallLineFootprint = buildWallLineFootprint(doc);
+    const wallLineFootprint = buildStandableWallLineFootprint(doc);
     const grid = doc.canvas!;
     const floorCells: [number, number][] = [];
     for (let col = 0; col < grid.width; col++)
@@ -374,7 +374,7 @@ describe('buildWalkContext — real showcase document (floorPlan present)', () =
   const doc = toDungeonDoc(cst);
   const floorPlan = SHOWCASE_FLOORPLAN;
   const floorTiles = buildFloorTiles(floorPlan, doc.holes, undefined);
-  const wallLineFootprint = buildWallLineFootprint(doc);
+  const wallLineFootprint = buildStandableWallLineFootprint(doc);
   const cells = buildPlaceableCells(
     floorPlan,
     doc,
@@ -411,7 +411,7 @@ describe('resolveWalkStart', () => {
     const doc = toDungeonDoc(cst);
     // start: is not set in the empty canvas fixture — use a doc override.
     const docWithStart = { ...doc, start: [3, 4] as [number, number] };
-    const wallLineFootprint = buildWallLineFootprint(doc);
+    const wallLineFootprint = buildStandableWallLineFootprint(doc);
     const grid = doc.canvas!;
     const floorCells: [number, number][] = [];
     for (let col = 0; col < grid.width; col++)
@@ -427,7 +427,7 @@ describe('resolveWalkStart', () => {
   it('falls back to the standable cell nearest the floor centroid when start: is unset', () => {
     const { cst } = parseDungeon(emptyCanvasYaml(4, 4));
     const doc = toDungeonDoc(cst);
-    const wallLineFootprint = buildWallLineFootprint(doc);
+    const wallLineFootprint = buildStandableWallLineFootprint(doc);
     const floorCells: [number, number][] = [];
     for (let col = 0; col < 4; col++)
       for (let row = 0; row < 4; row++) floorCells.push([col, row]);

--- a/src/author/preview3d/walkMovement.ts
+++ b/src/author/preview3d/walkMovement.ts
@@ -19,29 +19,53 @@
  * camera standing in" and "which cell would a click place into" can never
  * disagree.
  *
- * **Blocking rule, matched to Kirk's own rule for a drawn straight wall**
- * ("any hex that is not 100% uncovered would not be traversable") and
- * generalized to every source of impassability this document can author:
- * a cell is walkable floor MINUS three things — a straight-wall
- * (`wallLines:`) footprint cell, a `place:`/room-`place:` entry whose
- * `resolvePlacement(...).blocksMovement` resolves true (the SAME
- * inherited-default-aware resolver `isEntranceBlocked` already reads, so
- * a `defaults:`-inherited block is honored here exactly like an explicit
- * one), and a room's `boss:` cell (a monster standing there is always an
- * obstacle — `BossDoc` carries no `blocks_movement` field to resolve, so
- * this is a flat rule, not a resolved one). Separately, EDGE-crossing
- * between two individually-walkable cells is blocked by an edge-native
- * `walls:` (or server-truth `FloorPlan.edges`) entry whose `kind ===
- * 'solid'` — a `kind: 'door'` edge is deliberately NOT added to the
- * blocked-edge set, so a door is simply passable, matching this file's
- * neighbor `DungeonPreview3D.tsx`'s own `DoorGap` rendering (a genuine
- * open span, not a shortened solid box). A `wallLines:` door is already
- * handled one layer down: its cell is excluded from the OWNING line's own
- * footprint (`WallLineDoorDoc`'s own doc comment — "as if the line never
- * clipped it"), so it never enters `blockedCells`, and its own boundary
+ * **Blocking rule, generalized to every source of impassability this
+ * document can author:** a cell is walkable floor MINUS three things — a
+ * straight-wall (`wallLines:`) footprint cell whose
+ * `hexCoverageFraction` is AT/ABOVE `STANDABLE_COVERAGE_THRESHOLD`
+ * (`buildWalkContext`'s own `wallLineFootprint` PARAMETER is already the
+ * coverage-filtered subset by the time it reaches this function — see
+ * `DungeonPreview3D.tsx`'s `buildStandableWallLineFootprint`; this
+ * module itself needed no change for that refinement, since it always
+ * just union'd whatever set it was handed into `blockedCells`), a
+ * `place:`/room-`place:` entry whose `resolvePlacement(...).blocksMovement`
+ * resolves true (the SAME inherited-default-aware resolver
+ * `isEntranceBlocked` already reads, so a `defaults:`-inherited block is
+ * honored here exactly like an explicit one), and a room's `boss:` cell
+ * (a monster standing there is always an obstacle — `BossDoc` carries no
+ * `blocks_movement` field to resolve, so this is a flat rule, not a
+ * resolved one). Separately, EDGE-crossing between two
+ * individually-walkable cells is blocked by an edge-native `walls:` (or
+ * server-truth `FloorPlan.edges`) entry whose `kind === 'solid'` — a
+ * `kind: 'door'` edge is deliberately NOT added to the blocked-edge set,
+ * so a door is simply passable, matching this file's neighbor
+ * `DungeonPreview3D.tsx`'s own `DoorGap` rendering (a genuine open span,
+ * not a shortened solid box). A `wallLines:` door is already handled one
+ * layer down: its cell is excluded from the OWNING line's own footprint
+ * (`WallLineDoorDoc`'s own doc comment — "as if the line never clipped
+ * it"), so it never enters `blockedCells`, and its own boundary
  * crossings fall out of `straightWallCrossedEdges`'s ordinary
  * both-clear-cells rule with no separate door-crossing code needed here
  * either.
+ *
+ * **Coverage decides standing, the line's own crossing prohibition
+ * stays absolute** (rpg-project#169's coverage-based-standability
+ * follow-up, live design round with Kirk, 2026-08-07 — retires the
+ * original "any hex that is not 100% uncovered would not be traversable"
+ * rule for STANDING purposes; see `creation/straightWallGeometry.ts`'s
+ * own header comment on this section for the full geometry/rationale
+ * writeup). Below, `straightWallCrossedEdges` is still called against
+ * each line's OWN, UNFILTERED, full raw footprint
+ * (`straightWallFootprint`, computed fresh per line right here, never
+ * the caller-supplied coverage-filtered `wallLineFootprint` param) —
+ * mechanism (b)'s crossing-blocking is deliberately independent of
+ * coverage, exactly like Half A's own wire projection
+ * (`creation/straightWallGeometry.ts`'s `projectWallLineToEdges`) stays
+ * independent of it. A cell can be standable (below the threshold, not
+ * in `blockedCells`) while a specific edge into/out of it is still
+ * blocked by this same mechanism — a low-coverage cell isn't a free
+ * pass through the wall's own line, only a legal place to stand once
+ * you're in it via an unblocked approach.
  */
 import { HEX_SIZE } from '@/components/hex-grid/hexMath';
 import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';


### PR DESCRIPTION
## Summary

Two halves, one meaning — "walls that are real, and things that live against them."

**Half A — wallLines→edges projection.** `stripToV1Subset` now projects a `wallLines:` entry's footprint + crossed-edge geometry into wire-real `walls:` entries at send time, when this server accepts `walls:` (live today). A straight wall drawn in the builder now exists in the real game — rendered AND enforced — not just previewed client-side. Reuses `straightWallGeometry.ts`'s existing `straightWallFootprint`/`straightWallCrossedEdges` (the same primitives `preview3d/walkMovement.ts` already uses client-side), merged with any explicit `walls:` (explicit wins on a kind conflict, deduped), with rim edges (footprint touches the canvas boundary) counted and reported honestly rather than silently dropped. Doors project as `kind: door` (not a bare gap) so an authored doorway reads as a doorway in the real game's own per-edge wall renderer.

Fixed a real import cycle along the way: `straightWallGeometry.ts`/`creationGeometry.ts` imported `neighborCell` from `boardGeometry.ts`, which imports `dungeonYaml.ts` — a crashing cycle the moment `dungeonYaml.ts` needs to call the projection directly. Redirected both to `hexCorner.ts`'s own already-duplicated, leaf-level `neighborCell` instead.

**Half B — props on footprint cells.** `canvasPlacementRejectReason` gains a `requiresStandable` parameter: a prop only needs real floor (footprint cells included — Kirk's exact ask, a bookcase resting against a drawn wall); a monster/boss still needs standable ground. Both 2D (`CreationBoard.tsx`) and 3D (`DungeonPreview3D.tsx`) click-to-place paths updated to agree. The 2D board's retroactive "⚠ IN WALL FOOTPRINT" warning ring is now scoped to monster refs only, so a legitimately-placed prop renders normally.

**Half B v2 — coverage-based standability (live-design follow-up from Kirk, same day).** Retires the original "any hex not 100% uncovered would not be traversable" rule for STANDING purposes: a footprint cell now carries a coverage PERCENTAGE (`hexCoverageFraction` — Sutherland-Hodgman clip of the hex's true polygon against the wall line, the smaller resulting sub-area over the total), and a cell below `STANDABLE_COVERAGE_THRESHOLD` (10%) is standable for monsters/boss too, not just props. **Half A's wire projection is completely untouched** — the line's crossing prohibition stays absolute regardless of coverage, exactly as Kirk specified. `walkMovement.ts` and `canvasFloor.ts` needed zero logic changes (both already kept cell-blocking separate from edge-crossing); only which set callers pass in changed. The threshold is reasoned from real, independently-verified geometry (a documented, reproducible bench spanning ~1.7%–~44.9% coverage) rather than confirmed by a completed Walk-mode visual pass — that pass was attempted and blocked by a same-machine chrome-devtools MCP collision with a different concurrent agent's own active session; recorded honestly in CONTRACT.md's own ledger entry rather than fabricated. Slide-to-flush (Kirk's follow-on "we can slide a bookcase to a wall") is ledgered as a named next step, not landed this round.

## Live verification (not just unit tests)

- Built the real send-time YAML by calling the actual `stripToV1Subset` on a canvas doc with one vertical wallLine (footprint `[6,4]..[6,9]`), a door at `[6,6]`, and a bookcase placed at `[6,5]` (a footprint cell).
- `PutDungeon` against the live server (`:8092`, non-`validate_only`): `success: true`, 0 field errors, `floor_plan.edges`: **31**, matching the projection's own count — including 2 `FLOOR_PLAN_EDGE_KIND_DOOR` entries with real `doorId`s. Both the wall cell and door cell confirmed real floor.
- Started a real encounter on the saved dungeon. `MoveEntity`/`GetEncounter` transcript: a solid projected edge truncates movement at the wall boundary (verified by resulting position, not just absence of an error); a closed door (`WALL_KIND_DOOR_CLOSED`) blocks movement until `Interact`'d open, then passable — a genuine, honest finding about the real game's door mechanic that the client-side author-preview simplifies away; after opening, the player and the bookcase prop confirmed sharing the same footprint cell.
- Screenshot of the real GameView (`?playerId=...` auto-resume): a straight (non-hex-zigzag) wall run with a detailed bookcase model standing directly against it.

Full writeup with the complete transcript, including the Half B v2 threshold's own honest status: `src/author/CONTRACT.md`'s "Drawn walls become real" and "Half B v2: coverage-based standability" ledger entries. Design rationale (door-vs-gap decision, rim-edge honesty, explicit-wins merge rule, the coverage model): `src/author/TARGET-YAML.md`'s "Straight walls: stripToV1Subset" and "Coverage-based standability" sections.

## Test plan

- [x] `straightWallGeometry.test.ts`: 17 new tests (`projectWallLineToEdges` — footprint sealing, rim-edge counting invariant, door-vs-solid mechanism separation, dedup, a rule-5 regression guard proving the wire projection ignores coverage; `hexCoverageFraction` — structural/symmetry proofs and the real measurement bench; coverage-map helpers)
- [x] `dungeonYaml.test.ts`: 6 new tests for the `stripToV1Subset` projection/merge (live-doc untouched, explicit wins, door projection, rim honesty, not-accepted unchanged)
- [x] `canvasFloor.test.ts`: 7 new tests (`requiresStandable: false` for props, plus a full-pipeline integration test proving a low-coverage cell is standable for a MONSTER too, not just placeable for a prop)
- [x] Full suite: 139 files / 2331 tests passing
- [x] `ci-check` clean (format/lint/typecheck/build/test)
- [x] Live verification against the real server (see above)

— asset-pipeline agent, on behalf of KirkDiggler
