### PR TITLE
fix(encounter-state): vacate pass no longer evicts a moved entity (#741)

### DIFF
--- a/src/hooks/useEncounterState.test.ts
+++ b/src/hooks/useEncounterState.test.ts
@@ -852,6 +852,90 @@ describe('v1alpha2 reducer additions', () => {
         );
       });
 
+      it('does not evict an entity whose position was updated cross-event by mergeEntityPosition (rpg-dnd5e-web#741)', () => {
+        // Reproduces the reported "I could only free roam as 1 of the
+        // characters": the OWN-move fast path (mergeEntityPosition, fed by
+        // MovementCompletedEvent) updates `entities` but deliberately never
+        // touches `revealedHexes` — see its own doc comment. A LATER,
+        // unrelated HexKnowledgeChanged event that happens to re-cover the
+        // entity's now-stale old hex must not read that stale listing as
+        // "not re-placed this event, so gone."
+        let state = seedKnownEntity(createEmptyEncounterState(), 'player-1');
+        const origin = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+          makePlacement('player-1'),
+        ]);
+        state = applyHexRecordsMerged(state, [origin]);
+        expect(state.entities.get('player-1')?.position).toEqual(
+          create(PositionSchema, { x: 0, y: 0, z: 0 })
+        );
+
+        // player-1's own move arrives via the OTHER reducer, in a SEPARATE
+        // event — revealedHexes is left completely untouched by this call.
+        state = mergeEntityPosition(
+          state,
+          'player-1',
+          create(PositionSchema, { x: 5, y: -3, z: -2 })
+        );
+        expect(state.entities.get('player-1')?.position).toEqual(
+          create(PositionSchema, { x: 5, y: -3, z: -2 })
+        );
+
+        // A later, unrelated HexKnowledgeChanged re-covers player-1's OLD
+        // hex (e.g. recomputed because a DIFFERENT player moved). It
+        // correctly reports nobody there — player-1 really did leave — but
+        // this event says nothing about player-1 at all.
+        const staleHexResighted = makeHexRecord(
+          { x: 0, y: 0, z: 0 },
+          HexState.VISIBLE,
+          []
+        );
+        state = applyHexRecordsMerged(state, [staleHexResighted]);
+
+        expect(state.entities.has('player-1')).toBe(true);
+        expect(state.entities.get('player-1')?.position).toEqual(
+          create(PositionSchema, { x: 5, y: -3, z: -2 })
+        );
+      });
+
+      it('setPlacement preserves movePath/moveSeq from an in-flight move when re-placing a known entity (rpg-dnd5e-web#741)', () => {
+        let state = seedKnownEntity(createEmptyEncounterState(), 'player-1');
+        const origin = makeHexRecord({ x: 0, y: 0, z: 0 }, HexState.VISIBLE, [
+          makePlacement('player-1'),
+        ]);
+        state = applyHexRecordsMerged(state, [origin]);
+
+        // A genuine move starts: mergeEntityPosition sets movePath/moveSeq
+        // alongside the new position — the OWN-move fast path, a separate
+        // event from any HexKnowledgeChanged.
+        const path = [
+          create(PositionSchema, { x: 0, y: 0, z: 0 }),
+          create(PositionSchema, { x: 1, y: -1, z: 0 }),
+        ];
+        state = mergeEntityPosition(
+          state,
+          'player-1',
+          create(PositionSchema, { x: 1, y: -1, z: 0 }),
+          path
+        );
+        expect(state.entities.get('player-1')?.moveSeq).toBe(1);
+        expect(state.entities.get('player-1')?.movePath).toEqual(path);
+
+        // A different player's fog update re-discloses player-1 at the
+        // SAME hex mid-walk, with a fresh authored facing — a bare
+        // position+facing match would short-circuit as a no-op, so use a
+        // changed facing to force setPlacement's re-placement path.
+        const refresh = makeHexRecord({ x: 1, y: -1, z: 0 }, HexState.VISIBLE, [
+          makePlacement('player-1', 3),
+        ]);
+        state = applyHexRecordsMerged(state, [refresh]);
+
+        expect(state.entities.get('player-1')?.facing).toBe(3);
+        // The walk animation's movePath/moveSeq must survive — setPlacement
+        // no longer rebuilds the record from scratch on re-placement.
+        expect(state.entities.get('player-1')?.moveSeq).toBe(1);
+        expect(state.entities.get('player-1')?.movePath).toEqual(path);
+      });
+
       it('an empty event changes nothing (same reference)', () => {
         const state = createEmptyEncounterState();
         expect(applyHexRecordsMerged(state, [])).toBe(state);

--- a/src/hooks/useEncounterState.ts
+++ b/src/hooks/useEncounterState.ts
@@ -706,10 +706,30 @@ export function applyHexRecordsMerged(
       return;
     }
     if (!nextEntities) nextEntities = new Map(prev.entities);
-    nextEntities.set(entityId, {
-      ...create(EntityStateSchema, { entityId, position }),
-      facing,
-    });
+    // Re-placing a KNOWN entity updates position/facing on its EXISTING
+    // record rather than rebuilding one from scratch (rpg-dnd5e-web#741).
+    // `create(EntityStateSchema, {entityId, position})` produces a bare
+    // record — `movePath`/`moveSeq` are client-added fields with no proto
+    // counterpart, so `create` never repopulates them, and every re-
+    // placement silently wiped whatever move was in flight. Concretely: an
+    // unrelated player's fog update re-covers this entity's hex mid-walk
+    // (the very same live-diff channel a genuine move also arrives on —
+    // see the module doc comment above), and the walk animation
+    // mergeEntityPosition just started gets cancelled/snapped instead of
+    // continuing. Carrying `existing` forward is safe even when position
+    // ALSO genuinely changes here: useHexMovePath only treats a move as
+    // "genuine" when `moveSeq` itself advances (see its own doc comment),
+    // and `moveSeq` is exclusively bumped by `mergeEntityPosition`, never
+    // by this function — so an unchanged `moveSeq` makes the animation hook
+    // snap straight to the fresh `position` below rather than replay a
+    // stale path. Only a never-before-seen entity (no `existing` record)
+    // falls back to a fresh EntityState.
+    nextEntities.set(
+      entityId,
+      existing
+        ? { ...existing, position, facing }
+        : { ...create(EntityStateSchema, { entityId, position }), facing }
+    );
   };
 
   // Pass 1: every VISIBLE placement this event. Always wins — set
@@ -750,13 +770,46 @@ export function applyHexRecordsMerged(
   // updates, and isn't re-placed anywhere else this event, is gone from the
   // cache. Reads only `prev.revealedHexes` (untouched by the two passes
   // above), so its own ordering relative to them doesn't matter.
+  //
+  // Invariant (rpg-dnd5e-web#741): only vacate an entity whose CURRENT
+  // `entities` position still matches the hex we're about to clear it from.
+  // `entities` and `revealedHexes` are two independently-updated indexes —
+  // `mergeEntityPosition` (the OWN-move fast path fed by
+  // MovementCompletedEvent, see its doc comment) updates only `entities`,
+  // deliberately never touching `revealedHexes`. That leaves a STALE
+  // placement for the mover sitting in their old hex's cached `contents`
+  // until some later event happens to re-cover that hex. Without this
+  // guard, that stale listing reads as "used to be here, not re-placed" for
+  // an event that has nothing to do with the mover at all — e.g. a
+  // DIFFERENT player's own move whose fog diff happens to re-touch the
+  // mover's old hex — and the mover gets deleted from `entities` even
+  // though `entities` already holds their correct, newer position. This is
+  // exactly the reported "I could only free roam as 1 of the characters":
+  // whoever moved last (via mergeEntityPosition) evicted the other tab's
+  // own entity on the next unrelated hex update. Comparing positions before
+  // deleting makes vacation correct regardless of event ordering: a cached
+  // hex record is only ever authoritative for an entity `entities` still
+  // agrees was last placed there — if the two disagree, `entities` (the
+  // newer write) wins and the vacate pass defers to it instead of
+  // overwriting it with stale information.
   for (const hex of positioned) {
     const key = hexKey(protoPositionToHex(hex.position));
     const oldContents = prev.revealedHexes.get(key)?.contents ?? [];
     for (const oldPlacement of oldContents) {
       if (placedThisEvent.has(oldPlacement.entityId)) continue;
-      if (!(nextEntities ?? prev.entities).has(oldPlacement.entityId)) {
-        continue;
+      const current = (nextEntities ?? prev.entities).get(
+        oldPlacement.entityId
+      );
+      if (!current) continue;
+      if (current.position) {
+        const hexPos = v2PositionToV1(hex.position);
+        if (
+          current.position.x !== hexPos.x ||
+          current.position.y !== hexPos.y ||
+          current.position.z !== hexPos.z
+        ) {
+          continue;
+        }
       }
       if (!nextEntities) nextEntities = new Map(prev.entities);
       nextEntities.delete(oldPlacement.entityId);


### PR DESCRIPTION
## Root cause

`useEncounterState.ts` keeps two independently-updated indexes for entity position: `entities` (the authoritative live cache) and `revealedHexes` (per-hex occupant listings). They can legitimately drift out of sync for one entity — your own:

- `mergeEntityPosition` (:386-403), the OWN-move fast path fed by `MovementCompletedEvent`, updates `entities` but **deliberately never touches `revealedHexes`** (that's documented, intentional — it has no way to know the full `HexRecord` shape for the destination hex).
- That leaves your OLD hex's cached `contents` still listing you until some later event happens to re-cover it.
- The **vacate pass** in `applyHexRecordsMerged` (:749-764, pre-fix) reads any entity present in an old cached hex record but absent from a NEW event covering that same hex, and not re-placed elsewhere in that event, as "gone" — and deletes it from `entities`.
- When a **different** player's own move triggers a `HexKnowledgeChanged` diff that happens to re-cover your stale old hex, that diff has nothing to do with you at all, but the vacate pass reads your stale listing there as "not re-placed" and deletes **you** from your own tab's state.

Downstream: `myPosition` undefined → "Waiting for your position…" overlay (`EncounterView.tsx:1624`), `pathPreview` permanently `[]` (`useHexInteraction.ts:236`), `HexGrid.tsx`'s `onHexClick` never fires `onMoveComplete` — clicks land, nothing happens, no error, no RPC. Symmetric: whoever moves last (via their own `mergeEntityPosition`) evicts the other tab. This is exactly Kirk's reported symptom: "I could only free roam as 1 of the characters" while controlling two players in two tabs.

## Fix shape chosen

Two options were on the table: (a) teach `mergeEntityPosition` to keep `revealedHexes` in sync, or (b) guard the vacate pass so it defers to `entities` when the two indexes disagree. **Chose (b).**

Option (a) would require synthesizing a full `HexRecord` proto (state, zoneId, edges, contents) for the destination hex from inside a reducer that only ever receives a bare `Position` — information it fundamentally doesn't have. It also duplicates position bookkeeping across two indexes the architecture otherwise keeps cleanly separated (see the module's own `applyHexRecordsMerged` doc comment on why `entities` and `revealedHexes` are reconciled only there).

Option (b) is a single, explainable invariant: **the vacate pass only deletes an entity when its CURRENT `entities` position still matches the hex being cleared.** When `entities` (the newer write, from a self-move) disagrees with a stale `revealedHexes` listing, the vacate pass defers to `entities` instead of overwriting it. This composes correctly regardless of which event happens to touch a given hex next, and needs no new proto construction.

## Secondary fix, same surface

`setPlacement` (the internal placement setter `applyHexRecordsMerged` uses) rebuilt a KNOWN entity's whole record from scratch via `create(EntityStateSchema, {entityId, position})` on every re-placement — silently wiping the client-added `movePath`/`moveSeq` fields (no proto counterpart, so `create` never repopulates them) every time an unrelated player's fog update happened to re-cover your hex mid-walk, cancelling your in-flight walk animation instead of letting it continue.

`setPlacement` now spreads the existing record forward (`{...existing, position, facing}`) when one exists, falling back to a fresh `EntityState` only for a never-before-seen entity. This is safe even when position also legitimately changes here: `useHexMovePath` only treats a move as "genuine" when `moveSeq` itself advances (its own doc comment), and `moveSeq` is exclusively bumped by `mergeEntityPosition` — never by `setPlacement` — so an unchanged `moveSeq` makes the animation hook snap straight to the fresh position rather than replay a stale path.

## Tests

Added to `src/hooks/useEncounterState.test.ts`:
- `does not evict an entity whose position was updated cross-event by mergeEntityPosition (#741)` — the exact repro shape: seed a hex placement, move via `mergeEntityPosition` (separate event, `revealedHexes` untouched), then apply an unrelated `HexKnowledgeChanged` re-covering the stale old hex with empty contents. Entity must survive with its NEW position.
- `setPlacement preserves movePath/moveSeq from an in-flight move when re-placing a known entity (#741)` — start a move via `mergeEntityPosition` (sets `moveSeq`/`movePath`), then re-place the same entity via a second `applyHexRecordsMerged` call with a changed facing (forces the update path past the no-op short-circuit). `moveSeq`/`movePath` must survive.

Full suite: **2515/2515 passing**. `npm run ci-checks` (format, lint, typecheck, build) and the pre-push hook (full suite + build) both green.

Not in scope (per the issue): `heldControlStoryIdsRef` input-lock semantics — a separate, softer path to dead input, noted in #741 but untouched here. There is also a server-side lost-update race under concurrent free-roam movement tracked as a separate rpg-api issue; this PR fixes the client-side desync only.

Fixes #741

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZB1QSaqAphp5J3rdREPR5