### PR TITLE
unit: game-route fidelity — reliable entity clicks + authored facing

### DIFF
--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -62,6 +62,7 @@ import { useUnequipItem } from '../../api/useUnequipItem';
 import { useCombatLog } from '../../hooks/useCombatLog';
 import type { CharacterEquipment } from '../../hooks/useEncounterState';
 import {
+  facingByEntityIdFromHexes,
   positionByEntityIdFromHexes,
   useEncounterState,
 } from '../../hooks/useEncounterState';
@@ -332,6 +333,11 @@ export function EncounterView({
         // `hexes`' own array order — see its doc comment for why a plain
         // per-hex loop here corrupted the mover's own position on reconnect.
         const positionByEntityId = positionByEntityIdFromHexes(hexes);
+        // rpg-dnd5e-web unit/game-fidelity Bug B: same reverse-index shape
+        // as positionByEntityId above, resolving Placement.facing instead
+        // of Placement's implicit hex position — see
+        // facingByEntityIdFromHexes's own doc comment.
+        const facingByEntityId = facingByEntityIdFromHexes(hexes);
         const entityEntries = (e.encounter.space?.entities ?? [])
           .filter((entity) => positionByEntityId.has(entity.id))
           .map((entity) => ({
@@ -382,6 +388,11 @@ export function EncounterView({
               entity.data?.case === 'character'
                 ? characterEquipmentFrom(entity.data.value)
                 : undefined,
+            // rpg-dnd5e-web unit/game-fidelity Bug B: authored facing
+            // (statues/bookcases etc.) must render in-game, not just in the
+            // builder preview — see facingByEntityIdFromHexes's doc
+            // comment.
+            facing: facingByEntityId.get(entity.id),
           }));
         if (entityEntries.length > 0) {
           encounterState.applyEntityAppearedBatch(entityEntries);

--- a/src/components/hex-grid/ClassCharacterModel.tsx
+++ b/src/components/hex-grid/ClassCharacterModel.tsx
@@ -108,7 +108,27 @@ export function ClassCharacterModel({
   // one — the model would silently stop animating the moment a player was
   // first selected. Tinting is applied as a separate effect below instead
   // of folding into this clone step.
-  const cloned = useMemo(() => cloneSkeleton(scene), [scene]);
+  //
+  // Every mesh opts OUT of raycasting here too (rpg-dnd5e-web
+  // unit/game-fidelity, Bug A): a THREE.SkinnedMesh raycasts against its
+  // BIND-POSE geometry, never the pose the idle/walk clip actually renders,
+  // so a click on the visible (animated) body hits or misses depending on
+  // which frame is showing — with no console signal on a miss. HexEntity
+  // now mounts a static capsule raycast proxy alongside this model (see its
+  // own doc comment) that is unaffected by any animation; this model's own
+  // meshes have no business being raycast targets at all once that proxy
+  // exists, so disabling it here is both the actual bug fix and a perf win
+  // (R3F's raycaster no longer has to walk this whole skinned mesh tree on
+  // every pointer move). A no-op function, not `null`/`undefined` — three.js
+  // calls `object.raycast(raycaster, intersects)` unconditionally, so the
+  // override must stay callable.
+  const cloned = useMemo(() => {
+    const clone = cloneSkeleton(scene);
+    clone.traverse((child) => {
+      if (child instanceof THREE.Mesh) child.raycast = () => {};
+    });
+    return clone;
+  }, [scene]);
 
   // Snapshot each mesh's original (untinted) material once per `cloned`
   // identity, so the tint effect below always starts from a clean base —

--- a/src/components/hex-grid/HexEntity.test.tsx
+++ b/src/components/hex-grid/HexEntity.test.tsx
@@ -38,8 +38,17 @@ vi.mock('@react-three/drei', () => {
   return {
     useGLTF: () => ({ scene: make(), animations: [] }),
     useTexture: () => new THREE.Texture(),
+    // `names: []` (not omitted) — ClassCharacterModel's
+    // resolveIdleClipName(names) reads this unconditionally on every
+    // render; an undefined `names` throws past HexEntity's ErrorBoundary
+    // and silently swaps in the MediumHumanoid fallback, which would make
+    // every "monster"/"player" test below exercise the WRONG model path
+    // without any test ever noticing (resolveIdleClipName's own doc
+    // comment: `resolveIdleClipName([])` is the documented, safe
+    // zero-clip case — matches a real clip-less GLB, not a broken mock).
     useAnimations: () => ({
       actions: {},
+      names: [],
       mixer: new THREE.AnimationMixer(new THREE.Group()),
     }),
   };
@@ -119,6 +128,98 @@ describe('remembered entities are inert', () => {
     );
 
     expect(handlerCount(renderer, 'onClick')).toBe(0);
+  });
+});
+
+describe('raycast proxy (rpg-dnd5e-web unit/game-fidelity Bug A)', () => {
+  // A THREE.SkinnedMesh raycasts against its BIND-POSE geometry, not the
+  // pose the idle/walk clip actually renders — clicks on the visible
+  // (animated) body hit-or-miss by animation frame with no console signal
+  // on a miss. HexEntity now mounts an invisible, static capsule alongside
+  // the model and the model's own meshes opt OUT of raycasting entirely
+  // (ClassCharacterModel's `cloned` useMemo), so the proxy is the only
+  // thing left for R3F's raycaster to ever hit.
+  function meshes(
+    renderer: Awaited<ReturnType<typeof ReactThreeTestRenderer.create>>
+  ) {
+    return renderer.scene.findAllByType('Mesh') as unknown as {
+      instance: THREE.Mesh;
+    }[];
+  }
+
+  it('mounts an invisible capsule raycast proxy alongside a live monster model', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <HexEntity
+        {...base}
+        type="monster"
+        monsterRefId="skeleton"
+        onClick={() => {}}
+      />
+    );
+
+    const proxy = meshes(renderer).find(
+      (m) => m.instance.geometry.type === 'CapsuleGeometry'
+    );
+    expect(proxy).toBeDefined();
+    const material = proxy!.instance.material as THREE.MeshBasicMaterial;
+    expect(material.transparent).toBe(true);
+    expect(material.opacity).toBe(0);
+    // Untouched — only ClassCharacterModel's own GLB meshes opt out. A
+    // real THREE.Mesh.raycast takes (raycaster, intersects); the no-op
+    // override installed on the model's own meshes takes neither — arity
+    // is a robust way to tell them apart without an identity comparison
+    // against THREE.Mesh.prototype (this test environment can end up with
+    // more than one loaded copy of three.js, which would make a strict
+    // `toBe` comparison meaningless either way).
+    expect(proxy!.instance.raycast.length).toBe(2);
+  });
+
+  it('disables raycasting on the GLB-sourced model mesh so only the proxy is hittable', async () => {
+    const renderer = await ReactThreeTestRenderer.create(
+      <HexEntity
+        {...base}
+        type="monster"
+        monsterRefId="skeleton"
+        onClick={() => {}}
+      />
+    );
+
+    // The mocked useGLTF scene (top of this file) is a single BoxGeometry
+    // mesh standing in for the real skinned GLB.
+    const modelMesh = meshes(renderer).find(
+      (m) => m.instance.geometry.type === 'BoxGeometry'
+    );
+    expect(modelMesh).toBeDefined();
+    // Arity, not identity (see the proxy test's own comment for why) — a
+    // real THREE.Mesh.raycast takes (raycaster, intersects); the no-op
+    // override takes neither.
+    expect(modelMesh!.instance.raycast.length).toBe(0);
+
+    // The override is a genuine no-op, not merely a different function —
+    // calling it must never append an intersection.
+    const intersects: THREE.Intersection[] = [];
+    expect(() =>
+      modelMesh!.instance.raycast(new THREE.Raycaster(), intersects)
+    ).not.toThrow();
+    expect(intersects).toHaveLength(0);
+  });
+
+  it('mounts the same invisible capsule proxy for a live player entity', async () => {
+    // characters are skinned too (ClassCharacterModel renders both player
+    // and monster GLBs through the same component) — same proxy, same fix.
+    const renderer = await ReactThreeTestRenderer.create(
+      <HexEntity
+        {...base}
+        type="player"
+        classRefId="rogue"
+        onClick={() => {}}
+      />
+    );
+
+    const proxy = meshes(renderer).find(
+      (m) => m.instance.geometry.type === 'CapsuleGeometry'
+    );
+    expect(proxy).toBeDefined();
   });
 });
 

--- a/src/components/hex-grid/HexEntity.tsx
+++ b/src/components/hex-grid/HexEntity.tsx
@@ -535,6 +535,34 @@ export function HexEntity({
     // static prop did).
     return (
       <group ref={movingGroupRef} {...interactionProps}>
+        {/* Raycast proxy (rpg-dnd5e-web unit/game-fidelity, Bug A): a
+            THREE.SkinnedMesh raycasts against its BIND-POSE geometry, not
+            the pose the idle/walk clip actually renders — the animation
+            sways the visible body away from that invisible volume, so a
+            click on the visible model hits or misses depending on which
+            animation frame is showing, with no console signal on a miss.
+            This capsule is a plain (non-skinned) mesh at a FIXED local
+            transform, so it always raycasts exactly where it visually sits
+            — same footprint/height convention as the obstacle capsule
+            (`createEntityGeometry`/`ENTITY_HEIGHT` above), just invisible
+            (zero-opacity material, not `visible={false}` — an invisible
+            object is still raycast-testable in three.js, `visible={false}`
+            is not; `DungeonPreview3D.tsx`'s `FloorHitCell` establishes the
+            same zero-opacity-material idiom in this codebase). It carries
+            no handlers of its own — this group's `interactionProps` above
+            already bubble from any raycast-hit descendant, the same as
+            every other child here. ClassCharacterModel opts its own
+            skinned meshes OUT of raycasting entirely (see its `cloned`
+            useMemo), so this proxy is the only thing left to hit once a
+            GLB is mounted — also a perf win (one capsule test instead of
+            walking a full skinned mesh tree). MediumHumanoid's fallback
+            primitives are NOT skinned (ordinary transformed meshes, whose
+            raycast already tracks their real pose correctly) and are left
+            raycast-enabled, so this proxy only ADDS coverage there, never
+            removes any. */}
+        <mesh geometry={geometry} position={[0, ENTITY_HEIGHT / 2, 0]}>
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+        </mesh>
         {/* Dead/downed entities rendered with tilt when using the
             MediumHumanoid fallback (no separate collapsed pose asset); a
             resolved GLB's own downed/dead variant is already posed for it,

--- a/src/components/hex-grid/HexGrid.propRotation.test.ts
+++ b/src/components/hex-grid/HexGrid.propRotation.test.ts
@@ -1,0 +1,50 @@
+/**
+ * resolvePropRotationY (rpg-dnd5e-web unit/game-fidelity Bug B): the
+ * live game route's own facing-to-rotationY resolution, pulled out of
+ * HexGrid's render loop so the precedence rule (wall-adjacent computed
+ * rotation wins, then an authored wire facing, then no rotation at all) and
+ * the facing conversion itself are covered by a direct test instead of only
+ * a live-render assertion.
+ *
+ * The facing conversion MUST match the builder's 3D preview
+ * (author/preview3d/DungeonPreview3D.tsx) exactly — Kirk approved that
+ * preview's rotations as correct against TARGET-YAML.md's E/NE/NW/W/SW/SE
+ * convention, so the live game route has to render the SAME facing value
+ * as the SAME rotation, not an independently-derived equivalent (this
+ * codebase's own "MEASURED, not inferred" facing-offset discipline —
+ * facing.ts's doc comment names a prior naive-derivation hazard that
+ * silently cancelled to 2*PI). resolvePropRotationY delegates to
+ * boardGeometry.ts's facingToRotationY directly rather than reimplementing
+ * it, and the test below pins that delegation for all 6 directions.
+ */
+import { facingToRotationY } from '@/author/boardGeometry';
+import { describe, expect, it } from 'vitest';
+import { resolvePropRotationY } from './HexGrid';
+
+describe('resolvePropRotationY', () => {
+  it('returns undefined when neither a wall-adjacent rotation nor an authored facing is present', () => {
+    expect(resolvePropRotationY(undefined, undefined)).toBeUndefined();
+  });
+
+  it('prefers the computed wall-adjacent rotation over an authored facing', () => {
+    // Wall-adjacent rotation solves a DIFFERENT problem (flush against a
+    // specific wall face) than a bare facing conversion — it must win
+    // whenever both are present, same as before this field existed.
+    expect(resolvePropRotationY(1.2345, 3)).toBe(1.2345);
+  });
+
+  it('falls back to facingToRotationY(facing) when no wall-adjacent rotation is present', () => {
+    for (let facing = 0; facing < 6; facing++) {
+      expect(resolvePropRotationY(undefined, facing)).toBe(
+        facingToRotationY(facing)
+      );
+    }
+  });
+
+  it('E (facing 0) — the same anchor value the builder preview renders — is 0 radians', () => {
+    // Sanity anchor, not just a delegation check: E is the wire's facing=0
+    // and this codebase's `HEX_DIRECTIONS`/`HEX_FACING_LABELS` +x axis, so a
+    // statue authored facing East should render unrotated.
+    expect(resolvePropRotationY(undefined, 0)).toBeCloseTo(0);
+  });
+});

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -12,6 +12,16 @@
  * - Turn order overlay
  */
 
+// facingToRotationY is the Kirk-approved reference mapping for a wire
+// `facing` index (rpg-dnd5e-web unit/game-fidelity Bug B) — the builder's
+// 3D preview (author/preview3d/DungeonPreview3D.tsx) already renders
+// authored facing through this exact function, verified correct against
+// TARGET-YAML.md's E/NE/NW/W/SW/SE convention. The live game route reuses
+// it rather than re-deriving an equivalent, per this codebase's own
+// "MEASURED, not inferred" facing-offset discipline (facing.ts's own doc
+// comment on a prior naive-derivation hazard) — importing the single
+// existing measurement is the only way to GUARANTEE agreement with it.
+import { facingToRotationY } from '@/author/boardGeometry';
 import {
   doorHexKinds,
   doorHexPositions,
@@ -87,6 +97,11 @@ export interface HexGridEntity {
   isDowned?: boolean;
   obstacleType?: ObstacleType;
   propRefId?: string;
+  /** Authored runtime-override facing (rpg-dnd5e-web unit/game-fidelity Bug
+   * B) — wire hex-direction index E=0/NE=1/NW=2/W=3/SW=4/SE=5, converted to
+   * a rotationY by `resolvePropRotationY` below. Undefined means no
+   * authored override. */
+  facing?: number;
   movePath?: { x: number; y: number; z: number }[];
   moveSeq?: number;
   knowledgeState?: SceneKnowledgeState;
@@ -311,6 +326,30 @@ const GROUND_PLANE_SIZE = 200;
  * duplicating the whole rotation-computation wiring. */
 const WALL_ADJACENT_PROP_KEYS = new Set<string>(['dnd5e:props:wall-banner']);
 
+/** The rotationY HexEntity's `propRotationY` prop should actually receive
+ * for one entity (rpg-dnd5e-web unit/game-fidelity Bug B) — the computed
+ * wall-adjacent rotation (wall-banner, geometry-derived from wall
+ * neighbors, ignores `facing` entirely) wins when present, since it solves
+ * a DIFFERENT problem (flush-against-a-specific-wall-face) that a bare
+ * `facingToRotationY` conversion doesn't attempt; otherwise an authored
+ * wire `facing` (statues, bookcases, etc.) converts via the same
+ * Kirk-approved `facingToRotationY` the builder's 3D preview already uses.
+ * `undefined` (no wall-adjacent match AND no authored facing) falls
+ * through to PropModel's own rotationY=0 default, unchanged from every
+ * entity before this field existed. Pulled out of the render loop as a
+ * pure, exported function so the precedence rule is covered by a direct
+ * unit test instead of only a live-render assertion — same "pull the
+ * composition into arithmetic a test can pin" reasoning as
+ * HexEntity.tsx's `shouldTiltDeadOrDowned`. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function resolvePropRotationY(
+  wallAdjacentRotationY: number | undefined,
+  facing: number | undefined
+): number | undefined {
+  if (wallAdjacentRotationY !== undefined) return wallAdjacentRotationY;
+  return facing === undefined ? undefined : facingToRotationY(facing);
+}
+
 // Scene consumes this exact helper; exporting it permits pathfinding coverage.
 // eslint-disable-next-line react-refresh/only-export-components
 export function isHexBlocked(
@@ -497,6 +536,24 @@ function Scene({
     }
     return map;
   }, [entities, walls, wallKindByHex]);
+
+  // Final per-entity propRotationY (rpg-dnd5e-web unit/game-fidelity Bug B)
+  // — combines the wall-adjacent computation above with an authored wire
+  // `facing` via resolvePropRotationY's own precedence rule. Precomputed
+  // once per (entities, wallAdjacentRotations) change, same reasoning as
+  // wallAdjacentRotations itself: O(entities) here instead of resolving
+  // per-entity inline in the render loop below.
+  const propRotationYByEntity = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const entity of entities) {
+      const rotationY = resolvePropRotationY(
+        wallAdjacentRotations.get(entity.entityId),
+        entity.facing
+      );
+      if (rotationY !== undefined) map.set(entity.entityId, rotationY);
+    }
+    return map;
+  }, [entities, wallAdjacentRotations]);
 
   // Create character lookup map by ID for efficient entity -> character mapping
   const characterMap = useMemo(() => {
@@ -1054,7 +1111,7 @@ function Scene({
           isDowned={entity.isDowned}
           obstacleType={entity.obstacleType}
           propRefId={entity.propRefId}
-          propRotationY={wallAdjacentRotations.get(entity.entityId)}
+          propRotationY={propRotationYByEntity.get(entity.entityId)}
           movePath={entity.movePath}
           moveSeq={entity.moveSeq}
           knowledgeState={entity.knowledgeState}

--- a/src/components/playtest/PlaytestHarness.tsx
+++ b/src/components/playtest/PlaytestHarness.tsx
@@ -18,6 +18,7 @@ import { useMoveEntity } from '../../api/useMoveEntity';
 import { useSetReactionReady } from '../../api/useSetReactionReady';
 import { useTakeAction } from '../../api/useTakeAction';
 import {
+  facingByEntityIdFromHexes,
   positionByEntityIdFromHexes,
   useEncounterState,
 } from '../../hooks/useEncounterState';
@@ -221,6 +222,10 @@ export function PlaytestHarness() {
           // EncounterView.tsx) resolves VISIBLE over REMEMBERED for an
           // entity present in both, regardless of `hexes`' own array order.
           const positionByEntityId = positionByEntityIdFromHexes(hexes);
+          // rpg-dnd5e-web unit/game-fidelity Bug B: same reverse-index
+          // shape as positionByEntityId above, shared with EncounterView.tsx
+          // — see facingByEntityIdFromHexes's own doc comment.
+          const facingByEntityId = facingByEntityIdFromHexes(hexes);
           // Seed entities from the snapshot's space entities list in a single
           // batch setState call to avoid N intermediate renders for N entities.
           const entityEntries = (e.encounter.space?.entities ?? [])
@@ -251,6 +256,7 @@ export function PlaytestHarness() {
                 entity.data?.case === 'character'
                   ? entity.data.value.classRef?.id
                   : undefined,
+              facing: facingByEntityId.get(entity.id),
             }));
           if (entityEntries.length > 0) {
             encounterState.applyEntityAppearedBatch(entityEntries);

--- a/src/components/playtest/playtestMapHelpers.test.ts
+++ b/src/components/playtest/playtestMapHelpers.test.ts
@@ -211,6 +211,34 @@ describe('buildRenderableEntities', () => {
     });
   });
 
+  it('passes facing through untouched (rpg-dnd5e-web unit/game-fidelity Bug B)', () => {
+    const withFacing = {
+      ...makeEntityState('statue-1', { x: 2, y: -2, z: 0 }),
+      facing: 3,
+    };
+    const entities = new Map([['statue-1', withFacing]]);
+    const meta = new Map<string, EntityMeta>([
+      ['statue-1', { type: EntityType.OBSTACLE, monsterRefId: undefined }],
+    ]);
+
+    const list = buildRenderableEntities(entities, meta, new Map());
+
+    expect(list[0]).toMatchObject({ facing: 3 });
+  });
+
+  it('leaves facing undefined for an entity with no authored override', () => {
+    const entities = new Map([
+      ['statue-1', makeEntityState('statue-1', { x: 0, y: 0, z: 0 })],
+    ]);
+    const meta = new Map<string, EntityMeta>([
+      ['statue-1', { type: EntityType.OBSTACLE, monsterRefId: undefined }],
+    ]);
+
+    const list = buildRenderableEntities(entities, meta, new Map());
+
+    expect(list[0]?.facing).toBeUndefined();
+  });
+
   it('leaves movePath/moveSeq undefined for an entity that has never moved', () => {
     const entities = new Map([
       ['char-alice', makeEntityState('char-alice', { x: 0, y: 0, z: 0 })],

--- a/src/components/playtest/playtestMapHelpers.ts
+++ b/src/components/playtest/playtestMapHelpers.ts
@@ -67,6 +67,13 @@ export interface RenderableEntity {
    * (obstaclePropKeys.ts's resolvePropKeyForEntity). Undefined until
    * platform starts sending a ref (no server code path sets one yet). */
   propRefId?: string;
+  /** Authored runtime-override facing (rpg-dnd5e-web unit/game-fidelity Bug
+   * B) — the wire's `Placement.facing` (v1alpha2 types_pb.ts), a
+   * hex-direction index E=0/NE=1/NW=2/W=3/SW=4/SE=5. Undefined means no
+   * authored override; HexEntity/HexGrid fall back to whichever default
+   * orientation they already use (unchanged from every pre-existing
+   * caller). */
+  facing?: number;
   /** The most recent genuine move's real hex-by-hex route
    * (rpg-dnd5e-web#542), passed straight through to HexEntity's movement
    * interpolation. Undefined for an entity that has never moved. */
@@ -170,6 +177,7 @@ export function buildRenderableEntities(
       ghost?: boolean;
       movePath?: { x: number; y: number; z: number }[];
       moveSeq?: number;
+      facing?: number;
     }
   >,
   entityMeta: Map<string, EntityMeta>,
@@ -208,6 +216,7 @@ export function buildRenderableEntities(
       monsterRefId: meta?.monsterRefId,
       isDowned,
       propRefId: meta?.propRefId,
+      facing: entity.facing,
       movePath: entity.movePath,
       moveSeq: entity.moveSeq,
       knowledgeState: revealedHexes

--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -75,6 +75,7 @@ import {
   applyTurnStateChanged,
   applyWallsRevealed,
   createEmptyEncounterState,
+  facingByEntityIdFromHexes,
   hexesWithPosition,
   knowledgeStateForPosition,
   mergeEntityPosition,
@@ -980,6 +981,71 @@ describe('v1alpha2 reducer additions', () => {
           );
         });
       });
+
+      describe('facing propagation (rpg-dnd5e-web unit/game-fidelity Bug B)', () => {
+        // Placement.facing rides the SAME record as position (types_pb.ts's
+        // own doc comment: "facing rides HERE... on Placement, not
+        // Entity") — these pin that applyHexRecordsMerged actually carries
+        // it through instead of silently dropping it the way the pre-fix
+        // `setPosition` helper did.
+        it('carries an authored facing through to the cached entity state', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const hex = makeHexRecord({ x: 2, y: -1, z: -1 }, HexState.VISIBLE, [
+            makePlacement('goblin-1', 3),
+          ]);
+
+          state = applyHexRecordsMerged(state, [hex]);
+
+          expect(state.entities.get('goblin-1')?.facing).toBe(3);
+        });
+
+        it('leaves facing undefined for a placement carrying no authored override', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const hex = makeHexRecord({ x: 2, y: -1, z: -1 }, HexState.VISIBLE, [
+            create(PlacementSchema, { entityId: 'goblin-1' }),
+          ]);
+
+          state = applyHexRecordsMerged(state, [hex]);
+
+          expect(state.entities.get('goblin-1')?.facing).toBeUndefined();
+        });
+
+        it('a facing-only change at the SAME hex (turning in place) still produces a state update', () => {
+          let state = seedKnownEntity(createEmptyEncounterState(), 'goblin-1');
+          const facingEast = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1', 0)]
+          );
+          state = applyHexRecordsMerged(state, [facingEast]);
+          expect(state.entities.get('goblin-1')?.facing).toBe(0);
+
+          const facingNorthwest = makeHexRecord(
+            { x: 0, y: 0, z: 0 },
+            HexState.VISIBLE,
+            [makePlacement('goblin-1', 2)]
+          );
+          const after = applyHexRecordsMerged(state, [facingNorthwest]);
+
+          expect(after.entities).not.toBe(state.entities);
+          expect(after.entities.get('goblin-1')?.facing).toBe(2);
+        });
+
+        it('is idempotent on facing too — re-applying the same event twice leaves state identical', () => {
+          const seeded = seedKnownEntity(
+            createEmptyEncounterState(),
+            'goblin-1'
+          );
+          const hex = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+            makePlacement('goblin-1', 4),
+          ]);
+
+          const first = applyHexRecordsMerged(seeded, [hex]);
+          const second = applyHexRecordsMerged(first, [hex]);
+
+          expect(second.entities).toBe(first.entities);
+        });
+      });
     });
 
     describe('positionByEntityIdFromHexes (rpg-dnd5e-web#651)', () => {
@@ -1064,6 +1130,59 @@ describe('v1alpha2 reducer additions', () => {
         const positions = positionByEntityIdFromHexes([positionless]);
 
         expect(positions.has('goblin-1')).toBe(false);
+      });
+    });
+
+    describe('facingByEntityIdFromHexes (rpg-dnd5e-web unit/game-fidelity Bug B)', () => {
+      // Snapshot-hydration sibling of the applyHexRecordsMerged facing
+      // coverage above — same VISIBLE-over-REMEMBERED precedence
+      // (rpg-dnd5e-web#651), resolving Placement.facing instead of
+      // Placement's implicit hex position.
+      it('resolves an authored facing for a VISIBLE placement', () => {
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('statue-1', 5),
+        ]);
+
+        const facings = facingByEntityIdFromHexes([visible]);
+
+        expect(facings.get('statue-1')).toBe(5);
+      });
+
+      it('omits an entity whose placement carries no authored facing', () => {
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          create(PlacementSchema, { entityId: 'statue-1' }),
+        ]);
+
+        const facings = facingByEntityIdFromHexes([visible]);
+
+        expect(facings.has('statue-1')).toBe(false);
+      });
+
+      it('resolves to the VISIBLE facing when a REMEMBERED record for the same entity also carries one', () => {
+        const visible = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('goblin-1', 1),
+        ]);
+        const remembered = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1', 4)]
+        );
+
+        const facings = facingByEntityIdFromHexes([remembered, visible]);
+
+        expect(facings.get('goblin-1')).toBe(1);
+      });
+
+      it('still resolves a facing for an entity present ONLY in a REMEMBERED record', () => {
+        const remembered = makeHexRecord(
+          { x: 3, y: -2, z: -1 },
+          HexState.REMEMBERED,
+          [makePlacement('goblin-1', 2)]
+        );
+
+        const facings = facingByEntityIdFromHexes([remembered]);
+
+        expect(facings.get('goblin-1')).toBe(2);
       });
     });
 
