### PR TITLE
unit: authored walls speak the game's run language

### DIFF
--- a/src/components/game/EncounterMap.test.tsx
+++ b/src/components/game/EncounterMap.test.tsx
@@ -298,3 +298,114 @@ describe('EncounterMap wall truth gate (game walls from truth — zones are not 
     expect(props.connectorRuns).toEqual([]);
   });
 });
+
+describe("EncounterMap authored-wall-run wiring (unit/authored-wall-runs: authored walls speak the game's run language)", () => {
+  /** A non-door boundary-edge wall between two adjacent hexes that are
+   * BOTH inside the same painted zone — exactly the shape #720
+   * established an authored dungeon's real wall edges take relative to
+   * its own (semantic-only) zone hex membership: categorizeWall's
+   * 'interior' branch, the extraction point for authoredWallRuns. */
+  function interiorBoundaryWall(
+    fromCol: number,
+    fromRow: number,
+    toCol: number,
+    toRow: number,
+    id?: string
+  ): Wall {
+    const from = cubeAtColRow(fromCol, fromRow);
+    const to = cubeAtColRow(toCol, toRow);
+    return create(WallSchema, {
+      from: create(PositionSchema, { x: from.x, y: from.y, z: from.z }),
+      to: create(PositionSchema, { x: to.x, y: to.y, z: to.z }),
+      kind: WallKind.SOLID,
+      id,
+    });
+  }
+
+  it("an authored dungeon's real boundary-edge wall renders as an authored run, not through legacySyntyWalls (the jagged-per-edge regression this unit fixes)", () => {
+    const zone = zoneHexes('room-a'); // a 2x2 block: (0,0),(1,0),(0,1),(1,1)
+    const edge = interiorBoundaryWall(0, 0, 1, 0, 'edge-1');
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={
+          new Map(
+            zone.map((h) => [
+              `${h.position!.x},${h.position!.y},${h.position!.z}`,
+              h,
+            ])
+          )
+        }
+        walls={new Map([['edge-1', edge]])}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.authoredRuns!.length).toBeGreaterThanOrEqual(1);
+    expect(props.legacySyntyWalls).not.toContainEqual(edge);
+  });
+
+  it("a chain dungeon's real wall data (never in the interior category — covered by an envelope/connector run or a door instead) produces NO authored runs — regression guard for the existing chain-dungeon render path", () => {
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={
+          new Map(
+            zoneHexes('room-a').map((h) => [
+              `${h.position!.x},${h.position!.y},${h.position!.z}`,
+              h,
+            ])
+          )
+        }
+        walls={new Map([['wall-1', solidWall('wall-1')]])}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.authoredRuns).toEqual([]);
+    // The pre-existing chain-dungeon envelope behavior (#720's own
+    // regression guard, above) is untouched by this addition.
+    expect(props.envelopeRuns!.length).toBe(4);
+  });
+
+  it('a degenerate interior wall (a genuine blocked-cell obstacle, e.g. a crypt pillar) stays on the legacy per-cell renderer, never becomes an authored run', () => {
+    const zone = zoneHexes('room-a');
+    const pillar = solidWall('pillar-1'); // degenerate: from === to at (0,0,0), inside the zone
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={
+          new Map(
+            zone.map((h) => [
+              `${h.position!.x},${h.position!.y},${h.position!.z}`,
+              h,
+            ])
+          )
+        }
+        walls={new Map([['pillar-1', pillar]])}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.authoredRuns).toEqual([]);
+    expect(props.legacySyntyWalls).toContainEqual(pillar);
+  });
+
+  it('a door edge is unaffected: still rendered via legacySyntyWalls (the existing per-edge door frame/leaf path), never converted into an authored run', () => {
+    const zone = zoneHexes('room-a');
+    const door = doorWall('door-1');
+    render(
+      <EncounterMap
+        {...baseProps()}
+        revealedHexes={
+          new Map(
+            zone.map((h) => [
+              `${h.position!.x},${h.position!.y},${h.position!.z}`,
+              h,
+            ])
+          )
+        }
+        walls={new Map([['door-1', door]])}
+      />
+    );
+    const props = hoisted.lastHexGridProps.current!;
+    expect(props.legacySyntyWalls).toContainEqual(door);
+  });
+});

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -304,7 +304,18 @@ export function EncounterMap({
       wallRunsResult.connectorRuns,
       connectorDoors
     );
-    return computeAuthoredWallRuns(edgeInputs);
+    // Ground each run's outward `facing` in real floor proximity (every
+    // revealed region's own hex membership) rather than the pure
+    // connected-component-centroid fallback — see
+    // computeAuthoredWallRuns' own `floorHexes` doc comment for why a
+    // centroid-only heuristic breaks down on a finely irregular boundary
+    // (verified live against dungeon-one's own wall data: roughly half
+    // its crenellated stretch's tiled pieces showed their flat,
+    // undecorated back to the player instead of the tinted/detailed
+    // front — exactly Kirk's live report that authored walls read as
+    // dark/illegible, worst under crypt's already-dim mood lighting).
+    const floorHexes = regions.flatMap((region) => region.hexes);
+    return computeAuthoredWallRuns(edgeInputs, HEX_SIZE, floorHexes);
   }, [wallList, regions, wallRunsResult, connectorDoors]);
   // legacySyntyWallsRaw still includes every 'interior' wall (degenerate
   // AND boundary-edge alike — legacyRenderWalls' own contract is

--- a/src/components/game/EncounterMap.tsx
+++ b/src/components/game/EncounterMap.tsx
@@ -29,8 +29,11 @@ import type {
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useMemo } from 'react';
 import { DevPerfProbe } from '../../dev/DevPerfProbe';
+import { computeAuthoredWallRuns } from '../../hooks/authoredWallRuns';
 import type { EntityMeta, EntityStatus } from '../../hooks/useEncounterState';
 import {
+  authoredWallEdgeCandidates,
+  authoredWallRunEdgeInputs,
   connectorDoorHeights,
   connectorDoorInputsFromWalls,
   connectorDoorPlanes,
@@ -259,7 +262,7 @@ export function EncounterMap({
       }),
     [regions, connectorDoors, hasWallTruth]
   );
