### PR TITLE
unit: authoring robustness — the YAML is always fixable

### DIFF
--- a/src/author/BoardCrashRecovery.tsx
+++ b/src/author/BoardCrashRecovery.tsx
@@ -1,0 +1,170 @@
+/**
+ * BoardCrashRecovery — the Dungeon Builder's last line of defense (this
+ * unit, rpg-project#194 authoring-robustness, "the YAML is always
+ * fixable"). Kirk white-screened his entire builder hand-editing YAML:
+ * `walls:` entries the parser accepted (loose shape validation, since
+ * fixed — see `dungeonYaml.ts`'s `assertCellPair`) crashed the board on
+ * render, autosave captured the broken text, and every reload restored +
+ * re-crashed it — the only way out was manually clearing `localStorage`
+ * in DevTools.
+ *
+ * This component is the recovery surface for BOTH ways a document can
+ * still put the board in a state it can't show, even after parse-time
+ * shape validation closes the known gap:
+ *
+ * 1. **A live render crash** — `DungeonBuilderConcept.tsx` wraps the
+ *    board tree in an `ErrorBoundary`; its `onError` hands the caught
+ *    error + the CURRENT `creationYamlText` (whatever produced the
+ *    crash) to this component instead of the boundary's own generic
+ *    fallback UI.
+ * 2. **A restored draft that fails to (re-)parse** — the mount-time
+ *    draft-restore path used to silently discard an unparseable draft
+ *    (safe, but lossy: the author's broken text just vanished, exactly
+ *    the "had to manually clear localStorage" pain this unit exists to
+ *    retire). It now routes here instead, with the ORIGINAL draft text
+ *    intact.
+ *
+ * Either way the contract is the same: nothing the author typed is ever
+ * lost, the error is stated plainly, and the SAME editable-YAML +
+ * explicit-Apply interaction the (non-crashed) `ProposedYamlPane`
+ * offers is available here too — fixing the text and applying is always
+ * enough to get back in, no DevTools required.
+ */
+import { AlertTriangle } from 'lucide-react';
+
+export interface BoardCrashRecoveryProps {
+  /** The caught error's own message, or the `DungeonParseError` message
+   * from a failed (re-)parse — never a generic "something went wrong";
+   * see this file's own doc comment on why an honest message matters
+   * here specifically. */
+  errorMessage: string;
+  /** The exact text that produced the crash/parse-failure — NEVER the
+   * fresh-seed fallback the board itself is quietly showing underneath
+   * (draft-restore case) or was last showing (render-crash case). */
+  yamlText: string;
+  onChangeText: (text: string) => void;
+  /** Re-parses `yamlText` and, on success, hands the board a fresh doc to
+   * try rendering again. On failure, the caller updates `errorMessage`
+   * in place — this component never guesses at success/failure itself. */
+  onApply: () => void;
+  /** Throws the stuck draft/document away entirely and reloads the
+   * mode's fresh empty-canvas seed — the explicit escape hatch for when
+   * the content itself isn't worth saving. */
+  onDiscardDraft: () => void;
+}
+
+export function BoardCrashRecovery({
+  errorMessage,
+  yamlText,
+  onChangeText,
+  onApply,
+  onDiscardDraft,
+}: BoardCrashRecoveryProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 560,
+        border: '1px solid #5a2a20',
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          background: '#2a1512',
+          borderBottom: '1px solid #5a2a20',
+          color: '#ff9a8a',
+          padding: '14px 18px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            fontSize: 15,
+            fontWeight: 700,
+          }}
+        >
+          <AlertTriangle size={18} />
+          The board couldn't show this dungeon
+        </div>
+        <p
+          style={{
+            margin: '8px 0 0',
+            fontSize: 12.5,
+            lineHeight: 1.5,
+            fontFamily: 'ui-monospace, Consolas, Menlo, monospace',
+          }}
+        >
+          {errorMessage}
+        </p>
+        <p style={{ margin: '6px 0 0', fontSize: 12, color: '#c9a89a' }}>
+          Nothing has been lost — the YAML below is exactly what caused this.
+          Fix it and Apply to try again, or discard it and start from a fresh
+          canvas.
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 10 }}>
+          <button
+            onClick={onApply}
+            style={{
+              background: '#5fd1c9',
+              color: '#14110f',
+              border: 'none',
+              borderRadius: 4,
+              padding: '5px 12px',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Apply &amp; retry
+          </button>
+          <button
+            onClick={onDiscardDraft}
+            style={{
+              background: 'transparent',
+              color: '#ff9a8a',
+              border: '1px solid #5a2a20',
+              borderRadius: 4,
+              padding: '5px 12px',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Discard draft &amp; start fresh
+          </button>
+        </div>
+      </div>
+      <textarea
+        aria-label="Dungeon YAML (recovery)"
+        value={yamlText}
+        onChange={(e) => onChangeText(e.target.value)}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+            e.preventDefault();
+            onApply();
+          }
+        }}
+        spellCheck={false}
+        style={{
+          flex: 1,
+          minHeight: 420,
+          resize: 'vertical',
+          border: 'none',
+          outline: 'none',
+          background: '#170f22',
+          color: '#d9c9f0',
+          fontFamily: 'ui-monospace, Consolas, Menlo, monospace',
+          fontSize: 12,
+          lineHeight: 1.5,
+          padding: '10px 12px',
+          whiteSpace: 'pre',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/author/CONTRACT.md
+++ b/src/author/CONTRACT.md
@@ -7762,3 +7762,154 @@ placeable for a prop; a high-coverage cell on the same real line stays
 blocked. Full suite: 139 files / 2329 tests, `ci-check` clean.
 
 — asset-pipeline agent, on behalf of KirkDiggler
+
+## Authoring robustness — "the YAML is always fixable" (2026-08-07, rpg-project#194)
+
+Kirk white-screened the entire builder hand-editing YAML: he pasted
+`wallLines:`-shaped objects into `walls:` (entries with no real
+`[col, row]` `from`/`to`) and used Load .yaml. `parseDungeon` accepted
+it — `walls:`'s parse was a blind `w.from as [number, number]` cast, no
+shape check at all — so the malformed entry sailed through with
+`from: undefined`, and the crash didn't happen until board render tried
+`wall.from.join(',')` (`CreationBoard.tsx`'s `wallEls` loop). By then
+autosave had already captured the broken text, so every reload restored
+it and re-crashed — the only way back in was manually clearing
+`localStorage` in DevTools. This unit exists to make that whole class of
+breakage structurally impossible, four ways.
+
+### 1. Strict shape validation at parse (`dungeonYaml.ts`)
+
+Every list-shaped/tuple-shaped construct `toDungeonDoc` used to trust
+with a blind cast now goes through `assertCellPair`/
+`assertOptionalCellPair`/`assertWallLineEndpointShape` first: `walls:`
+(the incident itself), `wallLines:` endpoints and `doors[].cell`,
+`holes:`, `start:`/`end:` (present-but-malformed only — genuinely absent
+stays a legitimate unset, not an error), `canvas:` width/height,
+`lighting.ambient`, `connectors:` `from`/`to`/`locked`, `place:` (both
+room-scoped and top-level — tightened from "is it an array" to "are the
+elements actually numbers"), `regions[].cells`, and room `boss.at`. Each
+throws `DungeonParseError` naming the exact entry and field —
+`walls[3]: missing 'from'`-style, matching this file's own pre-existing
+`rooms[i]`/`regions[i]` shape-check discipline, not a new pattern. The
+invariant this file now holds everywhere: **anything `parseDungeon`
+accepts must be safe to render.**
+
+Audited every construct the brief named (place/regions/wallLines/start)
+plus everything else `toDungeonDoc` builds; the fields left untouched
+(`obstacles:`, `defaults:`) were already either genuinely inert (rolled
+content, unexercised per this file's own earlier "rolled content panel
+is untested against real data" finding) or already `typeof`-guarded —
+no accept-then-crash risk found there worth the diff.
+
+### 2. Crash-recovery surface (`BoardCrashRecovery.tsx` + `DungeonBuilderConcept.tsx`)
+
+Tooth 1 closes the KNOWN gap; this is the safety net for anything else —
+a shape validation doesn't catch, or a genuine render bug. `CreationConcept`
+is now wrapped in a real `ErrorBoundary` (`@/components/ui/Feedback/ErrorBoundary`,
+already used elsewhere in this codebase — e.g. `RealWallPieces.tsx`'s GLB
+fallback — same pattern, not a new one); its `onError` hands the caught
+error + the EXACT `creationYamlText` that produced it to a new
+`creationCrash` state, and the composition root's own render swaps the
+whole boundary out for `BoardCrashRecovery` — an editable textarea (the
+broken text, untouched), the real error message, and two explicit
+actions: **Apply & retry** (re-parses; on success hands the board a fresh
+doc and mounts a brand-new `ErrorBoundary` instance to try again; on
+failure updates the error in place, text never lost) and **Discard draft
+& start fresh**. `fallback={null}` on the boundary itself — the very next
+render replaces it with `BoardCrashRecovery` entirely, so there's nothing
+worth showing in the boundary's own fallback slot.
+
+Both mounts (`AuthorView.tsx`'s real `/author` route, `ConceptsView.tsx`'s
+dev sandbox) get this for free — they both mount the SAME
+`DungeonBuilderConcept`, so the boundary living inside it, not at each
+call site, is what makes "both mounts" true without duplicating anything.
+
+### 3. The live YAML pane was already two-way — confirmed, not rebuilt
+
+Read the brief's "retire the display-only fossil" literally and went
+looking for a display-only pane; there wasn't one left to retire.
+`creation/ProposedYamlPane.tsx`'s "PROPOSED SCHEMA" hazard framing and
+its non-editable posture were ALREADY retired earlier the same day (this
+file's own "PROPOSED SCHEMA framing retired" section above, rpg-project#194
+ratification round) — the pane has been a real, editable `serializeDungeon(cst)`
+view with debounced reparse (`APPLY_DEBOUNCE_MS = 700`, `applyCreationText`)
+and inline `parseError` display (text never auto-reverted on a bad edit)
+since before this unit started. What THIS unit adds on top: `BoardCrashRecovery`
+reuses the identical editable-textarea / explicit-action / never-lose-what-
+was-typed contract as the error-recovery surface (tooth 2), and new
+end-to-end tests (`DungeonBuilderConcept.test.tsx`) prove the live pane's
+two-way behavior at the composition level for the first time — a
+malformed edit rejects inline without losing the text or triggering the
+crash-recovery surface (parse rejection is not a render crash), and a
+subsequent valid edit applies cleanly and clears the error.
+
+### 4. Draft restore, crash-proof by construction
+
+The mount-time draft-restore path used to `try { parseDungeon(draft.yamlText) } catch { discardDraft('create') }`
+— safe (nothing crashed) but LOSSY: a draft that failed to parse just
+vanished, exactly the "had to manually clear localStorage" pain Kirk
+hit. It now keeps the draft in storage, still falls the WORKING doc back
+to the fresh seed so the rest of the component's state initializes
+normally, but carries the broken text + a real error message out as the
+SAME `creationCrash` shape a live render crash uses — one recovery
+surface, two ways in. `createRestoredDraftAt` stays `null` on this path
+(nothing was actually loaded onto the board, so `DraftRestoredBanner`
+doesn't claim it was).
+
+Also: `emptyCanvasDoc.ts`'s `emptyCanvasYaml` now stamps `theme: crypt` —
+a from-scratch canvas omitted `theme:` entirely, which every real
+consumer (`HexGrid.tsx`, `SyntyHexFloor`/`SyntyHexWall`, `EncounterMap.tsx`)
+reads as full-bright default lighting, so every "New Dungeon" Kirk played
+came out flat, not the crypt look `SHOWCASE_YAML`'s own `theme: crypt`
+already demonstrates. `theme` is plain v1-real `DungeonDoc` state, never
+touched by `stripToV1Subset` — a one-line fix, no compiler changes.
+
+### Live verification (2026-08-07, against the Wave-1 server, `localhost:8092`)
+
+Own dev server, port 3057, `VITE_API_HOST`/`VITE_DEV_PLAYER_ID` pointed at
+the live server in `.env.local` (gitignored, never committed), never
+touching the shared port-3001 dev server or any other in-flight unit's
+port. A throwaway Playwright script drove the real Home → Dungeon
+Builder flow end to end:
+
+1. Fresh "New Dungeon" open — YAML pane's own text confirmed `theme: crypt`
+   present.
+2. Typed Kirk's exact malformed paste (`wallLines`-shaped `walls:` entry)
+   into the live pane — rejected inline (`walls[0].from: expected [col, row], got {"cell":[1,1],"corner":0}`),
+   typed text preserved verbatim, and confirmed the crash-recovery surface
+   did NOT appear (a parse rejection is not a render crash — different
+   code path, both verified live).
+3. Fixed the text in place — inline error cleared, board applied normally.
+4. Seeded the EXACT broken draft into `localStorage`, reloaded: the
+   crash-recovery surface appeared with the broken text byte-for-byte
+   intact and the same specific error message — no white screen, no blank
+   page.
+5. Reloaded AGAIN against the same untouched broken draft — the
+   incident's own "every reload re-crashed" symptom, directly disproved:
+   recovery surface reappears cleanly every time, never a crash.
+6. Fixed the text in the recovery surface, clicked **Apply & retry** — the
+   real board returned.
+7. Repeated from a fresh broken-draft reload, clicked **Discard draft &
+   start fresh** instead — storage cleared, fresh canvas rendered, and
+   its YAML pane confirmed `theme: crypt` present on the new seed too.
+
+No unexpected console errors across the whole run — only the
+pre-existing, deliberately-invalid liveness-probe errors this file has
+already documented elsewhere (`usePutDungeonPreview`/`probeAuthoringGate`'s
+own `key "" must match ...` self-checks).
+
+### Tests
+
+`dungeonYaml.test.ts`: 21 new tests — the full parse-time shape-validation
+sweep (walls/wallLines/holes/start/end/canvas/lighting/connectors/place/
+regions.cells/boss.at, including Kirk's exact incident repro) plus the
+`theme: crypt` seed check. `DungeonBuilderConcept.test.tsx` (new file): 8
+end-to-end tests — the incident regression (seed a broken draft, mount,
+expect the recovery surface with the text intact, never a thrown render
+exception), the "every reload re-crashes" symptom made safe across two
+consecutive mounts, Apply & retry succeeding and failing-safely, Discard
+draft, a healthy draft still restoring normally (no false-positive
+recovery surface), and the live pane's own two-way malformed/valid-edit
+round trip. Full suite: 143 files / 2437 tests, `ci-check` clean.
+
+— asset-pipeline agent, on behalf of KirkDiggler

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -62,9 +62,7 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
   it('does not throw mounting on a broken-walls draft, and shows the recovery surface with the text intact', () => {
     seedBrokenDraft();
 
-    expect(() =>
-      render(<DungeonBuilderConcept forceFixtures />)
-    ).not.toThrow();
+    expect(() => render(<DungeonBuilderConcept forceFixtures />)).not.toThrow();
 
     // The crash-recovery surface, not the normal board/pane.
     const recoveryBox = screen.getByLabelText(
@@ -86,18 +84,12 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
   it('every reload restores the SAME recovery surface, never a crash (the incident\'s "every reload re-crashed" symptom, made safe)', () => {
     seedBrokenDraft();
     const { unmount } = render(<DungeonBuilderConcept forceFixtures />);
-    expect(
-      screen.getByLabelText('Dungeon YAML (recovery)')
-    ).toBeTruthy();
+    expect(screen.getByLabelText('Dungeon YAML (recovery)')).toBeTruthy();
     unmount();
 
     // Simulate a second reload against the same (untouched) localStorage.
-    expect(() =>
-      render(<DungeonBuilderConcept forceFixtures />)
-    ).not.toThrow();
-    expect(
-      screen.getByLabelText('Dungeon YAML (recovery)')
-    ).toBeTruthy();
+    expect(() => render(<DungeonBuilderConcept forceFixtures />)).not.toThrow();
+    expect(screen.getByLabelText('Dungeon YAML (recovery)')).toBeTruthy();
   });
 
   it('Apply & retry: fixing the text in place returns the real board', () => {
@@ -112,9 +104,7 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
     fireEvent.change(recoveryBox, { target: { value: fixed } });
     fireEvent.click(screen.getByText('Apply & retry'));
 
-    expect(
-      screen.queryByLabelText('Dungeon YAML (recovery)')
-    ).toBeNull();
+    expect(screen.queryByLabelText('Dungeon YAML (recovery)')).toBeNull();
     expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
   });
 
@@ -146,18 +136,16 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
 
     fireEvent.click(screen.getByText('Discard draft & start fresh'));
 
-    expect(
-      screen.queryByLabelText('Dungeon YAML (recovery)')
-    ).toBeNull();
+    expect(screen.queryByLabelText('Dungeon YAML (recovery)')).toBeNull();
     expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
     expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
   });
 
   it('a healthy draft still restores normally (no false-positive recovery surface)', () => {
-    const healthy = emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height).replace(
-      'name: "Untitled Dungeon"',
-      'name: "A Healthy Draft"'
-    );
+    const healthy = emptyCanvasYaml(
+      DEFAULT_CANVAS.width,
+      DEFAULT_CANVAS.height
+    ).replace('name: "Untitled Dungeon"', 'name: "A Healthy Draft"');
     localStorage.setItem(
       DRAFT_KEY,
       JSON.stringify({ yamlText: healthy, savedAt: Date.now() })
@@ -165,9 +153,7 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
 
     render(<DungeonBuilderConcept forceFixtures />);
 
-    expect(
-      screen.queryByLabelText('Dungeon YAML (recovery)')
-    ).toBeNull();
+    expect(screen.queryByLabelText('Dungeon YAML (recovery)')).toBeNull();
     expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
     expect(screen.getByText(/Draft restored/)).toBeTruthy();
   });

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * DungeonBuilderConcept.test.tsx — end-to-end regression coverage for
+ * Kirk's own incident (rpg-project#194 authoring-robustness unit, "the
+ * YAML is always fixable"): he hand-pasted `wallLines:`-shaped objects
+ * into `walls:` (entries with no real `[col, row]` `from`/`to`), the
+ * parser accepted it, the board crashed reading the missing coords —
+ * white screen, no UI — and because autosave had already captured the
+ * broken text, EVERY reload restored it and re-crashed. The only way
+ * back in was manually clearing `localStorage` in DevTools.
+ *
+ * `dungeonYaml.test.ts`'s new "shape validation at parse" suite already
+ * proves the fix at the unit level (a malformed `walls:` entry now
+ * throws `DungeonParseError` at parse time, not render time). This file
+ * proves the OTHER half: that the composition root actually wires that
+ * fix up correctly end to end — a broken draft sitting in `localStorage`
+ * at mount time must produce the crash-recovery surface, with the
+ * broken text intact and editable, never a thrown render exception and
+ * never a silently-discarded draft.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
+import { DungeonBuilderConcept } from './DungeonBuilderConcept';
+
+const DRAFT_KEY = 'dungeon-builder:draft:create';
+
+/** Kirk's exact repro: a `walls:` entry shaped like `wallLines:` instead
+ * — `{cell, corner}` where a real `[col, row]` `from` belongs. Genuinely
+ * different from the fresh seed (so the restore path's own
+ * `draftDiffersFromFreshSeed` honesty guard doesn't just discard it as a
+ * no-op) and — before this unit's parse-time validation — accepted by
+ * `parseDungeon`, only crashing later when `CreationBoard.tsx` tried
+ * `wall.from.join(',')`. */
+const BROKEN_WALLS_YAML = emptyCanvasYaml(
+  DEFAULT_CANVAS.width,
+  DEFAULT_CANVAS.height
+).replace(
+  'walls: []',
+  'walls:\n  - { from: { cell: [1, 1], corner: 0 }, to: [2, 2] }'
+);
+
+function seedBrokenDraft() {
+  localStorage.setItem(
+    DRAFT_KEY,
+    JSON.stringify({ yamlText: BROKEN_WALLS_YAML, savedAt: Date.now() })
+  );
+}
+
+describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident regression)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not throw mounting on a broken-walls draft, and shows the recovery surface with the text intact', () => {
+    seedBrokenDraft();
+
+    expect(() =>
+      render(<DungeonBuilderConcept forceFixtures />)
+    ).not.toThrow();
+
+    // The crash-recovery surface, not the normal board/pane.
+    const recoveryBox = screen.getByLabelText(
+      'Dungeon YAML (recovery)'
+    ) as HTMLTextAreaElement;
+    expect(recoveryBox.value).toBe(BROKEN_WALLS_YAML);
+    expect(recoveryBox.value).toContain('cell: [1, 1]');
+
+    // A real, specific error — not a generic "something went wrong".
+    expect(screen.getByText(/walls\[0\]\.from/)).toBeTruthy();
+
+    // The normal (non-crashed) pane never mounted.
+    expect(screen.queryByLabelText('Dungeon YAML')).toBeNull();
+
+    // The draft is still in storage — nothing was silently discarded.
+    expect(localStorage.getItem(DRAFT_KEY)).not.toBeNull();
+  });
+
+  it('every reload restores the SAME recovery surface, never a crash (the incident\'s "every reload re-crashed" symptom, made safe)', () => {
+    seedBrokenDraft();
+    const { unmount } = render(<DungeonBuilderConcept forceFixtures />);
+    expect(
+      screen.getByLabelText('Dungeon YAML (recovery)')
+    ).toBeTruthy();
+    unmount();
+
+    // Simulate a second reload against the same (untouched) localStorage.
+    expect(() =>
+      render(<DungeonBuilderConcept forceFixtures />)
+    ).not.toThrow();
+    expect(
+      screen.getByLabelText('Dungeon YAML (recovery)')
+    ).toBeTruthy();
+  });
+
+  it('Apply & retry: fixing the text in place returns the real board', () => {
+    seedBrokenDraft();
+    render(<DungeonBuilderConcept forceFixtures />);
+
+    const recoveryBox = screen.getByLabelText('Dungeon YAML (recovery)');
+    const fixed = BROKEN_WALLS_YAML.replace(
+      'walls:\n  - { from: { cell: [1, 1], corner: 0 }, to: [2, 2] }',
+      'walls:\n  - { from: [1, 1], to: [2, 2] }'
+    );
+    fireEvent.change(recoveryBox, { target: { value: fixed } });
+    fireEvent.click(screen.getByText('Apply & retry'));
+
+    expect(
+      screen.queryByLabelText('Dungeon YAML (recovery)')
+    ).toBeNull();
+    expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
+  });
+
+  it('Apply & retry with STILL-broken text keeps the recovery surface up and preserves what was typed', () => {
+    seedBrokenDraft();
+    render(<DungeonBuilderConcept forceFixtures />);
+
+    const recoveryBox = screen.getByLabelText('Dungeon YAML (recovery)');
+    // Fix `from` (so validation actually reaches `to`) but break `to` in
+    // the SAME wallLines-shaped way `from` originally was — still broken,
+    // just on the other field now.
+    const stillBroken = BROKEN_WALLS_YAML.replace(
+      'from: { cell: [1, 1], corner: 0 }, to: [2, 2]',
+      'from: [1, 1], to: { cell: [2, 2], corner: 0 }'
+    );
+    fireEvent.change(recoveryBox, { target: { value: stillBroken } });
+    fireEvent.click(screen.getByText('Apply & retry'));
+
+    const box = screen.getByLabelText(
+      'Dungeon YAML (recovery)'
+    ) as HTMLTextAreaElement;
+    expect(box.value).toBe(stillBroken);
+    expect(screen.getByText(/walls\[0\]\.to/)).toBeTruthy();
+  });
+
+  it('Discard draft: clears storage and returns a fresh canvas', () => {
+    seedBrokenDraft();
+    render(<DungeonBuilderConcept forceFixtures />);
+
+    fireEvent.click(screen.getByText('Discard draft & start fresh'));
+
+    expect(
+      screen.queryByLabelText('Dungeon YAML (recovery)')
+    ).toBeNull();
+    expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
+    expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  it('a healthy draft still restores normally (no false-positive recovery surface)', () => {
+    const healthy = emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height).replace(
+      'name: "Untitled Dungeon"',
+      'name: "A Healthy Draft"'
+    );
+    localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ yamlText: healthy, savedAt: Date.now() })
+    );
+
+    render(<DungeonBuilderConcept forceFixtures />);
+
+    expect(
+      screen.queryByLabelText('Dungeon YAML (recovery)')
+    ).toBeNull();
+    expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
+    expect(screen.getByText(/Draft restored/)).toBeTruthy();
+  });
+});

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -17,10 +17,15 @@
  * broken text intact and editable, never a thrown render exception and
  * never a silently-discarded draft.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import { DungeonBuilderConcept } from './DungeonBuilderConcept';
+
+/** `DungeonBuilderConcept.tsx`'s own `APPLY_DEBOUNCE_MS` (not exported —
+ * this is the pane's debounced-reparse delay the two-way-pane tests below
+ * flush past with fake timers). */
+const APPLY_DEBOUNCE_MS = 700;
 
 const DRAFT_KEY = 'dungeon-builder:draft:create';
 
@@ -165,5 +170,86 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
     ).toBeNull();
     expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
     expect(screen.getByText(/Draft restored/)).toBeTruthy();
+  });
+});
+
+describe('DungeonBuilderConcept — the live YAML pane is genuinely two-way (tooth 3)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('typing a malformed change rejects inline, without losing what was typed or crashing the board', async () => {
+    render(<DungeonBuilderConcept forceFixtures />);
+
+    const pane = screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement;
+    const malformed = pane.value.replace(
+      'walls: []',
+      'walls:\n  - { from: { cell: [1, 1], corner: 0 }, to: [2, 2] }'
+    );
+    fireEvent.change(pane, { target: { value: malformed } });
+
+    // Debounced reparse (`APPLY_DEBOUNCE_MS`) — nothing has applied yet,
+    // but the textarea already reflects every keystroke.
+    expect(
+      (screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement).value
+    ).toBe(malformed);
+
+    await act(async () => {
+      vi.advanceTimersByTime(APPLY_DEBOUNCE_MS + 50);
+    });
+
+    // Rejected inline — the SAME shape error dungeonYaml.ts now throws at
+    // parse time — and the typed text is still exactly what was typed,
+    // never silently reverted to the last-good doc.
+    expect(screen.getByText(/walls\[0\]\.from/)).toBeTruthy();
+    expect(
+      (screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement).value
+    ).toBe(malformed);
+    // No crash: the pane and board are both still mounted normally, not
+    // swapped for the crash-recovery surface — parse rejection is not a
+    // render crash.
+    expect(screen.queryByLabelText('Dungeon YAML (recovery)')).toBeNull();
+  });
+
+  it('typing a valid change applies and clears any prior error', async () => {
+    render(<DungeonBuilderConcept forceFixtures />);
+    const pane = screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement;
+    const original = pane.value;
+
+    // First, a malformed edit to produce an inline error…
+    const malformed = original.replace(
+      'walls: []',
+      'walls:\n  - { from: { cell: [1, 1], corner: 0 }, to: [2, 2] }'
+    );
+    fireEvent.change(pane, { target: { value: malformed } });
+    await act(async () => {
+      vi.advanceTimersByTime(APPLY_DEBOUNCE_MS + 50);
+    });
+    expect(screen.getByText(/walls\[0\]\.from/)).toBeTruthy();
+
+    // …then a genuinely valid edit (a real, well-shaped wall this time),
+    // which should apply cleanly and clear the error.
+    const valid = original
+      .replace('walls: []', 'walls:\n  - { from: [1, 1], to: [2, 2] }')
+      .replace('name: "Untitled Dungeon"', 'name: "Fixed Dungeon"');
+    fireEvent.change(
+      screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement,
+      { target: { value: valid } }
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(APPLY_DEBOUNCE_MS + 50);
+    });
+
+    const finalPane = screen.getByLabelText(
+      'Dungeon YAML'
+    ) as HTMLTextAreaElement;
+    expect(finalPane.value).toBe(valid);
+    expect(screen.queryByText(/walls\[0\]\.from/)).toBeNull();
+    expect(screen.queryByLabelText('Dungeon YAML (recovery)')).toBeNull();
   });
 });

