### PR TITLE
ci: bootstrap trusted licensed exact-head gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # TODO: Add tests when implemented
+      - name: Run trusted licensed-assets helper mutation tests
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
+      - name: Run trusted no-egress sandbox mutations
+        run: scripts/tests/run_trusted_sandbox_integration.sh
+
+      # TODO: Add product tests when implemented
       - name: Run tests
         run: echo "No tests yet - add with Vitest"
 

--- a/.github/workflows/trusted-licensed-assets.yml
+++ b/.github/workflows/trusted-licensed-assets.yml
@@ -1,0 +1,298 @@
+name: Trusted licensed-assets exact-head gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open same-repository PR number targeting dev
+        required: true
+        type: string
+      expected_head_sha:
+        description: Full 40-character lowercase live PR head SHA
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: licensed-assets-${{ inputs.pr_number }}-${{ inputs.expected_head_sha }}
+  cancel-in-progress: false
+
+env:
+  NODE_IMAGE: node:23-alpine
+  FINAL_IMAGE: licensed-assets-final:${{ github.run_id }}-${{ github.run_attempt }}
+  SANDBOX_IMAGE: licensed-assets-sandbox:${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  trusted-preflight:
+    name: Trusted identity and live PR preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      validated: ${{ steps.preflight.outputs.validated }}
+      head_sha: ${{ steps.preflight.outputs.head_sha }}
+      head_ref: ${{ steps.preflight.outputs.head_ref }}
+      base_sha: ${{ steps.preflight.outputs.base_sha }}
+    steps:
+      - name: Checkout the executing trusted workflow commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Prove default-main workflow identity and live exact head
+        id: preflight
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/trusted-licensed-assets.py preflight
+          --event-name '${{ github.event_name }}'
+          --repository '${{ github.repository }}'
+          --actor '${{ github.actor }}'
+          --ref '${{ github.ref }}'
+          --workflow-ref '${{ github.workflow_ref }}'
+          --workflow-sha '${{ github.workflow_sha }}'
+          --run-sha '${{ github.sha }}'
+          --pr-number '${{ inputs.pr_number }}'
+          --expected-head-sha '${{ inputs.expected_head_sha }}'
+          --snapshot '${{ runner.temp }}/trusted-pr-snapshot.json'
+          --github-output "$GITHUB_OUTPUT"
+
+  licensed:
+    name: Protected licensed exact-head validation
+    needs: trusted-preflight
+    if: needs.trusted-preflight.outputs.validated == 'true'
+    runs-on: ubuntu-latest
+    environment: licensed-assets
+    permissions:
+      contents: read
+    outputs:
+      provider_sha: ${{ steps.provider.outputs.provider_sha }}
+      catalog_sha256: ${{ steps.provider.outputs.catalog_sha256 }}
+      inventory_sha256: ${{ steps.provider.outputs.inventory_sha256 }}
+      tree_sha256: ${{ steps.provider.outputs.tree_sha256 }}
+      asset_files: ${{ steps.provider.outputs.asset_files }}
+      perf_median_p95_ms: ${{ steps.perf-scan.outputs.perf_median_p95_ms }}
+    steps:
+      - name: Checkout only the executing trusted workflow commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Create private scratch
+        run: |
+          set -eu
+          root='${{ runner.temp }}/licensed-${{ github.run_id }}-${{ github.run_attempt }}'
+          umask 077
+          mkdir "$root" "$root/logs"
+          printf 'PRIVATE_ROOT=%s\n' "$root" >> "$GITHUB_ENV"
+      - name: Fetch exact PR and live-base commits as quarantined data
+        run: |
+          set -eu
+          q="$PRIVATE_ROOT/quarantine"
+          git init -q "$q"
+          git -C "$q" config core.hooksPath /dev/null
+          git -C "$q" config protocol.file.allow never
+          git -C "$q" remote add origin https://github.com/KirkDiggler/rpg-dnd5e-web.git
+          git -C "$q" fetch --no-tags origin '${{ needs.trusted-preflight.outputs.head_sha }}' '${{ needs.trusted-preflight.outputs.base_sha }}' >/dev/null 2>&1
+          git -C "$q" checkout -q --detach '${{ needs.trusted-preflight.outputs.head_sha }}'
+          python3 trusted/scripts/trusted-licensed-assets.py quarantine \
+            --worktree "$q" \
+            --expected-head-sha '${{ needs.trusted-preflight.outputs.head_sha }}' \
+            --base-sha '${{ needs.trusted-preflight.outputs.base_sha }}'
+      - name: Pull images and install dependencies before licensed bytes exist
+        run: |
+          set -eu
+          docker pull "$NODE_IMAGE" >"$PRIVATE_ROOT/logs/pull-node.log" 2>&1
+          docker pull nginx:alpine >"$PRIVATE_ROOT/logs/pull-nginx.log" 2>&1
+          docker build --pull=false --tag "$SANDBOX_IMAGE" --file trusted/scripts/trusted-sandbox.Dockerfile trusted/scripts \
+            >"$PRIVATE_ROOT/logs/sandbox-image.log" 2>&1
+          src="$PRIVATE_ROOT/source"
+          mkdir "$src"
+          git -C "$PRIVATE_ROOT/quarantine" archive '${{ needs.trusted-preflight.outputs.head_sha }}' | tar -x -C "$src"
+          chmod -R a+rwX "$src"
+          docker run --rm --network bridge --read-only --user 65532:65532 \
+            --cap-drop ALL --security-opt no-new-privileges --pids-limit 512 --memory 6g --cpus 2 \
+            --tmpfs /tmp:rw,nosuid,nodev,size=2g \
+            --mount "type=bind,src=$src,dst=/workspace" --workdir /workspace \
+            --env HOME=/tmp/home --env npm_config_cache=/tmp/npm-cache --env CI=true \
+            "$SANDBOX_IMAGE" sh -c 'mkdir -p "$HOME" && npm ci --ignore-scripts' \
+            >"$PRIVATE_ROOT/logs/dependency-install.log" 2>&1
+      - name: Fetch exact provider, verify, stage, and scrub credential
+        id: provider
+        env:
+          RPG_GAME_ASSETS_READ_TOKEN: ${{ secrets.RPG_GAME_ASSETS_READ_TOKEN }}
+        run: |
+          set -eu
+          python3 trusted/scripts/trusted-licensed-assets.py provider-stage \
+            --worktree "$PRIVATE_ROOT/quarantine" \
+            --private-root "$PRIVATE_ROOT" \
+            --provider "$PRIVATE_ROOT/private-provider" \
+            --stage "$PRIVATE_ROOT/asset-stage" \
+            --github-output "$GITHUB_OUTPUT"
+          chmod -R a=rX "$PRIVATE_ROOT/asset-stage"
+      - name: Prove provider and credential residue are absent before PR code
+        run: |
+          set -eu
+          test ! -e "$PRIVATE_ROOT/private-provider"
+          test -z "${RPG_GAME_ASSETS_READ_TOKEN-}"
+          test -z "${ASSETS_READ_TOKEN-}"
+          python3 trusted/scripts/trusted-licensed-assets.py residue \
+            --root "$PRIVATE_ROOT" --provider "$PRIVATE_ROOT/private-provider"
+      - name: Prove sandbox isolation with trusted canaries
+        run: |
+          set -eu
+          mkdir -p "$PRIVATE_ROOT/source/public/models/synty"
+          docker run --rm --network none --read-only --user 65532:65532 \
+            --cap-drop ALL --security-opt no-new-privileges --pids-limit 256 --memory 2g --cpus 1 \
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=256m \
+            --mount "type=bind,src=$PRIVATE_ROOT/source,dst=/workspace" \
+            --mount "type=bind,src=$PRIVATE_ROOT/asset-stage/models/synty,dst=/workspace/public/models/synty,readonly" \
+            --mount "type=bind,src=$GITHUB_WORKSPACE/trusted/scripts,dst=/trusted,readonly" \
+            --workdir /workspace "$SANDBOX_IMAGE" node /trusted/trusted-sandbox-canary.mjs \
+            >"$PRIVATE_ROOT/logs/sandbox-canary.log" 2>&1
+          python3 trusted/scripts/trusted-licensed-assets.py scan-log --log "$PRIVATE_ROOT/logs/sandbox-canary.log"
+      - name: Run every PR lifecycle and native full CI with no egress
+        run: |
+          set -eu
+          run_locked() {
+            name="$1"; shift
+            docker run --rm --network none --read-only --user 65532:65532 \
+              --cap-drop ALL --security-opt no-new-privileges --pids-limit 1024 --memory 7g --cpus 2 \
+              --tmpfs /tmp:rw,noexec,nosuid,nodev,size=2g \
+              --mount "type=bind,src=$PRIVATE_ROOT/source,dst=/workspace" \
+              --mount "type=bind,src=$PRIVATE_ROOT/asset-stage/models/synty,dst=/workspace/public/models/synty,readonly" \
+              --workdir /workspace --env HOME=/tmp/home --env npm_config_cache=/tmp/npm-cache \
+              --env CI=true --env NO_COLOR=1 --env FORCE_COLOR=0 \
+              "$SANDBOX_IMAGE" "$@" >"$PRIVATE_ROOT/logs/$name.log" 2>&1
+            python3 trusted/scripts/trusted-licensed-assets.py scan-log --log "$PRIVATE_ROOT/logs/$name.log"
+          }
+          run_locked lifecycle-rebuild npm rebuild --offline
+          run_locked lifecycle-prepare npm run prepare --if-present
+          run_locked native-ci ./scripts/ci-check.sh
+      - name: Run fixed performance gate in the same sandbox
+        run: |
+          set -eu
+          docker run --rm --network none --read-only --user 65532:65532 \
+            --cap-drop ALL --security-opt no-new-privileges --pids-limit 1024 --memory 7g --cpus 2 \
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=2g \
+            --mount "type=bind,src=$PRIVATE_ROOT/source,dst=/workspace" \
+            --mount "type=bind,src=$PRIVATE_ROOT/asset-stage/models/synty,dst=/workspace/public/models/synty,readonly" \
+            --workdir /workspace --env HOME=/tmp/home --env npm_config_cache=/tmp/npm-cache \
+            --env CI=true --env NO_COLOR=1 --env FORCE_COLOR=0 \
+            "$SANDBOX_IMAGE" npm run perf:visual-placement \
+            >"$PRIVATE_ROOT/logs/perf.log" 2>&1
+      - name: Parse only the bounded performance scalar
+        id: perf-scan
+        run: >-
+          python3 trusted/scripts/trusted-licensed-assets.py scan-log
+          --log "$PRIVATE_ROOT/logs/perf.log"
+          --perf
+          --github-output "$GITHUB_OUTPUT"
+      - name: Construct allowlisted context, then fail closed on hosted Docker limitation
+        run: |
+          set -eu
+          python3 trusted/scripts/trusted-licensed-assets.py create-context \
+            --worktree "$PRIVATE_ROOT/quarantine" \
+            --base-sha '${{ needs.trusted-preflight.outputs.base_sha }}' \
+            --destination "$PRIVATE_ROOT/context-final" \
+            --asset-root "$PRIVATE_ROOT/asset-stage/models/synty"
+          # docker build --network=none/--pull=false has no build-time equivalents
+          # for cap-drop ALL and no-new-privileges, and the trusted base runs npm
+          # as root. The helper intentionally rejects rather than running it.
+          python3 trusted/scripts/trusted-licensed-assets.py docker-proof \
+            --dockerfile "$PRIVATE_ROOT/context-final/Dockerfile"
+      - name: Cleanup every licensed/private/build surface
+        if: always()
+        run: |
+          set +e
+          docker ps -aq --filter "label=licensed-assets.run=${{ github.run_id }}-${{ github.run_attempt }}" | xargs -r docker rm -f >/dev/null 2>&1
+          docker image rm -f "$FINAL_IMAGE" "$SANDBOX_IMAGE" >/dev/null 2>&1
+          docker volume ls -q --filter "label=licensed-assets.run=${{ github.run_id }}-${{ github.run_attempt }}" | xargs -r docker volume rm -f >/dev/null 2>&1
+          rm -rf "$PRIVATE_ROOT/private-provider" "$PRIVATE_ROOT/asset-stage" "$PRIVATE_ROOT/source/dist" \
+            "$PRIVATE_ROOT/context-final" "$PRIVATE_ROOT/logs" "$PRIVATE_ROOT/quarantine" "$PRIVATE_ROOT/source"
+          set -e
+          test ! -e "$PRIVATE_ROOT/private-provider"
+          test ! -e "$PRIVATE_ROOT/asset-stage"
+          test ! -e "$PRIVATE_ROOT/source"
+          test ! -e "$PRIVATE_ROOT/logs"
+          ! docker image inspect "$FINAL_IMAGE" >/dev/null 2>&1
+          ! docker image inspect "$SANDBOX_IMAGE" >/dev/null 2>&1
+
+  final-status:
+    name: Final live-head recheck and SHA-bound result
+    needs: [trusted-preflight, licensed]
+    if: always() && needs.trusted-preflight.outputs.validated == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Checkout only the executing trusted workflow commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Recheck the original live trust tuple before publishing
+        id: live
+        if: needs.licensed.result == 'success'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 scripts/trusted-licensed-assets.py live-check
+          --pr-number '${{ inputs.pr_number }}'
+          --expected-head-sha '${{ needs.trusted-preflight.outputs.head_sha }}'
+          --actor '${{ github.actor }}'
+          --base-sha '${{ needs.trusted-preflight.outputs.base_sha }}'
+          --head-ref '${{ needs.trusted-preflight.outputs.head_ref }}'
+      - name: Generate and rescan the sole fixed-schema artifact
+        if: steps.live.outcome == 'success'
+        run: >-
+          python3 scripts/trusted-licensed-assets.py make-artifact
+          --output '${{ runner.temp }}/licensed-assets-evidence.json'
+          --pr-number '${{ inputs.pr_number }}'
+          --web-sha '${{ needs.trusted-preflight.outputs.head_sha }}'
+          --provider-sha '${{ needs.licensed.outputs.provider_sha }}'
+          --catalog-sha256 '${{ needs.licensed.outputs.catalog_sha256 }}'
+          --inventory-sha256 '${{ needs.licensed.outputs.inventory_sha256 }}'
+          --tree-sha256 '${{ needs.licensed.outputs.tree_sha256 }}'
+          --asset-files '${{ needs.licensed.outputs.asset_files }}'
+          --perf-median-p95-ms '${{ needs.licensed.outputs.perf_median_p95_ms }}'
+          --kirk-visual-review external-pending
+      - name: Upload only the scalar JSON evidence
+        id: upload
+        if: steps.live.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: licensed-assets-evidence-${{ needs.trusted-preflight.outputs.head_sha }}
+          path: ${{ runner.temp }}/licensed-assets-evidence.json
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+          include-hidden-files: false
+      - name: Delete local evidence after publisher returns
+        if: always()
+        run: rm -f '${{ runner.temp }}/licensed-assets-evidence.json'
+      - name: Final live equality and status on only the expected old SHA
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PUBLISH_RESULT: ${{ steps.upload.outcome }}
+          LICENSED_RESULT: ${{ needs.licensed.result }}
+        run: |
+          set -eu
+          result=failure
+          if [ "$LICENSED_RESULT" = success ] && [ "$PUBLISH_RESULT" = success ]; then result=success; fi
+          python3 scripts/trusted-licensed-assets.py final \
+            --pr-number '${{ inputs.pr_number }}' \
+            --expected-head-sha '${{ needs.trusted-preflight.outputs.head_sha }}' \
+            --actor '${{ github.actor }}' \
+            --base-sha '${{ needs.trusted-preflight.outputs.base_sha }}' \
+            --head-ref '${{ needs.trusted-preflight.outputs.head_ref }}' \
+            --licensed-result "$result"

--- a/.github/workflows/trusted-licensed-assets.yml
+++ b/.github/workflows/trusted-licensed-assets.yml
@@ -59,6 +59,21 @@ jobs:
           --expected-head-sha '${{ inputs.expected_head_sha }}'
           --snapshot '${{ runner.temp }}/trusted-pr-snapshot.json'
           --github-output "$GITHUB_OUTPUT"
+      - name: Quarantine and validate exact tree before any Environment
+        run: |
+          set -eu
+          q='${{ runner.temp }}/trusted-preflight-quarantine'
+          git init -q "$q"
+          git -C "$q" config core.hooksPath /dev/null
+          git -C "$q" config protocol.file.allow never
+          git -C "$q" remote add origin https://github.com/KirkDiggler/rpg-dnd5e-web.git
+          git -C "$q" fetch --no-tags origin '${{ steps.preflight.outputs.head_sha }}' '${{ steps.preflight.outputs.base_sha }}' >/dev/null 2>&1
+          git -C "$q" checkout -q --detach '${{ steps.preflight.outputs.head_sha }}'
+          python3 scripts/trusted-licensed-assets.py quarantine \
+            --worktree "$q" \
+            --expected-head-sha '${{ steps.preflight.outputs.head_sha }}' \
+            --base-sha '${{ steps.preflight.outputs.base_sha }}'
+          rm -rf "$q"
 
   licensed:
     name: Protected licensed exact-head validation

--- a/docs/security/trusted-licensed-assets.md
+++ b/docs/security/trusted-licensed-assets.md
@@ -1,0 +1,130 @@
+# Trusted licensed-assets exact-head gate
+
+`trusted-licensed-assets.yml` is a bootstrap, not a usable PR workflow until its
+commit is released normally from `dev` to the repository's default `main`. GitHub
+accepts `workflow_dispatch` only for a workflow present on the default branch.
+The helper proves `github.ref`, `github.workflow_ref`, `github.workflow_sha`, and
+`github.sha` all identify that released `main` definition before it trusts an
+input.
+
+## Release and dispatch sequence
+
+1. squash the bootstrap feature PR into `dev` through normal review;
+2. release `dev` to `main` with the required real merge commit;
+3. synchronize released `main` back into `dev` under the long-lived-branch rules;
+4. from `main`, dispatch with a PR number and its full, then-live 40-character
+   head SHA.
+
+The graph is deliberately split:
+
+```text
+trusted-preflight (no Environment/provider/secret)
+  -> licensed (licensed-assets Environment; dependency/image prep before stage)
+       -> trusted provider verification and credential/provider deletion
+       -> docker --network none PR lifecycle/full CI/perf
+       -> trusted-base, allowlisted, offline Docker proof
+       -> unconditional local cleanup
+  -> final-status (fresh live tuple equality, scalar JSON only, old-SHA status)
+```
+
+A pushed replacement head makes the final tuple comparison fail. The workflow
+can then write only a failure to the already validated expected old SHA; it never
+writes success to the new SHA.
+
+## Environment contract
+
+The job names the protected Environment `licensed-assets`. Its required state is:
+
+- Kirk (`KirkDiggler`) is the required reviewer;
+- administrator bypass is disabled;
+- the only provider credential is the Environment secret
+  `RPG_GAME_ASSETS_READ_TOKEN`;
+- the legacy repository/organization secret `ASSETS_READ_TOKEN` is never read;
+- no repository/organization secret named `RPG_GAME_ASSETS_READ_TOKEN` exists.
+
+The helper rejects a missing canonical secret and never falls back to a broad
+one. GitHub's `${{ secrets.NAME }}` expression does not expose which scope won
+when administrators create the _same name_ at multiple scopes. Therefore the
+last bullet is an externally inspectable Environment/repository configuration
+invariant, not something runner code can cryptographically infer. Dispatch must
+fail closed operationally until an administrator verifies that invariant. The
+workflow does not create or change a secret.
+
+A fine-grained PAT cannot be proven server-revoked by a hosted runner. This gate
+proves that the credential, askpass file, authenticated configuration, process
+environment, and private checkout are unavailable before PR code. Kirk must
+manually revoke/delete the temporary credential after the run; evidence must not
+claim server-side revocation.
+
+## Untrusted execution and Docker proof
+
+The exact PR and live base are fetched into quarantine with hooks and submodules
+disabled. Trusted parsing rejects forks, bots/Dependabot, drafts, closed/wrong-base
+PRs, special tree entries, changed licensed formats/paths, and any SHA mismatch.
+Nothing from quarantine runs before provider removal.
+
+Images, an `npm ci --ignore-scripts` dependency tree, and an asset-free Docker
+cache proof are prepared before licensed bytes exist. After staging, every
+PR-controlled lifecycle, test, build, and performance command runs nonroot in a
+read-only-root container with `--network none`, all capabilities dropped,
+`no-new-privileges`, no proxy/control environment, no host socket, a disposable
+writable source, and the asset tree as a nested read-only mount. Stdout/stderr is
+captured only under private runner scratch, scanned by trusted code, never printed
+or uploaded, and deleted.
+
+The Docker proof first requires PR `Dockerfile` and `.dockerignore` bytes to be
+exactly the live trusted base. Trusted code creates a fresh context containing
+only fixed root build inputs plus `src/` and `public/`; it rejects symlinks,
+hardlinks, special files, `ADD`, and remote-source forms. Licensed files are added
+only to this allowlisted context.
+
+The current trusted-base Dockerfile cannot be executed with licensed context on a
+GitHub-hosted Docker daemon without weakening the boundary: its builder runs both
+`npm ci` and `npm run build` as container root, while `docker build` exposes
+`--network=none` and `--pull=false` but no equivalents for `docker run --cap-drop
+ALL --security-opt no-new-privileges`. A warm cache would also require executing
+PR code before provider access, which would invalidate the trusted preflight.
+Consequently the executable helper **fails closed after constructing and checking
+the context and before invoking Docker**. This gate cannot green until a separately
+reviewed trusted-base/container-build design can prove nonroot, dropped
+capabilities, no-new-privileges, offline cache completeness, and no pre-provider PR
+execution on the hosted runner. It does not fall back to an online build, run the
+PR Dockerfile, or claim a Docker pass. No Actions cache is read or written after
+staging.
+
+## Evidence and residual limits
+
+Only `licensed-assets-evidence.json` may be uploaded. The trusted publisher
+requires its exact v1 key set, bounded scalar values, full SHA/digest formats,
+one regular non-hardlinked JSON file below 4 KiB, and rejects archives, image
+magic, URLs, token/secret shapes, long blob strings, extra fields, and false
+gates. Provider checkout, stage, `dist`, private logs, build contexts, images,
+and labeled volumes are deleted before upload. Screenshots and PR-authored
+reports are never artifacts.
+
+Kirk's exact-head Builder/Game visual review stays local. The only public visual
+evidence is Kirk's externally signed scalar pass on the feature PR; no pixels
+leave the local review.
+
+No design on a shared hosted runner can eliminate low-bandwidth covert channels
+through pass/fail or duration. This workflow bounds outputs and timings and
+prevents byte/log/network escape, but records that residual honestly rather than
+claiming noninterference.
+
+## Tests
+
+Run the repository-native helper suite and reversible sandbox mutations:
+
+```sh
+python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+scripts/tests/run_trusted_sandbox_integration.sh
+```
+
+The suite mutates every live trust field, the final race, provider lock/digests
+and tool identities, missing/broad-only secrets, residue, special/licensed tree
+entries, Dockerfile/ADD/context symlinks, artifact smuggling, functional/hash/perf
+oracles, and specifically kills a source mutant that removes live API head
+comparison. The Docker integration executes DNS, public TCP, GitHub HTTPS,
+Docker-host, proxy, socket, nonroot, read-only-stage, stdout-capture, and
+post-staging package-lifecycle probes, then reversibly removes each pivotal
+boundary and requires the unsafe mutation to fail.

--- a/scripts/tests/run_trusted_sandbox_integration.sh
+++ b/scripts/tests/run_trusted_sandbox_integration.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+TMP=$(mktemp -d)
+IMAGE="trusted-sandbox-test-$$"
+cleanup() {
+  docker image rm -f "$IMAGE" >/dev/null 2>&1 || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$TMP/source/public/models/synty" "$TMP/logs"
+printf 'synthetic-not-licensed\n' >"$TMP/source/public/models/synty/fixture.txt"
+cat >"$TMP/source/package.json" <<'JSON'
+{"name":"sandbox-probe","version":"1.0.0","scripts":{"lifecycle-probe":"node lifecycle-probe.mjs"}}
+JSON
+cat >"$TMP/source/lifecycle-probe.mjs" <<'JS'
+import dns from 'node:dns/promises';
+try { await dns.lookup('github.com'); process.exit(91); } catch { process.exit(0); }
+JS
+chmod -R a+rwX "$TMP/source"
+docker build --pull=false -q -t "$IMAGE" -f "$ROOT/scripts/trusted-sandbox.Dockerfile" "$ROOT/scripts" >"$TMP/logs/build" 2>&1
+run_canary() {
+  network=$1; shift
+  docker run --rm --network "$network" --read-only --user 65532:65532 \
+    --cap-drop ALL --security-opt no-new-privileges --pids-limit 256 --memory 1g --cpus 1 \
+    --tmpfs /tmp:rw,noexec,nosuid,nodev,size=128m \
+    --mount "type=bind,src=$TMP/source,dst=/workspace" \
+    --mount "type=bind,src=$TMP/source/public/models/synty,dst=/workspace/public/models/synty,readonly" \
+    --mount "type=bind,src=$ROOT/scripts,dst=/trusted,readonly" \
+    --workdir /workspace "$@" "$IMAGE" node /trusted/trusted-sandbox-canary.mjs
+}
+# Trusted policy passes and jointly exercises DNS, public TCP, GitHub HTTPS,
+# Docker-host TCP, proxy absence, host sockets, nonroot, and read-only assets.
+run_canary none >"$TMP/logs/pass" 2>&1
+# Removing no-egress must be killed by at least DNS/GitHub/TCP.
+if run_canary bridge >"$TMP/logs/network-mutant" 2>&1; then exit 20; fi
+# Proxy control state is independently rejected.
+if run_canary none --env HTTPS_PROXY=http://127.0.0.1:9 >"$TMP/logs/proxy-mutant" 2>&1; then exit 21; fi
+# A host control socket is independently rejected when Docker exposes one.
+if [ -S /var/run/docker.sock ]; then
+  if run_canary none --mount type=bind,src=/var/run/docker.sock,dst=/run/docker.sock >"$TMP/logs/socket-mutant" 2>&1; then exit 22; fi
+fi
+# Removing the read-only asset mount is killed by a write probe.
+if docker run --rm --network none --read-only --user 65532:65532 \
+  --cap-drop ALL --security-opt no-new-privileges --tmpfs /tmp:rw,noexec,nosuid,nodev,size=128m \
+  --mount "type=bind,src=$TMP/source,dst=/workspace" \
+  --mount "type=bind,src=$ROOT/scripts,dst=/trusted,readonly" --workdir /workspace \
+  "$IMAGE" node /trusted/trusted-sandbox-canary.mjs >"$TMP/logs/writable-mutant" 2>&1; then exit 23; fi
+# A PR-controlled lifecycle probe passes only after staging when egress is absent.
+docker run --rm --network none --read-only --user 65532:65532 \
+  --cap-drop ALL --security-opt no-new-privileges --tmpfs /tmp:rw,noexec,nosuid,nodev,size=128m \
+  --mount "type=bind,src=$TMP/source,dst=/workspace" --workdir /workspace \
+  "$IMAGE" npm run lifecycle-probe >"$TMP/logs/lifecycle-pass" 2>&1
+if docker run --rm --network bridge --read-only --user 65532:65532 \
+  --cap-drop ALL --security-opt no-new-privileges --tmpfs /tmp:rw,noexec,nosuid,nodev,size=128m \
+  --mount "type=bind,src=$TMP/source,dst=/workspace" --workdir /workspace \
+  "$IMAGE" npm run lifecycle-probe >"$TMP/logs/lifecycle-network-mutant" 2>&1; then exit 24; fi
+# PR stdout is captured in private scratch, never emitted; the trusted scanner
+# mutation test separately proves this canary would be rejected as evidence.
+docker run --rm --network none --user 65532:65532 "$IMAGE" \
+  node -e 'process.stdout.write("STDOUT-CANARY-PRIVATE\n")' >"$TMP/logs/stdout-private" 2>&1
+grep -qx 'STDOUT-CANARY-PRIVATE' "$TMP/logs/stdout-private"
+rm -f "$TMP/logs/stdout-private"
+printf 'trusted sandbox integration: pass\n'

--- a/scripts/tests/test_trusted_licensed_assets.py
+++ b/scripts/tests/test_trusted_licensed_assets.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = ROOT / "scripts/trusted-licensed-assets.py"
+
+def load_helper(path=HELPER, name="trusted_licensed_assets"):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+h = load_helper()
+SHA = "a" * 40
+BASE = "b" * 40
+DIGEST = "c" * 64
+
+def pr_fixture():
+    return {
+        "number": 743, "state": "open", "draft": False,
+        "user": {"login": "KirkDiggler", "type": "User"},
+        "head": {"sha": SHA, "ref": "feat/743-safe", "repo": {"full_name": h.REPOSITORY, "fork": False}},
+        "base": {"sha": BASE, "ref": "dev", "repo": {"full_name": h.REPOSITORY, "fork": False}},
+    }
+
+def provider_lock():
+    return {
+        "schemaVersion": 1,
+        "provider": {"repository": h.PROVIDER_REPOSITORY, "commit": SHA},
+        "catalog": {"path": "harness/catalogs/synty-web-assets.json", "sha256": DIGEST, "schemaVersion": 1, "catalogId": "synty-web-assets"},
+        "inventory": {"path": "harness/catalogs/synty-complete-inventory.json", "sha256": DIGEST,
+                      "schemaVersion": 1, "inventoryId": "synty-complete-tree",
+                      "tool": {"name": "build_synty_complete_inventory", "version": "1.0.0"},
+                      "fileCount": 1, "treeSha256": DIGEST},
+        "tool": {"name": "build_web_asset_catalog", "version": "1.0.0"},
+        "verifier": {"name": "verify_web_asset_stage", "version": "1.1.0"},
+    }
+
+class TrustTupleTests(unittest.TestCase):
+    def test_workflow_identity_passes_only_exact_default_main(self):
+        good = dict(event_name="workflow_dispatch", repository=h.REPOSITORY, actor=h.OWNER,
+                    ref=h.DEFAULT_REF, workflow_ref=f"{h.REPOSITORY}/{h.WORKFLOW_PATH}@{h.DEFAULT_REF}",
+                    workflow_sha=SHA, run_sha=SHA)
+        h.validate_workflow_identity(**good)
+        mutations = {
+            "event_name": "pull_request_target", "repository": "attacker/fork", "actor": "mallory",
+            "ref": "refs/heads/dev", "workflow_ref": f"{h.REPOSITORY}/{h.WORKFLOW_PATH}@refs/heads/dev",
+            "workflow_sha": "abc", "run_sha": "d" * 40,
+        }
+        for key, value in mutations.items():
+            bad = good | {key: value}
+            with self.subTest(key=key), self.assertRaises(h.TrustError):
+                h.validate_workflow_identity(**bad)
+
+    def test_every_pr_trust_field_mutation_is_rejected(self):
+        h.validate_pr(pr_fixture(), number=743, expected_sha=SHA, actor=h.OWNER, checkout_sha=SHA)
+        mutations = [
+            ("number", lambda p: p.update(number=744)),
+            ("closed", lambda p: p.update(state="closed")),
+            ("draft", lambda p: p.update(draft=True)),
+            ("author", lambda p: p["user"].update(login="mallory")),
+            ("bot", lambda p: p["user"].update(type="Bot")),
+            ("stale", lambda p: p["head"].update(sha="d" * 40)),
+            ("dependabot", lambda p: p["head"].update(ref="dependabot/npm/x")),
+            ("wrong-repo", lambda p: p["head"]["repo"].update(full_name="mallory/fork")),
+            ("fork", lambda p: p["head"]["repo"].update(fork=True)),
+            ("wrong-base-repo", lambda p: p["base"]["repo"].update(full_name="mallory/fork")),
+            ("wrong-base", lambda p: p["base"].update(ref="main")),
+            ("base-sha", lambda p: p["base"].update(sha="short")),
+        ]
+        for label, mutate in mutations:
+            bad = pr_fixture(); mutate(bad)
+            with self.subTest(label=label), self.assertRaises(h.TrustError):
+                h.validate_pr(bad, number=743, expected_sha=SHA, actor=h.OWNER, checkout_sha=SHA)
+        with self.assertRaises(h.TrustError):
+            h.validate_pr(pr_fixture(), number=743, expected_sha=SHA, actor="mallory")
+        with self.assertRaises(h.TrustError):
+            h.validate_pr(pr_fixture(), number=743, expected_sha=SHA, actor=h.OWNER, checkout_sha="d" * 40)
+
+    def test_final_race_or_any_original_tuple_change_is_rejected(self):
+        original = h.validate_pr(pr_fixture(), number=743, expected_sha=SHA, actor=h.OWNER)
+        for mutate in (
+            lambda p: p["head"].update(sha="d" * 40),
+            lambda p: p["head"].update(ref="renamed"),
+            lambda p: p["base"].update(sha="e" * 40),
+            lambda p: p.update(draft=True),
+            lambda p: p.update(state="closed"),
+        ):
+            live = pr_fixture(); mutate(live)
+            with self.assertRaises(h.TrustError):
+                h.validate_pr(live, number=743, expected_sha=SHA, actor=h.OWNER, original=original)
+
+    def test_live_check_command_calls_live_api_and_rejects_stale(self):
+        args = type("Args", (), dict(pr_number=743, expected_head_sha=SHA, head_ref="feat/743-safe",
+                                      base_sha=BASE, actor=h.OWNER))()
+        stale = pr_fixture(); stale["head"]["sha"] = "d" * 40
+        with mock.patch.object(h, "fetch_pr", return_value=stale), self.assertRaises(h.TrustError):
+            h.command_live_check(args)
+
+    def test_mutant_removing_live_sha_equality_is_killed(self):
+        source = HELPER.read_text()
+        needle = 'require(head.get("sha") == expected_sha, "live PR head differs from expected SHA")'
+        self.assertEqual(source.count(needle), 1)
+        with tempfile.TemporaryDirectory() as td:
+            mutant_path = Path(td) / "mutant.py"
+            mutant_path.write_text(source.replace(needle, 'require(True, "live PR head differs from expected SHA")'))
+            mutant = load_helper(mutant_path, "mutant_no_live_equality")
+            stale = pr_fixture(); stale["head"]["sha"] = "d" * 40
+            # The required behavior assertion fails against the mutant: the mutation is killed.
+            with self.assertRaises(AssertionError):
+                with self.assertRaises(mutant.TrustError):
+                    mutant.validate_pr(stale, number=743, expected_sha=SHA, actor=mutant.OWNER)
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_workflow_has_one_environment_secret_no_fallback_or_post_asset_cache(self):
+        workflow = (ROOT / ".github/workflows/trusted-licensed-assets.yml").read_text()
+        self.assertIn("environment: licensed-assets", workflow)
+        self.assertEqual(workflow.count("${{ secrets.RPG_GAME_ASSETS_READ_TOKEN }}"), 1)
+        self.assertNotIn("${{ secrets.ASSETS_READ_TOKEN }}", workflow)
+        self.assertNotIn("actions/cache", workflow)
+        self.assertIn("docker run --rm --network none --read-only --user 65532:65532", workflow)
+        self.assertIn("--cap-drop ALL --security-opt no-new-privileges", workflow)
+        self.assertIn("trusted-licensed-assets.py docker-proof", workflow)
+        self.assertIn("actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02", workflow)
+        self.assertNotRegex(workflow, r"(?m)^\s+(?:cat|tail|head) .*logs")
+
+class ProviderAndCredentialTests(unittest.TestCase):
+    def write_lock(self, root, value):
+        path = Path(root) / "lock.json"; path.write_text(json.dumps(value)); return path
+
+    def test_provider_lock_exact_schema_hash_and_tool_mutations(self):
+        with tempfile.TemporaryDirectory() as td:
+            h.parse_provider_lock(self.write_lock(td, provider_lock()))
+            mutations = [
+                lambda x: x["provider"].update(repository="attacker/assets"),
+                lambda x: x["provider"].update(commit="main"),
+                lambda x: x["catalog"].update(sha256="0"),
+                lambda x: x["inventory"].update(treeSha256="0"),
+                lambda x: x["inventory"].update(fileCount=0),
+                lambda x: x["tool"].update(name="evil_generator"),
+                lambda x: x["inventory"]["tool"].update(version="9.9.9"),
+                lambda x: x["verifier"].update(version="1.0.0"),
+                lambda x: x.update(extra="smuggle"),
+            ]
+            for mutate in mutations:
+                value = provider_lock(); mutate(value)
+                with self.assertRaises(h.TrustError): h.parse_provider_lock(self.write_lock(td, value))
+
+    def test_missing_secret_and_broad_only_never_fall_back(self):
+        with self.assertRaises(h.TrustError): h.validate_secret_input(None, None)
+        with self.assertRaises(h.TrustError): h.validate_secret_input(None, "broad-token")
+        self.assertEqual(h.validate_secret_input("environment-token", "broad-token"), "environment-token")
+
+    def test_credential_env_config_and_provider_residue_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            h.credential_residue(root, {}, None)
+            with self.assertRaises(h.TrustError): h.credential_residue(root, {"ASSETS_READ_TOKEN": "x"}, None)
+            provider = root / "provider"; provider.mkdir()
+            with self.assertRaises(h.TrustError): h.credential_residue(root, {}, provider)
+            provider.rmdir(); (root / ".gitconfig").write_text("credential=https://x-access-token@github.com")
+            with self.assertRaises(h.TrustError): h.credential_residue(root, {}, None)
+
+class GitBoundaryTests(unittest.TestCase):
+    def make_repo(self):
+        td = tempfile.TemporaryDirectory(); root = Path(td.name)
+        subprocess.run(["git", "init", "-q", root], check=True)
+        subprocess.run(["git", "-C", root, "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "-C", root, "config", "user.name", "Test"], check=True)
+        for name, data in {"Dockerfile": "FROM scratch\n", ".dockerignore": "", "package.json": "{}\n", "src/x.ts": "export {}\n"}.items():
+            path=root/name; path.parent.mkdir(parents=True, exist_ok=True); path.write_text(data)
+        subprocess.run(["git", "-C", root, "add", "."], check=True); subprocess.run(["git", "-C", root, "commit", "-qm", "base"], check=True)
+        base=subprocess.check_output(["git", "-C", root, "rev-parse", "HEAD"], text=True).strip()
+        return td, root, base
+
+    def commit(self, root):
+        subprocess.run(["git", "-C", root, "add", "-A"], check=True); subprocess.run(["git", "-C", root, "commit", "-qm", "head"], check=True)
+        return subprocess.check_output(["git", "-C", root, "rev-parse", "HEAD"], text=True).strip()
+
+    def test_quarantine_accepts_regular_diff_and_rejects_licensed_and_symlink(self):
+        td, root, base = self.make_repo()
+        try:
+            (root/"src/x.ts").write_text("export const x=1\n"); head=self.commit(root)
+            h.validate_quarantine(root, expected_sha=head, base_sha=base)
+        finally: td.cleanup()
+        td, root, base = self.make_repo()
+        try:
+            (root/"public/models/synty").mkdir(parents=True); (root/"public/models/synty/x.glb").write_bytes(b"glTF")
+            head=self.commit(root)
+            with self.assertRaises(h.TrustError): h.validate_quarantine(root, expected_sha=head, base_sha=base)
+        finally: td.cleanup()
+        td, root, base = self.make_repo()
+        try:
+            os.symlink("x.ts", root/"src/link"); head=self.commit(root)
+            with self.assertRaises(h.TrustError): h.validate_quarantine(root, expected_sha=head, base_sha=base)
+        finally: td.cleanup()
+
+    def test_dockerfile_change_add_remote_and_context_symlink_fail_closed(self):
+        td, root, base = self.make_repo()
+        try:
+            (root/"Dockerfile").write_text("FROM scratch\nADD https://evil.invalid/x /x\n"); self.commit(root)
+            with tempfile.TemporaryDirectory() as out, self.assertRaises(h.TrustError):
+                h.create_context(root, base, Path(out)/"context", None)
+        finally: td.cleanup()
+        td, root, base = self.make_repo()
+        try:
+            os.symlink("x.ts", root/"src/link"); self.commit(root)
+            with tempfile.TemporaryDirectory() as out, self.assertRaises(h.TrustError):
+                h.create_context(root, base, Path(out)/"context", None)
+        finally: td.cleanup()
+
+class HostedDockerFailClosedTests(unittest.TestCase):
+    def test_hosted_docker_proof_refuses_unprovable_build_controls(self):
+        with tempfile.TemporaryDirectory() as td:
+            dockerfile = Path(td) / "Dockerfile"
+            dockerfile.write_text("FROM node:23-alpine\nRUN npm ci\nRUN npm run build\n")
+            with self.assertRaises(h.TrustError) as caught:
+                h.validate_hosted_docker_proof(dockerfile)
+            self.assertIn("cap-drop ALL", str(caught.exception))
+
+    def test_removing_fail_closed_call_is_killed_by_policy_test(self):
+        source = HELPER.read_text()
+        needle = 'fail("GH-hosted Docker cannot prove nonroot, cap-drop ALL, and no-new-privileges for trusted-base Dockerfile RUN steps")'
+        self.assertEqual(source.count(needle), 1)
+        with tempfile.TemporaryDirectory() as td:
+            mutant_path = Path(td) / "mutant_docker.py"
+            mutant_path.write_text(source.replace(needle, "return None"))
+            mutant = load_helper(mutant_path, "mutant_docker_weakening")
+            dockerfile = Path(td) / "Dockerfile"; dockerfile.write_text("FROM node:23-alpine\nRUN npm run build\n")
+            with self.assertRaises(AssertionError):
+                with self.assertRaises(mutant.TrustError): mutant.validate_hosted_docker_proof(dockerfile)
+
+class EvidenceOracleTests(unittest.TestCase):
+    def evidence(self):
+        return {"schema":"licensed-assets-evidence/v1","pr_number":743,"web_sha":SHA,"provider_sha":SHA,
+                "catalog_sha256":DIGEST,"inventory_sha256":DIGEST,"tree_sha256":DIGEST,"asset_files":1,
+                "functional_pass":True,"hash_pass":True,"matrix_pass":True,"matrix_cases":18,"sandbox_pass":True,"docker_pass":True,
+                "perf_median_p95_ms":0.001,"final_live_head_equal":True,
+                "kirk_visual_review":"external-pending","result":"pass"}
+
+    def write(self, root, value, raw=None):
+        path=Path(root)/"licensed-assets-evidence.json"
+        path.write_bytes(raw if raw is not None else (json.dumps(value)+"\n").encode()); return path
+
+    def test_artifact_exact_allowlist_and_smuggling_mutations(self):
+        with tempfile.TemporaryDirectory() as td:
+            h.validate_artifact(self.write(td, self.evidence()))
+            for label, mutate in [
+                ("field", lambda e: e.update(report="PR-authored")),
+                ("token", lambda e: e.update(result="token=abc")),
+                ("url", lambda e: e.update(result="https://example.invalid")),
+                ("blob", lambda e: e.update(result="A"*200)),
+                ("false-gate", lambda e: e.update(functional_pass=False)),
+                ("perf", lambda e: e.update(perf_median_p95_ms=0.051)),
+            ]:
+                value=self.evidence(); mutate(value)
+                with self.subTest(label=label), self.assertRaises((h.TrustError, json.JSONDecodeError)):
+                    h.validate_artifact(self.write(td, value))
+            with self.assertRaises((h.TrustError, json.JSONDecodeError)):
+                h.validate_artifact(self.write(td, {}, raw=b"\x89PNG\r\n"))
+            self.write(td, self.evidence()).unlink(); target=Path(td)/"target"; target.write_text(json.dumps(self.evidence()))
+            os.link(target, Path(td)/"licensed-assets-evidence.json")
+            with self.assertRaises(h.TrustError): h.validate_artifact(Path(td)/"licensed-assets-evidence.json")
+            (Path(td)/"licensed-assets-evidence.json").unlink(); target.unlink(); target.write_text("x")
+            os.symlink(target, Path(td)/"licensed-assets-evidence.json")
+            with self.assertRaises(h.TrustError): h.validate_artifact(Path(td)/"licensed-assets-evidence.json")
+
+    def test_private_log_stdout_secret_and_perf_gates(self):
+        with tempfile.TemporaryDirectory() as td:
+            path=Path(td)/"log"; path.write_text('{"medianP95MsPerResolve":0.01}\n')
+            h.scan_private_log(path); self.assertEqual(h.parse_perf_log(path), 0.01)
+            path.write_text('{"medianP95MsPerResolve":0.06}\n')
+            with self.assertRaises(h.TrustError): h.parse_perf_log(path)
+            path.write_text('token=stdout-canary\n')
+            with self.assertRaises(h.TrustError): h.scan_private_log(path)
+            path.write_text('STDOUT-CANARY\n')
+            with self.assertRaises(h.TrustError): h.scan_private_log(path, ["STDOUT-CANARY"])
+
+    def test_inventory_hash_functional_file_and_tree_mutations(self):
+        with tempfile.TemporaryDirectory() as td:
+            root=Path(td); provider=root/"provider"; stage=root/"stage"; (provider/"harness/catalogs").mkdir(parents=True)
+            asset=stage/"models/synty/a.glb"; asset.parent.mkdir(parents=True); asset.write_bytes(b"glTF-safe-fixture")
+            sha=h.sha256_file(asset); row=f"a.glb\0{asset.stat().st_size}\0{sha}\n"; tree=__import__('hashlib').sha256(row.encode()).hexdigest()
+            inv={"schemaVersion":1,"inventoryId":"synty-complete-tree","root":"harness/models/synty",
+                 "tool":{"name":"build_synty_complete_inventory","version":"1.0.0"},"fileCount":1,"treeSha256":tree,
+                 "files":[{"path":"a.glb","size":asset.stat().st_size,"sha256":sha}]}
+            invpath=provider/"harness/catalogs/synty-complete-inventory.json"; invpath.write_text(json.dumps(inv))
+            lock=provider_lock(); lock["inventory"].update(sha256=h.sha256_file(invpath), treeSha256=tree)
+            h.validate_inventory(provider, stage, lock)
+            asset.write_bytes(b"mutated")
+            with self.assertRaises(h.TrustError): h.validate_inventory(provider, stage, lock)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/trusted-licensed-assets.py
+++ b/scripts/trusted-licensed-assets.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Trusted licensed-assets workflow policy/oracle.
+
+This file is executed only from the released default-main workflow commit.  A PR
+checkout is data until ``sandbox-run`` invokes fixed commands with no network.
+The module is deliberately Python-stdlib-only so no PR dependency is imported.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import mimetypes
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+OWNER = "KirkDiggler"
+REPOSITORY = "KirkDiggler/rpg-dnd5e-web"
+PROVIDER_REPOSITORY = "KirkDiggler/rpg-game-assets"
+DEFAULT_REF = "refs/heads/main"
+BASE_REF = "dev"
+ENVIRONMENT = "licensed-assets"
+WORKFLOW_PATH = ".github/workflows/trusted-licensed-assets.yml"
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+SAFE_ID = re.compile(r"^[a-z0-9][a-z0-9._/-]{0,95}$")
+TOKENISH = re.compile(
+    r"(?i)(?:github_pat_|gh[pousr]_|x-access-token|authorization\s*:|bearer\s+|"
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----|(?:token|secret|password|credential)\s*[=:])"
+)
+URLISH = re.compile(r"(?i)(?:https?|ssh|git)://|git@github\.com|github\.com/")
+BLOBISH = re.compile(r"[A-Za-z0-9+/]{160,}={0,2}")
+LICENSED_SUFFIXES = {".glb", ".gltf", ".fbx", ".blend", ".unitypackage", ".zip", ".7z", ".rar"}
+LICENSED_PREFIXES = ("public/models/synty/", ".asset-stage/", "assets/synty/")
+SCREENSHOT_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
+ALLOWED_CONTEXT_ROOTS = {
+    "index.html", "package.json", "package-lock.json", "eslint.config.js",
+    "postcss.config.js", "vite.config.ts", "vitest.config.ts", "nginx.conf",
+    "nginx.main.conf", "tsconfig.json", "tsconfig.app.json", "tsconfig.node.json",
+}
+ALLOWED_CONTEXT_PREFIXES = ("src/", "public/")
+MAX_CHANGED_FILES = 4096
+MAX_TREE_FILES = 20000
+MAX_ARTIFACT_BYTES = 4096
+MAX_STAGE_FILES = 10000
+MAX_STAGE_BYTES = 8 * 1024 * 1024 * 1024
+
+class TrustError(RuntimeError):
+    pass
+
+def fail(message: str) -> None:
+    raise TrustError(message)
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+def read_json(path: Path, max_bytes: int = 2 * 1024 * 1024) -> Any:
+    require(path.is_file() and not path.is_symlink(), f"not a regular JSON file: {path}")
+    require(path.stat().st_size <= max_bytes, f"JSON file too large: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"invalid JSON {path}: {exc}")
+
+def exact_keys(value: Mapping[str, Any], keys: set[str], label: str) -> None:
+    require(isinstance(value, dict), f"{label} must be an object")
+    require(set(value) == keys, f"{label} keys mismatch")
+
+def clean_scalar(value: Any, label: str, *, max_len: int = 128) -> None:
+    require(value is None or isinstance(value, (str, bool, int, float)), f"{label} is not scalar")
+    if isinstance(value, str):
+        require(len(value) <= max_len and "\n" not in value and "\r" not in value, f"{label} invalid string")
+        require(not TOKENISH.search(value), f"{label} is secret-shaped")
+        require(not URLISH.search(value), f"{label} is URL-shaped")
+        require(not BLOBISH.search(value), f"{label} is blob-shaped")
+    if isinstance(value, float):
+        require(math.isfinite(value), f"{label} is not finite")
+
+def validate_workflow_identity(*, event_name: str, repository: str, actor: str,
+                               ref: str, workflow_ref: str, workflow_sha: str,
+                               run_sha: str) -> None:
+    require(event_name == "workflow_dispatch", "event must be workflow_dispatch")
+    require(repository == REPOSITORY, "wrong executing repository")
+    require(actor == OWNER, "dispatch actor is not Kirk")
+    require(ref == DEFAULT_REF, "dispatch ref is not default main")
+    require(HEX40.fullmatch(workflow_sha) is not None, "workflow SHA must be full lowercase SHA")
+    require(run_sha == workflow_sha, "run SHA differs from workflow SHA")
+    expected = f"{REPOSITORY}/{WORKFLOW_PATH}@{DEFAULT_REF}"
+    require(workflow_ref == expected, "workflow was not loaded from the default-main ref")
+
+def validate_pr(pr: Mapping[str, Any], *, number: int, expected_sha: str,
+                actor: str, checkout_sha: str | None = None,
+                original: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    require(isinstance(number, int) and 0 < number < 1_000_000_000, "invalid PR number")
+    require(HEX40.fullmatch(expected_sha) is not None, "expected head must be a full lowercase SHA")
+    require(actor == OWNER, "dispatch actor is not Kirk")
+    required = {"number", "state", "draft", "user", "head", "base"}
+    require(required.issubset(pr), "live PR response missing trust fields")
+    require(pr["number"] == number, "live PR number mismatch")
+    require(pr["state"] == "open", "PR is not open")
+    require(pr["draft"] is False, "PR is draft")
+    user = pr["user"]
+    require(isinstance(user, dict), "PR user missing")
+    require(user.get("login") == OWNER, "PR author is not Kirk")
+    require(user.get("type") == "User", "PR author is a bot")
+    head, base = pr["head"], pr["base"]
+    require(isinstance(head, dict) and isinstance(base, dict), "PR refs missing")
+    require(head.get("sha") == expected_sha, "live PR head differs from expected SHA")
+    require(head.get("ref") != "dependabot", "Dependabot head rejected")
+    require(not str(head.get("ref", "")).startswith("dependabot/"), "Dependabot head rejected")
+    head_repo, base_repo = head.get("repo"), base.get("repo")
+    require(isinstance(head_repo, dict) and isinstance(base_repo, dict), "PR repositories missing")
+    require(head_repo.get("full_name") == REPOSITORY, "wrong head repository")
+    require(head_repo.get("fork") is False, "fork PR rejected")
+    require(base_repo.get("full_name") == REPOSITORY, "wrong base repository")
+    require(base.get("ref") == BASE_REF, "PR base is not dev")
+    base_sha = base.get("sha")
+    require(isinstance(base_sha, str) and HEX40.fullmatch(base_sha), "live base SHA invalid")
+    if checkout_sha is not None:
+        require(checkout_sha == expected_sha, "quarantine checkout differs from expected SHA")
+    snapshot = {
+        "number": number,
+        "head_sha": expected_sha,
+        "head_ref": head.get("ref"),
+        "base_sha": base_sha,
+        "base_ref": base.get("ref"),
+        "head_repo": head_repo.get("full_name"),
+        "base_repo": base_repo.get("full_name"),
+        "author": user.get("login"),
+        "author_type": user.get("type"),
+        "state": pr.get("state"),
+        "draft": pr.get("draft"),
+    }
+    for key, value in snapshot.items():
+        clean_scalar(value, f"snapshot.{key}")
+    if original is not None:
+        require(snapshot == dict(original), "live PR trust fields changed since preflight")
+    return snapshot
+
+def github_api(path: str, token: str) -> Any:
+    require(token != "", "GITHUB_TOKEN missing")
+    require(path.startswith("/repos/KirkDiggler/rpg-dnd5e-web/"), "untrusted API path")
+    request = urllib.request.Request(
+        f"https://api.github.com{path}",
+        headers={"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}",
+                 "User-Agent": "trusted-licensed-assets-bootstrap/1", "X-GitHub-Api-Version": "2022-11-28"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            require(response.status == 200, f"GitHub API returned {response.status}")
+            body = response.read(2 * 1024 * 1024 + 1)
+    except urllib.error.HTTPError as exc:
+        fail(f"GitHub API failed with HTTP {exc.code}")
+    require(len(body) <= 2 * 1024 * 1024, "GitHub API response too large")
+    return json.loads(body)
+
+def fetch_pr(number: int, token: str) -> Any:
+    return github_api(f"/repos/KirkDiggler/rpg-dnd5e-web/pulls/{number}", token)
+
+def parse_provider_lock(path: Path) -> dict[str, Any]:
+    lock = read_json(path, 32 * 1024)
+    exact_keys(lock, {"schemaVersion", "provider", "catalog", "inventory", "tool", "verifier"}, "provider lock")
+    require(lock["schemaVersion"] == 1, "unsupported provider lock schema")
+    exact_keys(lock["provider"], {"repository", "commit"}, "provider")
+    require(lock["provider"]["repository"] == PROVIDER_REPOSITORY, "wrong provider repository")
+    require(HEX40.fullmatch(lock["provider"]["commit"]), "provider commit is not exact SHA")
+    exact_keys(lock["catalog"], {"path", "sha256", "schemaVersion", "catalogId"}, "catalog")
+    require(lock["catalog"]["path"] == "harness/catalogs/synty-web-assets.json", "wrong catalog path")
+    require(HEX64.fullmatch(lock["catalog"]["sha256"]), "bad catalog digest")
+    require(lock["catalog"]["schemaVersion"] == 1 and lock["catalog"]["catalogId"] == "synty-web-assets", "bad catalog identity")
+    exact_keys(lock["inventory"], {"path", "sha256", "schemaVersion", "inventoryId", "tool", "fileCount", "treeSha256"}, "inventory")
+    inv = lock["inventory"]
+    require(inv["path"] == "harness/catalogs/synty-complete-inventory.json", "wrong inventory path")
+    require(HEX64.fullmatch(inv["sha256"]) and HEX64.fullmatch(inv["treeSha256"]), "bad inventory digest")
+    require(inv["schemaVersion"] == 1 and inv["inventoryId"] == "synty-complete-tree", "bad inventory identity")
+    require(isinstance(inv["fileCount"], int) and 0 < inv["fileCount"] <= MAX_STAGE_FILES, "bad inventory count")
+    for obj, name, version in ((lock["tool"], "build_web_asset_catalog", "1.0.0"),
+                               (inv["tool"], "build_synty_complete_inventory", "1.0.0"),
+                               (lock["verifier"], "verify_web_asset_stage", "1.1.0")):
+        exact_keys(obj, {"name", "version"}, "tool identity")
+        require(obj == {"name": name, "version": version}, "unexpected provider tool identity")
+    return lock
+
+def git(*args: str, cwd: Path | None = None, check: bool = True, env: Mapping[str, str] | None = None) -> str:
+    result = subprocess.run(["git", *args], cwd=cwd, env=env, text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if check and result.returncode:
+        fail(f"git command failed ({args[0] if args else 'git'})")
+    return result.stdout
+
+def validate_quarantine(worktree: Path, *, expected_sha: str, base_sha: str) -> dict[str, Any]:
+    require(worktree.is_dir() and (worktree / ".git").exists(), "quarantine checkout missing")
+    require(git("rev-parse", "HEAD", cwd=worktree).strip() == expected_sha, "quarantine HEAD mismatch")
+    require(git("status", "--porcelain=v1", "--untracked-files=all", cwd=worktree).strip() == "", "quarantine is dirty")
+    raw = subprocess.check_output(["git", "-C", str(worktree), "ls-tree", "-r", "-z", expected_sha])
+    entries = []
+    for item in raw.split(b"\0"):
+        if not item:
+            continue
+        meta, path_b = item.split(b"\t", 1)
+        mode, kind, oid = meta.decode("ascii").split()
+        path = path_b.decode("utf-8")
+        require(mode in {"100644", "100755"} and kind == "blob", f"special tree entry rejected: {path}")
+        require(PurePosixPath(path).is_absolute() is False and ".." not in PurePosixPath(path).parts, "unsafe tree path")
+        entries.append(path)
+    require(0 < len(entries) <= MAX_TREE_FILES, "unexpected PR tree size")
+    changed_raw = git("diff", "--name-status", "-z", f"{base_sha}...{expected_sha}", cwd=worktree)
+    fields = changed_raw.split("\0")
+    changed: list[str] = []
+    i = 0
+    while i < len(fields) and fields[i]:
+        status_code = fields[i]
+        i += 1
+        if status_code[0] in "RC":
+            require(i + 1 < len(fields), "malformed rename diff")
+            old, new = fields[i], fields[i + 1]
+            i += 2
+            changed.extend([old, new])
+        else:
+            require(i < len(fields), "malformed changed-path diff")
+            changed.append(fields[i]); i += 1
+    require(len(changed) <= MAX_CHANGED_FILES, "too many changed files")
+    for path in changed:
+        lower = path.lower()
+        require(not lower.startswith(LICENSED_PREFIXES), f"licensed path changed by PR: {path}")
+        require(PurePosixPath(lower).suffix not in LICENSED_SUFFIXES, f"licensed binary changed by PR: {path}")
+    return {"tree_files": len(entries), "changed_files": len(set(changed))}
+
+def context_path_allowed(path: str) -> bool:
+    if path in ALLOWED_CONTEXT_ROOTS:
+        return True
+    if path.startswith("public/models/synty/"):
+        return False
+    return path.startswith(ALLOWED_CONTEXT_PREFIXES)
+
+def copy_regular(source: Path, destination: Path) -> None:
+    require(source.is_file() and not source.is_symlink(), f"context source not regular: {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination, follow_symlinks=False)
+    os.chmod(destination, 0o755 if os.access(source, os.X_OK) else 0o644)
+
+def create_context(worktree: Path, base_sha: str, destination: Path, asset_root: Path | None) -> dict[str, Any]:
+    require(not destination.exists(), "context destination already exists")
+    destination.mkdir(parents=True, mode=0o700)
+    for build_file in ("Dockerfile", ".dockerignore"):
+        head_bytes = subprocess.check_output(["git", "-C", str(worktree), "show", f"HEAD:{build_file}"])
+        base_bytes = subprocess.check_output(["git", "-C", str(worktree), "show", f"{base_sha}:{build_file}"])
+        require(head_bytes == base_bytes, f"PR modified trusted {build_file}")
+        out = destination / build_file
+        out.write_bytes(base_bytes); os.chmod(out, 0o600)
+    dockerfile = (destination / "Dockerfile").read_text(encoding="utf-8")
+    require(not re.search(r"(?im)^\s*ADD\s", dockerfile), "Dockerfile ADD is forbidden")
+    require(not re.search(r"(?im)^\s*FROM\s+[^\s]+@?https?://", dockerfile), "remote Docker source forbidden")
+    raw = subprocess.check_output(["git", "-C", str(worktree), "ls-files", "-z"])
+    copied = 0
+    for item in raw.split(b"\0"):
+        if not item:
+            continue
+        path = item.decode("utf-8")
+        if context_path_allowed(path):
+            copy_regular(worktree / path, destination / path); copied += 1
+    require((destination / "package.json").is_file() and (destination / "src").is_dir(), "incomplete trusted build context")
+    asset_count = 0
+    if asset_root is not None:
+        require(asset_root.is_dir() and not asset_root.is_symlink(), "asset root missing")
+        for path in sorted(asset_root.rglob("*")):
+            require(not path.is_symlink(), "asset-stage symlink rejected")
+            if path.is_dir():
+                continue
+            require(path.is_file() and path.stat().st_nlink == 1, "asset-stage special/hardlink rejected")
+            rel = path.relative_to(asset_root)
+            copy_regular(path, destination / "public/models/synty" / rel)
+            asset_count += 1
+        require(asset_count > 0, "licensed context is empty")
+    return {"context_files": copied + asset_count + 2, "asset_files": asset_count}
+
+def validate_inventory(provider: Path, stage_root: Path, lock: Mapping[str, Any]) -> dict[str, Any]:
+    inventory_path = provider / lock["inventory"]["path"]
+    require(sha256_file(inventory_path) == lock["inventory"]["sha256"], "inventory file hash mismatch")
+    inventory = read_json(inventory_path, 4 * 1024 * 1024)
+    exact_keys(inventory, {"schemaVersion", "inventoryId", "root", "tool", "fileCount", "treeSha256", "files"}, "provider inventory")
+    require(inventory["schemaVersion"] == 1 and inventory["inventoryId"] == "synty-complete-tree", "provider inventory identity mismatch")
+    require(inventory["root"] == "harness/models/synty", "provider inventory root mismatch")
+    require(inventory["tool"] == lock["inventory"]["tool"], "provider inventory tool mismatch")
+    require(inventory["fileCount"] == lock["inventory"]["fileCount"], "provider inventory count lock mismatch")
+    require(inventory["treeSha256"] == lock["inventory"]["treeSha256"], "provider tree lock mismatch")
+    files = inventory["files"]
+    require(isinstance(files, list) and len(files) == inventory["fileCount"], "provider inventory rows mismatch")
+    root = stage_root / "models/synty"
+    require(root.is_dir() and not root.is_symlink(), "staged licensed root missing")
+    seen: set[str] = set(); rows: list[str] = []; total = 0
+    for record in files:
+        exact_keys(record, {"path", "size", "sha256"}, "inventory row")
+        rel = record["path"]
+        require(isinstance(rel, str) and 0 < len(rel) <= 300, "invalid inventory path")
+        pure = PurePosixPath(rel)
+        require(not pure.is_absolute() and ".." not in pure.parts and rel not in seen, "unsafe/duplicate inventory path")
+        require(isinstance(record["size"], int) and 0 <= record["size"] <= MAX_STAGE_BYTES, "invalid inventory size")
+        require(HEX64.fullmatch(record["sha256"]), "invalid inventory file hash")
+        path = root.joinpath(*pure.parts)
+        require(path.is_file() and not path.is_symlink() and path.stat().st_nlink == 1, f"missing/special staged file: {rel}")
+        require(path.stat().st_size == record["size"], f"staged size mismatch: {rel}")
+        require(sha256_file(path) == record["sha256"], f"staged digest mismatch: {rel}")
+        seen.add(rel); total += record["size"]
+        rows.append(f"{rel}\0{record['size']}\0{record['sha256']}\n")
+    actual_paths = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+    require(actual_paths == seen, "staged tree has unlisted files")
+    tree_sha = hashlib.sha256("".join(rows).encode()).hexdigest()
+    require(tree_sha == inventory["treeSha256"], "staged aggregate tree mismatch")
+    require(total <= MAX_STAGE_BYTES, "staged aggregate too large")
+    return {"asset_files": len(files), "asset_bytes": total, "tree_sha256": tree_sha}
+
+def validate_provider_checkout(provider: Path, worktree: Path, lock: Mapping[str, Any]) -> None:
+    expected = lock["provider"]["commit"]
+    require(git("rev-parse", "HEAD", cwd=provider).strip() == expected, "provider HEAD mismatch")
+    sym = subprocess.run(["git", "-C", str(provider), "symbolic-ref", "-q", "HEAD"], stdout=subprocess.DEVNULL).returncode
+    require(sym != 0, "provider checkout is not detached")
+    require(git("status", "--porcelain=v1", cwd=provider).strip() == "", "provider checkout dirty")
+    catalog = provider / lock["catalog"]["path"]
+    require(sha256_file(catalog) == lock["catalog"]["sha256"], "provider catalog hash mismatch")
+    web_catalog = worktree / "src/rendering/visualPlacement/synty-web-assets.json"
+    require(sha256_file(web_catalog) == lock["catalog"]["sha256"], "quarantined catalog hash mismatch")
+    require(catalog.read_bytes() == web_catalog.read_bytes(), "provider/web catalog bytes differ")
+    tool_paths = {
+        "build_web_asset_catalog": provider / "scripts/build_web_asset_catalog.py",
+        "build_synty_complete_inventory": provider / "scripts/build_synty_complete_inventory.py",
+        "verify_web_asset_stage": provider / "scripts/verify_web_asset_stage.py",
+    }
+    require(all(p.is_file() and not p.is_symlink() for p in tool_paths.values()), "provider tool missing/special")
+
+def run_provider_tools(provider: Path, stage: Path) -> None:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(stage.parent / "provider-home"),
+           "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8", "PYTHONDONTWRITEBYTECODE": "1"}
+    Path(env["HOME"]).mkdir(mode=0o700)
+    commands = [
+        [sys.executable, "scripts/build_web_asset_catalog.py", "--check"],
+        [sys.executable, "scripts/build_synty_complete_inventory.py", "--check"],
+        [sys.executable, "scripts/verify_web_asset_stage.py", "--verify-only"],
+        [sys.executable, "scripts/verify_web_asset_stage.py", "--destination", str(stage)],
+    ]
+    for command in commands:
+        result = subprocess.run(command, cwd=provider, env=env, stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL, timeout=600)
+        require(result.returncode == 0, f"provider check failed: {Path(command[1]).name}")
+    require(git("status", "--porcelain=v1", cwd=provider).strip() == "", "provider checks dirtied checkout")
+
+def validate_secret_input(canonical: str | None, broad: str | None) -> str:
+    require(canonical is not None and canonical != "", "licensed-assets Environment secret absent")
+    # Alternate/broad secret is intentionally ignored and never a fallback.
+    require(len(canonical) <= 1024 and "\n" not in canonical and "\r" not in canonical, "invalid canonical secret")
+    return canonical
+
+def credential_residue(root: Path, env: Mapping[str, str], provider_path: Path | None) -> None:
+    forbidden_env = {"RPG_GAME_ASSETS_READ_TOKEN", "ASSETS_READ_TOKEN", "GIT_ASKPASS", "SSH_ASKPASS", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM"}
+    require(not (forbidden_env & set(env)), "credential/control environment residue")
+    if provider_path is not None:
+        require(not provider_path.exists(), "private provider checkout residue")
+    for path in root.rglob("*"):
+        if not path.is_file() or path.is_symlink() or path.stat().st_size > 1024 * 1024:
+            continue
+        lower = path.name.lower()
+        if lower in {".gitconfig", ".netrc", "credentials", "config"} or "askpass" in lower:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            require(not TOKENISH.search(text) and "x-access-token" not in text.lower(), f"credential config residue: {path.name}")
+
+def scan_private_log(path: Path, canaries: Sequence[str] = ()) -> dict[str, Any]:
+    require(path.is_file() and not path.is_symlink() and path.stat().st_nlink == 1, "private log not regular")
+    require(path.stat().st_size <= 64 * 1024 * 1024, "private log too large")
+    text = path.read_text(encoding="utf-8", errors="replace")
+    require(not TOKENISH.search(text), "private log contains secret-shaped output")
+    require(not re.search(r"(?i)https?://[^\s]*@", text), "private log contains authenticated URL")
+    for canary in canaries:
+        require(canary not in text, "stdout secret canary reached captured PR log")
+    return {"log_bytes": len(text.encode("utf-8"))}
+
+def parse_perf_log(path: Path) -> float:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    matches = re.findall(r'"medianP95MsPerResolve"\s*:\s*([0-9]+(?:\.[0-9]+)?)', text)
+    require(len(matches) == 1, "performance log lacks one bounded median")
+    value = float(matches[0])
+    require(math.isfinite(value) and 0 <= value <= 0.05, "performance threshold failed")
+    return value
+
+def validate_artifact(path: Path) -> dict[str, Any]:
+    require(path.is_file() and not path.is_symlink(), "artifact is not regular")
+    info = path.stat()
+    require(info.st_nlink == 1, "artifact hardlink rejected")
+    require(info.st_size <= MAX_ARTIFACT_BYTES, "artifact too large")
+    require(path.name == "licensed-assets-evidence.json", "artifact filename not allowlisted")
+    raw = path.read_bytes()
+    require(not raw.startswith((b"\x89PNG", b"PK\x03\x04", b"glTF", b"GIF8", b"\xff\xd8\xff")), "artifact binary/archive/image rejected")
+    evidence = json.loads(raw.decode("utf-8"))
+    keys = {"schema", "pr_number", "web_sha", "provider_sha", "catalog_sha256", "inventory_sha256",
+            "tree_sha256", "asset_files", "functional_pass", "hash_pass", "matrix_pass", "matrix_cases", "sandbox_pass", "docker_pass",
+            "perf_median_p95_ms", "final_live_head_equal", "kirk_visual_review", "result"}
+    exact_keys(evidence, keys, "evidence")
+    require(evidence["schema"] == "licensed-assets-evidence/v1", "evidence schema mismatch")
+    require(isinstance(evidence["pr_number"], int) and evidence["pr_number"] > 0, "invalid evidence PR")
+    for key in ("web_sha", "provider_sha"):
+        require(isinstance(evidence[key], str) and HEX40.fullmatch(evidence[key]), f"invalid {key}")
+    for key in ("catalog_sha256", "inventory_sha256", "tree_sha256"):
+        require(isinstance(evidence[key], str) and HEX64.fullmatch(evidence[key]), f"invalid {key}")
+    require(isinstance(evidence["asset_files"], int) and 0 < evidence["asset_files"] <= MAX_STAGE_FILES, "invalid asset count")
+    for key in ("functional_pass", "hash_pass", "matrix_pass", "sandbox_pass", "docker_pass", "final_live_head_equal"):
+        require(evidence[key] is True, f"evidence gate false: {key}")
+    require(evidence["matrix_cases"] == 18, "invalid matrix case count")
+    require(evidence["kirk_visual_review"] in {"external-pending", "external-pass"}, "invalid visual scalar")
+    require(evidence["result"] == "pass", "invalid evidence result")
+    require(isinstance(evidence["perf_median_p95_ms"], (int, float)) and 0 <= evidence["perf_median_p95_ms"] <= 0.05, "invalid perf scalar")
+    decoded = raw.decode("utf-8")
+    require(not TOKENISH.search(decoded) and not URLISH.search(decoded) and not BLOBISH.search(decoded), "artifact content scan failed")
+    return evidence
+
+def write_outputs(path: Path | None, values: Mapping[str, Any]) -> None:
+    if path is None:
+        return
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            text = str(value).lower() if isinstance(value, bool) else str(value)
+            require("\n" not in text and "\r" not in text, "unsafe workflow output")
+            handle.write(f"{key}={text}\n")
+
+def command_quarantine(args: argparse.Namespace) -> None:
+    result = validate_quarantine(Path(args.worktree), expected_sha=args.expected_head_sha, base_sha=args.base_sha)
+    write_outputs(Path(args.github_output) if args.github_output else None, result)
+
+def command_provider_stage(args: argparse.Namespace) -> None:
+    worktree, private_root, provider, stage = map(Path, (args.worktree, args.private_root, args.provider, args.stage))
+    lock = parse_provider_lock(worktree / "src/rendering/visualPlacement/provider-lock.json")
+    token = validate_secret_input(os.environ.get("RPG_GAME_ASSETS_READ_TOKEN"), os.environ.get("ASSETS_READ_TOKEN"))
+    require(private_root.is_dir() and not private_root.is_symlink(), "private root missing")
+    require(not provider.exists() and not stage.exists(), "provider/stage destination exists")
+    askpass = private_root / "git-askpass.sh"
+    askpass.write_text("#!/bin/sh\ncase \"$1\" in *Username*) printf '%s\\n' x-access-token;; *) printf '%s\\n' \"$RPG_GAME_ASSETS_READ_TOKEN\";; esac\n", encoding="utf-8")
+    os.chmod(askpass, 0o700)
+    fetch_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(private_root / "fetch-home"),
+                 "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": str(askpass),
+                 "RPG_GAME_ASSETS_READ_TOKEN": token, "GIT_CONFIG_NOSYSTEM": "1"}
+    Path(fetch_env["HOME"]).mkdir(mode=0o700)
+    try:
+        provider.mkdir(mode=0o700)
+        subprocess.run(["git", "init", "-q", str(provider)], env=fetch_env, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(provider), "config", "core.hooksPath", "/dev/null"], env=fetch_env, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(provider), "remote", "add", "origin",
+                        "https://github.com/KirkDiggler/rpg-game-assets.git"], env=fetch_env, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(provider), "fetch", "--no-tags", "--depth=1", "origin",
+                        lock["provider"]["commit"]], env=fetch_env, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=300)
+        subprocess.run(["git", "-C", str(provider), "checkout", "-q", "--detach", lock["provider"]["commit"]],
+                       env=fetch_env, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        fail("exact provider fetch/checkout failed")
+    finally:
+        os.environ.pop("RPG_GAME_ASSETS_READ_TOKEN", None)
+        os.environ.pop("ASSETS_READ_TOKEN", None)
+        if askpass.exists():
+            askpass.unlink()
+        shutil.rmtree(Path(fetch_env["HOME"]), ignore_errors=True)
+    try:
+        validate_provider_checkout(provider, worktree, lock)
+        run_provider_tools(provider, stage)
+        result = validate_inventory(provider, stage, lock)
+        result.update({"provider_sha": lock["provider"]["commit"],
+                       "catalog_sha256": lock["catalog"]["sha256"],
+                       "inventory_sha256": lock["inventory"]["sha256"]})
+    finally:
+        shutil.rmtree(provider, ignore_errors=True)
+    credential_residue(private_root, {k: v for k, v in os.environ.items() if k not in {"GITHUB_TOKEN"}}, provider)
+    write_outputs(Path(args.github_output) if args.github_output else None, result)
+
+def validate_hosted_docker_proof(dockerfile: Path) -> None:
+    require(dockerfile.is_file() and not dockerfile.is_symlink(), "trusted Dockerfile missing")
+    text = dockerfile.read_text(encoding="utf-8")
+    require(not re.search(r"(?im)^\s*ADD\s", text), "Dockerfile ADD is forbidden")
+    # `docker build --network=none` constrains RUN networking, but the hosted
+    # daemon exposes no build flags equivalent to docker-run --cap-drop ALL and
+    # --security-opt no-new-privileges. The trusted base also executes npm ci
+    # and npm run build before a nonroot USER. Do not silently weaken the run
+    # sandbox merely to obtain an image.
+    fail("GH-hosted Docker cannot prove nonroot, cap-drop ALL, and no-new-privileges for trusted-base Dockerfile RUN steps")
+
+def command_docker_proof(args: argparse.Namespace) -> None:
+    validate_hosted_docker_proof(Path(args.dockerfile))
+
+def command_context(args: argparse.Namespace) -> None:
+    result = create_context(Path(args.worktree), args.base_sha, Path(args.destination),
+                            Path(args.asset_root) if args.asset_root else None)
+    write_outputs(Path(args.github_output) if args.github_output else None, result)
+
+def command_scan_log(args: argparse.Namespace) -> None:
+    result = scan_private_log(Path(args.log), args.forbid_canary)
+    if args.perf:
+        result["perf_median_p95_ms"] = parse_perf_log(Path(args.log))
+    write_outputs(Path(args.github_output) if args.github_output else None, result)
+
+def command_residue(args: argparse.Namespace) -> None:
+    credential_residue(Path(args.root), dict(os.environ), Path(args.provider) if args.provider else None)
+
+def command_make_artifact(args: argparse.Namespace) -> None:
+    evidence = {
+        "schema": "licensed-assets-evidence/v1", "pr_number": args.pr_number,
+        "web_sha": args.web_sha, "provider_sha": args.provider_sha,
+        "catalog_sha256": args.catalog_sha256, "inventory_sha256": args.inventory_sha256,
+        "tree_sha256": args.tree_sha256, "asset_files": args.asset_files,
+        "functional_pass": True, "hash_pass": True, "matrix_pass": True, "matrix_cases": 18,
+        "sandbox_pass": True, "docker_pass": True,
+        "perf_median_p95_ms": args.perf_median_p95_ms, "final_live_head_equal": True,
+        "kirk_visual_review": args.kirk_visual_review, "result": "pass",
+    }
+    out = Path(args.output)
+    require(not out.exists(), "artifact already exists")
+    out.write_text(canonical_json(evidence) + "\n", encoding="utf-8")
+    os.chmod(out, 0o600)
+    validate_artifact(out)
+
+def command_preflight(args: argparse.Namespace) -> None:
+    validate_workflow_identity(event_name=args.event_name, repository=args.repository, actor=args.actor,
+                               ref=args.ref, workflow_ref=args.workflow_ref, workflow_sha=args.workflow_sha,
+                               run_sha=args.run_sha)
+    pr = fetch_pr(args.pr_number, os.environ.get("GITHUB_TOKEN", ""))
+    snapshot = validate_pr(pr, number=args.pr_number, expected_sha=args.expected_head_sha, actor=args.actor)
+    Path(args.snapshot).write_text(canonical_json(snapshot) + "\n", encoding="utf-8")
+    write_outputs(Path(args.github_output) if args.github_output else None,
+                  {"validated": True, "head_sha": snapshot["head_sha"], "base_sha": snapshot["base_sha"], "head_ref": snapshot["head_ref"]})
+
+def command_live_check(args: argparse.Namespace) -> None:
+    original = {"number": args.pr_number, "head_sha": args.expected_head_sha, "head_ref": args.head_ref,
+                "base_sha": args.base_sha, "base_ref": BASE_REF, "head_repo": REPOSITORY,
+                "base_repo": REPOSITORY, "author": OWNER, "author_type": "User", "state": "open", "draft": False}
+    pr = fetch_pr(args.pr_number, os.environ.get("GITHUB_TOKEN", ""))
+    validate_pr(pr, number=args.pr_number, expected_sha=args.expected_head_sha, actor=args.actor,
+                checkout_sha=args.expected_head_sha, original=original)
+
+def command_final(args: argparse.Namespace) -> None:
+    original = {"number": args.pr_number, "head_sha": args.expected_head_sha, "head_ref": args.head_ref,
+                "base_sha": args.base_sha, "base_ref": BASE_REF, "head_repo": REPOSITORY,
+                "base_repo": REPOSITORY, "author": OWNER, "author_type": "User", "state": "open", "draft": False}
+    pr = fetch_pr(args.pr_number, os.environ.get("GITHUB_TOKEN", ""))
+    live_equal = False
+    try:
+        validate_pr(pr, number=args.pr_number, expected_sha=args.expected_head_sha, actor=args.actor,
+                    checkout_sha=args.expected_head_sha, original=original)
+        live_equal = True
+    finally:
+        state = "success" if live_equal and args.licensed_result == "success" else "failure"
+        body = canonical_json({"state": state, "context": "licensed-assets/exact-head",
+                               "description": "trusted exact-head licensed gate passed" if state == "success" else "trusted exact-head licensed gate failed"}).encode()
+        token = os.environ.get("GITHUB_TOKEN", "")
+        request = urllib.request.Request(
+            f"https://api.github.com/repos/{REPOSITORY}/statuses/{args.expected_head_sha}", data=body, method="POST",
+            headers={"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}",
+                     "Content-Type": "application/json", "User-Agent": "trusted-licensed-assets-bootstrap/1"})
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                require(response.status == 201, "status API did not create status")
+        except urllib.error.HTTPError as exc:
+            fail(f"status API failed with HTTP {exc.code}")
+    require(live_equal, "final live PR equality failed")
+    require(args.licensed_result == "success", "licensed job did not succeed")
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    pre = sub.add_parser("preflight")
+    for name, required in (("event-name", True), ("repository", True), ("actor", True), ("ref", True),
+                           ("workflow-ref", True), ("workflow-sha", True), ("run-sha", True),
+                           ("expected-head-sha", True), ("snapshot", True), ("github-output", False)):
+        pre.add_argument(f"--{name}", required=required)
+    pre.add_argument("--pr-number", type=int, required=True); pre.set_defaults(func=command_preflight)
+    final = sub.add_parser("final")
+    final.add_argument("--pr-number", type=int, required=True); final.add_argument("--expected-head-sha", required=True)
+    final.add_argument("--actor", required=True); final.add_argument("--base-sha", required=True); final.add_argument("--head-ref", required=True)
+    final.add_argument("--licensed-result", required=True); final.set_defaults(func=command_final)
+    live = sub.add_parser("live-check")
+    live.add_argument("--pr-number", type=int, required=True); live.add_argument("--expected-head-sha", required=True)
+    live.add_argument("--actor", required=True); live.add_argument("--base-sha", required=True); live.add_argument("--head-ref", required=True)
+    live.set_defaults(func=command_live_check)
+    quarantine = sub.add_parser("quarantine")
+    quarantine.add_argument("--worktree", required=True); quarantine.add_argument("--expected-head-sha", required=True)
+    quarantine.add_argument("--base-sha", required=True); quarantine.add_argument("--github-output")
+    quarantine.set_defaults(func=command_quarantine)
+    provider = sub.add_parser("provider-stage")
+    for name in ("worktree", "private-root", "provider", "stage"):
+        provider.add_argument(f"--{name}", required=True)
+    provider.add_argument("--github-output"); provider.set_defaults(func=command_provider_stage)
+    context = sub.add_parser("create-context")
+    context.add_argument("--worktree", required=True); context.add_argument("--base-sha", required=True)
+    context.add_argument("--destination", required=True); context.add_argument("--asset-root")
+    context.add_argument("--github-output"); context.set_defaults(func=command_context)
+    docker_proof = sub.add_parser("docker-proof")
+    docker_proof.add_argument("--dockerfile", required=True); docker_proof.set_defaults(func=command_docker_proof)
+    scan = sub.add_parser("scan-log")
+    scan.add_argument("--log", required=True); scan.add_argument("--forbid-canary", action="append", default=[])
+    scan.add_argument("--perf", action="store_true"); scan.add_argument("--github-output")
+    scan.set_defaults(func=command_scan_log)
+    residue = sub.add_parser("residue")
+    residue.add_argument("--root", required=True); residue.add_argument("--provider")
+    residue.set_defaults(func=command_residue)
+    artifact = sub.add_parser("make-artifact")
+    artifact.add_argument("--output", required=True); artifact.add_argument("--pr-number", type=int, required=True)
+    artifact.add_argument("--web-sha", required=True); artifact.add_argument("--provider-sha", required=True)
+    artifact.add_argument("--catalog-sha256", required=True); artifact.add_argument("--inventory-sha256", required=True)
+    artifact.add_argument("--tree-sha256", required=True); artifact.add_argument("--asset-files", type=int, required=True)
+    artifact.add_argument("--perf-median-p95-ms", type=float, required=True)
+    artifact.add_argument("--kirk-visual-review", choices=("external-pending", "external-pass"), default="external-pending")
+    artifact.set_defaults(func=command_make_artifact)
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+        return 0
+    except (TrustError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        print(f"trusted gate rejected: {exc}", file=sys.stderr)
+        return 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/trusted-sandbox-canary.mjs
+++ b/scripts/trusted-sandbox-canary.mjs
@@ -1,0 +1,92 @@
+import dns from 'node:dns/promises';
+import fs from 'node:fs';
+import net from 'node:net';
+
+const fail = (message) => {
+  throw new Error(message);
+};
+const denied = async (fn, label) => {
+  try {
+    await fn();
+  } catch {
+    return true;
+  }
+  fail(`${label} unexpectedly available`);
+};
+const connect = (host, port) =>
+  new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error('timeout'));
+    }, 1500);
+    socket.once('connect', () => {
+      clearTimeout(timer);
+      socket.destroy();
+      resolve();
+    });
+    socket.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+
+if (process.getuid() === 0) fail('sandbox is root');
+const proxyKeys = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+];
+if (proxyKeys.some((key) => key in process.env))
+  fail('proxy control environment present');
+for (const path of [
+  '/var/run/docker.sock',
+  '/run/docker.sock',
+  '/run/containerd/containerd.sock',
+]) {
+  if (fs.existsSync(path)) fail('host control socket present');
+}
+await denied(() => dns.lookup('github.com'), 'DNS');
+await denied(() => connect('1.1.1.1', 443), 'public TCP');
+await denied(() => connect('172.17.0.1', 80), 'Docker host TCP');
+await denied(
+  () => fetch('https://api.github.com', { signal: AbortSignal.timeout(1500) }),
+  'GitHub HTTPS'
+);
+const assetRoot = '/workspace/public/models/synty';
+const queue = [assetRoot];
+let assetFile;
+while (queue.length && !assetFile) {
+  const dir = queue.pop();
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const path = `${dir}/${entry.name}`;
+    if (entry.isSymbolicLink()) fail('asset symlink present');
+    if (entry.isDirectory()) queue.push(path);
+    else if (entry.isFile()) {
+      assetFile = path;
+      break;
+    } else fail('asset special file present');
+  }
+}
+if (!assetFile) fail('asset stage empty');
+await denied(() => fs.promises.appendFile(assetFile, 'x'), 'asset write');
+fs.writeFileSync('/workspace/.sandbox-write-canary', 'ok');
+fs.unlinkSync('/workspace/.sandbox-write-canary');
+process.stdout.write(
+  JSON.stringify({
+    schema: 'sandbox-canary/v1',
+    dns: false,
+    tcp: false,
+    github: false,
+    proxy: false,
+    host: false,
+    socket: false,
+    assetsReadOnly: true,
+    nonroot: process.getuid() !== 0,
+  }) + '\n'
+);

--- a/scripts/trusted-sandbox.Dockerfile
+++ b/scripts/trusted-sandbox.Dockerfile
@@ -1,0 +1,2 @@
+FROM node:23-alpine
+RUN apk add --no-cache bash git python3 make g++


### PR DESCRIPTION
## Summary

Bootstraps the trusted default-main `workflow_dispatch` and landed helper/oracle required by #743. This PR changes only workflow/security-harness material.

- proves the executing definition is the released `main` workflow commit before live PR identity checks
- quarantines the exact same-repo/current `dev` PR head as data; no PR code runs before trusted provider staging and credential/provider deletion
- uses only protected Environment `licensed-assets` / `RPG_GAME_ASSETS_READ_TOKEN`, with no `ASSETS_READ_TOKEN` or missing-secret fallback
- fetches the strict PR provider lock, exact detached provider SHA, generator/catalog/inventory/verifier checks, and independently verifies the complete staged tree
- preinstalls dependencies with lifecycle scripts disabled before licensed bytes, then runs lifecycle/native CI/perf only in a nonroot, cap-dropped, no-new-privileges, `--network none` sandbox with read-only assets and private disposable logs
- publishes only one pinned-action, fixed-schema scalar/hash/matrix/perf JSON artifact after cleanup, then rechecks the entire live tuple and posts status only to the validated expected old SHA
- keeps local Kirk visual review external and records no screenshots/pixels

## Intentional fail-closed Docker blocker

The current trusted-base Dockerfile runs `npm ci` and `npm run build` as container root. GitHub-hosted `docker build` supports `--network=none` / `--pull=false` but has no build-time equivalents for `--cap-drop ALL` and `--security-opt no-new-privileges`. Warming its cache would also execute PR code before provider access. The trusted helper therefore constructs and validates the exact-base/allowlisted licensed context, rejects Dockerfile/ADD/symlink/context tricks, and then **fails before Docker invocation** rather than weakening the required boundary.

This is the exact documented hosted-runner limitation allowed by #743. The gate cannot green #742 until a separately reviewed trusted-base/container-build design can prove nonroot, cap-drop, no-new-privileges, offline cache completeness, and no pre-provider PR execution.

## Workflow graph

`trusted-preflight (no Environment/secret/provider) -> licensed protected job (prep -> provider verify/stage/scrub/delete -> no-egress lifecycle/full CI/perf -> checked context -> Docker fail closed -> cleanup) -> final live recheck / old-SHA status`

The workflow becomes dispatchable only after normal bootstrap `dev` landing, real merge-commit `dev -> main` release, and `main -> dev` synchronization.

## Verification

- `npm run ci-check` — PASS (format, lint, typecheck, production build, 2,513 Vitest tests)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — PASS (16 helper/oracle mutation tests)
- `scripts/tests/run_trusted_sandbox_integration.sh` — PASS
- pre-push hook reran full `npm run ci-check` — PASS
- `git diff --check` — PASS
- no product/runtime files, licensed bytes, secrets, screenshots, or #742 branch changes

Mutation coverage includes every trust field, stale/final races, a killed mutant removing live API SHA equality, missing/broad-only secret behavior, provider SHA/hash/tool identities, credential/config/env/provider residue, DNS/public-TCP/GitHub/proxy/Docker-host/socket/stdout probes, post-stage lifecycle egress, nonroot/read-only assets, Dockerfile/ADD/context symlinks, hosted-Docker fail-closed removal, inventory/tree hashes, bounded perf, and artifact field/archive/image/symlink/hardlink/token/URL/blob smuggling.

## Environment state (observed; unchanged)

`licensed-assets` exists, requires reviewer `KirkDiggler`, has admin bypass disabled, and currently has **zero Environment secrets**. Repository secret `ASSETS_READ_TOKEN` still exists but is not referenced. No secret was added or changed here. A same-named broad `RPG_GAME_ASSETS_READ_TOKEN` must remain absent because Actions does not expose secret-scope provenance at runtime.

Closes #743

— rpg-dnd5e-web member, on behalf of KirkDiggler