@@ -1844,6 +1963,33 @@ describe('applyEntityAppearedBatch', () => {
       },
     ]);
     expect(after.entityMeta.get('obstacle-1')?.propRefId).toBe('barrel');
+  });
+
+  it('stores facing per entity (rpg-dnd5e-web unit/game-fidelity Bug B)', () => {
+    const prev = createEmptyEncounterState();
+    const after = applyEntityAppearedBatch(prev, [
+      {
+        entity: makeTestEntity('statue-1', { x: 2, y: 0, z: -2 }),
+        type: EntityType.OBSTACLE,
+        monsterRefId: undefined,
+        initialHP: undefined,
+        initialAC: undefined,
+        displayName: 'Statue',
+        propRefId: 'statue',
+        facing: 4,
+      },
+      {
+        entity: makeTestEntity('bookcase-1', { x: 3, y: 0, z: -3 }),
+        type: EntityType.OBSTACLE,
+        monsterRefId: undefined,
+        initialHP: undefined,
+        initialAC: undefined,
+        displayName: 'Bookcase',
+        propRefId: 'bookcase',
+      },
+    ]);
+    expect(after.entities.get('statue-1')?.facing).toBe(4);
+    expect(after.entities.get('bookcase-1')?.facing).toBeUndefined();
   });
 
   it('is a no-op on empty array (returns same reference)', () => {

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -156,9 +156,26 @@ export interface LocalEncounterState {
    * (e.g. bounced off a wall and sent back) still each count as a fresh
    * move worth animating, not a no-op React dependency.
    */
+  /**
+   * `facing` (rpg-dnd5e-web unit/game-fidelity Bug B): the wire's
+   * `Placement.facing` (v1alpha2 types_pb.ts — an authored runtime-override
+   * hex-direction index, E=0/NE=1/NW=2/W=3/SW=4/SE=5, `optional uint32` so
+   * presence distinguishes "no override" from explicit E=0), carried
+   * through by `applyHexRecordsMerged`/`applyEntityAppearedBatch` alongside
+   * `position` since both ride the SAME `Placement` record on the wire.
+   * Undefined means no authored override — the renderer keeps whatever
+   * default orientation it already uses (unchanged from every pre-existing
+   * caller). See `facingByEntityIdFromHexes`'s doc comment for the
+   * snapshot-hydration counterpart of this same field.
+   */
   entities: Map<
     string,
-    EntityState & { ghost?: boolean; movePath?: Position[]; moveSeq?: number }
+    EntityState & {
+      ghost?: boolean;
+      movePath?: Position[];
+      moveSeq?: number;
+      facing?: number;
+    }
   >;
   /** v1alpha2-revealed hexes, keyed by stable cube coordinate. */
   revealedHexes: Map<string, HexRecord>;
@@ -451,6 +468,52 @@ export function positionByEntityIdFromHexes(
 }
 
 /**
+ * Sibling to `positionByEntityIdFromHexes` — resolves each entity's
+ * `Placement.facing` (rpg-dnd5e-web unit/game-fidelity Bug B: "authored
+ * facing must render in-game") under the exact same VISIBLE-over-REMEMBERED
+ * precedence (rpg-dnd5e-web#651), for the snapshot-hydration counterpart of
+ * `applyHexRecordsMerged`'s own live-merge facing wire-up above. A separate
+ * pass over the same `hexes` rather than folding into
+ * `positionByEntityIdFromHexes`'s established `Map<string, Position>`
+ * return shape — that function's own contract (and every existing
+ * caller/test asserting against it) shouldn't have to change for a field
+ * most callers don't need.
+ *
+ * `Placement.facing` is `optional uint32` (types_pb.ts's own doc comment:
+ * "Presence distinguishes absent from explicit E=0") — a placement with no
+ * authored override is simply absent from the returned Map, which is
+ * exactly the "keep the model's default orientation" signal callers want:
+ * `.get()` on an unlisted id returns `undefined`, indistinguishable from
+ * every pre-existing caller that never set a facing at all.
+ */
+export function facingByEntityIdFromHexes(
+  hexes: HexRecord[]
+): Map<string, number> {
+  const positioned = hexesWithPosition(hexes);
+  const facings = new Map<string, number>();
+  const claimedByVisible = new Set<string>();
+  for (const hex of positioned) {
+    if (hex.state !== HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      claimedByVisible.add(placement.entityId);
+      if (placement.facing !== undefined) {
+        facings.set(placement.entityId, placement.facing);
+      }
+    }
+  }
+  for (const hex of positioned) {
+    if (hex.state === HexState.VISIBLE) continue;
+    for (const placement of hex.contents ?? []) {
+      if (claimedByVisible.has(placement.entityId)) continue;
+      if (placement.facing !== undefined) {
+        facings.set(placement.entityId, placement.facing);
+      }
+    }
+  }
+  return facings;
+}
+
+/**
  * Replace region metadata from the server's snapshot. A reconnect snapshot is
  * authoritative, so omitted theme/zones/hexes clear stale local values.
  * Exported for testing.
@@ -622,20 +685,31 @@ export function applyHexRecordsMerged(
   }
 
   let nextEntities: LocalEncounterState['entities'] | undefined;
-  const setPosition = (entityId: string, position: Position) => {
+  // `facing` rides the SAME Placement record as `position` (types_pb.ts's
+  // own doc comment: "facing rides HERE" — on Placement, not Entity), so it
+  // is set alongside position rather than by a separate pass. The identity
+  // short-circuit above now also compares `facing` — an entity that turns
+  // in place (same hex, new authored facing) must still produce a state
+  // update, which a position-only comparison would have swallowed.
+  const setPlacement = (
+    entityId: string,
+    position: Position,
+    facing: number | undefined
+  ) => {
     const existing = (nextEntities ?? prev.entities).get(entityId);
     if (
       existing?.position?.x === position.x &&
       existing?.position?.y === position.y &&
-      existing?.position?.z === position.z
+      existing?.position?.z === position.z &&
+      existing?.facing === facing
     ) {
       return;
     }
     if (!nextEntities) nextEntities = new Map(prev.entities);
-    nextEntities.set(
-      entityId,
-      create(EntityStateSchema, { entityId, position })
-    );
+    nextEntities.set(entityId, {
+      ...create(EntityStateSchema, { entityId, position }),
+      facing,
+    });
   };
 
   // Pass 1: every VISIBLE placement this event. Always wins — set
@@ -647,7 +721,11 @@ export function applyHexRecordsMerged(
     for (const placement of hex.contents ?? []) {
       if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
       claimedByVisibleThisEvent.add(placement.entityId);
-      setPosition(placement.entityId, v2PositionToV1(hex.position));
+      setPlacement(
+        placement.entityId,
+        v2PositionToV1(hex.position),
+        placement.facing
+      );
     }
   }
   // Pass 2: REMEMBERED placements — only for entities no VISIBLE record
@@ -660,7 +738,11 @@ export function applyHexRecordsMerged(
     for (const placement of hex.contents ?? []) {
       if (claimedByVisibleThisEvent.has(placement.entityId)) continue;
       if (!prev.entityMeta.has(placement.entityId)) continue; // fail closed
-      setPosition(placement.entityId, v2PositionToV1(hex.position));
+      setPlacement(
+        placement.entityId,
+        v2PositionToV1(hex.position),
+        placement.facing
+      );
     }
   }
 
@@ -731,6 +813,13 @@ function toEntityStatus(effect: StatusEffect): EntityStatus | undefined {
  * one map. Omitting statusEffects entirely (existing callers) leaves
  * entityStatuses untouched, matching the pre-#462 behavior exactly.
  *
+ * `facing` (rpg-dnd5e-web unit/game-fidelity Bug B) is the snapshot's own
+ * `facingByEntityIdFromHexes` resolution for this entity — the caller
+ * resolves it the same way it resolves `entity.position` (a one-shot
+ * reverse index off the snapshot's `hexes`), passed straight through here
+ * rather than re-derived. Undefined (every pre-existing caller) leaves the
+ * entity's `facing` unset, matching every renderer's existing default.
+ *
  * Exported for testing.
  */
 export function applyEntityAppearedBatch(
@@ -746,6 +835,7 @@ export function applyEntityAppearedBatch(
     classRefId?: string;
     propRefId?: string;
     equipment?: CharacterEquipment;
+    facing?: number;
   }>
 ): LocalEncounterState {
   if (entries.length === 0) return prev;
@@ -770,8 +860,9 @@ export function applyEntityAppearedBatch(
     classRefId,
     propRefId,
     equipment,
+    facing,
   } of entries) {
-    newEntities.set(entity.entityId, { ...entity, ghost: false });
+    newEntities.set(entity.entityId, { ...entity, ghost: false, facing });
     newMeta.set(entity.entityId, {
       type,
       monsterRefId,
@@ -1435,6 +1526,7 @@ export interface UseEncounterStateResult {
       classRefId?: string;
       propRefId?: string;
       equipment?: CharacterEquipment;
+      facing?: number;
     }>
   ) => void;
   /**
@@ -1581,6 +1673,7 @@ export function useEncounterState(): UseEncounterStateResult {
         classRefId?: string;
         propRefId?: string;
         equipment?: CharacterEquipment;
+        facing?: number;
       }>
     ) => {
       setState((prev) => applyEntityAppearedBatch(prev, entries));


### PR DESCRIPTION
## Summary

Two live-play bugs Kirk found on his own canvas dungeon ("Hey Stans" / `untitled-creation`), both on the real GameView route:

**Bug A — intermittent entity clicks.** A `THREE.SkinnedMesh` raycasts against its bind-pose geometry, not the pose the idle/walk clip actually renders — the animation sways the visible body away from that invisible volume, so a click hit-or-missed depending on which animation frame was showing, with no console signal on a miss. Obstacles (static meshes) always worked; monsters/characters (skinned) didn't.

**Bug B — authored prop facing ignored in-game.** The wire carries `Placement.facing` (an authored runtime override), but the live route silently dropped it on the way from `StreamEncounter` into render state — every statue/bookcase rendered at the prop's default rotation regardless of what was authored, even though the builder's own 3D preview already rendered the same facing correctly.

## Bug A — proxy design

`HexEntity` now mounts an invisible, static capsule (`createEntityGeometry`/`ENTITY_HEIGHT`, the same footprint/height convention the obstacle capsule already uses) alongside every player/monster entity's model — positioned at `[0, ENTITY_HEIGHT / 2, 0]` inside the entity's existing group, material `transparent opacity={0}` (not `visible={false}`, which three.js still raycasts through — matches the same idiom `DungeonPreview3D.tsx`'s `FloorHitCell` already established in this codebase).

`ClassCharacterModel` opts every mesh in its cloned GLB tree out of raycasting entirely (`mesh.raycast = () => {}`, set once in the existing `cloned` useMemo) — so the proxy is the only raycastable thing left once a real model mounts. The entity group's existing `onClick`/`onPointerOver`/`onPointerOut` handlers are unchanged and bubble from the proxy exactly as they already bubble from every other descendant — this is also a perf win (R3F no longer walks a full skinned mesh tree on every pointer move).

`MediumHumanoid`'s fallback primitives are ordinary (non-skinned) meshes whose raycast already tracks their real pose correctly, so they're untouched — the proxy only *adds* coverage there, it never removes any.

Applies identically to players and monsters (both render through `ClassCharacterModel`), so no separate treatment was needed for "characters are skinned too."

## Bug B — the facing mapping

**Wire field → client `facing`:** `v1alpha2.encounter.Placement.facing` (`optional uint32`), hex-direction index `E=0, NE=1, NW=2, W=3, SW=4, SE=5` (types_pb.ts's own doc comment). This is carried through the client's whole reducer chain (`useEncounterState`'s `applyHexRecordsMerged`/`applyEntityAppearedBatch`, `facingByEntityIdFromHexes` for snapshot hydration, `playtestMapHelpers.buildRenderableEntities`) as a plain `number | undefined` on the renderable entity — no re-encoding.

**Facing → rotationY:** `HexGrid`'s new `resolvePropRotationY` converts it via `author/boardGeometry.ts`'s `facingToRotationY` — the *exact same function* the builder's 3D preview (`author/preview3d/DungeonPreview3D.tsx`) already uses and Kirk approved as visually correct. Verified the wire convention matches: `HEX_FACING_LABELS = ['E','NE','NW','W','SW','SE']` (`authorGridHelpers.ts`) is index-aligned with the proto's own E/NE/NW/W/SW/SE ordering, so no offset/measurement was needed — reusing the function directly (rather than re-deriving an equivalent) is what *guarantees* the two renderers can't silently disagree, per this codebase's own "measured, not inferred" facing-offset discipline (`facing.ts`'s doc comment names a prior naive-derivation hazard that silently cancelled to 2π).

The existing wall-adjacent computed rotation (wall-banner, geometry-derived from wall neighbors) still wins over an authored facing when both are present — a different problem (flush against a specific wall face), unchanged behavior.

## Verification

**Bug A** — unit-level (deterministic, `HexEntity.test.tsx`): confirms the proxy mesh mounts (capsule geometry, zero-opacity material) for both live monster and player entities, and that `ClassCharacterModel`'s GLB-sourced mesh's `raycast` is overridden to a genuine no-op (arity-based check, not identity — this test environment can load more than one copy of three.js). Live: hovered the player's own skinned model (identical proxy/bubbling path to a monster) at a fixed screen point 14 times across ~2.8s (spanning the idle clip's loop) on the real GameView route (`untitled-creation` encounter) — **14/14 cursor hits**. I also tried a live pre-fix A/B (temporarily reverted just these two files, reran 40 samples) and did *not* get a clean repro of a miss at that specific target/zoom — consistent with a prior investigation's own note that synthetic testing struggled to reproduce this intermittent bug cleanly; the fix's correctness rests on the structural guarantee (a static, non-skinned proxy cannot exhibit animation-frame-dependent raycast divergence by construction) plus the unit-level proof that the skinned mesh's raycast is genuinely disabled, not on this live sample size.

**Bug B** — unit-level: `facingByEntityIdFromHexes`/`applyHexRecordsMerged` facing propagation (incl. same-hex facing-only updates and idempotency), `buildRenderableEntities` passthrough, `resolvePropRotationY`'s precedence rule and its delegation to `facingToRotationY` for all 6 directions. Live: walked the real GameView route's React fiber to read the raw `entities` array `HexGrid.Scene` received, for the actual `untitled-creation` encounter — **every authored facing matched its YAML label exactly**: `statue-knight-hooded` W→3, `bookcase` NW→2 / SE→5, `skeleton-remains` SE→5 / SW→4, `skeleton-cage` SW→4, `skeleton-table` SW→4, `barricade` SE→5 / W→3, and props with no authored `facing:` (pillar, torch-ornate, one unfaced barricade) correctly carried none.

**Full suite:** `npm run ci-check` clean (format, lint, typecheck, build, tests) — 2325 tests passing, including this unit's ~20 new tests across `HexEntity.test.tsx`, `useEncounterState.test.ts`, `playtestMapHelpers.test.ts`, and the new `HexGrid.propRotation.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4

— asset-pipeline agent, on behalf of KirkDiggler