--- a/src/author/DungeonBuilderConcept.tsx
+++ b/src/author/DungeonBuilderConcept.tsx
@@ -36,7 +36,9 @@
  * for a SCRIPTED straight drag; `nearestEdge`/`dragFamily` (which a real
  * interactive drag actually calls) are untouched.
  */
+import { ErrorBoundary } from '@/components/ui/Feedback/ErrorBoundary';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { BoardCrashRecovery } from './BoardCrashRecovery';
 import { CreationConcept } from './creation/CreationConcept';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import type { CornerRef } from './creation/hexCorner';
@@ -77,6 +79,18 @@ import {
 import { useSaveDungeon } from './useSaveDungeon';
 
 const APPLY_DEBOUNCE_MS = 700;
+
+/** Crash-recovery state (this unit, rpg-project#194 authoring-robustness)
+ * — non-null whenever the board can't be shown for either of the two
+ * reasons `BoardCrashRecovery.tsx`'s own doc comment covers: a restored
+ * draft that fails to (re-)parse, or a live render crash caught by the
+ * `ErrorBoundary` around `CreationConcept` below. `yamlText` is always
+ * the EXACT text responsible — never the fresh-seed fallback quietly
+ * backing `creationDoc`/`creationCst` underneath while this is shown. */
+interface CreationCrash {
+  message: string;
+  yamlText: string;
+}
 
 /** `draftDiffersFromFreshSeed`'s canonicalize function — the real
  * parse+serialize round trip, module-level since it needs nothing from
@@ -145,48 +159,74 @@ export function DungeonBuilderConcept({
   // Local drafts (this unit): before falling back to the fresh seed,
   // check for a locally-saved 'create' draft (`draftStorage.ts`) and
   // restore it instead — the author never loses a board to a refresh/
-  // crash. A corrupt/unparseable draft is discarded rather than left to
-  // keep failing on every future mount (`createRestoredDraftAt` stays
-  // null in that case, so `DraftRestoredBanner` never appears for
-  // content that was never actually loaded).
+  // crash.
+  //
+  // Crash-proof by construction (authoring-robustness unit, rpg-project#194):
+  // a draft that fails to (re-)parse used to be silently discarded here —
+  // safe (nothing crashed) but LOSSY, the exact "had to manually clear
+  // localStorage" failure mode Kirk hit. It's kept in storage now, the
+  // WORKING doc still falls back to the fresh seed so the rest of this
+  // component's state initializes normally, but the broken text + a real
+  // error message are carried out as `crash` so the render below can show
+  // `BoardCrashRecovery` instead of quietly losing it (`createRestoredDraftAt`
+  // stays null in this branch too — nothing was actually loaded onto the
+  // board, so `DraftRestoredBanner` shouldn't claim it was).
   //
   // Honesty guard (Copilot review, PR #717): a stored draft that's
   // canonically indistinguishable from the fresh seed is NOT a real
   // authored draft — announcing it as one would be dishonest.
-  const [{ parsed: creationInitial, restoredAt: createRestoredDraftAt }] =
-    useState(() => {
-      const freshCreationSeed = emptyCanvasYaml(
-        DEFAULT_CANVAS.width,
-        DEFAULT_CANVAS.height
-      );
-      const draft = loadDraft('create');
-      if (draft) {
-        if (
-          draftDiffersFromFreshSeed(
-            draft.yamlText,
-            freshCreationSeed,
-            canonicalizeYaml
-          )
-        ) {
-          try {
-            return {
-              parsed: parseDungeon(draft.yamlText),
-              restoredAt: draft.savedAt,
-            };
-          } catch {
-            discardDraft('create');
-          }
-        } else {
-          discardDraft('create');
+  const [
+    {
+      parsed: creationInitial,
+      restoredAt: createRestoredDraftAt,
+      crash: creationInitialCrash,
+    },
+  ] = useState(() => {
+    const freshCreationSeed = emptyCanvasYaml(
+      DEFAULT_CANVAS.width,
+      DEFAULT_CANVAS.height
+    );
+    const draft = loadDraft('create');
+    if (draft) {
+      if (
+        draftDiffersFromFreshSeed(
+          draft.yamlText,
+          freshCreationSeed,
+          canonicalizeYaml
+        )
+      ) {
+        try {
+          return {
+            parsed: parseDungeon(draft.yamlText),
+            restoredAt: draft.savedAt,
+            crash: null as CreationCrash | null,
+          };
+        } catch (err) {
+          return {
+            parsed: parseDungeon(freshCreationSeed),
+            restoredAt: null as number | null,
+            crash: {
+              message:
+                err instanceof DungeonParseError ? err.message : String(err),
+              yamlText: draft.yamlText,
+            } as CreationCrash | null,
+          };
         }
+      } else {
+        discardDraft('create');
       }
-      return {
-        parsed: parseDungeon(freshCreationSeed),
-        restoredAt: null as number | null,
-      };
-    });
+    }
+    return {
+      parsed: parseDungeon(freshCreationSeed),
+      restoredAt: null as number | null,
+      crash: null as CreationCrash | null,
+    };
+  });
   const [createDraftBannerDismissed, setCreateDraftBannerDismissed] =
     useState(false);
+  const [creationCrash, setCreationCrash] = useState<CreationCrash | null>(
+    creationInitialCrash
+  );
   const [creationCst, setCreationCst] = useState(creationInitial.cst);
   const [creationDoc, setCreationDoc] = useState<DungeonDoc>(
     creationInitial.doc
@@ -426,6 +466,50 @@ export function DungeonBuilderConcept({
     setCreationParseError(null);
     creationEdit.setSelectedPlacement(null);
     setCreateDraftBannerDismissed(true);
+    // Also the crash-recovery surface's own "start fresh" escape hatch
+    // (this unit) — same reset, plus clearing whichever crash reason
+    // (restore-parse-failure or live render crash) put us here.
+    setCreationCrash(null);
+  };
+
+  // Crash-recovery surface (this unit, rpg-project#194 authoring-
+  // robustness) — `BoardCrashRecovery.tsx`'s own doc comment has the full
+  // "why this exists" writeup. Edits the crash's OWN `yamlText` (never
+  // `creationYamlText`, which the board itself isn't necessarily showing
+  // while crashed) and re-parses on explicit Apply, same
+  // editable-text/explicit-Apply/never-lose-what-was-typed contract
+  // `ProposedYamlPane`'s (non-crashed) textarea already offers.
+  const handleCreationCrashTextChange = (text: string) => {
+    setCreationCrash((c) => (c ? { ...c, yamlText: text } : c));
+  };
+
+  const handleCreationCrashApply = () => {
+    if (!creationCrash) return;
+    try {
+      const parsed = parseDungeon(creationCrash.yamlText);
+      setCreationCst(parsed.cst);
+      setCreationDoc(parsed.doc);
+      setCreationYamlText(creationCrash.yamlText);
+      setCreationParseError(null);
+      creationEdit.setSelectedPlacement(null);
+      // Clearing this is what lets the board attempt to render again —
+      // `creationCrash === null` is the render-time switch back to the
+      // real `ErrorBoundary`-wrapped board below, a fresh boundary
+      // instance with its own hasError reset. If the newly-applied doc
+      // crashes too, `onError` sets `creationCrash` right back with the
+      // new error — the loop this unit's own "apply-to-retry" ask names.
+      setCreationCrash(null);
+    } catch (err) {
+      setCreationCrash((c) =>
+        c
+          ? {
+              ...c,
+              message:
+                err instanceof DungeonParseError ? err.message : String(err),
+            }
+          : c
+      );
+    }
   };
 
   // Delete/Backspace removes the selected placement — creation mode's
@@ -463,45 +547,76 @@ export function DungeonBuilderConcept({
           onDiscard={handleDiscardCreateDraft}
         />
       )}
-      <CreationConcept
-        doc={creationDoc}
-        yamlText={creationYamlText}
-        yamlParseError={creationParseError}
-        onChangeYamlText={handleChangeCreationText}
-        edit={creationEdit}
-        selectedTool={creationSelectedTool}
-        onSelectTool={setCreationSelectedTool}
-        onToggleWallEdge={handleCreationToggleWallEdge}
-        onAddStraightWall={handleCreationAddStraightWall}
-        onRemoveStraightWallAt={handleCreationRemoveStraightWallAt}
-        onSetStraightWallEndpoint={handleCreationSetStraightWallEndpoint}
-        onToggleStraightWallDoorAt={handleCreationToggleStraightWallDoorAt}
-        onToggleHole={handleCreationToggleHole}
-        onSetPoint={handleCreationSetPoint}
-        onNewCanvas={handleNewCanvas}
-        toast={flashToast}
-        regionEdit={regionEdit}
-        paletteCollapsed={createPaletteCollapsed}
-        onTogglePalette={() => setCreatePaletteCollapsed((c) => !c)}
-        yamlCollapsed={createYamlCollapsed}
-        onToggleYaml={() => setCreateYamlCollapsed((c) => !c)}
-        serverState={preview.serverState}
-        capabilities={preview.capabilities}
-        onRefreshCapabilities={preview.refreshCapabilities}
-        liveFloorPlan={creationFloorPreview.floorPlan}
-        v1Subset={creationV1Subset}
-        onSaveAndPlay={handleCreationSaveAndPlay}
-        saveState={creationSave.state}
-        savedKey={creationSave.savedKey}
-        saveFieldErrors={creationSave.fieldErrors}
-        saveErrorMessage={creationSave.errorMessage}
-        boardDim={createBoardDim}
-        onSetBoardDim={setCreateBoardDim}
-        yamlDownloadFilename={creationDownloadFilename}
-        onLoadYamlFile={handleLoadCreationYamlFile}
-        onLoadYamlFileError={handleLoadCreationYamlFileError}
-        specCompat={creationSpecCompat}
-      />
+      {creationCrash ? (
+        <BoardCrashRecovery
+          errorMessage={creationCrash.message}
+          yamlText={creationCrash.yamlText}
+          onChangeText={handleCreationCrashTextChange}
+          onApply={handleCreationCrashApply}
+          onDiscardDraft={handleDiscardCreateDraft}
+        />
+      ) : (
+        // Crash-proof by construction (this unit): if the board throws
+        // ANYWAY — a shape `dungeonYaml.ts`'s parse-time validation
+        // doesn't catch, or any other render bug — this boundary catches
+        // it instead of white-screening the whole app, and hands the
+        // error + the text that caused it to `creationCrash` above
+        // rather than rendering its own generic fallback (`fallback={null}`:
+        // the very next render swaps this whole branch for
+        // `BoardCrashRecovery`, so there's nothing worth showing here).
+        // A fresh `ErrorBoundary` instance mounts here every time
+        // `creationCrash` goes back to `null` (Apply & retry, Discard),
+        // so its own `hasError` is always reset for the next attempt.
+        <ErrorBoundary
+          fallback={null}
+          onError={(error) =>
+            setCreationCrash({
+              message: error.message,
+              yamlText: creationYamlText,
+            })
+          }
+        >
+          <CreationConcept
+            doc={creationDoc}
+            yamlText={creationYamlText}
+            yamlParseError={creationParseError}
+            onChangeYamlText={handleChangeCreationText}
+            edit={creationEdit}
+            selectedTool={creationSelectedTool}
+            onSelectTool={setCreationSelectedTool}
+            onToggleWallEdge={handleCreationToggleWallEdge}
+            onAddStraightWall={handleCreationAddStraightWall}
+            onRemoveStraightWallAt={handleCreationRemoveStraightWallAt}
+            onSetStraightWallEndpoint={handleCreationSetStraightWallEndpoint}
+            onToggleStraightWallDoorAt={handleCreationToggleStraightWallDoorAt}
+            onToggleHole={handleCreationToggleHole}
+            onSetPoint={handleCreationSetPoint}
+            onNewCanvas={handleNewCanvas}
+            toast={flashToast}
+            regionEdit={regionEdit}
+            paletteCollapsed={createPaletteCollapsed}
+            onTogglePalette={() => setCreatePaletteCollapsed((c) => !c)}
+            yamlCollapsed={createYamlCollapsed}
+            onToggleYaml={() => setCreateYamlCollapsed((c) => !c)}
+            serverState={preview.serverState}
+            capabilities={preview.capabilities}
+            onRefreshCapabilities={preview.refreshCapabilities}
+            liveFloorPlan={creationFloorPreview.floorPlan}
+            v1Subset={creationV1Subset}
+            onSaveAndPlay={handleCreationSaveAndPlay}
+            saveState={creationSave.state}
+            savedKey={creationSave.savedKey}
+            saveFieldErrors={creationSave.fieldErrors}
+            saveErrorMessage={creationSave.errorMessage}
+            boardDim={createBoardDim}
+            onSetBoardDim={setCreateBoardDim}
+            yamlDownloadFilename={creationDownloadFilename}
+            onLoadYamlFile={handleLoadCreationYamlFile}
+            onLoadYamlFileError={handleLoadCreationYamlFileError}
+            specCompat={creationSpecCompat}
+          />
+        </ErrorBoundary>
+      )}
       {toast && <ToastBanner message={toast} />}
     </div>
   );

--- a/src/author/creation/emptyCanvasDoc.ts
+++ b/src/author/creation/emptyCanvasDoc.ts
@@ -36,6 +36,17 @@
  * `specCompat.ts`'s `inferSpecCut` for what happens the moment an author
  * adds a draft-only construct (the declared value stops matching the
  * inferred one, and the compat report says so).
+ *
+ * `theme: crypt` (authoring-robustness unit, rpg-project#194) — a
+ * from-scratch canvas used to omit `theme:` entirely, which every real
+ * consumer (`HexGrid.tsx`, `SyntyHexFloor`/`SyntyHexWall`, `EncounterMap.tsx`)
+ * reads as full-bright default lighting: every "New Dungeon" Kirk played
+ * came out flat and shadowless, not the crypt look `SHOWCASE_YAML`'s own
+ * `theme: crypt` already demonstrates. Unlike every OTHER field this
+ * template writes, `theme` is NOT target-dialect/proposed — it's a plain
+ * v1-real `DungeonDoc.theme` field (`dungeonYaml.ts`), never touched by
+ * `stripToV1Subset`, so stamping it here needed no compiler/strip changes
+ * at all.
  */
 export const DEFAULT_CANVAS = { width: 20, height: 30 };
 
@@ -44,6 +55,7 @@ export function emptyCanvasYaml(width: number, height: number): string {
 spec: "0.3"
 key: untitled-creation
 name: "Untitled Dungeon"
+theme: crypt
 height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads
 canvas:
   width: ${width}

--- a/src/author/dungeonYaml.test.ts
+++ b/src/author/dungeonYaml.test.ts
@@ -131,6 +131,13 @@ describe('parseDungeon', () => {
   });
 });
 
