### PR TITLE
feat(combat-log): scrollable panel + movement narrative (#738)

### DIFF
--- a/src/components/game/CombatLog.test.tsx
+++ b/src/components/game/CombatLog.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { CombatLogEntry } from '../../hooks/useCombatLog';
+import type { MovementNarration } from '../../utils/combatFormat';
 import { CombatLog } from './CombatLog';
+import { isScrolledAwayFromBottom } from './combatLogScroll';
 
 describe('CombatLog', () => {
   it('renders the empty state when there are no entries', () => {
@@ -278,5 +280,138 @@ describe('CombatLog', () => {
     expect(
       screen.getByTestId('combat-log-entry-encounterEnded-3').textContent
     ).toContain('all hostiles defeated');
+  });
+
+  describe('entityMoved narration (#738)', () => {
+    const movedEntry = (narration: MovementNarration): CombatLogEntry => ({
+      id: 0,
+      round: 1,
+      kind: 'entityMoved',
+      event: { entityId: 'skeleton-1' } as never,
+      narration,
+    });
+
+    it('renders a "closes" line naming the target, in-fiction voice, no coordinates', () => {
+      const entries: CombatLogEntry[] = [
+        movedEntry({ verb: 'closes', targetEntityId: 'char-finn' }),
+      ];
+      render(<CombatLog entries={entries} />);
+      const text = screen.getByTestId(
+        'combat-log-entry-entityMoved-0'
+      ).textContent;
+      expect(text).toContain('skeleton-1');
+      expect(text).toContain('closes on char-finn');
+      expect(text).not.toMatch(/\d+,\s*-?\d+,\s*-?\d+/); // no raw coordinates
+    });
+
+    it('renders a "retreats" line with no named target', () => {
+      const entries: CombatLogEntry[] = [movedEntry({ verb: 'retreats' })];
+      render(<CombatLog entries={entries} />);
+      expect(
+        screen.getByTestId('combat-log-entry-entityMoved-0').textContent
+      ).toContain('skeleton-1 retreats');
+    });
+
+    it('renders a neutral "moves" line when direction could not be derived', () => {
+      const entries: CombatLogEntry[] = [movedEntry({ verb: 'moves' })];
+      render(<CombatLog entries={entries} />);
+      expect(
+        screen.getByTestId('combat-log-entry-entityMoved-0').textContent
+      ).toContain('skeleton-1 moves');
+    });
+  });
+
+  describe('scroll behavior (#738)', () => {
+    it('isScrolledAwayFromBottom is false when at the bottom (within the pin threshold)', () => {
+      // scrollHeight - scrollTop - clientHeight = 0
+      expect(isScrolledAwayFromBottom(180, 200, 20)).toBe(false);
+      // Within slack (10px < default 24px threshold).
+      expect(isScrolledAwayFromBottom(170, 200, 20)).toBe(false);
+    });
+
+    it('isScrolledAwayFromBottom is true once scrolled up past the threshold', () => {
+      expect(isScrolledAwayFromBottom(50, 200, 20)).toBe(true);
+    });
+
+    function damaged(id: number): CombatLogEntry {
+      return {
+        id,
+        round: 1,
+        kind: 'damage',
+        event: {
+          entityId: 'goblin-1',
+          amount: 1,
+          hpAfter: { current: 5, max: 7 },
+          damageBreakdown: [],
+        } as never,
+      };
+    }
+
+    it('auto-follows to the bottom on mount and as entries stream in while pinned', () => {
+      const { rerender } = render(<CombatLog entries={[damaged(0)]} />);
+      const scrollEl = screen.getByTestId(
+        'combat-log-scroll'
+      ) as HTMLDivElement;
+      // jsdom never lays out scrollHeight, so simulate a real value.
+      Object.defineProperty(scrollEl, 'scrollHeight', {
+        value: 500,
+        configurable: true,
+      });
+      rerender(<CombatLog entries={[damaged(0), damaged(1)]} />);
+      expect(scrollEl.scrollTop).toBe(500);
+    });
+
+    it('pauses auto-follow once the user scrolls up, and shows a jump-to-latest affordance', () => {
+      const { rerender } = render(<CombatLog entries={[damaged(0)]} />);
+      const scrollEl = screen.getByTestId(
+        'combat-log-scroll'
+      ) as HTMLDivElement;
+      Object.defineProperty(scrollEl, 'scrollHeight', {
+        value: 500,
+        configurable: true,
+      });
+      Object.defineProperty(scrollEl, 'clientHeight', {
+        value: 100,
+        configurable: true,
+      });
+      // User scrolls up, well past the pin threshold.
+      scrollEl.scrollTop = 50;
+      fireEvent.scroll(scrollEl);
+
+      expect(screen.getByTestId('combat-log-jump-to-latest')).toBeTruthy();
+
+      // A new entry arrives — auto-follow must NOT yank the reader back down.
+      scrollEl.scrollTop = 50;
+      rerender(<CombatLog entries={[damaged(0), damaged(1)]} />);
+      expect(scrollEl.scrollTop).toBe(50);
+    });
+
+    it('resumes auto-follow and hides the affordance after jumping to latest', () => {
+      render(<CombatLog entries={[damaged(0)]} />);
+      const scrollEl = screen.getByTestId(
+        'combat-log-scroll'
+      ) as HTMLDivElement;
+      Object.defineProperty(scrollEl, 'scrollHeight', {
+        value: 500,
+        configurable: true,
+      });
+      Object.defineProperty(scrollEl, 'clientHeight', {
+        value: 100,
+        configurable: true,
+      });
+      scrollEl.scrollTop = 50;
+      fireEvent.scroll(scrollEl);
+      expect(screen.getByTestId('combat-log-jump-to-latest')).toBeTruthy();
+
+      fireEvent.click(screen.getByTestId('combat-log-jump-to-latest'));
+
+      expect(scrollEl.scrollTop).toBe(500);
+      expect(screen.queryByTestId('combat-log-jump-to-latest')).toBeNull();
+    });
+
+    it('does not show the jump-to-latest affordance on an empty log', () => {
+      render(<CombatLog entries={[]} />);
+      expect(screen.queryByTestId('combat-log-jump-to-latest')).toBeNull();
+    });
   });
 });

--- a/src/components/game/CombatLog.tsx
+++ b/src/components/game/CombatLog.tsx
@@ -11,10 +11,11 @@
  * recomputes a roll, total, or hit/miss verdict.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { CombatLogEntry } from '../../hooks/useCombatLog';
 import { formatSourceRefs } from '../../utils/combatFormat';
 import { getConditionDisplay } from '../../utils/conditionIcons';
+import { isScrolledAwayFromBottom } from './combatLogScroll';
 
 export interface CombatLogProps {
   entries: CombatLogEntry[];
@@ -26,13 +27,33 @@ export interface CombatLogProps {
 
 export function CombatLog({ entries, translucent = false }: CombatLogProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  // Auto-follow (#738): pinned to the newest entry by default, same as
+  // before. Reading back through a fight while it continues means this has
+  // to pause the instant the player scrolls up — otherwise every new event
+  // yanks them back to the bottom mid-read. Resumes (and jumps to the
+  // bottom) either by scrolling back down manually or via the "jump to
+  // latest" affordance below.
+  const [pinnedToBottom, setPinnedToBottom] = useState(true);
 
-  // Auto-scroll to the newest entry, mirroring the old sidebar's behavior.
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [entries.length]);
+    const el = scrollRef.current;
+    if (!el || !pinnedToBottom) return;
+    el.scrollTop = el.scrollHeight;
+  }, [entries.length, pinnedToBottom]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setPinnedToBottom(
+      !isScrolledAwayFromBottom(el.scrollTop, el.scrollHeight, el.clientHeight)
+    );
+  };
+
+  const jumpToLatest = () => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+    setPinnedToBottom(true);
+  };
 
   return (
     <div
@@ -72,26 +93,54 @@ export function CombatLog({ entries, translucent = false }: CombatLogProps) {
       >
         📜 Combat Log
       </div>
-      <div
-        ref={scrollRef}
-        data-testid="combat-log-scroll"
-        style={{
-          overflowY: 'auto',
-          maxHeight: 200,
-          padding: '6px 10px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 4,
-          fontSize: 12,
-          fontFamily: 'monospace',
-        }}
-      >
-        {entries.length === 0 ? (
-          <div style={{ opacity: 0.5, padding: '8px 0' }}>
-            The fight hasn&apos;t started yet…
-          </div>
-        ) : (
-          entries.map((entry) => <CombatLogLine key={entry.id} entry={entry} />)
+      <div style={{ position: 'relative' }}>
+        <div
+          ref={scrollRef}
+          data-testid="combat-log-scroll"
+          onScroll={handleScroll}
+          style={{
+            overflowY: 'auto',
+            maxHeight: 200,
+            padding: '6px 10px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+            fontSize: 12,
+            fontFamily: 'monospace',
+          }}
+        >
+          {entries.length === 0 ? (
+            <div style={{ opacity: 0.5, padding: '8px 0' }}>
+              The fight hasn&apos;t started yet…
+            </div>
+          ) : (
+            entries.map((entry) => (
+              <CombatLogLine key={entry.id} entry={entry} />
+            ))
+          )}
+        </div>
+        {!pinnedToBottom && entries.length > 0 && (
+          <button
+            type="button"
+            data-testid="combat-log-jump-to-latest"
+            onClick={jumpToLatest}
+            style={{
+              position: 'absolute',
+              bottom: 6,
+              right: 10,
+              padding: '3px 8px',
+              fontSize: 11,
+              fontWeight: 700,
+              color: 'var(--text-primary, #fff)',
+              background: 'var(--bg-tertiary, #333)',
+              border: '1px solid var(--border-primary, #555)',
+              borderRadius: 12,
+              cursor: 'pointer',
+              boxShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+            }}
+          >
+            ↓ Jump to latest
+          </button>
         )}
       </div>
     </div>
@@ -151,6 +200,9 @@ function lineStyle(entry: CombatLogEntry): React.CSSProperties {
       };
     case 'entityStabilized':
       return { color: '#4ade80', fontWeight: 700 };
+    case 'entityMoved':
+      // Flavor, not a combat beat — muted like turnEnded/removed.
+      return { opacity: 0.6, fontStyle: 'italic' };
   }
 }
 
@@ -232,5 +284,16 @@ function lineText(entry: CombatLogEntry): string {
     }
     case 'entityStabilized':
       return `🩹 ${entry.event.entityId} is stabilized`;
+    case 'entityMoved': {
+      const e = entry.event;
+      switch (entry.narration.verb) {
+        case 'closes':
+          return `👣 ${e.entityId} closes on ${entry.narration.targetEntityId}`;
+        case 'retreats':
+          return `👣 ${e.entityId} retreats`;
+        case 'moves':
+          return `👣 ${e.entityId} moves`;
+      }
+    }
   }
 }

--- a/src/components/game/EncounterDock.tsx
+++ b/src/components/game/EncounterDock.tsx
@@ -366,15 +366,25 @@ export function EncounterDock({
               width: 360,
               maxWidth: '45%',
               zIndex: 4,
-              // #556 gate: the log floats OVER the map — without this, its
-              // ~360px footprint pointer-captures the bottom-right map
-              // region (move tiles / armed targets unclickable) in every
-              // state. Click-through by design: targeting and movement
-              // beat scroll-back; the log is informational. Deliberate
-              // trade-off: no scroll-back while floating (the 📜 toggle
-              // still hides/shows; a hover-reveal scroll affordance is a
-              // possible future refinement).
-              pointerEvents: 'none',
+              // #556 made this click-through (pointer-events: none) so the
+              // log's ~360px footprint never pointer-captured the
+              // bottom-right map region (move tiles / armed targets stayed
+              // clickable underneath it) — but click-through also meant no
+              // scroll-back: every wheel/touch gesture over the panel fell
+              // straight through hit-testing to the R3F canvas beneath it
+              // and zoomed the camera instead (useCameraControls.ts's wheel
+              // listener is bound to the canvas element, so it's the only
+              // thing left to receive an event the log was never a hit-test
+              // candidate for). #738 (Kirk: "our combat log — which I
+              // cannot even scroll — should tell the story") supersedes
+              // that trade-off the other way: the log is a default-open,
+              // opt-in-visible panel (round 7: "we always want to see the
+              // info there", the 📜 toggle hides it for anyone who wants
+              // click-through back) — scroll-back wins. `auto` restores
+              // normal hit-testing so wheel/touch/click land on the panel
+              // itself; overflow-y: auto on combat-log-scroll then handles
+              // scrolling with no extra listener needed.
+              pointerEvents: 'auto',
             }}
           >
             <CombatLog entries={combatLogEntries} translucent />

--- a/src/components/game/EncounterView.tsx
+++ b/src/components/game/EncounterView.tsx
@@ -81,6 +81,7 @@ import {
   useEncounterState,
 } from '../../hooks/useEncounterState';
 import { errorMessage } from '../../utils/combatFormat';
+import type { CubeCoord } from '../hex-grid/hexMath';
 import {
   actionKey,
   targetKindNeedsPrompt,
@@ -723,6 +724,34 @@ export function EncounterView({
           });
           canonicalEntitiesRef.current = nextEntities;
         }
+        // #738: narrate monster movement into the combat log. All gating
+        // (TURN_BASED + MONSTER only) and toward/away derivation happens
+        // inside recordEntityMoved — this call site just gathers what's
+        // already cheaply on hand: the mover's pre-move position (`existing`,
+        // above) and every known CHARACTER's current position.
+        const characterPositions: Array<{
+          entityId: string;
+          position: CubeCoord;
+        }> = [];
+        for (const [id, ent] of canonicalEntitiesRef.current) {
+          if (id === e.entityId || !ent.position) continue;
+          if (
+            encounterState.state.entityMeta.get(id)?.type !==
+            EntityType.CHARACTER
+          ) {
+            continue;
+          }
+          characterPositions.push({ entityId: id, position: ent.position });
+        }
+        combatLog.recordEntityMoved(e, {
+          movingEntityType:
+            encounterState.state.entityMeta.get(e.entityId)?.type ??
+            EntityType.UNSPECIFIED,
+          mode: encounterState.state.mode,
+          from: existing?.position,
+          to: position,
+          characterPositions,
+        });
       }
     },
     // DoorOpened is a pure notification now (door identity only,