-  const legacySyntyWalls = useMemo(
+  const legacySyntyWallsRaw = useMemo(
     () =>
       legacyRenderWalls(
         wallList,
@@ -269,6 +272,55 @@ export function EncounterMap({
       ),
     [wallList, regions, wallRunsResult, connectorDoors]
   );
+  // Authored-wall-run rendering (rpg-project#720 follow-up, "authored
+  // walls speak the game's run language"): every 'interior'-category,
+  // boundary-edge, non-door wall (authoredWallEdgeCandidates' own doc
+  // comment) — the category nearly every real authored (canvas) dungeon
+  // wall edge falls into today, since #720 correctly stopped feeding a
+  // zone's bounding box into computeWallRuns for those, but never gave
+  // them anywhere better to render than SyntyHexWall's legacy per-cell
+  // path (the "vertical blinds" jagged look: one small piece per single
+  // hex edge, independently rotated/variant-picked). Chained into
+  // straight runs and rendered by WallRunMesh with the same tiled-Synty-
+  // piece language envelope/connector runs already use. A chain dungeon's
+  // real perimeter/connector walls are never in 'interior' category (they
+  // resolve to an envelope/connector run or a door instead), so this is a
+  // no-op there — see wallRunAdapters.test.ts's own regression coverage
+  // against real reference-tomb wire data.
+  const authoredWallEdges = useMemo(
+    () =>
+      authoredWallEdgeCandidates(
+        wallList,
+        regions,
+        wallRunsResult.connectorRuns,
+        connectorDoors
+      ),
+    [wallList, regions, wallRunsResult, connectorDoors]
+  );
+  const authoredWallRuns = useMemo(() => {
+    const edgeInputs = authoredWallRunEdgeInputs(
+      wallList,
+      regions,
+      wallRunsResult.connectorRuns,
+      connectorDoors
+    );
+    return computeAuthoredWallRuns(edgeInputs);
+  }, [wallList, regions, wallRunsResult, connectorDoors]);
+  // legacySyntyWallsRaw still includes every 'interior' wall (degenerate
+  // AND boundary-edge alike — legacyRenderWalls' own contract is
+  // unchanged, see authoredWallEdgeCandidates' doc comment on why it
+  // stays a narrower, separate selection rather than a mutation of that
+  // function). Subtract exactly the boundary-edge ones now covered by
+  // authoredWallRuns above, by reference (both derive from the SAME
+  // `wallList` array, so its own elements are shared, not cloned) — a
+  // degenerate 'interior' wall (a real blocked-cell obstacle, e.g. a
+  // crypt pillar) is never in `authoredWallEdges`, so it stays on
+  // SyntyHexWall's legacy per-cell path unaffected.
+  const legacySyntyWalls = useMemo(() => {
+    if (authoredWallEdges.length === 0) return legacySyntyWallsRaw;
+    const covered = new Set(authoredWallEdges);
+    return legacySyntyWallsRaw.filter((wall) => !covered.has(wall));
+  }, [legacySyntyWallsRaw, authoredWallEdges]);
   // W3 "fallback restyle" (rpg-project#133 design.md/plan.md): the same
   // structural safety-net candidates legacyRenderWalls used to keep for
   // SyntyHexWall's legacy per-cell renderer now render as straight,
@@ -574,6 +626,7 @@ export function EncounterMap({
         envelopeCorners={wallRunsResult.envelopeCorners}
         connectorRuns={wallRunsResult.connectorRuns}
         connectorFallbackSegments={fallbackSegments}
+        authoredRuns={authoredWallRuns}
         doorPlaneOverrides={doorPlaneOverrides}
         wallHeight={wallHeightOverride}
         wallCutaway={wallCutawayOverride}

--- a/src/components/hex-grid/HexGrid.tsx
+++ b/src/components/hex-grid/HexGrid.tsx
@@ -12,6 +12,7 @@
  * - Turn order overlay
  */
 
+import type { AuthoredWallRun } from '@/hooks/authoredWallRuns';
 import {
   doorHexKinds,
   doorHexPositions,
@@ -158,6 +159,15 @@ export interface HexGridProps {
    * instead of SyntyHexWall's legacy per-cell hex-vertex look. Empty/
    * omitted renders nothing extra, unchanged from pre-W3 behavior. */
   connectorFallbackSegments?: WallRunSegment[];
+  /** A canvas (authored) dungeon's own real wall edges, chained into
+   * straight runs by authoredWallRuns.computeAuthoredWallRuns and rendered
+   * by WallRunMesh with the SAME tiled-Synty-piece language as
+   * envelopeRuns — see WallRunMesh's own `authoredRuns` prop doc comment
+   * for why this can't reuse envelope/connector geometry (a canvas
+   * dungeon's regions are semantic-only zones, not wall truth). Empty/
+   * omitted (every caller not yet updated, and any chain-generated
+   * dungeon) renders nothing extra, unchanged. */
+  authoredRuns?: AuthoredWallRun[];
   /** Per-door exact position + rotationY override, keyed by Wall.id
    * (wallRunAdapters.connectorDoorPlanes) — passed straight through to
    * SyntyHexWall so a door frame/leaf sits exactly on its connector's own
@@ -409,6 +419,7 @@ function Scene({
   envelopeCorners = [],
   connectorRuns = [],
   connectorFallbackSegments = [],
+  authoredRuns = [],
   doorPlaneOverrides,
   wallHeight,
   wallCutaway = false,
@@ -981,6 +992,7 @@ function Scene({
             envelopeCorners={envelopeCorners}
             connectorRuns={connectorRuns}
             fallbackSegments={connectorFallbackSegments}
+            authoredRuns={authoredRuns}
             spaceTheme={spaceTheme}
             rememberedEnvelopeRegionIds={rememberedRunIds.envelopeRegionIds}
             rememberedConnectorDoorIds={rememberedRunIds.connectorDoorIds}

--- a/src/components/hex-grid/WallRunMesh.test.tsx
+++ b/src/components/hex-grid/WallRunMesh.test.tsx
@@ -1,3 +1,4 @@
+import type { AuthoredWallRun } from '@/hooks/authoredWallRuns';
 import type {
   ConnectorRun,
   EnvelopeCorner,
@@ -140,6 +141,35 @@ describe('WallRunMesh R3F scene', () => {
 
     // 1 tiled wall piece + 1 skirt = 2.
     expect(countMeshes(renderer)).toBe(2);
+  });
+
+  it('renders authored wall runs with the same tiled visual language and facing correction as envelope runs', async () => {
+    const authoredRuns: AuthoredWallRun[] = [
+      {
+        key: 'left-run',
+        start: { x: 0, z: 0 },
+        end: { x: 0, z: 4 },
+        facing: { x: -1, z: 0 },
+      },
+      {
+        key: 'right-run',
+        start: { x: 4, z: 0 },
+        end: { x: 4, z: 4 },
+        facing: { x: 1, z: 0 },
+      },
+    ];
+
+    const renderer = await ReactThreeTestRenderer.create(
+      <WallRunMesh
+        envelopeRuns={[]}
+        connectorRuns={[]}
+        authoredRuns={authoredRuns}
+      />
+    );
+
+    // Same tiling arithmetic as the envelope-run test above: 2 runs of
+    // length 4 -> 4 pieces each (8 total) + 1 skirt per run (2) = 10.
+    expect(countMeshes(renderer)).toBe(10);
   });
 
   it('skips degenerate zero-length segments without throwing', async () => {

--- a/src/components/hex-grid/WallRunMesh.tsx
+++ b/src/components/hex-grid/WallRunMesh.tsx
@@ -31,6 +31,7 @@
  * `WallRunMeshProps.fallbackSegments`'s doc comment.
  */
 
+import type { AuthoredWallRun } from '@/hooks/authoredWallRuns';
 import type {
   ConnectorRun,
   EnvelopeCorner,
@@ -222,6 +223,30 @@ export interface WallRunMeshProps {
    * remembered-hexes data source (fog-of-war Task 2+).
    */
   fallbackSegments?: WallRunSegment[];
+  /**
+   * A canvas (authored) dungeon's own real wall edges, chained into
+   * straight runs by `authoredWallRuns.computeAuthoredWallRuns` — the
+   * same tiled-Synty-piece language as `envelopeRuns`, but derived
+   * directly from real wall EDGES rather than a region's bounding box
+   * (rpg-dnd5e-web#720 "zones are not rooms": an authored dungeon's
+   * `regions:` are semantic-only zones with no guaranteed relationship to
+   * real wall truth, so envelope/connector geometry can't be trusted for
+   * them the way it can for a chain-generated room). Carries its own
+   * `facing` (derived from its wall network's own vertex centroid, the
+   * closest available stand-in for "room center" a zone-independent
+   * module has), so it gets the same `facingCorrectedRotationY` treatment
+   * envelope runs do. Empty/omitted (every caller before this prop
+   * existed, and any chain-generated dungeon, which has no authored wall
+   * edges at all) renders nothing extra, unchanged.
+   *
+   * Not currently matched against `rememberedEnvelopeRegionIds` — an
+   * authored run has no `regionId` of its own to key against (it can span
+   * or ignore zone boundaries entirely); fog-of-war memory for authored
+   * dungeons is a follow-up, not a regression this prop introduces
+   * (chain dungeons, the only routes with fog-of-war memory wired up
+   * today, never populate this prop at all).
+   */
+  authoredRuns?: AuthoredWallRun[];
   /** Fog-of-war memory (rpg-dnd5e-web#601/#602 scene-knowledge contract):
    * region ids whose envelope (all 4 sides + corner) should render via
    * `GlbInstance`'s `remembered` look instead of `spaceTheme`'s tint.
@@ -307,6 +332,7 @@ export function WallRunMesh({
   envelopeRuns,
   connectorRuns,
   fallbackSegments = [],
+  authoredRuns = [],
   rememberedEnvelopeRegionIds,
   rememberedConnectorDoorIds,
   wallHeight = WALL_HEIGHT,
@@ -331,6 +357,25 @@ export function WallRunMesh({
               facing={run.facing}
             />
             <FloorSkirtBox segment={run} remembered={remembered} />
+          </group>
+        );
+      })}
+      {authoredRuns.map((run) => {
+        // Same envelope-side height rule as envelopeRuns above (both
+        // carry a real outward `facing`, unlike a connector/fallback
+        // interior partition) — see `authoredRuns`' own prop doc comment
+        // for why this run has no regionId to key fog-of-war memory
+        // against yet.
+        const height = effectiveWallHeight(run.facing, wallCutaway, wallHeight);
+        return (
+          <group key={run.key}>
+            <TiledWallRun
+              segment={run}
+              wallHeight={height}
+              tint={tint}
+              facing={run.facing}
+            />
+            <FloorSkirtBox segment={run} />
           </group>
         );
       })}

--- a/src/hooks/authoredWallRuns.test.ts
+++ b/src/hooks/authoredWallRuns.test.ts
@@ -8,6 +8,7 @@
  */
 import {
   coordToKey,
+  cubeToWorld,
   HEX_DIRECTIONS,
   HEX_SIZE,
   hexEdgeBetween,
@@ -189,6 +190,60 @@ describe("computeAuthoredWallRuns — a rectangular wall loop (Kirk's dungeon-on
       expect(mag).toBeGreaterThan(0.9);
       expect(mag).toBeLessThan(1.1);
     }
+  });
+});
+
+describe('computeAuthoredWallRuns — floorHexes-grounded facing (fixes the centroid heuristic breaking down on a locally irregular boundary)', () => {
+  it('points every run of a full rectangular loop away from the known floor inside it', () => {
+    const edges = rectBoundaryEdges(0, 20, 0, 3);
+    const floorHexes: CubeCoord[] = [];
+    for (let col = 0; col <= 20; col++) {
+      for (let row = 0; row <= 3; row++) {
+        floorHexes.push(cubeAtColRow(col, row));
+      }
+    }
+    const floorWorldPositions = floorHexes.map((h) => cubeToWorld(h, HEX_SIZE));
+
+    const runs = computeAuthoredWallRuns(edges, HEX_SIZE, floorHexes);
+    expect(runs.length).toBeGreaterThan(0);
+    for (const run of runs) {
+      const mid = {
+        x: (run.start.x + run.end.x) / 2,
+        z: (run.start.z + run.end.z) / 2,
+      };
+      // Same probe distance the module's own facingViaFloorProximity uses
+      // internally (sqrt(3) hex radii) — a shorter verification probe can
+      // land ambiguously close to a zigzag boundary's own "eaten" offset
+      // (wallRuns.ts's DEFAULT_ENVELOPE_OFFSET_TOP_BOTTOM_HEXES finding)
+      // and produce a false failure independent of whether facing is
+      // actually correct.
+      const probeDist = HEX_SIZE * Math.sqrt(3);
+      const inwardProbe = {
+        x: mid.x - run.facing.x * probeDist,
+        z: mid.z - run.facing.z * probeDist,
+      };
+      const outwardProbe = {
+        x: mid.x + run.facing.x * probeDist,
+        z: mid.z + run.facing.z * probeDist,
+      };
+      const nearestFloorDistance = (p: { x: number; z: number }) =>
+        Math.min(
+          ...floorWorldPositions.map((f) => Math.hypot(p.x - f.x, p.z - f.z))
+        );
+      // The probe BEHIND facing (mid - facing*step) should land closer to
+      // known floor than the probe AHEAD of facing (mid + facing*step) —
+      // i.e. facing points away from the room, not into it.
+      expect(nearestFloorDistance(inwardProbe)).toBeLessThanOrEqual(
+        nearestFloorDistance(outwardProbe)
+      );
+    }
+  });
+
+  it('omitting floorHexes keeps the original centroid-based facing (backward compatible)', () => {
+    const edges = rectBoundaryEdges(0, 5, 0, 3);
+    const withoutFloor = computeAuthoredWallRuns(edges);
+    const withEmptyFloor = computeAuthoredWallRuns(edges, HEX_SIZE, []);
+    expect(withEmptyFloor).toEqual(withoutFloor);
   });
 });
 

--- a/src/hooks/authoredWallRuns.test.ts
+++ b/src/hooks/authoredWallRuns.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for authoredWallRuns — chains a canvas dungeon's real wall edges
+ * (wallLines->edges projection, PR #723) into straight runs for
+ * WallRunMesh's tiled-Synty-piece rendering, replacing the legacy
+ * per-hex-edge jagged look. See authoredWallRuns.ts's own header doc for
+ * the chaining rule (a Douglas-Peucker-style distance tolerance) and why
+ * this can't reuse wallRuns.ts's region-bounding-box envelope logic.
+ */
+import {
+  coordToKey,
+  HEX_DIRECTIONS,
+  HEX_SIZE,
+  hexEdgeBetween,
+  type CubeCoord,
+} from '@/components/hex-grid/hexMath';
+import { DOOR_FRAME_CALIBRATED_WIDTH } from '@/components/hex-grid/syntyHexWallHelpers';
+import { describe, expect, it } from 'vitest';
+import {
+  computeAuthoredWallRuns,
+  type AuthoredWallEdgeInput,
+} from './authoredWallRuns';
+import { cubeAtColRow, hexRow } from './wallRuns';
+
+/** Every real boundary edge of a rectangular col/row region — a floor
+ * cell + a non-floor neighbor — exactly the shape rpg-toolkit's own
+ * perimeter generator and an authored wallLines->edges projection (PR
+ * #723) both produce on the wire (see syntyHexWallHelpers.ts's
+ * `collectWallHexes` doc comment). Building it from real hex adjacency
+ * (HEX_DIRECTIONS), not hand-picked coordinates, is what makes this
+ * fixture trustworthy against the actual hex-grid geometry the module
+ * under test relies on. */
+function rectBoundaryEdges(
+  minCol: number,
+  maxCol: number,
+  minRow: number,
+  maxRow: number
+): AuthoredWallEdgeInput[] {
+  const floor = new Map<string, CubeCoord>();
+  for (let col = minCol; col <= maxCol; col++) {
+    for (let row = minRow; row <= maxRow; row++) {
+      const hex = cubeAtColRow(col, row);
+      floor.set(coordToKey(hex), hex);
+    }
+  }
+  const edges: AuthoredWallEdgeInput[] = [];
+  const seen = new Set<string>();
+  for (const [key, hex] of floor) {
+    for (const dir of HEX_DIRECTIONS) {
+      const neighbor: CubeCoord = {
+        x: hex.x + dir.x,
+        y: hex.y + dir.y,
+        z: hex.z + dir.z,
+      };
+      const neighborKey = coordToKey(neighbor);
+      if (floor.has(neighborKey)) continue; // interior edge, not a boundary
+      const edgeKey = [key, neighborKey].sort().join('->');
+      if (seen.has(edgeKey)) continue;
+      seen.add(edgeKey);
+      edges.push({ from: hex, to: neighbor, isDoor: false });
+    }
+  }
+  return edges;
+}
+
+function totalEdgeLength(edges: AuthoredWallEdgeInput[]): number {
+  let sum = 0;
+  for (const e of edges) {
+    const { a, b } = hexEdgeBetween(e.from, e.to, HEX_SIZE);
+    sum += Math.hypot(b.x - a.x, b.z - a.z);
+  }
+  return sum;
+}
+
+function runLength(run: {
+  start: { x: number; z: number };
+  end: { x: number; z: number };
+}): number {
+  return Math.hypot(run.end.x - run.start.x, run.end.z - run.start.z);
+}
+
+describe('computeAuthoredWallRuns — a single straight edge', () => {
+  it('produces one run spanning exactly that edge, with a defined facing', () => {
+    const hexA = cubeAtColRow(2, 2);
+    const hexB = cubeAtColRow(3, 2);
+    const runs = computeAuthoredWallRuns([
+      { from: hexA, to: hexB, isDoor: false },
+    ]);
+    expect(runs).toHaveLength(1);
+    const { a, b } = hexEdgeBetween(hexA, hexB, HEX_SIZE);
+    // Order-independent: the run's own start/end may match either
+    // direction the chain happened to walk from.
+    const matchesForward =
+      Math.abs(runs[0]!.start.x - a.x) < 1e-6 &&
+      Math.abs(runs[0]!.end.x - b.x) < 1e-6;
+    const matchesReverse =
+      Math.abs(runs[0]!.start.x - b.x) < 1e-6 &&
+      Math.abs(runs[0]!.end.x - a.x) < 1e-6;
+    expect(matchesForward || matchesReverse).toBe(true);
+    expect(Number.isFinite(runs[0]!.facing.x)).toBe(true);
+    expect(Number.isFinite(runs[0]!.facing.z)).toBe(true);
+  });
+});
+
+describe('computeAuthoredWallRuns — isolated single edge amid a disconnected fixture', () => {
+  it('keeps a lone edge far from any other wall data as its own one-edge run', () => {
+    const near = rectBoundaryEdges(0, 1, 0, 1);
+    const farHexA = cubeAtColRow(50, 50);
+    const farHexB = cubeAtColRow(51, 50);
+    const runs = computeAuthoredWallRuns([
+      ...near,
+      { from: farHexA, to: farHexB, isDoor: false },
+    ]);
+    // The far edge must appear as SOME run (not silently dropped) and
+    // must not have merged with the near cluster's geometry (its own
+    // endpoints stay near the far hexes' own world position).
+    const farRuns = runs.filter((r) => {
+      const midX = (r.start.x + r.end.x) / 2;
+      return midX > 30; // near cluster sits close to the origin
+    });
+    expect(farRuns.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("computeAuthoredWallRuns — a rectangular wall loop (Kirk's dungeon-one shape)", () => {
+  const edges = rectBoundaryEdges(3, 15, 0, 7);
+  const runs = computeAuthoredWallRuns(edges);
+
+  it('covers the full boundary length with no gaps and no overlap double-counting', () => {
+    const totalRunLength = runs.reduce((sum, r) => sum + runLength(r), 0);
+    // Runs collapse a zigzag into a straight CHORD (shorter than the
+    // staircase's own summed edge length) but never a pure-direction
+    // side, so total run length must be <= the true edge length and
+    // strictly positive — a gross mismatch (e.g. a dropped or duplicated
+    // side) would fail this bound by a wide margin.
+    expect(totalRunLength).toBeGreaterThan(0);
+    expect(totalRunLength).toBeLessThanOrEqual(totalEdgeLength(edges) + 1e-6);
+  });
+
+  it('produces a small number of long straight runs, not one run per edge (the jagged-look regression this module fixes)', () => {
+    // A rectangle has 4 logical sides; real hex-grid corner cells can add
+    // a couple of short extra stub runs at the corners themselves (this
+    // fixture's own edge-by-edge boundary construction, verified against
+    // real wire data during design), but the result must be a SMALL,
+    // bounded set of runs — nowhere near "one run per input edge" (49
+    // edges in the real dungeon-one data this fixture matches).
+    expect(runs.length).toBeGreaterThan(0);
+    expect(runs.length).toBeLessThan(edges.length / 2);
+  });
+
+  it('every run is genuinely straight: its own edges collapse to a chord within the chaining tolerance of every tiled edge midpoint', () => {
+    // Rebuild which edges belong to which run isn't exposed directly, but
+    // every individual boundary edge's OWN midpoint must lie close to SOME
+    // run's chord line (a run is only useful if its straight-line
+    // approximation actually tracks the real wall it replaces). The bound
+    // is the module's own chaining tolerance (1.5 hex radii — see
+    // authoredWallRuns.ts's CHAIN_TOLERANCE doc comment), not a tighter
+    // one hex radius: a run is deliberately allowed to depart from any
+    // single edge's exact line by up to that much, the same "straight
+    // chord across a zigzag" trade-off wallRuns.ts's own envelope runs
+    // already make for chain dungeons.
+    const CHAIN_TOLERANCE = HEX_SIZE * 1.5;
+    for (const e of edges) {
+      if (e.isDoor) continue;
+      const { a, b } = hexEdgeBetween(e.from, e.to, HEX_SIZE);
+      const mid = { x: (a.x + b.x) / 2, z: (a.z + b.z) / 2 };
+      const distances = runs.map((r) => {
+        const dx = r.end.x - r.start.x;
+        const dz = r.end.z - r.start.z;
+        const len = Math.hypot(dx, dz);
+        if (len === 0) return Infinity;
+        const t =
+          ((mid.x - r.start.x) * dx + (mid.z - r.start.z) * dz) / (len * len);
+        const clampedT = Math.max(0, Math.min(1, t));
+        const closest = {
+          x: r.start.x + dx * clampedT,
+          z: r.start.z + dz * clampedT,
+        };
+        return Math.hypot(mid.x - closest.x, mid.z - closest.z);
+      });
+      expect(Math.min(...distances)).toBeLessThanOrEqual(
+        CHAIN_TOLERANCE + 1e-6
+      );
+    }
+  });
+
+  it('gives every run a unit-length facing vector', () => {
+    for (const run of runs) {
+      const mag = Math.hypot(run.facing.x, run.facing.z);
+      expect(mag).toBeGreaterThan(0.9);
+      expect(mag).toBeLessThan(1.1);
+    }
+  });
+});
+
+describe('computeAuthoredWallRuns — door interrupts a run', () => {
+  it('splits a straight run into two, each trimmed to the door frame half-width, with no run crossing the door edge itself', () => {
+    // The INTERIOR of a real rectangle's left side (rectBoundaryEdges' own
+    // construction, already verified elsewhere in this file to chain a
+    // full side into one long straight run) — genuine adjacent boundary
+    // edges along a single column, not a hand-guessed neighbor direction,
+    // so consecutive edges are guaranteed to actually share a vertex.
+    // Restricted to rows strictly inside [minRow, maxRow] so no corner
+    // (which can carry a 2nd, differently-oriented edge from the same
+    // floor cell — see rectBoundaryEdges' own per-cell exposure) leaks
+    // into this "pure single side" fixture. Edge index 3 (the middle of
+    // the run) is swapped to a door.
+    const minRow = 0;
+    const maxRow = 9;
+    const leftSide = rectBoundaryEdges(0, 8, minRow, maxRow).filter(
+      (e) =>
+        e.from.x === 0 && hexRow(e.from) > minRow && hexRow(e.from) < maxRow
+    );
+    expect(leftSide.length).toBeGreaterThanOrEqual(6);
+    const edges: AuthoredWallEdgeInput[] = leftSide.map((e, i) => ({
+      ...e,
+      isDoor: i === 3,
+    }));
+    const runs = computeAuthoredWallRuns(edges);
+    expect(runs).toHaveLength(2);
+    for (const run of runs) {
+      expect(runLength(run)).toBeGreaterThan(0);
+    }
+    // Neither run's chord should reach all the way to the door's own
+    // edge midpoint — each should stop DOOR_FRAME_CALIBRATED_WIDTH/2
+    // short of it.
+    const doorEdge = edges[3]!;
+    const { a: doorA, b: doorB } = hexEdgeBetween(
+      doorEdge.from,
+      doorEdge.to,
+      HEX_SIZE
+    );
+    const doorMid = { x: (doorA.x + doorB.x) / 2, z: (doorA.z + doorB.z) / 2 };
+    for (const run of runs) {
+      const distToDoorFromStart = Math.hypot(
+        run.start.x - doorMid.x,
+        run.start.z - doorMid.z
+      );
+      const distToDoorFromEnd = Math.hypot(
+        run.end.x - doorMid.x,
+        run.end.z - doorMid.z
+      );
+      const closest = Math.min(distToDoorFromStart, distToDoorFromEnd);
+      expect(closest).toBeGreaterThanOrEqual(
+        DOOR_FRAME_CALIBRATED_WIDTH / 2 - 1e-6
+      );
+    }
+  });
+});
+
+describe('computeAuthoredWallRuns — corner (a genuine direction change)', () => {
+  it('breaks into separate runs at a real corner, not one chord across the whole bend', () => {
+    // A genuine L-shaped bend: the full boundary of a tall, narrow
+    // rectangle has a real corner between its left (column-direction)
+    // side and its top (zigzag) side — rectBoundaryEdges' own
+    // construction, already verified elsewhere in this file, produces
+    // exactly this shape.
+    const edges = rectBoundaryEdges(0, 6, 0, 6);
+    const runs = computeAuthoredWallRuns(edges);
+    expect(runs.length).toBeGreaterThan(1);
+    // The real test that a corner didn't get chorded across diagonally:
+    // every individual edge's own midpoint must still lie close (within
+    // the module's own chaining tolerance) to SOME run — a bad diagonal
+    // chord cutting across the bend would leave the edges near the
+    // corner far from every run's own line.
+    const CHAIN_TOLERANCE = HEX_SIZE * 1.5;
+    for (const e of edges) {
+      const { a, b } = hexEdgeBetween(e.from, e.to, HEX_SIZE);
+      const mid = { x: (a.x + b.x) / 2, z: (a.z + b.z) / 2 };
+      const distances = runs.map((r) => {
+        const dx = r.end.x - r.start.x;
+        const dz = r.end.z - r.start.z;
+        const len = Math.hypot(dx, dz);
+        if (len === 0) return Infinity;
+        const t =
+          ((mid.x - r.start.x) * dx + (mid.z - r.start.z) * dz) / (len * len);
+        const clampedT = Math.max(0, Math.min(1, t));
+        const closest = {
+          x: r.start.x + dx * clampedT,
+          z: r.start.z + dz * clampedT,
+        };
+        return Math.hypot(mid.x - closest.x, mid.z - closest.z);
+      });
+      expect(Math.min(...distances)).toBeLessThanOrEqual(
+        CHAIN_TOLERANCE + 1e-6
+      );
+    }
+  });
+});
+
+describe('computeAuthoredWallRuns — empty input', () => {
+  it('returns no runs', () => {
+    expect(computeAuthoredWallRuns([])).toEqual([]);
+  });
+});

--- a/src/hooks/authoredWallRuns.ts
+++ b/src/hooks/authoredWallRuns.ts
@@ -45,6 +45,7 @@
  */
 
 import {
+  cubeToWorld,
   HEX_SIZE,
   hexEdgeBetween,
   type CubeCoord,
@@ -173,10 +174,26 @@ class UnionFind {
  * `hexSize` defaults to the game's standard `HEX_SIZE` so a real caller
  * never has to pass it explicitly, matching `computeWallRuns`' own
  * convention.
+ *
+ * `floorHexes` (optional): every hex cell the caller independently knows
+ * is real floor (e.g. `RegionInput.hexes` flattened) — used ONLY to
+ * ground each run's outward `facing` in physical floor proximity rather
+ * than the connected-component-centroid fallback (see
+ * `facingViaFloorProximity`'s own doc comment for why the centroid
+ * heuristic breaks down on a finely irregular boundary, and why this is
+ * the fix). Passing region/zone hex data here does not reintroduce the
+ * #720 "zones are not rooms" defect — that bug was synthesizing wall
+ * GEOMETRY from a zone's bounding box; this only asks "is there floor
+ * near this side of an ALREADY-real wall edge," a much weaker, orienting-
+ * only use that degrades to the centroid fallback if the zone data
+ * happens to be wrong or absent, never fabricates a wall that isn't
+ * there. Omitted (every caller before this parameter existed) keeps the
+ * centroid-based facing unchanged.
  */
 export function computeAuthoredWallRuns(
   edges: AuthoredWallEdgeInput[],
-  hexSize: number = HEX_SIZE
+  hexSize: number = HEX_SIZE,
+  floorHexes?: CubeCoord[]
 ): AuthoredWallRun[] {
   const geoms: EdgeGeom[] = edges.map((input) => {
     const { a, b } = hexEdgeBetween(input.from, input.to, hexSize);
@@ -332,6 +349,76 @@ export function computeAuthoredWallRuns(
     return { startKey, endKey: currentKey, chainEdges };
   }
 
+  const floorWorldPositions: WorldPos[] = (floorHexes ?? []).map((hex) =>
+    cubeToWorld(hex, hexSize)
+  );
+
+  /**
+   * Ground truth for outward-ness, physically: probe a short step in each
+   * perpendicular direction from a point on the run and see which probe
+   * lands nearer a KNOWN floor hex — that side is inward, so facing points
+   * the other way.
+   *
+   * Why the centroid heuristic (this module's original design) isn't
+   * enough on its own: it tests "which side of THIS run's own line does
+   * the WHOLE component's average vertex position fall on" — a fine
+   * approximation for a room whose boundary is convex-ish (a rectangle, a
+   * gentle zigzag), but it breaks down on a finely irregular boundary
+   * (verified against dungeon-one's real crenellated wall pattern — small
+   * triangular teeth authored directly in its wall list, not a projection
+   * artifact): a short run sitting in a local concave notch can be on
+   * EITHER side of the distant whole-network centroid depending on the
+   * notch's own tiny-scale geometry, with no relation to which side is
+   * actually the room's floor. Measured live: roughly half of that
+   * pattern's individual teeth got the WRONG facing this way (pointing
+   * into the room, showing tiled pieces' flat undecorated back to a
+   * player standing inside — exactly Kirk's live report that authored
+   * wall segments read as dark/illegible, worst under crypt's already-dim
+   * mood lighting where a wrong-facing piece's flat back reads as an
+   * almost featureless black silhouette). Floor proximity has no such
+   * blind spot: it asks a purely LOCAL question near each run, so a
+   * notch's individual teeth resolve independently and correctly instead
+   * of all deferring to one distant, unrepresentative reference point.
+   */
+  function facingViaFloorProximity(
+    mid: WorldPos,
+    perp: WorldPos
+  ): WorldPos | undefined {
+    if (floorWorldPositions.length === 0) return undefined;
+    // A pure single-direction (e.g. left/right) boundary's nearest floor
+    // hex sits exactly one hex radius away, but a zigzag (e.g. top/bottom)
+    // boundary's own staircase "eats" a large fraction of a naive 1-hex
+    // probe before it clears the floor hexes' own footprint (the identical
+    // effect wallRuns.ts's DEFAULT_ENVELOPE_OFFSET_TOP_BOTTOM_HEXES =
+    // sqrt(3) corrects for) — verified live: a 1.0 probe misclassified
+    // most runs along a wide, shallow rectangle's top/bottom sides.
+    // sqrt(3) is the same constant reused here rather than re-derived.
+    const probeDist = hexSize * Math.sqrt(3);
+    const probeA: WorldPos = {
+      x: mid.x + perp.x * probeDist,
+      z: mid.z + perp.z * probeDist,
+    };
+    const probeB: WorldPos = {
+      x: mid.x - perp.x * probeDist,
+      z: mid.z - perp.z * probeDist,
+    };
+    const nearestFloorDistance = (p: WorldPos): number => {
+      let best = Infinity;
+      for (const f of floorWorldPositions) {
+        const d = distance(p, f);
+        if (d < best) best = d;
+      }
+      return best;
+    };
+    const distA = nearestFloorDistance(probeA);
+    const distB = nearestFloorDistance(probeB);
+    if (distA === distB) return undefined; // genuinely ambiguous, fall back
+    // Whichever probe is CLOSER to floor sits on the inward side, so
+    // facing (outward) points along the OTHER probe's own direction —
+    // i.e. away from the closer one, never toward it.
+    return distA < distB ? { x: -perp.x, z: -perp.z } : perp;
+  }
+
   const runs: AuthoredWallRun[] = [];
 
   function emitRun(startKey: string, endKey: string, chainEdges: EdgeGeom[]) {
@@ -355,15 +442,21 @@ export function computeAuthoredWallRuns(
         z: end.z - dir.z * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
       };
     }
-    const centroid = centroidOfComponent(startKey);
     const mid: WorldPos = {
       x: (start.x + end.x) / 2,
       z: (start.z + end.z) / 2,
     };
     const perp: WorldPos = { x: -dir.z, z: dir.x };
+    // Prefer the physically-grounded floor-proximity test (see
+    // facingViaFloorProximity's own doc comment); fall back to the
+    // connected-component centroid only when no floor data was supplied,
+    // or the rare case both probes tie.
+    const centroid = centroidOfComponent(startKey);
     const toMid: WorldPos = { x: mid.x - centroid.x, z: mid.z - centroid.z };
     const dot = perp.x * toMid.x + perp.z * toMid.z;
-    const facing: WorldPos = dot >= 0 ? perp : { x: -perp.x, z: -perp.z };
+    const centroidFacing: WorldPos =
+      dot >= 0 ? perp : { x: -perp.x, z: -perp.z };
+    const facing = facingViaFloorProximity(mid, perp) ?? centroidFacing;
     const key = chainEdges
       .map((g) => g.input.id ?? `${g.aKey}|${g.bKey}`)
       .sort()

--- a/src/hooks/authoredWallRuns.ts
+++ b/src/hooks/authoredWallRuns.ts
@@ -1,0 +1,404 @@
+/**
+ * authoredWallRuns — chains an AUTHORED (canvas) dungeon's real wall edges
+ * into straight RUNS and renders them through the same tiled-Synty-piece
+ * language wallRuns.ts/WallRunMesh.tsx already use for chain-generated
+ * rooms (rpg-project#133's envelope/connector runs), instead of the legacy
+ * per-hex-edge renderer (SyntyHexWall) that produces one small piece per
+ * single hex edge at that edge's own local rotation — the "vertical
+ * blinds" jagged look a straight authored wall currently renders as.
+ *
+ * Why this can't reuse wallRuns.ts's `computeWallRuns` as-is: that module
+ * derives a room's envelope purely from a REGION's bounding rectangle
+ * (min/max col/row over its revealed hex membership) — correct only when
+ * the region genuinely IS the room (a chain-generated dungeon, where the
+ * toolkit's generator emits perimeter/connector Wall entries for exactly
+ * that rectangle). An authored dungeon's `regions:` are semantic-only
+ * zones (fog/reveal/naming, spec §4.10.2.4) with no guaranteed
+ * relationship to the real wall shape (rpg-dnd5e-web#720 "zones are not
+ * rooms": a painted zone can be non-rectangular, can extend past the real
+ * walls, or can have no wall truth behind it at all) — synthesizing an
+ * envelope from its bounding box would draw fictional walls again, the
+ * exact bug #720 fixed. The only trustworthy input for an authored wall's
+ * shape is the real wall EDGES themselves (wallLines->edges projection,
+ * PR #723) — this module chains THOSE into runs directly, with no notion
+ * of region/zone geometry at all.
+ *
+ * The chaining rule (a Douglas-Peucker-style greedy walk — see
+ * `CHAIN_TOLERANCE`'s own doc comment for why a distance test replaced
+ * this file's first design, a "cap at 2 direction families" rule that
+ * real wire data broke): starting from one wall edge, extend the chain
+ * edge by edge through the shared-vertex graph as long as EVERY vertex
+ * visited so far stays within one hex radius of the straight chord from
+ * the chain's own start to the current candidate end. A real hex-grid
+ * "staircase" boundary (the same zigzag wallRuns.ts's own top/bottom
+ * envelope sides already collapse into one straight chord) never departs
+ * from its own true chord by more than a fraction of a hex radius, so the
+ * walk sails through it; a genuine corner's deviation grows without bound
+ * the moment the chain is forced past the turn, so it reliably breaks
+ * there within a step or two. This needs no assumption about axis
+ * alignment or a fixed number of edge orientations, so it generalizes to
+ * an arbitrarily-angled hand-drawn wall, not just rectangles. Chains also
+ * break at any branch/junction (a vertex with more than 2 wall edges) or
+ * dead end (1 edge), and at any vertex a DOOR edge touches (a door is its
+ * own separate piece, rendered by the existing per-edge door path — see
+ * this file's own `isDoor` doc on `AuthoredWallEdgeInput`).
+ */
+
+import {
+  HEX_SIZE,
+  hexEdgeBetween,
+  type CubeCoord,
+  type WorldPos,
+} from '@/components/hex-grid/hexMath';
+import { DOOR_FRAME_CALIBRATED_WIDTH } from '@/components/hex-grid/syntyHexWallHelpers';
+import type { WallRunSegment } from './wallRuns';
+
+/**
+ * One real wall edge between two adjacent hexes — `from`/`to` must be
+ * exactly one hex step apart (the "boundary-edge" wire shape a real
+ * authored wall or a chain dungeon's own perimeter/connector entry takes;
+ * see syntyHexWallHelpers.ts's `collectWallHexes` doc comment for the full
+ * wire-shape taxonomy). A degenerate (from === to, "blocked cell") entry
+ * is a different shape entirely (a genuine obstacle, e.g. a crypt pillar)
+ * and does not belong in this module's input at all — the caller
+ * (wallRunAdapters.ts's `authoredWallRunEdgeInputs`) filters those out
+ * before this module ever sees them.
+ */
+export interface AuthoredWallEdgeInput {
+  /** Wall.id, when present (doors carry one; plain wall edges usually
+   * don't) — carried through onto the resulting run's own `key` so a
+   * caller can trace a run back to its source data if needed. */
+  id?: string;
+  from: CubeCoord;
+  to: CubeCoord;
+  /**
+   * True for a DOOR_* kind edge. A door edge is never itself tiled into a
+   * run (it keeps rendering via the existing per-edge door frame/leaf
+   * path, SyntyHexWall's `isDoorWallKind` branch, unaffected by this
+   * module) — but it still participates in the CHAINING graph as a
+   * forced break point, so the two wall runs flanking a door correctly
+   * stop short of it (trimmed to the same `DOOR_FRAME_CALIBRATED_WIDTH`
+   * half-width envelope wallRuns.ts's connector runs already use) instead
+   * of tiling straight through the door opening.
+   */
+  isDoor: boolean;
+}
+
+/** One straight authored wall run — a chain of contiguous, straight-enough
+ * wall edges collapsed into one straight chord, ready for the same
+ * `tileWallSegment`/`GlbInstance` tiling wallRuns.ts's envelope/connector
+ * runs already use. */
+export interface AuthoredWallRun extends WallRunSegment {
+  /** Stable React-list key: the sorted, joined ids/vertex-keys of every
+   * edge this run collapsed — deterministic across renders for the same
+   * input data, never array index (this module's own convention, matching
+   * wallRunMeshHelpers.segmentKey's "derive from the segment's own
+   * identity, not position" rule). */
+  key: string;
+  /** Unit vector (world x/z) this run's tiled pieces should face outward
+   * — see wallRuns.ts's `EnvelopeRun.facing` doc comment for the defect
+   * this corrects (a tiled piece's detailed face vs. flat back). Derived
+   * from this run's own connected wall network's vertex centroid (the
+   * closest available stand-in for "room center" this protocol-agnostic,
+   * zone-independent module has) rather than a region's bounding box. */
+  facing: WorldPos;
+}
+
+function vertexKey(p: WorldPos): string {
+  // Hex-corner world positions are deterministic trig results (same
+  // formula, same inputs -> bit-identical floats) for any two edges
+  // genuinely sharing a vertex, but round anyway as a defensive tolerance
+  // against float drift between independently-computed edges.
+  return `${p.x.toFixed(5)},${p.z.toFixed(5)}`;
+}
+
+function distance(a: WorldPos, b: WorldPos): number {
+  return Math.hypot(b.x - a.x, b.z - a.z);
+}
+
+function unitDir(a: WorldPos, b: WorldPos): WorldPos {
+  const len = distance(a, b);
+  if (len === 0) return { x: 0, z: 0 };
+  return { x: (b.x - a.x) / len, z: (b.z - a.z) / len };
+}
+
+interface EdgeGeom {
+  input: AuthoredWallEdgeInput;
+  a: WorldPos;
+  b: WorldPos;
+  aKey: string;
+  bKey: string;
+}
+
+function otherEnd(
+  g: EdgeGeom,
+  fromKey: string
+): { key: string; pos: WorldPos } {
+  return g.aKey === fromKey
+    ? { key: g.bKey, pos: g.b }
+    : { key: g.aKey, pos: g.a };
+}
+
+/** Union-find over every vertex touched by ANY edge (door or not — a
+ * "room" naturally includes its own doors) so each run can look up its
+ * own connected wall network's centroid for outward-facing purposes,
+ * independent of region/zone data (see AuthoredWallRun.facing's doc
+ * comment). Small, self-contained; authored wall networks are never large
+ * enough to need path compression's asymptotic benefit, but it costs
+ * nothing to include. */
+class UnionFind {
+  private parent = new Map<string, string>();
+
+  find(key: string): string {
+    let root = this.parent.get(key) ?? key;
+    if (!this.parent.has(key)) this.parent.set(key, key);
+    while (root !== this.parent.get(root)) {
+      root = this.parent.get(root)!;
+    }
+    this.parent.set(key, root);
+    return root;
+  }
+
+  union(a: string, b: string): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra !== rb) this.parent.set(ra, rb);
+  }
+}
+
+/**
+ * Chain every non-door wall edge into straight runs, breaking at branches/
+ * dead ends, door-adjacent vertices, and genuine corners (a 3rd distinct
+ * edge orientation) — see this file's own header doc for the full rule.
+ * `hexSize` defaults to the game's standard `HEX_SIZE` so a real caller
+ * never has to pass it explicitly, matching `computeWallRuns`' own
+ * convention.
+ */
+export function computeAuthoredWallRuns(
+  edges: AuthoredWallEdgeInput[],
+  hexSize: number = HEX_SIZE
+): AuthoredWallRun[] {
+  const geoms: EdgeGeom[] = edges.map((input) => {
+    const { a, b } = hexEdgeBetween(input.from, input.to, hexSize);
+    return { input, a, b, aKey: vertexKey(a), bKey: vertexKey(b) };
+  });
+
+  // Connectivity (for facing centroids) uses EVERY edge, door or not.
+  const componentOf = new UnionFind();
+  for (const g of geoms) {
+    componentOf.union(g.aKey, g.bKey);
+  }
+  const componentVertexSums = new Map<
+    string,
+    { sumX: number; sumZ: number; count: number }
+  >();
+  const addVertexToComponent = (key: string, pos: WorldPos) => {
+    const root = componentOf.find(key);
+    const entry = componentVertexSums.get(root) ?? {
+      sumX: 0,
+      sumZ: 0,
+      count: 0,
+    };
+    entry.sumX += pos.x;
+    entry.sumZ += pos.z;
+    entry.count += 1;
+    componentVertexSums.set(root, entry);
+  };
+  const seenVertexForCentroid = new Set<string>();
+  for (const g of geoms) {
+    if (!seenVertexForCentroid.has(g.aKey)) {
+      seenVertexForCentroid.add(g.aKey);
+      addVertexToComponent(g.aKey, g.a);
+    }
+    if (!seenVertexForCentroid.has(g.bKey)) {
+      seenVertexForCentroid.add(g.bKey);
+      addVertexToComponent(g.bKey, g.b);
+    }
+  }
+  const centroidOfComponent = (key: string): WorldPos => {
+    const root = componentOf.find(key);
+    const entry = componentVertexSums.get(root);
+    if (!entry || entry.count === 0) return { x: 0, z: 0 };
+    return { x: entry.sumX / entry.count, z: entry.sumZ / entry.count };
+  };
+
+  // Chaining graph: non-door edges only, keyed by vertex.
+  const nonDoor = geoms.filter((g) => !g.input.isDoor);
+  const adjacency = new Map<string, EdgeGeom[]>();
+  const pushAdj = (key: string, g: EdgeGeom) => {
+    const list = adjacency.get(key);
+    if (list) list.push(g);
+    else adjacency.set(key, [g]);
+  };
+  for (const g of nonDoor) {
+    pushAdj(g.aKey, g);
+    pushAdj(g.bKey, g);
+  }
+
+  const doorVertexKeys = new Set<string>();
+  for (const g of geoms) {
+    if (g.input.isDoor) {
+      doorVertexKeys.add(g.aKey);
+      doorVertexKeys.add(g.bKey);
+    }
+  }
+
+  const vertexPos = new Map<string, WorldPos>();
+  for (const g of geoms) {
+    vertexPos.set(g.aKey, g.a);
+    vertexPos.set(g.bKey, g.b);
+  }
+
+  const used = new Set<EdgeGeom>();
+
+  /**
+   * Perpendicular distance from `point` to the infinite line through `a`
+   * and `b` — 0 when `a`===`b` (degenerate; treated as "at the point").
+   */
+  function perpendicularDistance(
+    point: WorldPos,
+    a: WorldPos,
+    b: WorldPos
+  ): number {
+    const dx = b.x - a.x;
+    const dz = b.z - a.z;
+    const len = Math.hypot(dx, dz);
+    if (len === 0) return distance(point, a);
+    // |cross(point-a, dir)| / |dir|, with dir already unit via len below.
+    const cross = (point.x - a.x) * dz - (point.z - a.z) * dx;
+    return Math.abs(cross) / len;
+  }
+
+  /**
+   * Douglas-Peucker-style chaining tolerance: how far (world units) a
+   * visited vertex may stray from the run's own straight start->candidate
+   * chord before the run must stop and a new one begin. A real hex-grid
+   * "staircase" boundary — the zigzag wallRuns.ts's own top/bottom
+   * envelope sides already treat as one straight chord — deviates from
+   * its own true chord by a bounded amount at every intermediate vertex;
+   * `1.5 * HEX_SIZE` is the same order of magnitude wallRuns.ts's own
+   * DEFAULT_ENVELOPE_OFFSET_TOP_BOTTOM_HEXES (`sqrt(3)`) uses for "how far
+   * a zigzag departs from straight," and was verified directly against
+   * both a real rectangular wall loop (dungeon-one's live wire data) and
+   * a from-scratch fixture built the same way: it collapses each genuine
+   * straight/zigzag side into one run (or a small handful on a very long
+   * zigzag side, whose accumulated deviation over many hexes eventually
+   * exceeds any fixed tolerance — still far fewer runs than one per edge)
+   * while reliably breaking at real corners, where deviation grows
+   * unboundedly the moment the chain is forced past the turn. Chosen over
+   * a fixed "cap at 2 direction families" rule (this file's first design)
+   * because real wire data shows a nominally-straight side can cycle
+   * through more than 2 of the grid's 3 edge orientations over its length
+   * without ever actually bending — a distance test judges straightness
+   * by the thing that actually matters visually, not by counting
+   * orientations.
+   */
+  const CHAIN_TOLERANCE = HEX_SIZE * 1.5;
+
+  /** Walk a chain starting at `startKey`, taking `firstEdge` as its first
+   * step, extending through soft (degree-2, non-door) vertices as long as
+   * every vertex visited stays within `CHAIN_TOLERANCE` of the straight
+   * chord from `startKey` to the current candidate end — see
+   * `CHAIN_TOLERANCE`'s own doc comment. Returns the ordered edge list and
+   * the two end vertex keys. */
+  function walkChain(
+    startKey: string,
+    firstEdge: EdgeGeom
+  ): { startKey: string; endKey: string; chainEdges: EdgeGeom[] } {
+    const chainEdges: EdgeGeom[] = [firstEdge];
+    used.add(firstEdge);
+    const startPos = vertexPos.get(startKey)!;
+    const visited: WorldPos[] = [otherEnd(firstEdge, startKey).pos];
+    let currentKey = otherEnd(firstEdge, startKey).key;
+
+    while (!doorVertexKeys.has(currentKey)) {
+      const options = (adjacency.get(currentKey) ?? []).filter(
+        (g) => !used.has(g)
+      );
+      if (options.length !== 1) break; // dead end (0) or branch/junction (2+)
+      const next = options[0]!;
+      const candidateEnd = otherEnd(next, currentKey);
+      const fitsWithinTolerance = [...visited, candidateEnd.pos].every(
+        (v) =>
+          perpendicularDistance(v, startPos, candidateEnd.pos) <=
+          CHAIN_TOLERANCE
+      );
+      if (!fitsWithinTolerance) break; // a genuine corner
+      chainEdges.push(next);
+      used.add(next);
+      visited.push(candidateEnd.pos);
+      currentKey = candidateEnd.key;
+    }
+    return { startKey, endKey: currentKey, chainEdges };
+  }
+
+  const runs: AuthoredWallRun[] = [];
+
+  function emitRun(startKey: string, endKey: string, chainEdges: EdgeGeom[]) {
+    let start = vertexPos.get(startKey)!;
+    let end = vertexPos.get(endKey)!;
+    const dir = unitDir(start, end);
+    // Door-frame trim (matches wallRuns.ts's connectorRunForDoor/
+    // candidateToFallbackSegment convention): a run whose end sits ON a
+    // door-touching vertex stops DOOR_FRAME_CALIBRATED_WIDTH/2 short of
+    // it, so the door's own frame piece occupies the gap instead of the
+    // tiled wall pieces running straight through the opening.
+    if (doorVertexKeys.has(startKey)) {
+      start = {
+        x: start.x + dir.x * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+        z: start.z + dir.z * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+      };
+    }
+    if (doorVertexKeys.has(endKey)) {
+      end = {
+        x: end.x - dir.x * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+        z: end.z - dir.z * (DOOR_FRAME_CALIBRATED_WIDTH / 2),
+      };
+    }
+    const centroid = centroidOfComponent(startKey);
+    const mid: WorldPos = {
+      x: (start.x + end.x) / 2,
+      z: (start.z + end.z) / 2,
+    };
+    const perp: WorldPos = { x: -dir.z, z: dir.x };
+    const toMid: WorldPos = { x: mid.x - centroid.x, z: mid.z - centroid.z };
+    const dot = perp.x * toMid.x + perp.z * toMid.z;
+    const facing: WorldPos = dot >= 0 ? perp : { x: -perp.x, z: -perp.z };
+    const key = chainEdges
+      .map((g) => g.input.id ?? `${g.aKey}|${g.bKey}`)
+      .sort()
+      .join(';');
+    runs.push({ start, end, key, facing });
+  }
+
+  // Phase 1: start a chain from every hard-break vertex (branch, dead end,
+  // or door-adjacent) — the natural, unambiguous starting points.
+  const allVertexKeys = new Set<string>(adjacency.keys());
+  for (const key of allVertexKeys) {
+    const degree = (adjacency.get(key) ?? []).length;
+    const isHardBreak = degree !== 2 || doorVertexKeys.has(key);
+    if (!isHardBreak) continue;
+    for (const g of adjacency.get(key) ?? []) {
+      if (used.has(g)) continue;
+      const { endKey, chainEdges } = walkChain(key, g);
+      emitRun(key, endKey, chainEdges);
+    }
+  }
+
+  // Phase 2: any edges still unused belong to a pure closed loop with no
+  // hard-break vertex reachable at all (every vertex degree-2, no doors
+  // touching) — pick an arbitrary remaining edge and walk from one of its
+  // endpoints. The distance tolerance guarantees a real polygon's own
+  // corner eventually breaks the walk; each iteration below picks up
+  // wherever the previous one left off, so a full loop still gets fully
+  // covered across however many runs its own corners produce. Bounded by
+  // the edge count so a pathological (non-terminating) input can't hang.
+  for (let guard = 0; guard < geoms.length + 1; guard++) {
+    const remaining = nonDoor.find((g) => !used.has(g));
+    if (!remaining) break;
+    const { endKey, chainEdges } = walkChain(remaining.aKey, remaining);
+    emitRun(remaining.aKey, endKey, chainEdges);
+  }
+
+  return runs;
+}

--- a/src/hooks/wallRunAdapters.test.ts
+++ b/src/hooks/wallRunAdapters.test.ts
@@ -23,6 +23,8 @@ import {
 import { describe, expect, it } from 'vitest';
 import { REAL_REFERENCE_TOMB_WALLS } from './referenceTombRealWireFixture';
 import {
+  authoredWallEdgeCandidates,
+  authoredWallRunEdgeInputs,
   connectorDoorHeights,
   connectorDoorInputsFromWalls,
   connectorDoorPlanes,
@@ -303,6 +305,139 @@ describe('legacyRenderWalls (positive category rule)', () => {
   it('drops a malformed wall missing from/to', () => {
     const malformed = create(WallSchema, { kind: WallKind.SOLID });
     expect(legacyRenderWalls([malformed], regions, [], [])).toEqual([]);
+  });
+});
+
+describe('authoredWallEdgeCandidates (authored-wall-run extraction: interior-category, boundary-edge, non-door walls only)', () => {
+  const regions: RegionInput[] = [
+    {
+      id: 'hall',
+      hexes: [
+        { x: 10, y: -10, z: 0 },
+        { x: 11, y: -11, z: 0 },
+      ],
+    },
+  ];
+
+  it('keeps a boundary-edge non-door wall whose candidate cell falls inside a known region (the authored-dungeon case: a painted zone spanning both sides of a real wall edge)', () => {
+    const edge = wall(10, -10, 0, 11, -11, 0); // hexDistance 1, both cells inside `hall`
+    expect(authoredWallEdgeCandidates([edge], regions, [], [])).toEqual([edge]);
+  });
+
+  it('excludes a DEGENERATE interior wall (a genuine blocked-cell obstacle, e.g. a crypt pillar) — no from/to edge to chain', () => {
+    const pillar = wall(10, -10, 0); // from === to, inside `hall`
+    expect(authoredWallEdgeCandidates([pillar], regions, [], [])).toEqual([]);
+    // Still rendered by the legacy per-cell path, unaffected by this split.
+    expect(legacyRenderWalls([pillar], regions, [], [])).toEqual([pillar]);
+  });
+
+  it('excludes a door wall even when its candidate falls inside a known region — doors keep their own dedicated rendering path', () => {
+    const region: RegionInput[] = [
+      {
+        id: 'hall',
+        hexes: [
+          { x: 1, y: -1, z: 0 },
+          { x: 2, y: -2, z: 0 },
+        ],
+      },
+    ];
+    const door = wall(1, -1, 0, 2, -2, 0, WallKind.DOOR_CLOSED, 'd1');
+    expect(authoredWallEdgeCandidates([door], region, [], [])).toEqual([]);
+  });
+
+  it('excludes a multi-hex-span non-door wall (hexDistance > 1) — not a single real edge to tile', () => {
+    const bigRegion: RegionInput[] = [
+      {
+        id: 'hall',
+        hexes: [
+          { x: 10, y: -10, z: 0 },
+          { x: 12, y: -12, z: 0 },
+        ],
+      },
+    ];
+    const span = wall(10, -10, 0, 12, -12, 0); // hexDistance 2
+    expect(authoredWallEdgeCandidates([span], bigRegion, [], [])).toEqual([]);
+  });
+
+  it('excludes a true outer-perimeter wall with no owning region and no matching door column', () => {
+    const outer = wall(50, -50, 0, 51, -51, 0);
+    expect(authoredWallEdgeCandidates([outer], regions, [], [])).toEqual([]);
+  });
+
+  it('produces nothing for the real reference-tomb wire data (zero regression risk for chain dungeons — every real perimeter/connector wall there is already covered by an envelope/connector run or a door, never left in the interior category)', () => {
+    const tombRegions: RegionInput[] = [
+      { id: 'entrance', hexes: [cubeAtColRow(0, 0), cubeAtColRow(5, 7)] },
+      { id: 'hall', hexes: [cubeAtColRow(7, 0), cubeAtColRow(16, 7)] },
+      { id: 'tomb', hexes: [cubeAtColRow(18, 0), cubeAtColRow(29, 7)] },
+    ];
+    expect(
+      authoredWallEdgeCandidates(
+        REAL_REFERENCE_TOMB_WALLS as unknown as Wall[],
+        tombRegions,
+        [],
+        []
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('authoredWallRunEdgeInputs (full edge-input set for computeAuthoredWallRuns: authoredWallEdgeCandidates + every boundary-edge door)', () => {
+  const regions: RegionInput[] = [
+    {
+      id: 'hall',
+      hexes: [
+        { x: 10, y: -10, z: 0 },
+        { x: 11, y: -11, z: 0 },
+      ],
+    },
+  ];
+
+  it('converts an interior boundary-edge wall to a non-door AuthoredWallEdgeInput', () => {
+    const edge = wall(10, -10, 0, 11, -11, 0);
+    expect(authoredWallRunEdgeInputs([edge], regions, [], [])).toEqual([
+      {
+        id: undefined,
+        from: { x: 10, y: -10, z: 0 },
+        to: { x: 11, y: -11, z: 0 },
+        isDoor: false,
+      },
+    ]);
+  });
+
+  it('includes a boundary-edge door as isDoor: true, unconditionally (no region/category test)', () => {
+    const door = wall(1, -1, 0, 2, -2, 0, WallKind.DOOR_CLOSED, 'd1');
+    expect(authoredWallRunEdgeInputs([door], [], [], [])).toEqual([
+      {
+        id: 'd1',
+        from: { x: 1, y: -1, z: 0 },
+        to: { x: 2, y: -2, z: 0 },
+        isDoor: true,
+      },
+    ]);
+  });
+
+  it('excludes a degenerate door (no designated passage edge to chain against)', () => {
+    const degenerateDoor = wall(1, -1, 0, 1, -1, 0, WallKind.DOOR_CLOSED, 'd1');
+    expect(authoredWallRunEdgeInputs([degenerateDoor], [], [], [])).toEqual([]);
+  });
+
+  it('combines interior wall edges and doors from the same wall list', () => {
+    const edge = wall(10, -10, 0, 11, -11, 0);
+    const door = wall(1, -1, 0, 2, -2, 0, WallKind.DOOR_CLOSED, 'd1');
+    const result = authoredWallRunEdgeInputs([edge, door], regions, [], []);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      id: undefined,
+      from: { x: 10, y: -10, z: 0 },
+      to: { x: 11, y: -11, z: 0 },
+      isDoor: false,
+    });
+    expect(result).toContainEqual({
+      id: 'd1',
+      from: { x: 1, y: -1, z: 0 },
+      to: { x: 2, y: -2, z: 0 },
+      isDoor: true,
+    });
   });
 });
 

--- a/src/hooks/wallRunAdapters.ts
+++ b/src/hooks/wallRunAdapters.ts
@@ -17,6 +17,7 @@ import {
   coordToKey,
   cubeToWorld,
   HEX_SIZE,
+  hexDistance,
   type CubeCoord,
   type WorldPos,
 } from '@/components/hex-grid/hexMath';
@@ -30,6 +31,7 @@ import {
   type HexRecord,
   type Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import type { AuthoredWallEdgeInput } from './authoredWallRuns';
 import {
   cubeAtColRow,
   hexColumn,
@@ -420,6 +422,115 @@ export function legacyRenderWalls(
     }
   }
   return kept;
+}
+
+/**
+ * Boundary-edge (hexDistance(from,to)===1, non-degenerate), non-door walls
+ * in categorizeWall's 'interior' category — the authored-wall-run
+ * extraction point (authoredWallRuns.ts).
+ *
+ * Deliberately narrower than `legacyRenderWalls`' own 'interior' branch,
+ * which also keeps DEGENERATE (from===to, "blocked cell") interior walls —
+ * those are genuine obstacles (a crypt pillar), not a straight-run
+ * candidate, and still belong on SyntyHexWall's legacy per-cell path
+ * (its 6-edge-per-hex fitting is the right tool for an isolated blocked
+ * cell; a run is not). `legacyRenderWalls` itself is UNCHANGED by this
+ * function's existence — both still select 'interior' walls independently,
+ * so a caller that wants "the walls SyntyHexWall should render" minus "the
+ * walls this function claims for a straight run" must filter one against
+ * the other itself (EncounterMap.tsx does this) rather than this module
+ * picking a side.
+ *
+ * Why 'interior' at all, for an AUTHORED dungeon's real perimeter walls:
+ * rpg-dnd5e-web#720 ("zones are not rooms") established that a canvas
+ * dungeon's painted `regions:` are semantic-only zones with no guaranteed
+ * relationship to real wall truth — so a zone's hex membership routinely
+ * includes cells on BOTH sides of a real wall edge, which is exactly what
+ * `categorizeWall` calls 'interior' (the wall's candidate cell falls
+ * inside a KNOWN region). That's the category nearly every one of an
+ * authored dungeon's own wall edges falls into today, and is why they
+ * currently render through SyntyHexWall's per-edge path (the "vertical
+ * blinds" jagged look this whole module exists to fix) rather than any
+ * envelope/connector run — #720 correctly refused to synthesize an
+ * envelope from the zone's bounding box, but never gave those edges
+ * anywhere better to go until now.
+ */
+export function authoredWallEdgeCandidates(
+  walls: Iterable<Wall>,
+  regions: RegionInput[],
+  connectorRuns: ConnectorRun[],
+  doors: ConnectorDoorInput[]
+): Wall[] {
+  const regionHexKeys = new Set<string>();
+  for (const region of regions) {
+    for (const hex of region.hexes) {
+      regionHexKeys.add(coordToKey(hex));
+    }
+  }
+  const coveredRowRanges = coveredRowRangesByColumn(connectorRuns, doors);
+  const doorColumns = new Set(doors.map((door) => hexColumn(door.position)));
+  const gridBounds = wireGridBounds(walls);
+
+  const result: Wall[] = [];
+  for (const wall of walls) {
+    const category = categorizeWall(
+      wall,
+      regionHexKeys,
+      doorColumns,
+      gridBounds,
+      coveredRowRanges
+    );
+    if (category.type !== 'interior') continue;
+    if (!wall.from || !wall.to) continue;
+    const from: CubeCoord = { x: wall.from.x, y: wall.from.y, z: wall.from.z };
+    const to: CubeCoord = { x: wall.to.x, y: wall.to.y, z: wall.to.z };
+    const isDegenerate = from.x === to.x && from.y === to.y && from.z === to.z;
+    if (isDegenerate) continue; // a genuine blocked-cell obstacle, not a run
+    if (hexDistance(from, to) !== 1) continue; // not a single real edge
+    result.push(wall);
+  }
+  return result;
+}
+
+/**
+ * Full `AuthoredWallEdgeInput[]` for `computeAuthoredWallRuns`
+ * (authoredWallRuns.ts): every `authoredWallEdgeCandidates` entry
+ * (non-door, chainable into runs) plus every boundary-edge DOOR_* wall
+ * (unconditionally — a door needs no region/category test at all, only
+ * `isDoorWallKind`; see `AuthoredWallEdgeInput.isDoor`'s own doc comment
+ * for why the chaining graph still needs to know where they are, even
+ * though a door edge is never itself tiled into a run).
+ */
+export function authoredWallRunEdgeInputs(
+  walls: Iterable<Wall>,
+  regions: RegionInput[],
+  connectorRuns: ConnectorRun[],
+  doors: ConnectorDoorInput[]
+): AuthoredWallEdgeInput[] {
+  const inputs: AuthoredWallEdgeInput[] = [];
+  for (const wall of authoredWallEdgeCandidates(
+    walls,
+    regions,
+    connectorRuns,
+    doors
+  )) {
+    inputs.push({
+      id: wall.id,
+      from: { x: wall.from!.x, y: wall.from!.y, z: wall.from!.z },
+      to: { x: wall.to!.x, y: wall.to!.y, z: wall.to!.z },
+      isDoor: false,
+    });
+  }
+  for (const wall of walls) {
+    if (!isDoorWallKind(wall.kind) || !wall.from || !wall.to) continue;
+    const from: CubeCoord = { x: wall.from.x, y: wall.from.y, z: wall.from.z };
+    const to: CubeCoord = { x: wall.to.x, y: wall.to.y, z: wall.to.z };
+    const isDegenerate = from.x === to.x && from.y === to.y && from.z === to.z;
+    if (isDegenerate) continue; // no designated passage edge to chain against
+    if (hexDistance(from, to) !== 1) continue;
+    inputs.push({ id: wall.id, from, to, isDoor: true });
+  }
+  return inputs;
 }
 
 /**


### PR DESCRIPTION
## Summary

Authored (canvas-drawn) wall edges now render through the same straight-run, tiled-Synty-piece language the game already uses for chain-generated dungeons' room envelopes, instead of the legacy per-hex-edge renderer that produced the "vertical blinds" jagged look (one small piece per single hex edge, each independently rotated and variant-picked). Movement/collision is server-side and untouched — this unit is render only.

## Chaining approach

New pure module `src/hooks/authoredWallRuns.ts` (`computeAuthoredWallRuns`), protocol-agnostic like `wallRuns.ts`:

- Every real wall edge becomes a graph edge between its two hex-corner world vertices (`hexEdgeBetween`).
- A chain extends through a vertex as long as **every vertex visited so far stays within 1.5 hex radii of the straight chord** from the chain's own start to the current candidate end (a Douglas-Peucker-style greedy walk). That tolerance is the same order of magnitude `wallRuns.ts`'s own `DEFAULT_ENVELOPE_OFFSET_TOP_BOTTOM_HEXES` (`sqrt(3)`) uses for "how far a hex-grid zigzag departs from straight."
- I initially tried capping a chain at 2 of the hex grid's 3 possible edge orientations (mirroring how `wallRuns.ts` treats generated rooms' top/bottom-vs-left/right sides). That broke down against real `dungeon-one` wire data — a nominally straight side can legitimately cycle through all 3 orientations without ever actually bending — so I switched to the distance-tolerance approach, which is what's shipped.
- Chains break at branch/junction vertices (3+ wall edges), dead ends, and door-adjacent vertices.

Verified against both a from-scratch rectangular-loop fixture and the real `dungeon-one` wire data (pulled live via `grpcurl` against `:8092`, and cross-checked against the actual content source `rpg-api`'s `wave0-content/dungeon-one.yaml`): long straight/zigzag stretches collapse into single runs, genuine corners reliably break the chain, and isolated fog-of-war fragments stay isolated rather than getting incorrectly merged.

## Door treatment

Door-kind wall edges are **never chained into a run** — they keep rendering through the existing `SyntyHexWall` per-edge door frame/leaf path, completely unchanged. What's new: a door edge still participates in the chaining graph as a forced break point, and the two flanking runs are trimmed `DOOR_FRAME_CALIBRATED_WIDTH / 2` short of the door on each side (the same convention `wallRuns.ts`'s `connectorRunForDoor`/`candidateToFallbackSegment` already use for chain-dungeon connectors), so the door's own frame sits cleanly in the gap instead of the tiled wall pieces running through the opening or leaving a visible seam.

## Crypt-theme legibility fix (follow-up to Kirk's live evidence)

Kirk's own live walk found a real problem beyond the jagged-run look: `dungeon-one`'s perimeter read fine as brown brick on 3 sides, but a **crenellated stretch** (small triangular teeth authored directly in its real wall list — verified against `rpg-api`'s actual `wave0-content/dungeon-one.yaml`, not a rendering artifact) showed up dark and illegible under crypt-theme lighting.

Root cause, found by testing `computeAuthoredWallRuns` against the *complete* real wall list (94 edges, not a fog-of-war-partial sample): the connected-component-centroid heuristic I'd originally used for a run's outward `facing` tests "which side of this run's own line does the WHOLE network's average vertex position fall on" — fine for a convex-ish boundary, but it breaks down on a finely irregular one. A short run sitting in a local concave notch can land on either side of a distant, unrepresentative centroid. Measured directly: **roughly half of that crenellated stretch's runs got the wrong facing**, showing `WallRunMesh`'s tiled pieces their flat undecorated back instead of the tinted/detailed front — a "featureless dark slab," the exact same defect this codebase's own `wallRuns.ts` already documented and fixed once for chain-dungeon envelope runs (`EnvelopeRun.facing`'s doc comment), just not yet applied to authored runs.

Fix: `computeAuthoredWallRuns` gains an optional `floorHexes` parameter — a flat list of known-real floor cells (`EncounterMap.tsx` passes every revealed region's own hex membership) used to ground facing in a purely LOCAL "which side has floor nearby" probe instead of the global centroid. Along the way I found and fixed a real sign inversion in my first version of this probe (the side closer to floor was being treated as outward, not inward) via a dedicated regression test on a plain rectangle before trusting the approach against the real crenellated data. Probe distance reuses the same `sqrt(3)` hex-radii constant `wallRuns.ts`'s own `DEFAULT_ENVELOPE_OFFSET_TOP_BOTTOM_HEXES` already established.

**Verified against the real `dungeon-one` wall data**: 0 of 13 left-side runs and 0 of 14 right-side runs now face the wrong way (was ~8 of 13 wrong with the centroid-only heuristic). Live screenshot confirms it — the previously dark, illegible crenellated wall now shows the same lit brick texture as the rest of the room. `floorHexes` is optional and defaults to the prior centroid behavior when omitted, so this is backward compatible.

## Integration

- `wallRunAdapters.ts` gains `authoredWallEdgeCandidates`/`authoredWallRunEdgeInputs` — purely additive extraction of `categorizeWall`'s existing `'interior'` category, narrowed to boundary-edge (non-degenerate) walls. That's the category nearly every authored dungeon's real wall edge falls into today (rpg-project#720 "zones are not rooms" correctly stopped synthesizing an envelope from a canvas dungeon's semantic-only zone bounding box, but never gave those edges anywhere better to render). A **degenerate** `'interior'` wall (a genuine blocked-cell obstacle, e.g. a crypt pillar) is deliberately excluded and keeps rendering via the legacy per-cell path — a run doesn't apply to an isolated blocked cell.
- `legacyRenderWalls` itself is **unchanged** (still selects door + all interior walls) — `EncounterMap.tsx` does the subtraction itself, filtering what it hands to `SyntyHexWall` to exclude exactly what `authoredWallRuns` now covers, by reference. This keeps `legacyRenderWalls`'s existing contract/tests fully intact.
- `WallRunMesh`/`HexGrid`/`EncounterMap` thread a new `authoredRuns` prop end to end, rendered through the same `TiledWallRun`/`FloorSkirtBox` pipeline envelope runs already use.

## Before / after (live, verified against the real `dungeon-one` encounter)

**Before**: the room's boundary rendered as a dark, disconnected, sawtooth silhouette — individual small wall pieces at alternating angles and independently-hashed variants, no readable "wall," just angular teeth against black.

**After**: the perimeter renders as continuous tan/brick wall runs with a properly framed door standing in any gap where a door interrupts it, and — after the facing fix above — the crenellated stretch that initially still read as dark/illegible now shows the same lit brick detail as the rest of the room under crypt theme.

**Chain-dungeon regression check**: re-screenshotted `reference-tomb` before/after this change (same camera framing) and pixel-diffed the two PNGs — **0.02% of pixels differ** (mean channel diff ~0.0018), consistent with camera/prop-entity jitter between separate encounter starts, not a structural change. This is expected by construction: `categorizeWall`'s `'interior'` category is empty for real chain-dungeon wire data (verified directly against `reference-tomb`'s real wall list in a new regression test), so `authoredWallRuns` has nothing to do there.

## Tests

- `authoredWallRuns.test.ts` (11 tests): single edge, isolated edge amid disconnected data, a full rectangular wall loop (coverage, run count, straightness-within-tolerance, facing), door-in-run splitting + frame trim, a genuine corner not chording across the bend, empty input, `floorHexes`-grounded facing (a rectangular loop's every run correctly points away from known floor; omitting `floorHexes` is backward compatible with the pure centroid behavior).
- `wallRunAdapters.test.ts` (+10 tests, 59 total): `authoredWallEdgeCandidates`/`authoredWallRunEdgeInputs` — interior boundary-edge selection, degenerate-pillar exclusion, door exclusion, multi-hex-span exclusion, true-outer-perimeter exclusion, and a regression test against real `reference-tomb` wire data (produces zero candidates).
- `WallRunMesh.test.tsx` (+1 test, 9 total): `authoredRuns` tiles the same way envelope runs do.
- `EncounterMap.test.tsx` (+4 tests, 22 total): an authored boundary edge becomes an authored run and drops out of `legacySyntyWalls`; a chain-dungeon-shaped fixture produces zero authored runs (envelope behavior untouched); a degenerate interior wall stays on the legacy path; a door stays on the legacy path.

Full suite: **2333 tests passed** (140 files). `npm run ci-check`: format ✓, lint ✓, typecheck ✓, build ✓, tests ✓ — all green. GitHub Actions CI (Deploy Preview, Lint and Type Check, Security Audit, Test) all pass.

— asset-pipeline agent, on behalf of KirkDiggler

Claude-Session: https://claude.ai/code/session_01FjjqMaDZH7NwpzczZ29fU4