+describe('emptyCanvasYaml seed — theme: crypt (rpg-project#194 authoring-robustness unit)', () => {
+  it('stamps theme: crypt so a fresh "New Dungeon" canvas is never full-bright', () => {
+    const { doc } = parseDungeon(emptyCanvasYaml(20, 30));
+    expect(doc.theme).toBe('crypt');
+  });
+});
+
 describe('shape validation at parse (rpg-project#194 authoring-robustness unit — "the YAML is always fixable")', () => {
   const base = () => emptyCanvasYaml(10, 10);
 

--- a/src/author/dungeonYaml.test.ts
+++ b/src/author/dungeonYaml.test.ts
@@ -143,10 +143,7 @@ describe('shape validation at parse (rpg-project#194 authoring-robustness unit â
 
   describe('walls: â€” the incident repro (pasted wallLines-shaped objects, missing from/to)', () => {
     it('rejects an entry with no from/to at all, naming the entry and field', () => {
-      const yaml = base().replace(
-        'walls: []',
-        'walls:\n  - { kind: solid }'
-      );
+      const yaml = base().replace('walls: []', 'walls:\n  - { kind: solid }');
       expect(() => parseDungeon(yaml)).toThrow(DungeonParseError);
       expect(() => parseDungeon(yaml)).toThrow(/walls\[0\]\.from/);
     });
@@ -207,7 +204,9 @@ describe('shape validation at parse (rpg-project#194 authoring-robustness unit â
         'wallLines: []',
         'wallLines:\n  - { from: [0, 0], to: [2, 0], doors: [{ cell: [1] }] }'
       );
-      expect(() => parseDungeon(yaml)).toThrow(/wallLines\[0\]\.doors\[0\]\.cell/);
+      expect(() => parseDungeon(yaml)).toThrow(
+        /wallLines\[0\]\.doors\[0\]\.cell/
+      );
     });
   });
 

--- a/src/author/dungeonYaml.test.ts
+++ b/src/author/dungeonYaml.test.ts
@@ -131,6 +131,179 @@ describe('parseDungeon', () => {
   });
 });
 