--- a/src/components/game/combatLogScroll.ts
+++ b/src/components/game/combatLogScroll.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure scroll-pin math for CombatLog's auto-follow behavior (#738). Split
+ * out of CombatLog.tsx itself so the component file keeps its
+ * component-only export shape (react-refresh/only-export-components) — the
+ * predicate is tested directly here without mocking a DOM layout, since
+ * jsdom never computes real scrollHeight/clientHeight values.
+ */
+
+/** Slack (px) before "scrolled up" registers, so a scroll position that's
+ * merely a hair off the very bottom (e.g. mid-momentum-scroll) doesn't
+ * flicker the jump-to-latest affordance on and off. */
+export const SCROLL_PIN_THRESHOLD_PX = 24;
+
+/**
+ * Whether the panel is scrolled far enough from the newest entry that
+ * auto-follow should pause.
+ */
+export function isScrolledAwayFromBottom(
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number,
+  thresholdPx: number = SCROLL_PIN_THRESHOLD_PX
+): boolean {
+  return scrollHeight - scrollTop - clientHeight > thresholdPx;
+}

--- a/src/hooks/useCombatLog.test.ts
+++ b/src/hooks/useCombatLog.test.ts
@@ -5,6 +5,7 @@ import type {
   EncounterEnded,
   EntityDamaged,
   EntityDied,
+  EntityMoved,
   EntityRemoved,
   EntityStabilized,
   StatusApplied,
@@ -12,8 +13,13 @@ import type {
   TurnEnded,
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import {
+  EncounterMode,
+  EntityType,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import type { EntityMovedContext } from './useCombatLog';
 import { useCombatLog } from './useCombatLog';
 
 describe('useCombatLog', () => {
@@ -205,5 +211,141 @@ describe('useCombatLog', () => {
     expect(result.current.entries[result.current.entries.length - 1]?.id).toBe(
       104
     );
+  });
+
+  describe('recordEntityMoved (#738 story pass)', () => {
+    const moved = (entityId: string): EntityMoved =>
+      ({ entityId, from: undefined, to: undefined, actualPath: [] }) as never;
+
+    const baseContext = (): EntityMovedContext => ({
+      movingEntityType: EntityType.MONSTER,
+      mode: EncounterMode.TURN_BASED,
+      from: { x: 0, y: 0, z: 0 },
+      to: { x: 1, y: -1, z: 0 },
+      characterPositions: [],
+    });
+
+    it('produces a "closes" entry when a monster moves nearer its nearest character', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordEntityMoved(moved('skeleton-1'), {
+          ...baseContext(),
+          from: { x: 0, y: 0, z: 0 },
+          to: { x: 3, y: -3, z: 0 },
+          characterPositions: [
+            { entityId: 'char-finn', position: { x: 5, y: -5, z: 0 } },
+          ],
+        });
+      });
+
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries[0]).toMatchObject({
+        kind: 'entityMoved',
+        narration: { verb: 'closes', targetEntityId: 'char-finn' },
+      });
+    });
+
+    it('walks past a closer healthy target to narrate closing on the farther, more urgent one (the acceptance-run gap)', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordEntityMoved(moved('skeleton-1'), {
+          ...baseContext(),
+          // Skeleton starts adjacent to the healthy fighter but ends its
+          // move next to the wounded one five hexes further out.
+          from: { x: 0, y: 0, z: 0 },
+          to: { x: 5, y: -5, z: 0 },
+          characterPositions: [
+            { entityId: 'char-healthy', position: { x: 1, y: -1, z: 0 } },
+            { entityId: 'char-wounded', position: { x: 6, y: -6, z: 0 } },
+          ],
+        });
+      });
+
+      expect(result.current.entries[0]).toMatchObject({
+        narration: { verb: 'closes', targetEntityId: 'char-wounded' },
+      });
+    });
+
+    it('produces a "retreats" entry when a monster moves away from its nearest character', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordEntityMoved(moved('skeleton-1'), {
+          ...baseContext(),
+          from: { x: 1, y: -1, z: 0 },
+          to: { x: 4, y: -4, z: 0 },
+          characterPositions: [
+            { entityId: 'char-finn', position: { x: 0, y: 0, z: 0 } },
+          ],
+        });
+      });
+
+      expect(result.current.entries[0]).toMatchObject({
+        narration: { verb: 'retreats' },
+      });
+    });
+
+    it('degrades to a neutral "moves" entry when no prior position is known', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordEntityMoved(moved('skeleton-1'), {
+          ...baseContext(),
+          from: undefined,
+          characterPositions: [
+            { entityId: 'char-finn', position: { x: 5, y: -5, z: 0 } },
+          ],
+        });
+      });
+
+      expect(result.current.entries[0]).toMatchObject({
+        narration: { verb: 'moves' },
+      });
+    });
+
+    it('produces no entry for a CHARACTER (player) move — noise the log deliberately omits', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordEntityMoved(moved('char-alice'), {
+          ...baseContext(),
+          movingEntityType: EntityType.CHARACTER,
+        });
+      });
+
+      expect(result.current.entries).toHaveLength(0);
+    });
+
+    it('produces no entry outside TURN_BASED mode — free-roam movement is silent', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordEntityMoved(moved('skeleton-1'), {
+          ...baseContext(),
+          mode: EncounterMode.FREE_ROAM,
+        });
+      });
+
+      expect(result.current.entries).toHaveLength(0);
+    });
+
+    it('stamps the current round like every other entry kind', () => {
+      const { result } = renderHook(() => useCombatLog());
+
+      act(() => {
+        result.current.recordTurnStarted({
+          entityId: 'skeleton-1',
+          round: 3,
+        } as unknown as TurnStarted);
+        result.current.recordEntityMoved(moved('skeleton-1'), baseContext());
+      });
+
+      expect(result.current.entries[1]).toMatchObject({
+        round: 3,
+        kind: 'entityMoved',
+      });
+    });
   });
 });