+describe('shape validation at parse (rpg-project#194 authoring-robustness unit — "the YAML is always fixable")', () => {
+  const base = () => emptyCanvasYaml(10, 10);
+
+  describe('walls: — the incident repro (pasted wallLines-shaped objects, missing from/to)', () => {
+    it('rejects an entry with no from/to at all, naming the entry and field', () => {
+      const yaml = base().replace(
+        'walls: []',
+        'walls:\n  - { kind: solid }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(DungeonParseError);
+      expect(() => parseDungeon(yaml)).toThrow(/walls\[0\]\.from/);
+    });
+
+    it("rejects a wallLines-shaped from (Kirk's exact paste: {cell, corner} instead of [col, row])", () => {
+      const yaml = base().replace(
+        'walls: []',
+        'walls:\n  - { from: { cell: [1, 1], corner: 0 }, to: [2, 2], kind: solid }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/walls\[0\]\.from/);
+    });
+
+    it('rejects a from/to with non-numeric elements', () => {
+      const yaml = base().replace(
+        'walls: []',
+        'walls:\n  - { from: ["a", 1], to: [2, 2] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/walls\[0\]\.from/);
+    });
+
+    it('rejects an invalid kind', () => {
+      const yaml = base().replace(
+        'walls: []',
+        'walls:\n  - { from: [0, 0], to: [1, 0], kind: portcullis }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/walls\[0\]\.kind/);
+    });
+
+    it('accepts a well-formed entry (positive control)', () => {
+      const yaml = base().replace(
+        'walls: []',
+        'walls:\n  - { from: [0, 0], to: [1, 0], kind: door }'
+      );
+      const { doc } = parseDungeon(yaml);
+      expect(doc.walls).toEqual([{ from: [0, 0], to: [1, 0], kind: 'door' }]);
+    });
+  });
+
+  describe('wallLines:', () => {
+    it('rejects a from with neither [col,row] nor {cell,corner} shape', () => {
+      const yaml = base().replace(
+        'wallLines: []',
+        'wallLines:\n  - { from: "nope", to: [2, 2] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/wallLines\[0\]\.from/);
+    });
+
+    it('rejects a {cell, corner} endpoint whose cell is missing', () => {
+      const yaml = base().replace(
+        'wallLines: []',
+        'wallLines:\n  - { from: { corner: 0 }, to: [2, 2] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/wallLines\[0\]\.from\.cell/);
+    });
+
+    it('rejects a malformed doors[].cell', () => {
+      const yaml = base().replace(
+        'wallLines: []',
+        'wallLines:\n  - { from: [0, 0], to: [2, 0], doors: [{ cell: [1] }] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/wallLines\[0\]\.doors\[0\]\.cell/);
+    });
+  });
+
+  describe('holes: / start: / end:', () => {
+    it('rejects a malformed holes entry', () => {
+      const yaml = base().replace('holes: []', 'holes:\n  - [1]');
+      expect(() => parseDungeon(yaml)).toThrow(/holes\[0\]/);
+    });
+
+    it('rejects a present-but-malformed start', () => {
+      const yaml = base().replace('start: null', 'start: "middle"');
+      expect(() => parseDungeon(yaml)).toThrow(/^start:/);
+    });
+
+    it('rejects a present-but-malformed end', () => {
+      const yaml = base().replace('end: null', 'end: [1]');
+      expect(() => parseDungeon(yaml)).toThrow(/^end:/);
+    });
+
+    it('leaves start/end unset (not an error) when genuinely absent', () => {
+      const { doc } = parseDungeon(base());
+      expect(doc.start).toBeNull();
+      expect(doc.end).toBeNull();
+    });
+  });
+
+  describe('canvas: / lighting:', () => {
+    it('rejects a non-numeric canvas width/height', () => {
+      const yaml = base().replace(
+        'canvas:\n  width: 10\n  height: 10',
+        'canvas:\n  width: "10"\n  height: 10'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/^canvas:/);
+    });
+
+    it('rejects a non-numeric lighting.ambient', () => {
+      const yaml = base().replace(
+        'place: []',
+        'place: []\nlighting:\n  ambient: "bright"'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/lighting\.ambient/);
+    });
+  });
+
+  describe('connectors:', () => {
+    it('rejects a connector missing from/to', () => {
+      const yaml = SHOWCASE_YAML.replace(
+        '- { from: antechamber, to: shrine }',
+        '- { to: shrine }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/connectors\[0\]/);
+    });
+
+    it('rejects a malformed locked: block', () => {
+      const withBadLock = SHOWCASE_YAML.replace(
+        '- { from: shrine, to: vault }',
+        '- { from: shrine, to: vault, locked: { dc: "twelve", ability: dex } }'
+      );
+      expect(() => parseDungeon(withBadLock)).toThrow(
+        /connectors\[\d+\]\.locked/
+      );
+    });
+  });
+
+  describe('place: (top-level and room-scoped)', () => {
+    it('rejects a top-level place entry with a non-numeric at', () => {
+      const yaml = base().replace(
+        'place: []',
+        'place:\n  - { ref: "dnd5e:props:crate", at: ["a", 1] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/place\[0\]\.at/);
+    });
+
+    it('rejects a room-scoped place entry missing ref', () => {
+      const yaml = SHOWCASE_YAML.replace(
+        '- { ref: "dnd5e:props:brazier", at: [1, 1], blocks_movement: true, blocks_los: false }',
+        '- { at: [1, 1] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/place\[0\]/);
+    });
+  });
+
+  describe('regions: cells', () => {
+    it('rejects a malformed cell', () => {
+      const yaml = base().replace(
+        'place: []',
+        'place: []\nregions:\n  - { id: r1, archetype: chamber, cells: [[1, 1], [2]] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/regions\[0\]\.cells\[1\]/);
+    });
+  });
+
+  describe('boss: at', () => {
+    it('rejects a malformed boss.at', () => {
+      const yaml = SHOWCASE_YAML.replace(
+        'boss: { ref: "dnd5e:monsters:skeleton-captain", at: [5, 5] }',
+        'boss: { ref: "dnd5e:monsters:skeleton-captain", at: [5] }'
+      );
+      expect(() => parseDungeon(yaml)).toThrow(/boss\.at/);
+    });
+  });
+});
+
 describe('setConnectorLocked (door editing, rpg-dnd5e-web#667)', () => {
   it('adds a flow-style locked: block matching the real dungeonspec shape', () => {
     const { cst } = parseDungeon(SHOWCASE_YAML);

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -203,6 +203,78 @@ function parseTargeting(raw: unknown): string | null {
   return typeof raw === 'string' ? raw : null;
 }
 
+/** The shape check underlying this file's whole "the YAML is always
+ * fixable" incident response (rpg-project#194 authoring-robustness unit,
+ * 2026-08-07): Kirk pasted `wallLines:`-shaped objects into `walls:`
+ * (entries with no `from`/`to` at all) and `parseDungeon` accepted it —
+ * `walls: []`'s old parse was a blind `w.from as [number, number]` cast,
+ * no shape check — so a malformed entry sailed through parsing with
+ * `from: undefined` and the crash didn't happen until board render tried
+ * `wall.from.join(',')` (`CreationBoard.tsx`), by which point autosave
+ * had already captured the broken text and every reload re-crashed:
+ * white screen, no UI, no way back in short of manually clearing
+ * `localStorage`. The fix is this function and its callers below:
+ * validate every `[col, row]`-shaped field AT PARSE TIME, so a malformed
+ * entry throws a `DungeonParseError` naming exactly which entry and field
+ * is wrong — same failure mode as the existing `rooms[i]`/`regions[i]`
+ * shape checks just above, extended to every other list-shaped construct
+ * `toDungeonDoc` used to trust blindly. The invariant this file now holds
+ * everywhere: anything `parseDungeon` accepts must be safe to render. */
+function assertCellPair(raw: unknown, context: string): [number, number] {
+  if (
+    !Array.isArray(raw) ||
+    raw.length !== 2 ||
+    typeof raw[0] !== 'number' ||
+    typeof raw[1] !== 'number' ||
+    !Number.isFinite(raw[0]) ||
+    !Number.isFinite(raw[1])
+  ) {
+    throw new DungeonParseError(
+      `${context}: expected [col, row], got ${JSON.stringify(raw)}`
+    );
+  }
+  return [raw[0], raw[1]];
+}
+
+/** Same check as `assertCellPair`, but for a field that's legitimately
+ * absent/`null` (`start:`/`end:`) — only a PRESENT-but-malformed value is
+ * a shape error; an absent one is just "unset." */
+function assertOptionalCellPair(
+  raw: unknown,
+  context: string
+): [number, number] | null {
+  if (raw === undefined || raw === null) return null;
+  return assertCellPair(raw, context);
+}
+
+/** Validates one `wallLines[].from`/`.to` endpoint's raw shape BEFORE
+ * `parseWallLineEndpoint` (above) touches it — that function's own two
+ * accepted shapes (bare `[col,row]` legacy cell, or `{cell, corner}`
+ * corner-anchored) both assume the value already looks like one of the
+ * two; neither branch has ever shape-checked its input, so anything else
+ * (missing entirely, a string, `{cell: undefined}`) fell through to
+ * `migrateLegacyCenterEndpoint`/`canonicalCorner` with garbage and
+ * crashed downstream geometry instead of failing parse honestly. */
+function assertWallLineEndpointShape(raw: unknown, context: string): void {
+  if (Array.isArray(raw)) {
+    assertCellPair(raw, context);
+    return;
+  }
+  if (raw && typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    assertCellPair(obj.cell, `${context}.cell`);
+    if (obj.corner !== undefined && typeof obj.corner !== 'number') {
+      throw new DungeonParseError(
+        `${context}.corner: expected a number, got ${JSON.stringify(obj.corner)}`
+      );
+    }
+    return;
+  }
+  throw new DungeonParseError(
+    `${context}: missing/invalid endpoint (expected [col, row] or {cell: [col, row], corner})`
+  );
+}
+
 /** Shared by both `place:` sites — room-scoped (`rooms[].place`, real
  * dungeonspec, room-LOCAL `at`) and top-level (`place:`, target dialect,
  * proposed, absolute `at` — see TARGET-YAML.md's "top-level placement"
@@ -212,12 +284,13 @@ function parseTargeting(raw: unknown): string | null {
 function parsePlacementList(raw: unknown, context: string): PlacementDoc[] {
   if (!Array.isArray(raw)) return [];
   return (raw as Record<string, unknown>[]).map((p, pi) => {
-    if (typeof p.ref !== 'string' || !Array.isArray(p.at)) {
-      throw new DungeonParseError(`${context}[${pi}] missing ref/at`);
+    if (typeof p.ref !== 'string') {
+      throw new DungeonParseError(`${context}[${pi}]: missing "ref"`);
     }
+    const at = assertCellPair(p.at, `${context}[${pi}].at`);
     return {
       ref: p.ref,
-      at: [p.at[0] as number, p.at[1] as number] as [number, number],
+      at,
       blocksMovement: p.blocks_movement === true,
       blocksLos: p.blocks_los === true,
       isMonster: p.ref.startsWith('dnd5e:monsters:'),
@@ -649,9 +722,13 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
     const boss = room.boss
       ? (() => {
           const b = room.boss as Record<string, unknown>;
+          if (typeof b.ref !== 'string') {
+            throw new DungeonParseError(`Room "${room.id}" boss: missing "ref"`);
+          }
+          const at = assertCellPair(b.at, `Room "${room.id}" boss.at`);
           return {
-            ref: b.ref as string,
-            at: b.at as [number, number],
+            ref: b.ref,
+            at,
             facing: parseFacing(b.facing),
             targeting: parseTargeting(b.targeting),
           };
@@ -676,15 +753,28 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
   if (!Array.isArray(raw.connectors)) {
     throw new DungeonParseError('No connectors: list found');
   }
-  const connectors: ConnectorDoc[] = raw.connectors.map((c) => {
+  const connectors: ConnectorDoc[] = raw.connectors.map((c, ci) => {
     const conn = c as Record<string, unknown>;
-    const locked = conn.locked as Record<string, unknown> | undefined;
+    if (typeof conn.from !== 'string' || typeof conn.to !== 'string') {
+      throw new DungeonParseError(`connectors[${ci}]: missing "from"/"to"`);
+    }
+    const rawLocked = conn.locked as Record<string, unknown> | null | undefined;
+    let locked: LockedDoc | null = null;
+    if (rawLocked != null) {
+      if (
+        typeof rawLocked.dc !== 'number' ||
+        typeof rawLocked.ability !== 'string'
+      ) {
+        throw new DungeonParseError(
+          `connectors[${ci}].locked: expected {dc: number, ability: string}`
+        );
+      }
+      locked = { dc: rawLocked.dc, ability: rawLocked.ability };
+    }
     return {
-      from: conn.from as string,
-      to: conn.to as string,
-      locked: locked
-        ? { dc: locked.dc as number, ability: locked.ability as string }
-        : null,
+      from: conn.from,
+      to: conn.to,
+      locked,
     };
   });
 
@@ -694,20 +784,41 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
   const canvas = raw.canvas
     ? (() => {
         const c = raw.canvas as Record<string, unknown>;
-        return { width: c.width as number, height: c.height as number };
+        if (typeof c.width !== 'number' || typeof c.height !== 'number') {
+          throw new DungeonParseError(
+            `canvas: width/height must be numbers, got ${JSON.stringify(c)}`
+          );
+        }
+        return { width: c.width, height: c.height };
       })()
     : null;
 
+  // walls: — the incident this unit exists to close (see
+  // `assertCellPair`'s own doc comment): every entry must carry a real
+  // [col, row] `from`/`to` pair before it's trusted anywhere downstream.
   const walls: WallDoc[] = Array.isArray(raw.walls)
-    ? (raw.walls as Record<string, unknown>[]).map((w) => ({
-        from: w.from as [number, number],
-        to: w.to as [number, number],
-        kind: w.kind === 'door' ? 'door' : 'solid',
-      }))
+    ? (raw.walls as Record<string, unknown>[]).map((w, wi) => {
+        const from = assertCellPair(w.from, `walls[${wi}].from`);
+        const to = assertCellPair(w.to, `walls[${wi}].to`);
+        if (w.kind !== undefined && w.kind !== 'solid' && w.kind !== 'door') {
+          throw new DungeonParseError(
+            `walls[${wi}].kind: expected "solid" or "door", got ${JSON.stringify(w.kind)}`
+          );
+        }
+        return { from, to, kind: w.kind === 'door' ? 'door' : 'solid' };
+      })
     : [];
 
   const wallLines: WallLineDoc[] = Array.isArray(raw.wallLines)
-    ? (raw.wallLines as Record<string, unknown>[]).map((w) => {
+    ? (raw.wallLines as Record<string, unknown>[]).map((w, wi) => {
+        assertWallLineEndpointShape(w.from, `wallLines[${wi}].from`);
+        assertWallLineEndpointShape(w.to, `wallLines[${wi}].to`);
+        if (Array.isArray(w.doors)) {
+          (w.doors as unknown[]).forEach((d, di) => {
+            const door = d as Record<string, unknown>;
+            assertCellPair(door.cell, `wallLines[${wi}].doors[${di}].cell`);
+          });
+        }
         const from = parseWallLineEndpoint(w.from, w.to);
         const to = parseWallLineEndpoint(w.to, w.from);
         return {
@@ -719,18 +830,22 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
     : [];
 
   const holes: [number, number][] = Array.isArray(raw.holes)
-    ? (raw.holes as [number, number][]).map(
-        (h) => [h[0], h[1]] as [number, number]
-      )
+    ? (raw.holes as unknown[]).map((h, hi) => assertCellPair(h, `holes[${hi}]`))
     : [];
 
-  const start = Array.isArray(raw.start)
-    ? (raw.start as [number, number])
-    : null;
-  const end = Array.isArray(raw.end) ? (raw.end as [number, number]) : null;
+  const start = assertOptionalCellPair(raw.start, 'start');
+  const end = assertOptionalCellPair(raw.end, 'end');
 
   const lighting = raw.lighting
-    ? { ambient: (raw.lighting as Record<string, unknown>).ambient as number }
+    ? (() => {
+        const l = raw.lighting as Record<string, unknown>;
+        if (typeof l.ambient !== 'number') {
+          throw new DungeonParseError(
+            `lighting.ambient: must be a number, got ${JSON.stringify(l.ambient)}`
+          );
+        }
+        return { ambient: l.ambient };
+      })()
     : null;
 
   // Top-level, absolute-[col,row] placements — target dialect, proposed. See
@@ -753,8 +868,8 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
           throw new DungeonParseError(`region "${r.id}" has no archetype`);
         }
         const cells: [number, number][] = Array.isArray(r.cells)
-          ? (r.cells as [number, number][]).map(
-              (c) => [c[0], c[1]] as [number, number]
+          ? (r.cells as unknown[]).map((c, ci) =>
+              assertCellPair(c, `regions[${ri}].cells[${ci}]`)
             )
           : [];
         return {

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -723,7 +723,9 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
       ? (() => {
           const b = room.boss as Record<string, unknown>;
           if (typeof b.ref !== 'string') {
-            throw new DungeonParseError(`Room "${room.id}" boss: missing "ref"`);
+            throw new DungeonParseError(
+              `Room "${room.id}" boss: missing "ref"`
+            );
           }
           const at = assertCellPair(b.at, `Room "${room.id}" boss.at`);
           return {


### PR DESCRIPTION
## Summary

Kirk white-screened the entire Dungeon Builder hand-editing YAML: he pasted `wallLines:`-shaped objects into `walls:` (entries with no real `[col, row]` `from`/`to`), used Load .yaml, and the parser accepted it — `walls:` was a blind cast, no shape check. The board crashed on render (`wall.from.join(',')`), autosave had already captured the broken text, and every reload restored + re-crashed it. The only way back in was manually clearing `localStorage` in DevTools.

This unit makes that class of breakage impossible, four ways:

1. **Strict shape validation at parse** (`src/author/dungeonYaml.ts`) — every `walls:`/`wallLines:`/`holes:`/`start:`/`end:`/`canvas:`/`lighting:`/`connectors:`/`place:`/`regions.cells`/`boss.at` entry is now shape-checked at `parseDungeon` time, throwing `DungeonParseError` naming the exact offending entry and field. Anything `parseDungeon` accepts is now safe to render.
2. **Crash-recovery surface** (`src/author/BoardCrashRecovery.tsx`) — `CreationConcept` is wrapped in a real `ErrorBoundary`; any live render crash (or a draft that fails to re-parse on restore) surfaces an editable textarea with the exact broken text, the real error, and explicit **Apply & retry** / **Discard draft & start fresh** actions. Covers both mounts (`AuthorView.tsx` and the Concepts Lab sandbox) for free since both mount the same `DungeonBuilderConcept`.
3. **The live YAML pane** — confirmed already genuinely two-way (debounced reparse, inline error, text never auto-reverted) from an earlier unit the same day; added end-to-end composition-level test coverage that didn't exist before, and the recovery surface (2) reuses the same interaction contract.
4. **Draft restore, crash-proof by construction** — a draft that fails to (re-)parse on mount used to be silently discarded (safe but lossy); it now routes into the same recovery surface with the broken text intact instead of vanishing. Also: `emptyCanvasDoc.ts` now stamps `theme: crypt` on a fresh canvas (every "New Dungeon" was rendering full-bright).

Full writeup, including the live Playwright verification transcript against the Wave-1 server (`localhost:8092`), is in `src/author/CONTRACT.md`'s new ledger entry ("Authoring robustness — 'the YAML is always fixable'").

## Test plan

- [x] `npm run ci-check` clean (format, lint, typecheck, build, full test suite)
- [x] 143 files / 2437 tests passing repo-wide (21 new shape-validation tests in `dungeonYaml.test.ts`, 8 new end-to-end tests in the new `DungeonBuilderConcept.test.tsx`)
- [x] Live-verified against the Wave-1 server: malformed live-typed input rejects inline without crashing; a broken draft in `localStorage` produces the recovery surface (not a crash) across two consecutive reloads; Apply & retry and Discard draft both work; fresh canvases confirm `theme: crypt`

— asset-pipeline agent, on behalf of KirkDiggler