--- a/src/hooks/useCombatLog.ts
+++ b/src/hooks/useCombatLog.ts
@@ -11,6 +11,15 @@
  * CombatLog reads fields straight off `entry.event` at render time — nothing
  * here recomputes a roll, total, or hit/miss verdict.
  *
+ * `entityMoved` (#738) is the one deliberate exception: the wire carries
+ * positions, not narration, so `recordEntityMoved` derives a terse
+ * toward/away verb (see `describeEntityMovement` in `utils/combatFormat.ts`)
+ * and stores it alongside the raw event. It also gates on mode + entity
+ * type — TURN_BASED MONSTER movement only, matching the design's boundary
+ * voice (no coordinates/hex counts/HP) and its explicit v1 scope (player
+ * movement is silent for now; see the comment inside recordEntityMoved for
+ * the one-line change that widens it later).
+ *
  * Round tagging: only TurnStarted carries a `round` field on the wire, so
  * this hook tracks the current round internally (updated on every
  * TurnStarted) and stamps it onto every entry recorded afterward — mirrors
@@ -25,6 +34,7 @@ import type {
   EncounterEnded,
   EntityDamaged,
   EntityDied,
+  EntityMoved,
   EntityRemoved,
   EntityStabilized,
   StatusApplied,
@@ -32,7 +42,16 @@ import type {
   TurnEnded,
   TurnStarted,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/events_pb';
+import {
+  EncounterMode,
+  EntityType,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { useCallback, useRef, useState } from 'react';
+import type { CubeCoord } from '../components/hex-grid/hexMath';
+import {
+  describeEntityMovement,
+  type MovementNarration,
+} from '../utils/combatFormat';
 
 /** Cap on retained entries — bounds memory for a long fight. Oldest entries drop first. */
 const MAX_ENTRIES = 100;
@@ -64,7 +83,41 @@ export type CombatLogEntry =
       round: number;
       kind: 'entityStabilized';
       event: EntityStabilized;
+    }
+  | {
+      id: number;
+      round: number;
+      kind: 'entityMoved';
+      event: EntityMoved;
+      /** Derived toward/away verb — see the module doc comment's "one
+       * deliberate exception" note. */
+      narration: MovementNarration;
     };
+
+/**
+ * Everything `recordEntityMoved` needs to decide whether an `EntityMoved`
+ * event produces a log entry, and to derive its narration if so. All of it
+ * is cheaply available at the `onEntityMoved` call site (EncounterView
+ * already tracks entity positions/types/mode for rendering) — this hook
+ * does no lookups of its own, only the gating + derivation.
+ */
+export interface EntityMovedContext {
+  /** EntityType of the entity that moved. */
+  movingEntityType: EntityType;
+  /** Current encounter mode — movement is narrated only during TURN_BASED
+   * combat; FREE_ROAM wandering produces no entry. */
+  mode: EncounterMode;
+  /** The mover's position before this move. Undefined (a just-appeared
+   * entity, or a cache miss) degrades the narration to a neutral "moves"
+   * rather than fabricating a direction. */
+  from: CubeCoord | undefined;
+  /** The mover's resolved destination for this move (actualPath's last
+   * hex — the same value the position-cache update uses). */
+  to: CubeCoord;
+  /** Other CHARACTER entities' current positions, used to find whichever
+   * one this move brought the mover closer to or further from. */
+  characterPositions: Array<{ entityId: string; position: CubeCoord }>;
+}
 
 export interface UseCombatLogResult {
   entries: CombatLogEntry[];
@@ -80,6 +133,7 @@ export interface UseCombatLogResult {
   recordEncounterEnded: (event: EncounterEnded) => void;
   recordDeathSaveRolled: (event: DeathSaveRolled) => void;
   recordEntityStabilized: (event: EntityStabilized) => void;
+  recordEntityMoved: (event: EntityMoved, context: EntityMovedContext) => void;
 }
 
 export function useCombatLog(): UseCombatLogResult {
@@ -248,6 +302,37 @@ export function useCombatLog(): UseCombatLogResult {
     [pushEntry]
   );
 
+  // #738: narrate monster movement so a decisive positioning choice (walking
+  // past a closer target to reach a farther, more urgent one) isn't invisible
+  // in the log. Gated here rather than at the call site so the whole
+  // "should this produce an entry, and what does it say" decision lives in
+  // one tested place.
+  const recordEntityMoved = useCallback(
+    (event: EntityMoved, context: EntityMovedContext) => {
+      if (context.mode !== EncounterMode.TURN_BASED) return;
+      // v1 scope: only monster movement is narrated — a line per player
+      // step is noise the in-fiction voice doesn't want (design call,
+      // rpg-dnd5e-web#738). Widen to
+      // `context.movingEntityType === EntityType.MONSTER ||
+      //  context.movingEntityType === EntityType.CHARACTER`
+      // to narrate player movement too.
+      if (context.movingEntityType !== EntityType.MONSTER) return;
+      const narration = describeEntityMovement(
+        context.from,
+        context.to,
+        context.characterPositions
+      );
+      pushEntry({
+        id: idRef.current++,
+        round: roundRef.current,
+        kind: 'entityMoved',
+        event,
+        narration,
+      });
+    },
+    [pushEntry]
+  );
+
   return {
     entries,
     recordAttackResolved,
@@ -262,5 +347,6 @@ export function useCombatLog(): UseCombatLogResult {
     recordEncounterEnded,
     recordDeathSaveRolled,
     recordEntityStabilized,
+    recordEntityMoved,
   };
 }

--- a/src/utils/combatFormat.ts
+++ b/src/utils/combatFormat.ts
@@ -7,6 +7,8 @@
  * `conditionIcons.ts`'s `getConditionDisplay`.
  */
 
+import type { CubeCoord } from '../components/hex-grid/hexMath';
+import { hexDistance } from '../components/hex-grid/hexMath';
 import { getConditionDisplay } from './conditionIcons';
 
 /** Icon + label badge text for one entity's status list, e.g. "🏃 Dodging, 🫥 Hidden". */
@@ -34,4 +36,62 @@ export function formatSourceRefs(refs: Array<{ id: string }>): string {
  */
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * In-fiction verb for one `EntityMoved` event (rpg-dnd5e-web#738). The wire
+ * carries positions, not narration — a monster's move is a decisive combat
+ * fact (walking five hexes past a healthy target to reach a wounded one)
+ * that was previously invisible in the log, so this is a deliberate
+ * exception to the "no derived math" rule the rest of the combat log
+ * follows: there's no server-authored line to render verbatim, only
+ * positions to read a direction out of. `targetEntityId` is the raw wire id
+ * (matching every other combat-log line — attack/damage entries show
+ * `goblin-1`/`char-alice`, not a resolved display name), never a hex count
+ * or coordinate.
+ */
+export type MovementNarration =
+  | { verb: 'closes'; targetEntityId: string }
+  | { verb: 'retreats' }
+  | { verb: 'moves' };
+
+/**
+ * Derive a movement's narration from positions alone. `to` is whichever
+ * CHARACTER the mover ends up nearest to — the one the movement effectively
+ * targets. Comparing that same character's distance before vs. after the
+ * move (rather than "nearest before") is what correctly narrates a monster
+ * walking PAST a closer target to reach a farther, more urgent one: the
+ * character it ends up next to is what "closes on X" names, not whoever
+ * merely started closest.
+ *
+ * Degrades to a neutral `{ verb: 'moves' }` whenever there isn't enough to
+ * go on — no prior position (a just-appeared entity) or no characters to
+ * measure against — rather than fabricating a direction.
+ */
+export function describeEntityMovement(
+  from: CubeCoord | undefined,
+  to: CubeCoord,
+  characterPositions: Array<{ entityId: string; position: CubeCoord }>
+): MovementNarration {
+  if (!from || characterPositions.length === 0) return { verb: 'moves' };
+
+  let nearestAfter: { entityId: string; position: CubeCoord } | undefined;
+  let nearestAfterDistance = Infinity;
+  for (const c of characterPositions) {
+    const d = hexDistance(to, c.position);
+    if (d < nearestAfterDistance) {
+      nearestAfterDistance = d;
+      nearestAfter = c;
+    }
+  }
+  if (!nearestAfter) return { verb: 'moves' };
+
+  const distanceBeforeToTarget = hexDistance(from, nearestAfter.position);
+  if (nearestAfterDistance < distanceBeforeToTarget) {
+    return { verb: 'closes', targetEntityId: nearestAfter.entityId };
+  }
+  if (nearestAfterDistance > distanceBeforeToTarget) {
+    return { verb: 'retreats' };
+  }
+  return { verb: 'moves' };
 }


### PR DESCRIPTION
## Bug: scrolling was structurally impossible, not just fiddly

The panel rendered a scrollbar but couldn't be scrolled during play. Root cause: EncounterDock's `.floating-log` wrapper had `pointer-events: none` — a #556 fix so the panel's ~360px footprint would never block clicks to move tiles/armed targets rendering underneath it (the panel is translucent by design, #525, so the map is visibly clickable-looking through it). `pointer-events: none` removes an element from hit-testing *entirely*, not just from click handling — every wheel/touch gesture over that screen region fell straight through to the R3F canvas beneath, whose zoom listener (`useCameraControls.ts`) is bound directly to `gl.domElement`. So a wheel gesture over the log was never a candidate to scroll the log; it always zoomed the camera instead.

Fix: `pointer-events: auto`. This supersedes #556's click-through trade-off deliberately, not accidentally — the log is a default-open, opt-in-visible panel (round 7: "we always want to see the info there"; the existing 📜 toggle still hides it for anyone who wants click-through back), and Kirk's direct complaint ("our combat log — which I cannot even scroll — should tell the story") is the sharper signal here. Once hit-testing correctly targets the panel, plain `overflow-y: auto` on `combat-log-scroll` handles wheel/touch scrolling with no extra event plumbing.

Second half of the bug: auto-follow re-pinned to the bottom on every incoming event, which would yank a reader back down mid-fight even if scrolling worked. `CombatLog` now tracks whether the panel is scrolled away from the bottom and pauses auto-follow until the reader scrolls back down or clicks the new "↓ Jump to latest" affordance. The pin/unpin predicate (`isScrolledAwayFromBottom`) lives in a new `combatLogScroll.ts` (split out so `CombatLog.tsx` keeps a component-only export shape for `react-refresh/only-export-components`) and is unit-tested directly, since jsdom never computes real `scrollHeight`/`clientHeight`.

## Story pass: monster movement

`EntityMoved` was already on the stream (`encounterStreamDispatch.ts`) but never became a log entry, so a decisive monster move — a skeleton walking five hexes past a healthy fighter to reach a wounded one — was invisible. Verifying it took three Redis JSON files and a hand-drawn diagram.

Monster movement during **TURN_BASED** combat now produces a terse, in-fiction line:
- `👣 skeleton-1 closes on char-finn`
- `👣 skeleton-1 retreats`
- `👣 skeleton-1 moves` (neutral fallback when direction can't cheaply be derived — e.g. no prior position, no characters to measure against)

Derivation (`describeEntityMovement`, `src/utils/combatFormat.ts`) compares whichever **CHARACTER the mover ends up nearest to** (`to` position) against that *same* character's distance *before* the move — not "nearest before." That's the detail that makes it narrate correctly: a monster walking past a closer, healthy target to reach a farther, more urgent one closes on the farther one, because that's who it actually ended up next to. Comparing "nearest at start" would have gotten this backwards (misread as retreating from the healthy target, no mention of the real target at all).

No coordinates, hex counts, or HP numbers — matches the boundary-rule voice. Entity ids render raw (`skeleton-1`, `char-finn`), matching every existing log line (`⚔️ char-alice → goblin-1: HIT` already shows raw ids, not resolved display names) — no new display-name handling needed, and nothing to degrade if a monster's display name is empty (rpg-api#745 territory) since this path never touches `displayName` at all.

**Deliberately silent:** player movement (noise — a line per player step isn't wanted) and free-roam movement (no narrative outside combat). Both gates live in one place, `useCombatLog.recordEntityMoved`, with a one-line comment showing exactly what to flip to widen player-movement narration later.

## Rebase note for PR #734

This branch is based on plain `dev`. #734 (`target_rationale` on `actionResolved`, not yet merged) will rebase on top of this branch. The `actionResolved` arm of `CombatLog.tsx`'s `lineText` is untouched here specifically to keep that rebase small.

## Test evidence

```
npx vitest run
 Test Files  148 passed (148)
      Tests  2508 passed (2508)
```

New coverage:
- `src/hooks/useCombatLog.test.ts` — `recordEntityMoved`: closes (including the "walks past a closer target" acceptance-run scenario), retreats, neutral degrade with no prior position, silent for CHARACTER movers, silent outside TURN_BASED, round-stamped like every other kind.
- `src/components/game/CombatLog.test.tsx` — renders all three narration verbs (asserts no raw coordinates leak into the line); scroll-pin predicate unit tests; auto-follow-while-pinned, pause-on-scroll-up, jump-to-latest resume, and empty-log affordance suppression (via mocked `scrollHeight`/`clientHeight` on the jsdom node).
- Full existing suite (all 12 pre-existing entry kinds, `EncounterView.test.tsx`, `EncounterDock.test.tsx`) passes unchanged — regression-safe.

`npm run ci-checks` (format, lint, typecheck, build) is green; pre-push hook (full suite) passed on push.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB1QSaqAphp5J3rdREPR5