### PR TITLE
feat: add development-only toolkit contributor sandbox

### DIFF
--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -62,6 +62,14 @@ if npm run build > /dev/null 2>&1; then
     echo -e "${RED}✗ dist/themes/base.css is missing the combat-HUD styles (web#563 regression)${NC}"
     FAILED=1
   fi
+  # The contributor sandbox is development-only. Production must not even
+  # retain its fixed Dev identities or screen marker in a dead chunk.
+  if grep -R -q -E 'toolkit-sandbox-fighter|toolkit-sandbox-barbarian|Toolkit Contributor Sandbox' dist/assets 2>/dev/null; then
+    echo -e "${RED}✗ Production assets retain Toolkit Contributor Sandbox code${NC}"
+    FAILED=1
+  else
+    echo -e "${GREEN}✓ Production assets exclude Toolkit Contributor Sandbox code${NC}"
+  fi
 else
   echo -e "${RED}✗ Build failed${NC}"
   echo -e "${YELLOW}  Run 'npm run build' to see errors${NC}"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { ConceptsView } from './concepts/ConceptsView';
 import { ThumbHarness } from './dev/ThumbHarness';
 import { DiscordDebugPanel, useDiscord } from './discord';
 import { isToolkitContributorSandboxRoute } from './toolkit-contributor-sandbox/route';
+import { ToolkitContributorSandbox } from './toolkit-contributor-sandbox/ToolkitContributorSandbox';
 
 /**
  * Dev-only deep link: `?concept=<id>` opens the Concepts Lab directly and must
@@ -466,10 +467,7 @@ function App() {
       window.location.search
     )
   ) {
-    // Task 7 replaces this route-gated placeholder with the completed
-    // ToolkitContributorSandbox component. Keeping it inline preserves that
-    // task's required module-resolution RED while bypassing normal app state.
-    return <div>Toolkit Contributor Sandbox</div>;
+    return <ToolkitContributorSandbox />;
   }
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { ThemeSelector } from './components/ThemeSelector';
 import { ConceptsView } from './concepts/ConceptsView';
 import { ThumbHarness } from './dev/ThumbHarness';
 import { DiscordDebugPanel, useDiscord } from './discord';
+import { isToolkitContributorSandboxRoute } from './toolkit-contributor-sandbox/route';
 
 /**
  * Dev-only deep link: `?concept=<id>` opens the Concepts Lab directly and must
@@ -459,6 +460,18 @@ function HomeView({
 }
 
 function App() {
+  if (
+    isToolkitContributorSandboxRoute(
+      import.meta.env.MODE,
+      window.location.search
+    )
+  ) {
+    // Task 7 replaces this route-gated placeholder with the completed
+    // ToolkitContributorSandbox component. Keeping it inline preserves that
+    // task's required module-resolution RED while bypassing normal app state.
+    return <div>Toolkit Contributor Sandbox</div>;
+  }
+
   return (
     <CharacterDraftProvider>
       <AppContent />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { useListCharacters, useListDrafts } from './api/hooks';
 import { useDevPlayerIdAuth } from './api/useDevPlayerIdAuth';
 import { useMyActiveLobby } from './api/useMyActiveLobby';
@@ -18,7 +18,17 @@ import { ConceptsView } from './concepts/ConceptsView';
 import { ThumbHarness } from './dev/ThumbHarness';
 import { DiscordDebugPanel, useDiscord } from './discord';
 import { isToolkitContributorSandboxRoute } from './toolkit-contributor-sandbox/route';
-import { ToolkitContributorSandbox } from './toolkit-contributor-sandbox/ToolkitContributorSandbox';
+
+const LazyToolkitContributorSandbox =
+  import.meta.env.MODE === 'development'
+    ? lazy(() =>
+        import('./toolkit-contributor-sandbox/ToolkitContributorSandbox').then(
+          ({ ToolkitContributorSandbox }) => ({
+            default: ToolkitContributorSandbox,
+          })
+        )
+      )
+    : null;
 
 /**
  * Dev-only deep link: `?concept=<id>` opens the Concepts Lab directly and must
@@ -465,9 +475,14 @@ function App() {
     isToolkitContributorSandboxRoute(
       import.meta.env.MODE,
       window.location.search
-    )
+    ) &&
+    LazyToolkitContributorSandbox
   ) {
-    return <ToolkitContributorSandbox />;
+    return (
+      <Suspense fallback={null}>
+        <LazyToolkitContributorSandbox />
+      </Suspense>
+    );
   }
 
   return (

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -272,6 +272,65 @@ describe('DungeonBuilderConcept — injected sandbox contract', () => {
   });
 });
 
+describe('DungeonBuilderConcept — runtime draft-persistence opt-out', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('does not autosave any text after persistence is disabled at runtime', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const { rerender } = render(
+      <DungeonBuilderConcept forceFixtures persistDraft />
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000); // consume the normal mount skip
+    });
+    setItem.mockClear();
+
+    rerender(<DungeonBuilderConcept forceFixtures persistDraft={false} />);
+    fireEvent.change(screen.getByLabelText('Dungeon YAML'), {
+      target: { value: 'version: 1\nkey: edited-while-disabled\n' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it('resumes normal autosave only for edits made after persistence is re-enabled', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const { rerender } = render(
+      <DungeonBuilderConcept forceFixtures persistDraft={false} />
+    );
+
+    rerender(<DungeonBuilderConcept forceFixtures persistDraft />);
+    await act(async () => {
+      vi.advanceTimersByTime(1000); // the re-enabled mount skip
+    });
+    expect(setItem).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Dungeon YAML'), {
+      target: { value: 'version: 1\nkey: edited-after-reenable\n' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(setItem).toHaveBeenCalledOnce();
+    expect(JSON.parse(setItem.mock.calls[0][1]).yamlText).toBe(
+      'version: 1\nkey: edited-after-reenable\n'
+    );
+  });
+});
+
 describe('DungeonBuilderConcept — the live YAML pane is genuinely two-way (tooth 3)', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -228,15 +228,23 @@ describe('DungeonBuilderConcept — injected sandbox contract', () => {
     expect(screen.queryByRole('button', { name: 'Load .yaml' })).toBeNull();
     expect(screen.queryByLabelText('Load dungeon YAML file')).toBeNull();
 
-    await waitFor(() =>
-      expect(
-        (
-          screen.getByRole('button', {
-            name: /^Save/,
-          }) as HTMLButtonElement
-        ).disabled
-      ).toBe(false)
+    // The visible capability result proves the injected client completed
+    // liveness plus every concurrent per-field probe. Under the full
+    // parallel Vitest scheduler, that asynchronous prerequisite can take
+    // longer than Testing Library's one-second default. It remains a real
+    // readiness check: missing liveness/capability wiring never renders it.
+    await screen.findByText(
+      'server capabilities: accepts 17/17 dialect fields',
+      { exact: false },
+      { timeout: 3000 }
     );
+    expect(
+      (
+        screen.getByRole('button', {
+          name: /^Save/,
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(false);
     fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
 
     await waitFor(() => expect(onSaveSucceeded).toHaveBeenCalledTimes(1));

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -17,9 +17,27 @@
  * broken text intact and editable, never a thrown render exception and
  * never a silently-discarded draft.
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Code, ConnectError } from '@connectrpc/connect';
+import type { PutDungeonResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TOOLKIT_SANDBOX_YAML } from '../toolkit-contributor-sandbox/constants';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
+
+const hoisted = vi.hoisted(() => ({
+  globalPutDungeon: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  authoringClient: { putDungeon: hoisted.globalPutDungeon },
+}));
+
 import { DungeonBuilderConcept } from './DungeonBuilderConcept';
 
 /** `DungeonBuilderConcept.tsx`'s own `APPLY_DEBOUNCE_MS` (not exported —
@@ -156,6 +174,101 @@ describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident reg
     expect(screen.queryByLabelText('Dungeon YAML (recovery)')).toBeNull();
     expect(screen.getByLabelText('Dungeon YAML')).toBeTruthy();
     expect(screen.getByText(/Draft restored/)).toBeTruthy();
+  });
+});
+
+describe('DungeonBuilderConcept — injected sandbox contract', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    hoisted.globalPutDungeon.mockReset();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('uses only its injected client and literal template, disables draft persistence and sandbox-hidden controls, and calls back after a real save', async () => {
+    const editedDraft = TOOLKIT_SANDBOX_YAML.replace(
+      'Toolkit Contributor Sandbox',
+      'Local Draft Must Not Restore'
+    );
+    localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ yamlText: editedDraft, savedAt: Date.now() })
+    );
+    const getItem = vi.spyOn(Storage.prototype, 'getItem');
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const removeItem = vi.spyOn(Storage.prototype, 'removeItem');
+    const putDungeon = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ConnectError('bad key', Code.InvalidArgument) // liveness probe
+      )
+      .mockResolvedValue({
+        success: true,
+        fieldErrors: [],
+      } as unknown as PutDungeonResponse);
+    const onSaveSucceeded = vi.fn();
+
+    const props = {
+      initialYaml: TOOLKIT_SANDBOX_YAML,
+      authoringClient: { putDungeon },
+      persistDraft: false,
+      allowNewCanvas: false,
+      allowYamlFileIO: false,
+      onSaveSucceeded,
+      showSaveResultLink: false,
+    };
+    const { unmount } = render(<DungeonBuilderConcept {...props} />);
+
+    const pane = screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement;
+    expect(pane.value).toBe(TOOLKIT_SANDBOX_YAML);
+    expect(screen.queryByRole('button', { name: 'New Canvas' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Download .yaml' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Load .yaml' })).toBeNull();
+    expect(screen.queryByLabelText('Load dungeon YAML file')).toBeNull();
+
+    await waitFor(() =>
+      expect(
+        (
+          screen.getByRole('button', {
+            name: /^Save/,
+          }) as HTMLButtonElement
+        ).disabled
+      ).toBe(false)
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^Save/ }));
+
+    await waitFor(() => expect(onSaveSucceeded).toHaveBeenCalledTimes(1));
+    expect(onSaveSucceeded).toHaveBeenCalledWith('toolkit-contributor-sandbox');
+    expect(
+      putDungeon.mock.calls.some(
+        ([request]) =>
+          request.key === 'toolkit-contributor-sandbox' &&
+          request.validateOnly === false
+      )
+    ).toBe(true);
+    expect(
+      screen.getByText(/Saved as "toolkit-contributor-sandbox"/)
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('link', { name: 'http://localhost:3001/' })
+    ).toBeNull();
+    expect(hoisted.globalPutDungeon).not.toHaveBeenCalled();
+
+    fireEvent.change(pane, {
+      target: { value: editedDraft },
+    });
+    unmount();
+    render(<DungeonBuilderConcept {...props} />);
+
+    expect(
+      (screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement).value
+    ).toBe(TOOLKIT_SANDBOX_YAML);
+    expect(getItem).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
+    expect(hoisted.globalPutDungeon).not.toHaveBeenCalled();
   });
 });
 

--- a/src/author/DungeonBuilderConcept.tsx
+++ b/src/author/DungeonBuilderConcept.tsx
@@ -76,7 +76,7 @@ import {
   useCreationFloorPlanPreview,
   usePutDungeonPreview,
 } from './usePutDungeonPreview';
-import { useSaveDungeon } from './useSaveDungeon';
+import { useSaveDungeon, type AuthoringUnaryClient } from './useSaveDungeon';
 
 const APPLY_DEBOUNCE_MS = 700;
 
@@ -105,10 +105,24 @@ export interface DungeonBuilderConceptProps {
    * real `/author` mount (`AuthorView.tsx`) leaves it unset and gets
    * today's normal live-probing behavior, unchanged. */
   forceFixtures?: boolean;
+  initialYaml?: string;
+  authoringClient?: AuthoringUnaryClient;
+  persistDraft?: boolean;
+  allowNewCanvas?: boolean;
+  allowYamlFileIO?: boolean;
+  onSaveSucceeded?: (key: string) => void;
+  showSaveResultLink?: boolean;
 }
 
 export function DungeonBuilderConcept({
   forceFixtures = false,
+  initialYaml,
+  authoringClient,
+  persistDraft = true,
+  allowNewCanvas = true,
+  allowYamlFileIO = true,
+  onSaveSucceeded,
+  showSaveResultLink = true,
 }: DungeonBuilderConceptProps = {}) {
   const [toast, setToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -133,7 +147,12 @@ export function DungeonBuilderConcept({
   // no-document case — its per-edit live-preview effect no-ops entirely,
   // leaving only the mount-time reachability probe and capability suite
   // live, which is exactly what this component still needs from it.
-  const preview = usePutDungeonPreview(null, '', forceFixtures);
+  const preview = usePutDungeonPreview(
+    null,
+    '',
+    forceFixtures,
+    authoringClient
+  );
 
   const flashToast = (message: string) => {
     setToast(message);
@@ -182,11 +201,10 @@ export function DungeonBuilderConcept({
       crash: creationInitialCrash,
     },
   ] = useState(() => {
-    const freshCreationSeed = emptyCanvasYaml(
-      DEFAULT_CANVAS.width,
-      DEFAULT_CANVAS.height
-    );
-    const draft = loadDraft('create');
+    const freshCreationSeed =
+      initialYaml ??
+      emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height);
+    const draft = persistDraft ? loadDraft('create') : null;
     if (draft) {
       if (
         draftDiffersFromFreshSeed(
@@ -212,7 +230,7 @@ export function DungeonBuilderConcept({
             } as CreationCrash | null,
           };
         }
-      } else {
+      } else if (persistDraft) {
         discardDraft('create');
       }
     }
@@ -232,7 +250,9 @@ export function DungeonBuilderConcept({
     creationInitial.doc
   );
   const [creationYamlText, setCreationYamlText] = useState(() =>
-    serializeDungeon(creationInitial.cst)
+    initialYaml !== undefined && !persistDraft
+      ? initialYaml
+      : serializeDungeon(creationInitial.cst)
   );
   const [creationSelectedTool, setCreationSelectedTool] =
     useState<BoardTool | null>('wall');
@@ -258,7 +278,8 @@ export function DungeonBuilderConcept({
     creationDoc,
     creationYamlText,
     preview.serverState,
-    preview.capabilities
+    preview.capabilities,
+    authoringClient
   );
 
   // Creation mode's own Save & Play (capability-probed graduation unit).
@@ -266,7 +287,7 @@ export function DungeonBuilderConcept({
   // which document is being viewed, so probing once (on the shared
   // `usePutDungeonPreview` instance) is correct for creation mode's own
   // strip too — no second probe needed.
-  const creationSave = useSaveDungeon();
+  const creationSave = useSaveDungeon(authoringClient, onSaveSucceeded);
   const creationV1Subset = useMemo(() => {
     try {
       return stripToV1Subset(
@@ -452,17 +473,25 @@ export function DungeonBuilderConcept({
   );
 
   // Local drafts — creation mode's own autosave.
-  const createAutosave = useDraftAutosave('create', creationYamlText);
+  const createAutosave = useDraftAutosave(
+    'create',
+    persistDraft ? creationYamlText : ''
+  );
 
   const handleDiscardCreateDraft = () => {
-    discardDraft('create');
+    if (persistDraft) discardDraft('create');
     createAutosave.skipNextTick();
     const fresh = parseDungeon(
-      emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
+      initialYaml ??
+        emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
     );
     setCreationCst(fresh.cst);
     setCreationDoc(fresh.doc);
-    setCreationYamlText(serializeDungeon(fresh.cst));
+    setCreationYamlText(
+      initialYaml !== undefined && !persistDraft
+        ? initialYaml
+        : serializeDungeon(fresh.cst)
+    );
     setCreationParseError(null);
     creationEdit.setSelectedPlacement(null);
     setCreateDraftBannerDismissed(true);
@@ -592,6 +621,7 @@ export function DungeonBuilderConcept({
             onToggleHole={handleCreationToggleHole}
             onSetPoint={handleCreationSetPoint}
             onNewCanvas={handleNewCanvas}
+            allowNewCanvas={allowNewCanvas}
             toast={flashToast}
             regionEdit={regionEdit}
             paletteCollapsed={createPaletteCollapsed}
@@ -613,6 +643,8 @@ export function DungeonBuilderConcept({
             yamlDownloadFilename={creationDownloadFilename}
             onLoadYamlFile={handleLoadCreationYamlFile}
             onLoadYamlFileError={handleLoadCreationYamlFileError}
+            allowYamlFileIO={allowYamlFileIO}
+            showSaveResultLink={showSaveResultLink}
             specCompat={creationSpecCompat}
           />
         </ErrorBoundary>

--- a/src/author/DungeonBuilderConcept.tsx
+++ b/src/author/DungeonBuilderConcept.tsx
@@ -37,7 +37,13 @@
  * interactive drag actually calls) are untouched.
  */
 import { ErrorBoundary } from '@/components/ui/Feedback/ErrorBoundary';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from 'react';
 import { BoardCrashRecovery } from './BoardCrashRecovery';
 import { CreationConcept } from './creation/CreationConcept';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
@@ -71,7 +77,7 @@ import {
 import { buildSpecCompatReport } from './specCompat';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
-import { useDraftAutosave } from './useDraftAutosave';
+import { useDraftAutosave, type DraftAutosave } from './useDraftAutosave';
 import {
   useCreationFloorPlanPreview,
   usePutDungeonPreview,
@@ -262,6 +268,7 @@ export function DungeonBuilderConcept({
   const creationApplyDebounce = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
+  const createAutosaveRef = useRef<DraftAutosave | null>(null);
 
   // Creation mode's own live FloorPlan preview (v0.3 wire consumption
   // unit, 2026-08-05) — same "reuse the shared serverState/capabilities,
@@ -472,15 +479,11 @@ export function DungeonBuilderConcept({
     []
   );
 
-  // Local drafts — creation mode's own autosave.
-  const createAutosave = useDraftAutosave(
-    'create',
-    persistDraft ? creationYamlText : ''
-  );
-
   const handleDiscardCreateDraft = () => {
-    if (persistDraft) discardDraft('create');
-    createAutosave.skipNextTick();
+    if (persistDraft) {
+      discardDraft('create');
+      createAutosaveRef.current?.skipNextTick();
+    }
     const fresh = parseDungeon(
       initialYaml ??
         emptyCanvasYaml(DEFAULT_CANVAS.width, DEFAULT_CANVAS.height)
@@ -567,8 +570,16 @@ export function DungeonBuilderConcept({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [creationEdit.selectedPlacement, creationCst]);
 
+  // Keep draft autosave in its own child so switching persistence off
+  // unmounts it and cancels any pending debounce before it can write.
   return (
     <div>
+      {persistDraft && (
+        <CreationDraftAutosave
+          yamlText={creationYamlText}
+          autosaveRef={createAutosaveRef}
+        />
+      )}
       {createRestoredDraftAt !== null && !createDraftBannerDismissed && (
         <DraftRestoredBanner
           savedAt={createRestoredDraftAt}
@@ -652,6 +663,25 @@ export function DungeonBuilderConcept({
       {toast && <ToastBanner message={toast} />}
     </div>
   );
+}
+
+function CreationDraftAutosave({
+  yamlText,
+  autosaveRef,
+}: {
+  yamlText: string;
+  autosaveRef: MutableRefObject<DraftAutosave | null>;
+}) {
+  const autosave = useDraftAutosave('create', yamlText);
+
+  useEffect(() => {
+    autosaveRef.current = autosave;
+    return () => {
+      autosaveRef.current = null;
+    };
+  }, [autosave, autosaveRef]);
+
+  return null;
 }
 
 function ToastBanner({ message }: { message: string }) {

--- a/src/author/YamlPane.test.tsx
+++ b/src/author/YamlPane.test.tsx
@@ -13,6 +13,7 @@
  * vitest config has no such setup (`vite.config.ts`'s `test` block), so
  * assertions use plain DOM properties.
  */
+import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { DialectField, ServerCapabilities } from './capabilityProbe';
@@ -21,6 +22,7 @@ import {
   CapabilitiesLine,
   CompileBadgeStrip,
   SaveAndPlayButton,
+  SaveResultPanel,
 } from './YamlPane';
 
 function allCapabilities(accepted: DialectField[]): ServerCapabilities {
@@ -183,6 +185,58 @@ describe('CompileBadgeStrip — dual compiling/dropped halves', () => {
     expect(container.textContent).toContain(
       'Uses: 1 hole — not yet accepted by this server'
     );
+  });
+});
+
+describe('SaveResultPanel — optional generic lobby link', () => {
+  it('hides only the generic lobby anchor while retaining saved feedback', () => {
+    render(
+      <SaveResultPanel
+        saveState="saved"
+        savedKey="toolkit-contributor-sandbox"
+        saveFieldErrors={[]}
+        saveErrorMessage={null}
+        showLobbyLink={false}
+      />
+    );
+
+    expect(
+      screen.getByText(/Saved as "toolkit-contributor-sandbox"/)
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('link', { name: 'http://localhost:3001/' })
+    ).toBeNull();
+  });
+
+  it('retains validation feedback while the generic lobby anchor is hidden', () => {
+    render(
+      <SaveResultPanel
+        saveState="invalid"
+        savedKey={null}
+        saveFieldErrors={[
+          { field: '', message: 'boss required' } as unknown as ValidationError,
+        ]}
+        saveErrorMessage={null}
+        showLobbyLink={false}
+      />
+    );
+
+    expect(screen.getByText(/Save rejected/)).toBeTruthy();
+    expect(screen.getByText('boss required')).toBeTruthy();
+  });
+
+  it('retains transport feedback while the generic lobby anchor is hidden', () => {
+    render(
+      <SaveResultPanel
+        saveState="error"
+        savedKey={null}
+        saveFieldErrors={[]}
+        saveErrorMessage="Failed to fetch"
+        showLobbyLink={false}
+      />
+    );
+
+    expect(screen.getByText('Save failed: Failed to fetch')).toBeTruthy();
   });
 });
 

--- a/src/author/YamlPane.tsx
+++ b/src/author/YamlPane.tsx
@@ -391,12 +391,14 @@ export function SaveResultPanel({
   saveFieldErrors,
   saveErrorMessage,
   honestyNote,
+  showLobbyLink = true,
 }: {
   saveState: SaveState;
   savedKey: string | null;
   saveFieldErrors: ValidationError[];
   saveErrorMessage: string | null;
   honestyNote?: string;
+  showLobbyLink?: boolean;
 }) {
   if (saveState === 'saved') {
     return (
@@ -410,16 +412,22 @@ export function SaveResultPanel({
           lineHeight: 1.5,
         }}
       >
-        <strong>Saved as "{savedKey}".</strong> Open{' '}
-        <a
-          href="http://localhost:3001/"
-          target="_blank"
-          rel="noreferrer"
-          style={{ color: '#5fd1c9' }}
-        >
-          http://localhost:3001/
-        </a>{' '}
-        and pick "{savedKey}" in the dungeon dropdown to play it.
+        <strong>Saved as "{savedKey}".</strong>
+        {showLobbyLink && (
+          <>
+            {' '}
+            Open{' '}
+            <a
+              href="http://localhost:3001/"
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: '#5fd1c9' }}
+            >
+              http://localhost:3001/
+            </a>{' '}
+            and pick "{savedKey}" in the dungeon dropdown to play it.
+          </>
+        )}
         {honestyNote && (
           <div style={{ color: '#ffb347', marginTop: 4 }}>{honestyNote}</div>
         )}

--- a/src/author/capabilityProbe.test.ts
+++ b/src/author/capabilityProbe.test.ts
@@ -186,6 +186,21 @@ describe('probeAllCapabilities', () => {
       expect(req.validateOnly).toBe(true);
     }
   });
+
+  it('uses a supplied client for every validate-only probe without touching the global client', async () => {
+    const putDungeon = vi.fn().mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    });
+
+    await probeAllCapabilities({ putDungeon });
+
+    expect(putDungeon).toHaveBeenCalledTimes(DIALECT_FIELDS.length);
+    for (const [request] of putDungeon.mock.calls) {
+      expect(request.validateOnly).toBe(true);
+    }
+    expect(hoisted.putDungeonFn).not.toHaveBeenCalled();
+  });
 });
 
 // The fields whose only legal document mode is canvas mode (spec v0.3

--- a/src/author/capabilityProbe.ts
+++ b/src/author/capabilityProbe.ts
@@ -100,6 +100,7 @@ import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';
 import type { PutDungeonResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { PutDungeonRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import type { AuthoringUnaryClient } from './useSaveDungeon';
 
 /** One entry per target-dialect construct `stripToV1Subset` knows how to
  * drop. `facing` is split into 4 entry-type variants because the real
@@ -564,12 +565,14 @@ function classify(response: PutDungeonResponse): CapabilityResult {
  *   Not re-derived here — threaded verbatim from the server either way,
  *   per this module's own rule.
  */
-export async function probeAllCapabilities(): Promise<ServerCapabilities> {
+export async function probeAllCapabilities(
+  client: AuthoringUnaryClient = authoringClient
+): Promise<ServerCapabilities> {
   const entries = await Promise.all(
     DIALECT_FIELDS.map(async (field) => {
       const key = `capprobe-${field.toLowerCase()}`;
       try {
-        const response = await authoringClient.putDungeon(
+        const response = await client.putDungeon(
           create(PutDungeonRequestSchema, {
             key,
             yaml: buildProbeDoc(field, key),

--- a/src/author/creation/CreationConcept.tsx
+++ b/src/author/creation/CreationConcept.tsx
@@ -72,6 +72,7 @@ interface CreationConceptProps {
   onToggleHole: (col: number, row: number) => void;
   onSetPoint: (kind: 'start' | 'end', col: number, row: number) => void;
   onNewCanvas: (width: number, height: number) => void;
+  allowNewCanvas: boolean;
   toast: (message: string) => void;
   /** Cell-authored semantic region editing (rpg-project#180) —
    * creation-mode-only this round. See `useRegionEditing.ts`. */
@@ -118,6 +119,8 @@ interface CreationConceptProps {
   yamlDownloadFilename: string;
   onLoadYamlFile: (text: string) => void;
   onLoadYamlFileError: (message: string) => void;
+  allowYamlFileIO: boolean;
+  showSaveResultLink: boolean;
   specCompat: SpecCompatReport;
 }
 
@@ -137,6 +140,7 @@ export function CreationConcept({
   onToggleHole,
   onSetPoint,
   onNewCanvas,
+  allowNewCanvas,
   toast,
   regionEdit,
   paletteCollapsed,
@@ -158,6 +162,8 @@ export function CreationConcept({
   yamlDownloadFilename,
   onLoadYamlFile,
   onLoadYamlFileError,
+  allowYamlFileIO,
+  showSaveResultLink,
   specCompat,
 }: CreationConceptProps) {
   const [dims, setDims] = useState(DEFAULT_CANVAS);
@@ -227,75 +233,77 @@ export function CreationConcept({
           20×30 room → draw walls → start/end → door → monster → reaper statue,
           facing this way
         </span>
-        <div
-          style={{
-            marginLeft: 'auto',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            fontSize: 12,
-          }}
-        >
-          <label>
-            W:{' '}
-            <input
-              type="number"
-              min={4}
-              max={60}
-              value={dims.width}
-              onChange={(e) =>
-                setDims((d) => ({
-                  ...d,
-                  width: Number(e.target.value) || d.width,
-                }))
-              }
-              style={{
-                width: 48,
-                background: 'var(--bg-secondary)',
-                color: 'var(--text-primary)',
-                border: '1px solid var(--border-primary)',
-                borderRadius: 4,
-              }}
-            />
-          </label>
-          <label>
-            H:{' '}
-            <input
-              type="number"
-              min={4}
-              max={60}
-              value={dims.height}
-              onChange={(e) =>
-                setDims((d) => ({
-                  ...d,
-                  height: Number(e.target.value) || d.height,
-                }))
-              }
-              style={{
-                width: 48,
-                background: 'var(--bg-secondary)',
-                color: 'var(--text-primary)',
-                border: '1px solid var(--border-primary)',
-                borderRadius: 4,
-              }}
-            />
-          </label>
-          <button
-            onClick={() => onNewCanvas(dims.width, dims.height)}
+        {allowNewCanvas && (
+          <div
             style={{
-              background: '#c9a227',
-              color: '#14110f',
-              border: 'none',
-              borderRadius: 4,
-              padding: '4px 10px',
+              marginLeft: 'auto',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
               fontSize: 12,
-              fontWeight: 600,
-              cursor: 'pointer',
             }}
           >
-            New Canvas
-          </button>
-        </div>
+            <label>
+              W:{' '}
+              <input
+                type="number"
+                min={4}
+                max={60}
+                value={dims.width}
+                onChange={(e) =>
+                  setDims((d) => ({
+                    ...d,
+                    width: Number(e.target.value) || d.width,
+                  }))
+                }
+                style={{
+                  width: 48,
+                  background: 'var(--bg-secondary)',
+                  color: 'var(--text-primary)',
+                  border: '1px solid var(--border-primary)',
+                  borderRadius: 4,
+                }}
+              />
+            </label>
+            <label>
+              H:{' '}
+              <input
+                type="number"
+                min={4}
+                max={60}
+                value={dims.height}
+                onChange={(e) =>
+                  setDims((d) => ({
+                    ...d,
+                    height: Number(e.target.value) || d.height,
+                  }))
+                }
+                style={{
+                  width: 48,
+                  background: 'var(--bg-secondary)',
+                  color: 'var(--text-primary)',
+                  border: '1px solid var(--border-primary)',
+                  borderRadius: 4,
+                }}
+              />
+            </label>
+            <button
+              onClick={() => onNewCanvas(dims.width, dims.height)}
+              style={{
+                background: '#c9a227',
+                color: '#14110f',
+                border: 'none',
+                borderRadius: 4,
+                padding: '4px 10px',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              New Canvas
+            </button>
+          </div>
+        )}
         <div
           role="group"
           aria-label="2D or 3D board"
@@ -468,6 +476,8 @@ export function CreationConcept({
             downloadFilename={yamlDownloadFilename}
             onLoadFile={onLoadYamlFile}
             onLoadFileError={onLoadYamlFileError}
+            allowYamlFileIO={allowYamlFileIO}
+            showSaveResultLink={showSaveResultLink}
             specCompat={specCompat}
           />
         </CollapsibleSidePanel>

--- a/src/author/creation/ProposedYamlPane.tsx
+++ b/src/author/creation/ProposedYamlPane.tsx
@@ -64,6 +64,8 @@ interface ProposedYamlPaneProps {
   downloadFilename: string;
   onLoadFile: (text: string) => void;
   onLoadFileError: (message: string) => void;
+  allowYamlFileIO: boolean;
+  showSaveResultLink: boolean;
   specCompat: SpecCompatReport;
 }
 
@@ -83,6 +85,8 @@ export function ProposedYamlPane({
   downloadFilename,
   onLoadFile,
   onLoadFileError,
+  allowYamlFileIO,
+  showSaveResultLink,
   specCompat,
 }: ProposedYamlPaneProps) {
   const dropped = v1Subset?.dropped ?? [];
@@ -110,10 +114,15 @@ export function ProposedYamlPane({
           gap: 4,
         }}
       >
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <DownloadYamlButton yamlText={yamlText} filename={downloadFilename} />
-          <LoadYamlButton onLoad={onLoadFile} onLoadError={onLoadFileError} />
-        </div>
+        {allowYamlFileIO && (
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <DownloadYamlButton
+              yamlText={yamlText}
+              filename={downloadFilename}
+            />
+            <LoadYamlButton onLoad={onLoadFile} onLoadError={onLoadFileError} />
+          </div>
+        )}
         <CapabilitiesLine
           serverState={serverState}
           capabilities={capabilities}
@@ -169,6 +178,7 @@ export function ProposedYamlPane({
         savedKey={savedKey}
         saveFieldErrors={saveFieldErrors}
         saveErrorMessage={saveErrorMessage}
+        showLobbyLink={showSaveResultLink}
         honestyNote={
           hasDialectFields
             ? `Saved the compilable subset — dropped: ${dropped.join(', ')}.${compiling.length > 0 ? ` Compiled for real: ${compiling.join(', ')}.` : ''} (see TARGET-YAML.md).`

--- a/src/author/usePutDungeonPreview.test.ts
+++ b/src/author/usePutDungeonPreview.test.ts
@@ -15,7 +15,10 @@ vi.mock('@/api/client', () => ({
 import { capabilitySummary, DIALECT_FIELDS } from './capabilityProbe';
 import { parseDungeon } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
-import { usePutDungeonPreview } from './usePutDungeonPreview';
+import {
+  useCreationFloorPlanPreview,
+  usePutDungeonPreview,
+} from './usePutDungeonPreview';
 
 const { doc } = parseDungeon(SHOWCASE_YAML);
 
@@ -197,6 +200,70 @@ describe('usePutDungeonPreview — live mode per-edit preview', () => {
       timeout: 2000,
     });
     expect(result.current.fieldErrors).toEqual([]);
+  });
+});
+
+describe('usePutDungeonPreview — supplied authoring client', () => {
+  it('uses the supplied client for liveness, capabilities, and live preview without touching the global client', async () => {
+    const putDungeon = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new ConnectError('bad key', Code.InvalidArgument) // liveness probe
+      )
+      .mockResolvedValue({
+        success: true,
+        fieldErrors: [],
+      } as unknown as PutDungeonResponse);
+
+    renderHook(() =>
+      usePutDungeonPreview(doc, SHOWCASE_YAML, false, { putDungeon })
+    );
+
+    await waitFor(() =>
+      expect(putDungeon).toHaveBeenCalledWith(
+        expect.objectContaining({ key: '', validateOnly: true })
+      )
+    );
+    await waitFor(
+      () =>
+        expect(
+          putDungeon.mock.calls.some(
+            ([request]) =>
+              request.key === doc.key && request.validateOnly === true
+          )
+        ).toBe(true),
+      { timeout: 2000 }
+    );
+
+    expect(
+      putDungeon.mock.calls.some(
+        ([request]) =>
+          request.key.startsWith('capprobe-') && request.validateOnly === true
+      )
+    ).toBe(true);
+    expect(hoisted.putDungeonFn).not.toHaveBeenCalled();
+  });
+
+  it('uses the supplied client for creation-mode validate-only previews without touching the global client', async () => {
+    const putDungeon = vi.fn().mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+
+    renderHook(() =>
+      useCreationFloorPlanPreview(doc, SHOWCASE_YAML, 'live', null, {
+        putDungeon,
+      })
+    );
+
+    await waitFor(
+      () =>
+        expect(putDungeon).toHaveBeenCalledWith(
+          expect.objectContaining({ key: doc.key, validateOnly: true })
+        ),
+      { timeout: 2000 }
+    );
+    expect(hoisted.putDungeonFn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/author/usePutDungeonPreview.ts
+++ b/src/author/usePutDungeonPreview.ts
@@ -80,7 +80,7 @@ import {
   type FloorPlan,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type { ValidationError } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/common_pb';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   probeAllCapabilities,
   type ServerCapabilities,
@@ -88,6 +88,7 @@ import {
 import { stripToV1Subset, type DungeonDoc } from './dungeonYaml';
 import { SHOWCASE_FLOORPLAN } from './fixtures';
 import { compileFloorPlanLocally } from './floorPlanCompile';
+import type { AuthoringUnaryClient } from './useSaveDungeon';
 
 export type ServerState = 'probing' | 'live' | 'gate-off' | 'unreachable';
 
@@ -168,7 +169,8 @@ type LiveCompileResult =
 async function compileLive(
   doc: DungeonDoc,
   yamlText: string,
-  capabilities: ServerCapabilities | null
+  capabilities: ServerCapabilities | null,
+  client: AuthoringUnaryClient
 ): Promise<LiveCompileResult> {
   let subsetYaml: string;
   try {
@@ -181,7 +183,7 @@ async function compileLive(
     return { kind: 'unparseable' };
   }
   try {
-    const response = await authoringClient.putDungeon(
+    const response = await client.putDungeon(
       create(PutDungeonRequestSchema, {
         key: doc.key,
         yaml: subsetYaml,
@@ -217,7 +219,8 @@ export function usePutDungeonPreview(
    * regardless of whether one happens to be reachable. The real `/author`
    * mount (`AuthorView.tsx`) omits this and gets today's normal
    * live-probing behavior unchanged. */
-  forceFixtures = false
+  forceFixtures = false,
+  client: AuthoringUnaryClient = authoringClient
 ): UsePutDungeonPreviewResult {
   const [serverState, setServerState] = useState<ServerState>(
     forceFixtures ? 'gate-off' : 'probing'
@@ -231,6 +234,8 @@ export function usePutDungeonPreview(
   );
   const [capabilitiesNonce, setCapabilitiesNonce] = useState(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const putDungeon = client.putDungeon;
+  const resolvedClient = useMemo(() => ({ putDungeon }), [putDungeon]);
 
   // Mount-time (and manual retry) probe — never runs at all when
   // `forceFixtures` is set (see this function's own param doc comment).
@@ -243,7 +248,7 @@ export function usePutDungeonPreview(
     setServerState('probing');
     (async () => {
       try {
-        await authoringClient.putDungeon(
+        await resolvedClient.putDungeon(
           create(PutDungeonRequestSchema, {
             key: '',
             yaml: '',
@@ -260,7 +265,7 @@ export function usePutDungeonPreview(
     return () => {
       cancelled = true;
     };
-  }, [probeNonce, forceFixtures]);
+  }, [probeNonce, forceFixtures, resolvedClient]);
 
   // Capability probe: runs once per live connection (this effect's own
   // `serverState` dependency covers both the initial live transition and
@@ -275,13 +280,13 @@ export function usePutDungeonPreview(
       return;
     }
     let cancelled = false;
-    probeAllCapabilities().then((caps) => {
+    probeAllCapabilities(resolvedClient).then((caps) => {
       if (!cancelled) setCapabilities(caps);
     });
     return () => {
       cancelled = true;
     };
-  }, [serverState, capabilitiesNonce]);
+  }, [serverState, capabilitiesNonce, resolvedClient]);
 
   // Live per-edit preview, debounced, only while the probe found the gate on.
   useEffect(() => {
@@ -290,7 +295,12 @@ export function usePutDungeonPreview(
     debounceRef.current = setTimeout(() => {
       (async () => {
         setRequestError(null);
-        const result = await compileLive(doc, yamlText, capabilities);
+        const result = await compileLive(
+          doc,
+          yamlText,
+          capabilities,
+          resolvedClient
+        );
         switch (result.kind) {
           case 'unparseable':
             return;
@@ -315,7 +325,7 @@ export function usePutDungeonPreview(
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [serverState, doc, yamlText, capabilities]);
+  }, [serverState, doc, yamlText, capabilities, resolvedClient]);
 
   const fallbackFloorPlan = doc
     ? doc.key === 'showcase'
@@ -380,10 +390,13 @@ export function useCreationFloorPlanPreview(
   doc: DungeonDoc | null,
   yamlText: string,
   serverState: ServerState,
-  capabilities: ServerCapabilities | null
+  capabilities: ServerCapabilities | null,
+  client: AuthoringUnaryClient = authoringClient
 ): { floorPlan: FloorPlan | null } {
   const [liveFloorPlan, setLiveFloorPlan] = useState<FloorPlan | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const putDungeon = client.putDungeon;
+  const resolvedClient = useMemo(() => ({ putDungeon }), [putDungeon]);
 
   useEffect(() => {
     if (serverState !== 'live' || !doc) {
@@ -396,21 +409,23 @@ export function useCreationFloorPlanPreview(
     }
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      compileLive(doc, yamlText, capabilities).then((result) => {
-        if (result.kind === 'success') setLiveFloorPlan(result.floorPlan);
-        // 'unparseable' (mid-edit)/'field-errors'/'unreachable'/
-        // 'request-error': keep the last-good floor plan on screen,
-        // matching `usePutDungeonPreview`'s own field-errors discipline —
-        // this hook has no field_errors surface of its own (creation
-        // mode's own validation feedback is out of this unit's scope),
-        // so every non-success outcome is treated the same way here:
-        // don't blank a plan that was already rendering.
-      });
+      compileLive(doc, yamlText, capabilities, resolvedClient).then(
+        (result) => {
+          if (result.kind === 'success') setLiveFloorPlan(result.floorPlan);
+          // 'unparseable' (mid-edit)/'field-errors'/'unreachable'/
+          // 'request-error': keep the last-good floor plan on screen,
+          // matching `usePutDungeonPreview`'s own field-errors discipline —
+          // this hook has no field_errors surface of its own (creation
+          // mode's own validation feedback is out of this unit's scope),
+          // so every non-success outcome is treated the same way here:
+          // don't blank a plan that was already rendering.
+        }
+      );
     }, DEBOUNCE_MS);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [serverState, doc, yamlText, capabilities]);
+  }, [serverState, doc, yamlText, capabilities, resolvedClient]);
 
   return { floorPlan: liveFloorPlan };
 }

--- a/src/author/useSaveDungeon.test.ts
+++ b/src/author/useSaveDungeon.test.ts
@@ -138,4 +138,68 @@ describe('useSaveDungeon', () => {
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.fieldErrors).toEqual([]);
   });
+
+  it('uses a supplied client for an explicit non-validate save and calls its success callback with the exact request key once', async () => {
+    const putDungeon = vi.fn().mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+    const onSaveSucceeded = vi.fn();
+    const { result } = renderHook(() =>
+      useSaveDungeon({ putDungeon }, onSaveSucceeded)
+    );
+
+    act(() => {
+      result.current.save(
+        'toolkit-contributor-sandbox',
+        'version: 1\nkey: toolkit-contributor-sandbox\n'
+      );
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('saved'));
+    expect(putDungeon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'toolkit-contributor-sandbox',
+        validateOnly: false,
+      })
+    );
+    expect(hoisted.putDungeonFn).not.toHaveBeenCalled();
+    expect(onSaveSucceeded).toHaveBeenCalledTimes(1);
+    expect(onSaveSucceeded).toHaveBeenCalledWith('toolkit-contributor-sandbox');
+  });
+
+  it('does not call the supplied success callback for a validation rejection', async () => {
+    const putDungeon = vi.fn().mockResolvedValue({
+      success: false,
+      fieldErrors: [{ field: '', message: 'invalid dungeon' }],
+    } as unknown as PutDungeonResponse);
+    const onSaveSucceeded = vi.fn();
+    const { result } = renderHook(() =>
+      useSaveDungeon({ putDungeon }, onSaveSucceeded)
+    );
+
+    act(() => {
+      result.current.save('toolkit-contributor-sandbox', 'invalid');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('invalid'));
+    expect(onSaveSucceeded).not.toHaveBeenCalled();
+  });
+
+  it('does not call the supplied success callback when the save throws', async () => {
+    const putDungeon = vi
+      .fn()
+      .mockRejectedValue(new TypeError('Failed to fetch'));
+    const onSaveSucceeded = vi.fn();
+    const { result } = renderHook(() =>
+      useSaveDungeon({ putDungeon }, onSaveSucceeded)
+    );
+
+    act(() => {
+      result.current.save('toolkit-contributor-sandbox', 'invalid');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('error'));
+    expect(onSaveSucceeded).not.toHaveBeenCalled();
+  });
 });

--- a/src/author/useSaveDungeon.test.ts
+++ b/src/author/useSaveDungeon.test.ts
@@ -168,6 +168,54 @@ describe('useSaveDungeon', () => {
     expect(onSaveSucceeded).toHaveBeenCalledWith('toolkit-contributor-sandbox');
   });
 
+  it('keeps a successful save saved when its consumer callback throws', async () => {
+    const putDungeon = vi.fn().mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+    const onSaveSucceeded = vi.fn(() => {
+      throw new Error('consumer callback failed');
+    });
+    const { result } = renderHook(() =>
+      useSaveDungeon({ putDungeon }, onSaveSucceeded)
+    );
+
+    act(() => {
+      result.current.save('toolkit-contributor-sandbox', 'valid yaml');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('saved'));
+    expect(result.current.savedKey).toBe('toolkit-contributor-sandbox');
+    expect(result.current.errorMessage).toBeNull();
+    expect(onSaveSucceeded).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a successful save saved when its consumer callback returns a rejecting Promise', async () => {
+    const putDungeon = vi.fn().mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    } as unknown as PutDungeonResponse);
+    const onSaveSucceeded = vi.fn(() =>
+      Promise.reject(new Error('consumer callback rejected'))
+    );
+    const { result } = renderHook(() =>
+      useSaveDungeon({ putDungeon }, onSaveSucceeded)
+    );
+
+    act(() => {
+      result.current.save('toolkit-contributor-sandbox', 'valid yaml');
+    });
+
+    await waitFor(() => expect(result.current.state).toBe('saved'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.state).toBe('saved');
+    expect(result.current.savedKey).toBe('toolkit-contributor-sandbox');
+    expect(result.current.errorMessage).toBeNull();
+    expect(onSaveSucceeded).toHaveBeenCalledTimes(1);
+  });
+
   it('does not call the supplied success callback for a validation rejection', async () => {
     const putDungeon = vi.fn().mockResolvedValue({
       success: false,

--- a/src/author/useSaveDungeon.ts
+++ b/src/author/useSaveDungeon.ts
@@ -26,6 +26,12 @@ import { useState } from 'react';
 
 export type SaveState = 'idle' | 'saving' | 'saved' | 'invalid' | 'error';
 
+/** The only authoring RPC this slice needs. Kept structural so an isolated
+ * caller can supply a scoped unary client without pulling in global auth. */
+export interface AuthoringUnaryClient {
+  putDungeon: typeof authoringClient.putDungeon;
+}
+
 export interface UseSaveDungeonResult {
   state: SaveState;
   /** Set once a save succeeds — the request's own `key`, not anything
@@ -43,7 +49,10 @@ export interface UseSaveDungeonResult {
   save: (key: string, yamlText: string) => void;
 }
 
-export function useSaveDungeon(): UseSaveDungeonResult {
+export function useSaveDungeon(
+  client: AuthoringUnaryClient = authoringClient,
+  onSaveSucceeded?: (key: string) => void
+): UseSaveDungeonResult {
   const [state, setState] = useState<SaveState>('idle');
   const [savedKey, setSavedKey] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<ValidationError[]>([]);
@@ -55,7 +64,7 @@ export function useSaveDungeon(): UseSaveDungeonResult {
     setErrorMessage(null);
     (async () => {
       try {
-        const response = await authoringClient.putDungeon(
+        const response = await client.putDungeon(
           create(PutDungeonRequestSchema, {
             key,
             yaml: yamlText,
@@ -65,6 +74,7 @@ export function useSaveDungeon(): UseSaveDungeonResult {
         if (response.success) {
           setSavedKey(key);
           setState('saved');
+          onSaveSucceeded?.(key);
         } else {
           setFieldErrors(response.fieldErrors);
           setState('invalid');

--- a/src/author/useSaveDungeon.ts
+++ b/src/author/useSaveDungeon.ts
@@ -63,22 +63,15 @@ export function useSaveDungeon(
     setFieldErrors([]);
     setErrorMessage(null);
     (async () => {
+      let response;
       try {
-        const response = await client.putDungeon(
+        response = await client.putDungeon(
           create(PutDungeonRequestSchema, {
             key,
             yaml: yamlText,
             validateOnly: false,
           })
         );
-        if (response.success) {
-          setSavedKey(key);
-          setState('saved');
-          onSaveSucceeded?.(key);
-        } else {
-          setFieldErrors(response.fieldErrors);
-          setState('invalid');
-        }
       } catch (err) {
         setErrorMessage(
           err instanceof ConnectError
@@ -86,6 +79,23 @@ export function useSaveDungeon(
             : 'PutDungeon request failed'
         );
         setState('error');
+        return;
+      }
+
+      if (response.success) {
+        setSavedKey(key);
+        setState('saved');
+        // This is a consumer notification, not part of the RPC result. A
+        // throwing (or promise-rejecting) callback must not reclassify an
+        // already-persisted save as a PutDungeon failure.
+        try {
+          void Promise.resolve(onSaveSucceeded?.(key)).catch(() => undefined);
+        } catch {
+          // A synchronous callback failure is likewise isolated from save state.
+        }
+      } else {
+        setFieldErrors(response.fieldErrors);
+        setState('invalid');
       }
     })();
   };

--- a/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.test.tsx
+++ b/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.test.tsx
@@ -575,4 +575,28 @@ describe('ToolkitContributorSandbox', () => {
       fighter.lobby.startEncounter.mock.invocationCallOrder[0]
     );
   });
+
+  it('ignores a late successful save callback after the sandbox unmounts', async () => {
+    const persisted = deferred<{ success: boolean; fieldErrors: never[] }>();
+    fighter.authoring.putDungeon.mockImplementation((request) =>
+      request.validateOnly
+        ? Promise.resolve({ success: true, fieldErrors: [] })
+        : persisted.promise
+    );
+
+    const { unmount } = render(<ToolkitContributorSandbox />);
+    await clickTemplateSave();
+    expect(fighter.character.listCharacters).not.toHaveBeenCalled();
+    expect(barbarian.character.listCharacters).not.toHaveBeenCalled();
+
+    unmount();
+    await act(async () => {
+      persisted.resolve({ success: true, fieldErrors: [] });
+      await persisted.promise;
+    });
+    await settleDeferred();
+
+    expect(fighter.character.listCharacters).not.toHaveBeenCalled();
+    expect(barbarian.character.listCharacters).not.toHaveBeenCalled();
+  });
 });

--- a/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.test.tsx
+++ b/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   TOOLKIT_SANDBOX_BARBARIAN,
@@ -73,11 +79,9 @@ function resetClients() {
   barbarian.lobby.joinLobby.mockResolvedValue({ lobbyId: 'lobby-1' });
 }
 
-async function saveTemplate() {
-  render(<ToolkitContributorSandbox />);
-
+async function clickTemplateSave() {
   const saveButton = screen.getByRole('button', {
-    name: /save the compilable subset/i,
+    name: /^Save/,
   }) as HTMLButtonElement;
   await waitFor(() => expect(saveButton.disabled).toBe(false));
   fireEvent.click(saveButton);
@@ -87,11 +91,33 @@ async function saveTemplate() {
       validateOnly: false,
     })
   );
+}
+
+async function saveTemplate() {
+  render(<ToolkitContributorSandbox />);
+  await clickTemplateSave();
 
   await waitFor(() => {
     expect(fighter.character.listCharacters).toHaveBeenCalledOnce();
     expect(barbarian.character.listCharacters).toHaveBeenCalledOnce();
   });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function settleDeferred() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 async function chooseParty(
@@ -297,7 +323,7 @@ describe('ToolkitContributorSandbox', () => {
 
     render(<ToolkitContributorSandbox />);
     const saveButton = screen.getByRole('button', {
-      name: /save the compilable subset/i,
+      name: /^Save/,
     }) as HTMLButtonElement;
     await waitFor(() => expect(saveButton.disabled).toBe(false));
     fireEvent.click(saveButton);
@@ -326,5 +352,227 @@ describe('ToolkitContributorSandbox', () => {
     expect(barbarian.lobby.setReady).not.toHaveBeenCalled();
     expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
     expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('waits for a successful save callback before listing and ignores a stale list completion after a newer save', async () => {
+    const persisted = deferred<{ success: boolean; fieldErrors: never[] }>();
+    const staleFighterList = deferred<{ characters: Array<{ id: string }> }>();
+    fighter.authoring.putDungeon.mockImplementation((request) =>
+      request.validateOnly
+        ? Promise.resolve({ success: true, fieldErrors: [] })
+        : persisted.promise
+    );
+    fighter.character.listCharacters
+      .mockImplementationOnce(() => staleFighterList.promise)
+      .mockResolvedValue({ characters: [{ id: 'fighter-char' }] });
+
+    render(<ToolkitContributorSandbox />);
+    await clickTemplateSave();
+    expect(fighter.character.listCharacters).not.toHaveBeenCalled();
+
+    await act(async () => {
+      persisted.resolve({ success: true, fieldErrors: [] });
+      await persisted.promise;
+    });
+    await waitFor(() =>
+      expect(fighter.character.listCharacters).toHaveBeenCalledOnce()
+    );
+    expect(barbarian.character.listCharacters).not.toHaveBeenCalled();
+
+    await clickTemplateSave();
+    await waitFor(() => {
+      expect(fighter.character.listCharacters).toHaveBeenCalledTimes(2);
+      expect(barbarian.character.listCharacters).toHaveBeenCalledOnce();
+      expect(
+        (screen.getByRole('button', { name: 'Fighter' }) as HTMLButtonElement)
+          .disabled
+      ).toBe(false);
+    });
+
+    await act(async () => {
+      staleFighterList.resolve({ characters: [{ id: 'stale-fighter-char' }] });
+      await staleFighterList.promise;
+    });
+    await settleDeferred();
+
+    expect(barbarian.character.listCharacters).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('makes a stale in-flight lobby success inert after a newer successful save callback', async () => {
+    const staleCreate = deferred<{ lobbyId: string; joinRef: string }>();
+    fighter.lobby.createLobby.mockImplementationOnce(() => staleCreate.promise);
+
+    await saveTemplate();
+    const partyButton = screen.getByRole('button', {
+      name: 'Fighter',
+    }) as HTMLButtonElement;
+    fireEvent.click(partyButton);
+    expect(fighter.lobby.createLobby).toHaveBeenCalledOnce();
+
+    await clickTemplateSave();
+    await waitFor(() => {
+      expect(fighter.character.listCharacters).toHaveBeenCalledTimes(2);
+      expect(barbarian.character.listCharacters).toHaveBeenCalledTimes(2);
+      expect(partyButton.disabled).toBe(false);
+    });
+
+    await act(async () => {
+      staleCreate.resolve({ lobbyId: 'stale-lobby', joinRef: 'stale-join' });
+      await staleCreate.promise;
+    });
+    await settleDeferred();
+
+    expect(fighter.lobby.setReady).not.toHaveBeenCalled();
+    expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('ignores a stale in-flight lobby rejection after a newer successful save callback', async () => {
+    const staleCreate = deferred<{ lobbyId: string; joinRef: string }>();
+    fighter.lobby.createLobby.mockImplementationOnce(() => staleCreate.promise);
+
+    await saveTemplate();
+    fireEvent.click(screen.getByRole('button', { name: 'Fighter' }));
+    await waitFor(() => expect(fighter.lobby.createLobby).toHaveBeenCalled());
+
+    await clickTemplateSave();
+    await waitFor(() =>
+      expect(fighter.character.listCharacters).toHaveBeenCalledTimes(2)
+    );
+
+    await act(async () => {
+      staleCreate.reject(new Error('stale create rejected'));
+      try {
+        await staleCreate.promise;
+      } catch {
+        // The component is responsible for ignoring this stale rejection.
+      }
+    });
+    await settleDeferred();
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('does not start competing lobbies for rapid double party activation', async () => {
+    const create = deferred<{ lobbyId: string; joinRef: string }>();
+    fighter.lobby.createLobby.mockImplementation(() => create.promise);
+
+    await saveTemplate();
+    const partyButton = screen.getByRole('button', {
+      name: 'Fighter',
+    }) as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.click(partyButton);
+      fireEvent.click(partyButton);
+    });
+
+    expect(fighter.lobby.createLobby).toHaveBeenCalledOnce();
+    expect(fighter.lobby.setReady).not.toHaveBeenCalled();
+    expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
+  });
+
+  it('stops after SetReady rejects and renders no result link', async () => {
+    fighter.lobby.setReady.mockRejectedValue(
+      new Error('fighter ready rejected')
+    );
+
+    await saveTemplate();
+    fireEvent.click(screen.getByRole('button', { name: 'Fighter' }));
+
+    await screen.findByText('fighter ready rejected');
+    expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('stops after StartEncounter rejects and renders no result link', async () => {
+    fighter.lobby.startEncounter.mockRejectedValue(
+      new Error('fighter start rejected')
+    );
+
+    await saveTemplate();
+    fireEvent.click(screen.getByRole('button', { name: 'Fighter' }));
+
+    await screen.findByText('fighter start rejected');
+    expect(fighter.lobby.setReady).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('awaits each cross-client two-seat boundary in temporal order', async () => {
+    const created = deferred<{ lobbyId: string; joinRef: string }>();
+    const joined = deferred<{ lobbyId: string }>();
+    const fighterReady = deferred<Record<string, never>>();
+    const barbarianReady = deferred<Record<string, never>>();
+    const started = deferred<{ encounterId: string }>();
+    fighter.lobby.createLobby.mockImplementation(() => created.promise);
+    barbarian.lobby.joinLobby.mockImplementation(() => joined.promise);
+    fighter.lobby.setReady.mockImplementation(() => fighterReady.promise);
+    barbarian.lobby.setReady.mockImplementation(() => barbarianReady.promise);
+    fighter.lobby.startEncounter.mockImplementation(() => started.promise);
+
+    await saveTemplate();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Fighter then Barbarian' })
+    );
+    expect(fighter.lobby.createLobby).toHaveBeenCalledOnce();
+    expect(barbarian.lobby.joinLobby).not.toHaveBeenCalled();
+
+    await act(async () => {
+      created.resolve({ lobbyId: 'lobby-1', joinRef: 'join-fighter' });
+      await created.promise;
+    });
+    await waitFor(() =>
+      expect(barbarian.lobby.joinLobby).toHaveBeenCalledOnce()
+    );
+    expect(fighter.lobby.setReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      joined.resolve({ lobbyId: 'lobby-1' });
+      await joined.promise;
+    });
+    await waitFor(() => expect(fighter.lobby.setReady).toHaveBeenCalledOnce());
+    expect(barbarian.lobby.setReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fighterReady.resolve({});
+      await fighterReady.promise;
+    });
+    await waitFor(() =>
+      expect(barbarian.lobby.setReady).toHaveBeenCalledOnce()
+    );
+    expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
+
+    await act(async () => {
+      barbarianReady.resolve({});
+      await barbarianReady.promise;
+    });
+    await waitFor(() =>
+      expect(fighter.lobby.startEncounter).toHaveBeenCalledOnce()
+    );
+
+    await act(async () => {
+      started.resolve({ encounterId: 'enc-1' });
+      await started.promise;
+    });
+    await waitFor(() =>
+      expectResultLinks([TOOLKIT_SANDBOX_FIGHTER, TOOLKIT_SANDBOX_BARBARIAN])
+    );
+
+    expect(fighter.lobby.createLobby.mock.invocationCallOrder[0]).toBeLessThan(
+      barbarian.lobby.joinLobby.mock.invocationCallOrder[0]
+    );
+    expect(barbarian.lobby.joinLobby.mock.invocationCallOrder[0]).toBeLessThan(
+      fighter.lobby.setReady.mock.invocationCallOrder[0]
+    );
+    expect(fighter.lobby.setReady.mock.invocationCallOrder[0]).toBeLessThan(
+      barbarian.lobby.setReady.mock.invocationCallOrder[0]
+    );
+    expect(barbarian.lobby.setReady.mock.invocationCallOrder[0]).toBeLessThan(
+      fighter.lobby.startEncounter.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.test.tsx
+++ b/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.test.tsx
@@ -1,0 +1,330 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  TOOLKIT_SANDBOX_BARBARIAN,
+  TOOLKIT_SANDBOX_FIGHTER,
+  TOOLKIT_SANDBOX_KEY,
+  type ToolkitSandboxPlayer,
+} from './constants';
+
+const hoisted = vi.hoisted(() => ({
+  fighter: {
+    authoring: { putDungeon: vi.fn() },
+    character: { listCharacters: vi.fn() },
+    lobby: {
+      createLobby: vi.fn(),
+      joinLobby: vi.fn(),
+      setReady: vi.fn(),
+      startEncounter: vi.fn(),
+    },
+  },
+  barbarian: {
+    authoring: { putDungeon: vi.fn() },
+    character: { listCharacters: vi.fn() },
+    lobby: {
+      createLobby: vi.fn(),
+      joinLobby: vi.fn(),
+      setReady: vi.fn(),
+      startEncounter: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('./clients', () => ({
+  toolkitSandboxClients: hoisted,
+}));
+
+import { ToolkitContributorSandbox } from './ToolkitContributorSandbox';
+
+const fighter = hoisted.fighter;
+const barbarian = hoisted.barbarian;
+
+function resetClients() {
+  for (const client of [fighter, barbarian]) {
+    client.authoring.putDungeon.mockReset();
+    client.character.listCharacters.mockReset();
+    client.lobby.createLobby.mockReset();
+    client.lobby.joinLobby.mockReset();
+    client.lobby.setReady.mockReset();
+    client.lobby.startEncounter.mockReset();
+    client.authoring.putDungeon.mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+    });
+    client.lobby.setReady.mockResolvedValue({});
+    client.lobby.startEncounter.mockResolvedValue({ encounterId: 'enc-1' });
+  }
+
+  fighter.character.listCharacters.mockResolvedValue({
+    characters: [{ id: 'fighter-char' }],
+  });
+  barbarian.character.listCharacters.mockResolvedValue({
+    characters: [{ id: 'barbarian-char' }],
+  });
+  fighter.lobby.createLobby.mockResolvedValue({
+    lobbyId: 'lobby-1',
+    joinRef: 'join-fighter',
+  });
+  barbarian.lobby.createLobby.mockResolvedValue({
+    lobbyId: 'lobby-1',
+    joinRef: 'join-barbarian',
+  });
+  fighter.lobby.joinLobby.mockResolvedValue({ lobbyId: 'lobby-1' });
+  barbarian.lobby.joinLobby.mockResolvedValue({ lobbyId: 'lobby-1' });
+}
+
+async function saveTemplate() {
+  render(<ToolkitContributorSandbox />);
+
+  const saveButton = screen.getByRole('button', {
+    name: /save the compilable subset/i,
+  }) as HTMLButtonElement;
+  await waitFor(() => expect(saveButton.disabled).toBe(false));
+  fireEvent.click(saveButton);
+  expect(fighter.authoring.putDungeon).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      key: TOOLKIT_SANDBOX_KEY,
+      validateOnly: false,
+    })
+  );
+
+  await waitFor(() => {
+    expect(fighter.character.listCharacters).toHaveBeenCalledOnce();
+    expect(barbarian.character.listCharacters).toHaveBeenCalledOnce();
+  });
+}
+
+async function chooseParty(
+  label: string,
+  creator: typeof fighter | typeof barbarian
+) {
+  const partyButton = screen.getByRole('button', {
+    name: label,
+  }) as HTMLButtonElement;
+  await waitFor(() => expect(partyButton.disabled).toBe(false));
+  fireEvent.click(partyButton);
+  await waitFor(() => expect(creator.lobby.startEncounter).toHaveBeenCalled());
+}
+
+function expectResultLinks(players: readonly ToolkitSandboxPlayer[]) {
+  const links = screen.getAllByRole('link');
+  expect(links).toHaveLength(players.length);
+  expect(links.map((link) => link.getAttribute('href'))).toEqual(
+    players.map((player) => `/?playerId=${player}`)
+  );
+}
+
+beforeEach(() => {
+  resetClients();
+});
+
+describe('ToolkitContributorSandbox', () => {
+  it('saves the fixed dungeon then starts a fighter-only party through only the fighter client', async () => {
+    await saveTemplate();
+    await chooseParty('Fighter', fighter);
+
+    expect(fighter.lobby.createLobby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: TOOLKIT_SANDBOX_KEY,
+        characterId: 'fighter-char',
+      })
+    );
+    expect(fighter.lobby.setReady).toHaveBeenCalledWith(
+      expect.objectContaining({ lobbyId: 'lobby-1', ready: true })
+    );
+    expect(fighter.lobby.startEncounter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lobbyId: 'lobby-1',
+        dungeonKey: TOOLKIT_SANDBOX_KEY,
+      })
+    );
+    expect(barbarian.lobby.createLobby).not.toHaveBeenCalled();
+    expect(barbarian.lobby.joinLobby).not.toHaveBeenCalled();
+    expect(barbarian.lobby.setReady).not.toHaveBeenCalled();
+    expectResultLinks([TOOLKIT_SANDBOX_FIGHTER]);
+  });
+
+  it('starts a barbarian-only party through only the barbarian client', async () => {
+    await saveTemplate();
+    await chooseParty('Barbarian', barbarian);
+
+    expect(barbarian.lobby.createLobby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: TOOLKIT_SANDBOX_KEY,
+        characterId: 'barbarian-char',
+      })
+    );
+    expect(barbarian.lobby.setReady).toHaveBeenCalledWith(
+      expect.objectContaining({ lobbyId: 'lobby-1', ready: true })
+    );
+    expect(barbarian.lobby.startEncounter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lobbyId: 'lobby-1',
+        dungeonKey: TOOLKIT_SANDBOX_KEY,
+      })
+    );
+    expect(fighter.lobby.createLobby).not.toHaveBeenCalled();
+    expect(fighter.lobby.joinLobby).not.toHaveBeenCalled();
+    expect(fighter.lobby.setReady).not.toHaveBeenCalled();
+    expectResultLinks([TOOLKIT_SANDBOX_BARBARIAN]);
+  });
+
+  it('runs fighter then barbarian in the fixed create, join, ready, and start sequence', async () => {
+    await saveTemplate();
+    await chooseParty('Fighter then Barbarian', fighter);
+
+    expect(fighter.character.listCharacters).toHaveBeenCalledOnce();
+    expect(barbarian.character.listCharacters).toHaveBeenCalledOnce();
+    expect(fighter.lobby.createLobby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: 'toolkit-contributor-sandbox',
+        characterId: 'fighter-char',
+      })
+    );
+    expect(barbarian.lobby.joinLobby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        joinRef: 'join-fighter',
+        characterId: 'barbarian-char',
+      })
+    );
+    expect(fighter.lobby.setReady).toHaveBeenCalledWith(
+      expect.objectContaining({ lobbyId: 'lobby-1', ready: true })
+    );
+    expect(barbarian.lobby.setReady).toHaveBeenCalledWith(
+      expect.objectContaining({ lobbyId: 'lobby-1', ready: true })
+    );
+    expect(fighter.lobby.startEncounter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lobbyId: 'lobby-1',
+        dungeonKey: 'toolkit-contributor-sandbox',
+      })
+    );
+    expectResultLinks([TOOLKIT_SANDBOX_FIGHTER, TOOLKIT_SANDBOX_BARBARIAN]);
+  });
+
+  it('runs barbarian then fighter in the fixed create, join, ready, and start sequence', async () => {
+    await saveTemplate();
+
+    const partyButton = screen.getByRole('button', {
+      name: 'Barbarian then Fighter',
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(partyButton.disabled).toBe(false));
+    fireEvent.click(partyButton);
+    await waitFor(() =>
+      expect(barbarian.lobby.startEncounter).toHaveBeenCalled()
+    );
+
+    expect(barbarian.lobby.createLobby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: TOOLKIT_SANDBOX_KEY,
+        characterId: 'barbarian-char',
+      })
+    );
+    expect(fighter.lobby.joinLobby).toHaveBeenCalledWith(
+      expect.objectContaining({
+        joinRef: 'join-barbarian',
+        characterId: 'fighter-char',
+      })
+    );
+    expect(barbarian.lobby.setReady).toHaveBeenCalledWith(
+      expect.objectContaining({ lobbyId: 'lobby-1', ready: true })
+    );
+    expect(fighter.lobby.setReady).toHaveBeenCalledWith(
+      expect.objectContaining({ lobbyId: 'lobby-1', ready: true })
+    );
+    expect(barbarian.lobby.startEncounter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lobbyId: 'lobby-1',
+        dungeonKey: TOOLKIT_SANDBOX_KEY,
+      })
+    );
+    expectResultLinks([TOOLKIT_SANDBOX_BARBARIAN, TOOLKIT_SANDBOX_FIGHTER]);
+  });
+
+  it('surfaces a wrong-owner CreateLobby rejection and stops before ready, start, or a result link', async () => {
+    fighter.lobby.createLobby.mockRejectedValue(
+      new Error('fighter-char does not belong to toolkit-sandbox-fighter')
+    );
+
+    await saveTemplate();
+    const partyButton = screen.getByRole('button', {
+      name: 'Fighter',
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(partyButton.disabled).toBe(false));
+    fireEvent.click(partyButton);
+
+    await screen.findByText(
+      'fighter-char does not belong to toolkit-sandbox-fighter'
+    );
+    expect(fighter.lobby.setReady).not.toHaveBeenCalled();
+    expect(barbarian.lobby.setReady).not.toHaveBeenCalled();
+    expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
+    expect(barbarian.lobby.startEncounter).not.toHaveBeenCalled();
+    expect(partyButton.disabled).toBe(true);
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+
+  it('leaves every party choice disabled when either fixed character list is not exactly one character', async () => {
+    fighter.character.listCharacters.mockResolvedValue({ characters: [] });
+
+    await saveTemplate();
+
+    await screen.findByText('Expected exactly one fighter character.');
+    expect(
+      (screen.getByRole('button', { name: 'Fighter' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+    expect(
+      (
+        screen.getByRole('button', {
+          name: 'Barbarian then Fighter',
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true);
+  });
+
+  it('keeps party choices disabled when the template save receives validation errors', async () => {
+    fighter.authoring.putDungeon.mockImplementation((request) =>
+      Promise.resolve(
+        request.validateOnly
+          ? { success: true, fieldErrors: [] }
+          : {
+              success: false,
+              fieldErrors: [{ message: 'fixed template rejected' }],
+            }
+      )
+    );
+
+    render(<ToolkitContributorSandbox />);
+    const saveButton = screen.getByRole('button', {
+      name: /save the compilable subset/i,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(saveButton.disabled).toBe(false));
+    fireEvent.click(saveButton);
+
+    await screen.findByText('fixed template rejected');
+    expect(fighter.character.listCharacters).not.toHaveBeenCalled();
+    expect(barbarian.character.listCharacters).not.toHaveBeenCalled();
+    expect(
+      (screen.getByRole('button', { name: 'Fighter' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+  });
+
+  it('stops a two-player party after JoinLobby rejects', async () => {
+    barbarian.lobby.joinLobby.mockRejectedValue(new Error('join refused'));
+
+    await saveTemplate();
+    const partyButton = screen.getByRole('button', {
+      name: 'Fighter then Barbarian',
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(partyButton.disabled).toBe(false));
+    fireEvent.click(partyButton);
+
+    await screen.findByText('join refused');
+    expect(fighter.lobby.setReady).not.toHaveBeenCalled();
+    expect(barbarian.lobby.setReady).not.toHaveBeenCalled();
+    expect(fighter.lobby.startEncounter).not.toHaveBeenCalled();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+});

--- a/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.tsx
+++ b/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.tsx
@@ -6,7 +6,7 @@ import {
   StartEncounterRequestSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
 import { ListCharactersRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DungeonBuilderConcept } from '../author/DungeonBuilderConcept';
 import { toolkitSandboxClients as clients } from './clients';
 import {
@@ -39,8 +39,27 @@ export function ToolkitContributorSandbox() {
   >(null);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<SandboxResult>(null);
+  const operationGeneration = useRef(0);
+  const actionInFlight = useRef(false);
+
+  const invalidateOperations = () => {
+    operationGeneration.current += 1;
+    actionInFlight.current = false;
+    return operationGeneration.current;
+  };
+  const isCurrentOperation = (generation: number) =>
+    generation === operationGeneration.current;
+
+  useEffect(
+    () => () => {
+      operationGeneration.current += 1;
+      actionInFlight.current = false;
+    },
+    []
+  );
 
   const handleSaveSucceeded = async (key: string) => {
+    const generation = invalidateOperations();
     setPartyChoicesEnabled(false);
     setFighterCharacterId(null);
     setBarbarianCharacterId(null);
@@ -48,7 +67,9 @@ export function ToolkitContributorSandbox() {
     setResult(null);
 
     if (key !== TOOLKIT_SANDBOX_KEY) {
-      setError(`Unexpected saved dungeon key: ${key}`);
+      if (isCurrentOperation(generation)) {
+        setError(`Unexpected saved dungeon key: ${key}`);
+      }
       return;
     }
 
@@ -56,10 +77,13 @@ export function ToolkitContributorSandbox() {
       const fighterCharacters = await clients.fighter.character.listCharacters(
         create(ListCharactersRequestSchema)
       );
+      if (!isCurrentOperation(generation)) return;
+
       const barbarianCharacters =
         await clients.barbarian.character.listCharacters(
           create(ListCharactersRequestSchema)
         );
+      if (!isCurrentOperation(generation)) return;
 
       if (fighterCharacters.characters.length !== 1) {
         setError('Expected exactly one fighter character.');
@@ -74,12 +98,16 @@ export function ToolkitContributorSandbox() {
       setBarbarianCharacterId(barbarianCharacters.characters[0].id);
       setPartyChoicesEnabled(true);
     } catch (requestError) {
+      if (!isCurrentOperation(generation)) return;
       setError(messageFor(requestError));
     }
   };
 
   const startFighter = async () => {
-    if (!partyChoicesEnabled || !fighterCharacterId) return;
+    if (!partyChoicesEnabled || !fighterCharacterId || actionInFlight.current)
+      return;
+    actionInFlight.current = true;
+    const generation = ++operationGeneration.current;
     setPartyChoicesEnabled(false);
     setError(null);
     setResult(null);
@@ -91,25 +119,37 @@ export function ToolkitContributorSandbox() {
           characterId: fighterCharacterId,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.fighter.lobby.setReady(
         create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.fighter.lobby.startEncounter(
         create(StartEncounterRequestSchema, {
           lobbyId: created.lobbyId,
           dungeonKey: TOOLKIT_SANDBOX_KEY,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setResult('fighter');
     } catch (requestError) {
+      if (!isCurrentOperation(generation)) return;
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setError(messageFor(requestError));
     }
   };
 
   const startBarbarian = async () => {
-    if (!partyChoicesEnabled || !barbarianCharacterId) return;
+    if (!partyChoicesEnabled || !barbarianCharacterId || actionInFlight.current)
+      return;
+    actionInFlight.current = true;
+    const generation = ++operationGeneration.current;
     setPartyChoicesEnabled(false);
     setError(null);
     setResult(null);
@@ -121,26 +161,42 @@ export function ToolkitContributorSandbox() {
           characterId: barbarianCharacterId,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.barbarian.lobby.setReady(
         create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.barbarian.lobby.startEncounter(
         create(StartEncounterRequestSchema, {
           lobbyId: created.lobbyId,
           dungeonKey: TOOLKIT_SANDBOX_KEY,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setResult('barbarian');
     } catch (requestError) {
+      if (!isCurrentOperation(generation)) return;
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setError(messageFor(requestError));
     }
   };
 
   const startFighterThenBarbarian = async () => {
-    if (!partyChoicesEnabled || !fighterCharacterId || !barbarianCharacterId)
+    if (
+      !partyChoicesEnabled ||
+      !fighterCharacterId ||
+      !barbarianCharacterId ||
+      actionInFlight.current
+    )
       return;
+    actionInFlight.current = true;
+    const generation = ++operationGeneration.current;
     setPartyChoicesEnabled(false);
     setError(null);
     setResult(null);
@@ -152,35 +208,55 @@ export function ToolkitContributorSandbox() {
           characterId: fighterCharacterId,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.barbarian.lobby.joinLobby(
         create(JoinLobbyRequestSchema, {
           joinRef: created.joinRef,
           characterId: barbarianCharacterId,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.fighter.lobby.setReady(
         create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.barbarian.lobby.setReady(
         create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.fighter.lobby.startEncounter(
         create(StartEncounterRequestSchema, {
           lobbyId: created.lobbyId,
           dungeonKey: TOOLKIT_SANDBOX_KEY,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setResult('fighter-then-barbarian');
     } catch (requestError) {
+      if (!isCurrentOperation(generation)) return;
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setError(messageFor(requestError));
     }
   };
 
   const startBarbarianThenFighter = async () => {
-    if (!partyChoicesEnabled || !fighterCharacterId || !barbarianCharacterId)
+    if (
+      !partyChoicesEnabled ||
+      !fighterCharacterId ||
+      !barbarianCharacterId ||
+      actionInFlight.current
+    )
       return;
+    actionInFlight.current = true;
+    const generation = ++operationGeneration.current;
     setPartyChoicesEnabled(false);
     setError(null);
     setResult(null);
@@ -192,27 +268,40 @@ export function ToolkitContributorSandbox() {
           characterId: barbarianCharacterId,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.fighter.lobby.joinLobby(
         create(JoinLobbyRequestSchema, {
           joinRef: created.joinRef,
           characterId: fighterCharacterId,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.barbarian.lobby.setReady(
         create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.fighter.lobby.setReady(
         create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
       );
+      if (!isCurrentOperation(generation)) return;
+
       await clients.barbarian.lobby.startEncounter(
         create(StartEncounterRequestSchema, {
           lobbyId: created.lobbyId,
           dungeonKey: TOOLKIT_SANDBOX_KEY,
         })
       );
+      if (!isCurrentOperation(generation)) return;
+
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setResult('barbarian-then-fighter');
     } catch (requestError) {
+      if (!isCurrentOperation(generation)) return;
+      actionInFlight.current = false;
       setPartyChoicesEnabled(false);
       setError(messageFor(requestError));
     }

--- a/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.tsx
+++ b/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.tsx
@@ -41,6 +41,7 @@ export function ToolkitContributorSandbox() {
   const [result, setResult] = useState<SandboxResult>(null);
   const operationGeneration = useRef(0);
   const actionInFlight = useRef(false);
+  const mounted = useRef(false);
 
   const invalidateOperations = () => {
     operationGeneration.current += 1;
@@ -48,17 +49,19 @@ export function ToolkitContributorSandbox() {
     return operationGeneration.current;
   };
   const isCurrentOperation = (generation: number) =>
-    generation === operationGeneration.current;
+    mounted.current && generation === operationGeneration.current;
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
       operationGeneration.current += 1;
       actionInFlight.current = false;
-    },
-    []
-  );
+    };
+  }, []);
 
   const handleSaveSucceeded = async (key: string) => {
+    if (!mounted.current) return;
     const generation = invalidateOperations();
     setPartyChoicesEnabled(false);
     setFighterCharacterId(null);
@@ -104,7 +107,12 @@ export function ToolkitContributorSandbox() {
   };
 
   const startFighter = async () => {
-    if (!partyChoicesEnabled || !fighterCharacterId || actionInFlight.current)
+    if (
+      !mounted.current ||
+      !partyChoicesEnabled ||
+      !fighterCharacterId ||
+      actionInFlight.current
+    )
       return;
     actionInFlight.current = true;
     const generation = ++operationGeneration.current;
@@ -146,7 +154,12 @@ export function ToolkitContributorSandbox() {
   };
 
   const startBarbarian = async () => {
-    if (!partyChoicesEnabled || !barbarianCharacterId || actionInFlight.current)
+    if (
+      !mounted.current ||
+      !partyChoicesEnabled ||
+      !barbarianCharacterId ||
+      actionInFlight.current
+    )
       return;
     actionInFlight.current = true;
     const generation = ++operationGeneration.current;
@@ -189,6 +202,7 @@ export function ToolkitContributorSandbox() {
 
   const startFighterThenBarbarian = async () => {
     if (
+      !mounted.current ||
       !partyChoicesEnabled ||
       !fighterCharacterId ||
       !barbarianCharacterId ||
@@ -249,6 +263,7 @@ export function ToolkitContributorSandbox() {
 
   const startBarbarianThenFighter = async () => {
     if (
+      !mounted.current ||
       !partyChoicesEnabled ||
       !fighterCharacterId ||
       !barbarianCharacterId ||

--- a/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.tsx
+++ b/src/toolkit-contributor-sandbox/ToolkitContributorSandbox.tsx
@@ -1,0 +1,291 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  CreateLobbyRequestSchema,
+  JoinLobbyRequestSchema,
+  SetReadyRequestSchema,
+  StartEncounterRequestSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { ListCharactersRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import { useState } from 'react';
+import { DungeonBuilderConcept } from '../author/DungeonBuilderConcept';
+import { toolkitSandboxClients as clients } from './clients';
+import {
+  TOOLKIT_SANDBOX_BARBARIAN,
+  TOOLKIT_SANDBOX_BARBARIAN_LABEL,
+  TOOLKIT_SANDBOX_FIGHTER,
+  TOOLKIT_SANDBOX_FIGHTER_LABEL,
+  TOOLKIT_SANDBOX_KEY,
+  TOOLKIT_SANDBOX_YAML,
+} from './constants';
+
+type SandboxResult =
+  | 'fighter'
+  | 'barbarian'
+  | 'fighter-then-barbarian'
+  | 'barbarian-then-fighter'
+  | null;
+
+function messageFor(error: unknown): string {
+  return error instanceof Error ? error.message : 'Sandbox RPC failed.';
+}
+
+export function ToolkitContributorSandbox() {
+  const [partyChoicesEnabled, setPartyChoicesEnabled] = useState(false);
+  const [fighterCharacterId, setFighterCharacterId] = useState<string | null>(
+    null
+  );
+  const [barbarianCharacterId, setBarbarianCharacterId] = useState<
+    string | null
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<SandboxResult>(null);
+
+  const handleSaveSucceeded = async (key: string) => {
+    setPartyChoicesEnabled(false);
+    setFighterCharacterId(null);
+    setBarbarianCharacterId(null);
+    setError(null);
+    setResult(null);
+
+    if (key !== TOOLKIT_SANDBOX_KEY) {
+      setError(`Unexpected saved dungeon key: ${key}`);
+      return;
+    }
+
+    try {
+      const fighterCharacters = await clients.fighter.character.listCharacters(
+        create(ListCharactersRequestSchema)
+      );
+      const barbarianCharacters =
+        await clients.barbarian.character.listCharacters(
+          create(ListCharactersRequestSchema)
+        );
+
+      if (fighterCharacters.characters.length !== 1) {
+        setError('Expected exactly one fighter character.');
+        return;
+      }
+      if (barbarianCharacters.characters.length !== 1) {
+        setError('Expected exactly one barbarian character.');
+        return;
+      }
+
+      setFighterCharacterId(fighterCharacters.characters[0].id);
+      setBarbarianCharacterId(barbarianCharacters.characters[0].id);
+      setPartyChoicesEnabled(true);
+    } catch (requestError) {
+      setError(messageFor(requestError));
+    }
+  };
+
+  const startFighter = async () => {
+    if (!partyChoicesEnabled || !fighterCharacterId) return;
+    setPartyChoicesEnabled(false);
+    setError(null);
+    setResult(null);
+
+    try {
+      const created = await clients.fighter.lobby.createLobby(
+        create(CreateLobbyRequestSchema, {
+          campaignId: TOOLKIT_SANDBOX_KEY,
+          characterId: fighterCharacterId,
+        })
+      );
+      await clients.fighter.lobby.setReady(
+        create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
+      );
+      await clients.fighter.lobby.startEncounter(
+        create(StartEncounterRequestSchema, {
+          lobbyId: created.lobbyId,
+          dungeonKey: TOOLKIT_SANDBOX_KEY,
+        })
+      );
+      setPartyChoicesEnabled(false);
+      setResult('fighter');
+    } catch (requestError) {
+      setPartyChoicesEnabled(false);
+      setError(messageFor(requestError));
+    }
+  };
+
+  const startBarbarian = async () => {
+    if (!partyChoicesEnabled || !barbarianCharacterId) return;
+    setPartyChoicesEnabled(false);
+    setError(null);
+    setResult(null);
+
+    try {
+      const created = await clients.barbarian.lobby.createLobby(
+        create(CreateLobbyRequestSchema, {
+          campaignId: TOOLKIT_SANDBOX_KEY,
+          characterId: barbarianCharacterId,
+        })
+      );
+      await clients.barbarian.lobby.setReady(
+        create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
+      );
+      await clients.barbarian.lobby.startEncounter(
+        create(StartEncounterRequestSchema, {
+          lobbyId: created.lobbyId,
+          dungeonKey: TOOLKIT_SANDBOX_KEY,
+        })
+      );
+      setPartyChoicesEnabled(false);
+      setResult('barbarian');
+    } catch (requestError) {
+      setPartyChoicesEnabled(false);
+      setError(messageFor(requestError));
+    }
+  };
+
+  const startFighterThenBarbarian = async () => {
+    if (!partyChoicesEnabled || !fighterCharacterId || !barbarianCharacterId)
+      return;
+    setPartyChoicesEnabled(false);
+    setError(null);
+    setResult(null);
+
+    try {
+      const created = await clients.fighter.lobby.createLobby(
+        create(CreateLobbyRequestSchema, {
+          campaignId: TOOLKIT_SANDBOX_KEY,
+          characterId: fighterCharacterId,
+        })
+      );
+      await clients.barbarian.lobby.joinLobby(
+        create(JoinLobbyRequestSchema, {
+          joinRef: created.joinRef,
+          characterId: barbarianCharacterId,
+        })
+      );
+      await clients.fighter.lobby.setReady(
+        create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
+      );
+      await clients.barbarian.lobby.setReady(
+        create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
+      );
+      await clients.fighter.lobby.startEncounter(
+        create(StartEncounterRequestSchema, {
+          lobbyId: created.lobbyId,
+          dungeonKey: TOOLKIT_SANDBOX_KEY,
+        })
+      );
+      setPartyChoicesEnabled(false);
+      setResult('fighter-then-barbarian');
+    } catch (requestError) {
+      setPartyChoicesEnabled(false);
+      setError(messageFor(requestError));
+    }
+  };
+
+  const startBarbarianThenFighter = async () => {
+    if (!partyChoicesEnabled || !fighterCharacterId || !barbarianCharacterId)
+      return;
+    setPartyChoicesEnabled(false);
+    setError(null);
+    setResult(null);
+
+    try {
+      const created = await clients.barbarian.lobby.createLobby(
+        create(CreateLobbyRequestSchema, {
+          campaignId: TOOLKIT_SANDBOX_KEY,
+          characterId: barbarianCharacterId,
+        })
+      );
+      await clients.fighter.lobby.joinLobby(
+        create(JoinLobbyRequestSchema, {
+          joinRef: created.joinRef,
+          characterId: fighterCharacterId,
+        })
+      );
+      await clients.barbarian.lobby.setReady(
+        create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
+      );
+      await clients.fighter.lobby.setReady(
+        create(SetReadyRequestSchema, { lobbyId: created.lobbyId, ready: true })
+      );
+      await clients.barbarian.lobby.startEncounter(
+        create(StartEncounterRequestSchema, {
+          lobbyId: created.lobbyId,
+          dungeonKey: TOOLKIT_SANDBOX_KEY,
+        })
+      );
+      setPartyChoicesEnabled(false);
+      setResult('barbarian-then-fighter');
+    } catch (requestError) {
+      setPartyChoicesEnabled(false);
+      setError(messageFor(requestError));
+    }
+  };
+
+  return (
+    <main>
+      <h1>Toolkit Contributor Sandbox</h1>
+      <DungeonBuilderConcept
+        initialYaml={TOOLKIT_SANDBOX_YAML}
+        authoringClient={clients.fighter.authoring}
+        persistDraft={false}
+        allowNewCanvas={false}
+        allowYamlFileIO={false}
+        onSaveSucceeded={handleSaveSucceeded}
+        showSaveResultLink={false}
+      />
+      <section aria-labelledby="toolkit-sandbox-party-heading">
+        <h2 id="toolkit-sandbox-party-heading">Fixed party arrangements</h2>
+        <button disabled={!partyChoicesEnabled} onClick={startFighter}>
+          {TOOLKIT_SANDBOX_FIGHTER_LABEL}
+        </button>
+        <button disabled={!partyChoicesEnabled} onClick={startBarbarian}>
+          {TOOLKIT_SANDBOX_BARBARIAN_LABEL}
+        </button>
+        <button
+          disabled={!partyChoicesEnabled}
+          onClick={startFighterThenBarbarian}
+        >
+          Fighter then Barbarian
+        </button>
+        <button
+          disabled={!partyChoicesEnabled}
+          onClick={startBarbarianThenFighter}
+        >
+          Barbarian then Fighter
+        </button>
+        {error && <p role="alert">{error}</p>}
+        {result === 'fighter' && (
+          <p>
+            <a href={`/?playerId=${TOOLKIT_SANDBOX_FIGHTER}`}>
+              Play as Fighter
+            </a>
+          </p>
+        )}
+        {result === 'barbarian' && (
+          <p>
+            <a href={`/?playerId=${TOOLKIT_SANDBOX_BARBARIAN}`}>
+              Play as Barbarian
+            </a>
+          </p>
+        )}
+        {result === 'fighter-then-barbarian' && (
+          <p>
+            <a href={`/?playerId=${TOOLKIT_SANDBOX_FIGHTER}`}>
+              Play as Fighter
+            </a>{' '}
+            <a href={`/?playerId=${TOOLKIT_SANDBOX_BARBARIAN}`}>
+              Play as Barbarian
+            </a>
+          </p>
+        )}
+        {result === 'barbarian-then-fighter' && (
+          <p>
+            <a href={`/?playerId=${TOOLKIT_SANDBOX_BARBARIAN}`}>
+              Play as Barbarian
+            </a>{' '}
+            <a href={`/?playerId=${TOOLKIT_SANDBOX_FIGHTER}`}>
+              Play as Fighter
+            </a>
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/toolkit-contributor-sandbox/clients.test.ts
+++ b/src/toolkit-contributor-sandbox/clients.test.ts
@@ -1,0 +1,49 @@
+import type { UnaryResponse } from '@connectrpc/connect';
+import { describe, expect, it } from 'vitest';
+import { toolkitSandboxInterceptors } from './clients';
+
+type SandboxInterceptor =
+  (typeof toolkitSandboxInterceptors)[keyof typeof toolkitSandboxInterceptors];
+type SandboxRequest = Parameters<ReturnType<SandboxInterceptor>>[0];
+
+function makeFakeUnaryRequest(): SandboxRequest {
+  return {
+    header: new Headers(),
+  } as SandboxRequest;
+}
+
+function makeFakeUnaryResponse(): UnaryResponse {
+  return {
+    stream: false,
+    header: new Headers(),
+    trailer: new Headers(),
+  } as unknown as UnaryResponse;
+}
+
+describe('toolkit sandbox client interceptors', () => {
+  it('keeps each fixed Dev authorization header isolated for interleaved unary calls', async () => {
+    const capturedAuthorization: Array<string | null> = [];
+    const fighterInterceptor = toolkitSandboxInterceptors.fighter;
+    const barbarianInterceptor = toolkitSandboxInterceptors.barbarian;
+    const fighterRequest = makeFakeUnaryRequest();
+    const barbarianRequest = makeFakeUnaryRequest();
+    const secondFighterRequest = makeFakeUnaryRequest();
+    const captureAuthorization = async (request: SandboxRequest) => {
+      await Promise.resolve();
+      capturedAuthorization.push(request.header.get('authorization'));
+      return makeFakeUnaryResponse();
+    };
+
+    await Promise.all([
+      fighterInterceptor(captureAuthorization)(fighterRequest),
+      barbarianInterceptor(captureAuthorization)(barbarianRequest),
+      fighterInterceptor(captureAuthorization)(secondFighterRequest),
+    ]);
+
+    expect(capturedAuthorization).toEqual([
+      'Dev toolkit-sandbox-fighter',
+      'Dev toolkit-sandbox-barbarian',
+      'Dev toolkit-sandbox-fighter',
+    ]);
+  });
+});

--- a/src/toolkit-contributor-sandbox/clients.ts
+++ b/src/toolkit-contributor-sandbox/clients.ts
@@ -1,0 +1,103 @@
+import {
+  createClient,
+  type Client,
+  type Interceptor,
+} from '@connectrpc/connect';
+import { createGrpcWebTransport } from '@connectrpc/connect-web';
+import { AuthoringService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { LobbyService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/lobby/v1alpha1/service_pb';
+import { CharacterService } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
+import {
+  TOOLKIT_SANDBOX_BARBARIAN,
+  TOOLKIT_SANDBOX_FIGHTER,
+  type ToolkitSandboxPlayer,
+} from './constants';
+
+export interface ToolkitSandboxClients {
+  readonly fighter: SandboxUnaryClients;
+  readonly barbarian: SandboxUnaryClients;
+}
+
+export interface SandboxUnaryClients {
+  readonly authoring: Pick<Client<typeof AuthoringService>, 'putDungeon'>;
+  readonly character: Pick<Client<typeof CharacterService>, 'listCharacters'>;
+  readonly lobby: Pick<
+    Client<typeof LobbyService>,
+    'createLobby' | 'joinLobby' | 'setReady' | 'startEncounter'
+  >;
+}
+
+// Match the normal application API-host convention without importing its
+// mutable global auth clients or auth state.
+const isDiscordActivity = window.location.hostname.includes('discordsays.com');
+const apiHost = isDiscordActivity
+  ? '/.proxy'
+  : import.meta.env.VITE_API_HOST || window.location.origin;
+
+function fixedDevInterceptor(player: ToolkitSandboxPlayer): Interceptor {
+  return (next) => async (request) => {
+    request.header.set('authorization', `Dev ${player}`);
+    return next(request);
+  };
+}
+
+const fighterInterceptor = fixedDevInterceptor(TOOLKIT_SANDBOX_FIGHTER);
+const barbarianInterceptor = fixedDevInterceptor(TOOLKIT_SANDBOX_BARBARIAN);
+
+// This deliberately exposes only the two fixed interceptors for the focused
+// header-isolation test. It is not an arbitrary-identity interceptor factory.
+export const toolkitSandboxInterceptors = Object.freeze({
+  fighter: fighterInterceptor,
+  barbarian: barbarianInterceptor,
+});
+
+const fighterTransport = createGrpcWebTransport({
+  baseUrl: apiHost,
+  interceptors: [fighterInterceptor],
+});
+const barbarianTransport = createGrpcWebTransport({
+  baseUrl: apiHost,
+  interceptors: [barbarianInterceptor],
+});
+
+const fighterAuthoringClient = createClient(AuthoringService, fighterTransport);
+const fighterCharacterClient = createClient(CharacterService, fighterTransport);
+const fighterLobbyClient = createClient(LobbyService, fighterTransport);
+const barbarianAuthoringClient = createClient(
+  AuthoringService,
+  barbarianTransport
+);
+const barbarianCharacterClient = createClient(
+  CharacterService,
+  barbarianTransport
+);
+const barbarianLobbyClient = createClient(LobbyService, barbarianTransport);
+
+export const toolkitSandboxClients: ToolkitSandboxClients = Object.freeze({
+  fighter: Object.freeze({
+    authoring: Object.freeze({ putDungeon: fighterAuthoringClient.putDungeon }),
+    character: Object.freeze({
+      listCharacters: fighterCharacterClient.listCharacters,
+    }),
+    lobby: Object.freeze({
+      createLobby: fighterLobbyClient.createLobby,
+      joinLobby: fighterLobbyClient.joinLobby,
+      setReady: fighterLobbyClient.setReady,
+      startEncounter: fighterLobbyClient.startEncounter,
+    }),
+  }),
+  barbarian: Object.freeze({
+    authoring: Object.freeze({
+      putDungeon: barbarianAuthoringClient.putDungeon,
+    }),
+    character: Object.freeze({
+      listCharacters: barbarianCharacterClient.listCharacters,
+    }),
+    lobby: Object.freeze({
+      createLobby: barbarianLobbyClient.createLobby,
+      joinLobby: barbarianLobbyClient.joinLobby,
+      setReady: barbarianLobbyClient.setReady,
+      startEncounter: barbarianLobbyClient.startEncounter,
+    }),
+  }),
+});

--- a/src/toolkit-contributor-sandbox/constants.ts
+++ b/src/toolkit-contributor-sandbox/constants.ts
@@ -1,0 +1,48 @@
+export const TOOLKIT_SANDBOX_KEY = 'toolkit-contributor-sandbox' as const;
+
+export const TOOLKIT_SANDBOX_FIGHTER = 'toolkit-sandbox-fighter' as const;
+export const TOOLKIT_SANDBOX_BARBARIAN = 'toolkit-sandbox-barbarian' as const;
+
+export type ToolkitSandboxPlayer =
+  | typeof TOOLKIT_SANDBOX_FIGHTER
+  | typeof TOOLKIT_SANDBOX_BARBARIAN;
+
+export const TOOLKIT_SANDBOX_FIGHTER_LABEL = 'Fighter' as const;
+export const TOOLKIT_SANDBOX_BARBARIAN_LABEL = 'Barbarian' as const;
+
+export const TOOLKIT_SANDBOX_PARTY_ARRANGEMENTS = [
+  {
+    label: TOOLKIT_SANDBOX_FIGHTER_LABEL,
+    players: [TOOLKIT_SANDBOX_FIGHTER],
+  },
+  {
+    label: TOOLKIT_SANDBOX_BARBARIAN_LABEL,
+    players: [TOOLKIT_SANDBOX_BARBARIAN],
+  },
+  {
+    label: 'Fighter then Barbarian',
+    players: [TOOLKIT_SANDBOX_FIGHTER, TOOLKIT_SANDBOX_BARBARIAN],
+  },
+  {
+    label: 'Barbarian then Fighter',
+    players: [TOOLKIT_SANDBOX_BARBARIAN, TOOLKIT_SANDBOX_FIGHTER],
+  },
+] as const;
+
+export const TOOLKIT_SANDBOX_YAML = `version: 1
+key: toolkit-contributor-sandbox
+name: "Toolkit Contributor Sandbox"
+theme: crypt
+height: 1
+canvas: { width: 12, height: 6 }
+rooms: []
+connectors: []
+walls: []
+wallLines: []
+holes: []
+start: [1, 3]
+end: null
+place:
+  - { ref: "dnd5e:monsters:skeleton", at: [7, 2] }
+  - { ref: "dnd5e:monsters:skeleton", at: [9, 4] }
+`;

--- a/src/toolkit-contributor-sandbox/route.test.ts
+++ b/src/toolkit-contributor-sandbox/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isToolkitContributorSandboxRoute } from './route';
+
+describe('isToolkitContributorSandboxRoute', () => {
+  it('requires the literal development mode and toolkitSandbox=1 query value', () => {
+    expect(
+      isToolkitContributorSandboxRoute('development', '?toolkitSandbox=1')
+    ).toBe(true);
+    expect(
+      isToolkitContributorSandboxRoute('production', '?toolkitSandbox=1')
+    ).toBe(false);
+    expect(
+      isToolkitContributorSandboxRoute('development', '?toolkitSandbox=0')
+    ).toBe(false);
+  });
+});

--- a/src/toolkit-contributor-sandbox/route.ts
+++ b/src/toolkit-contributor-sandbox/route.ts
@@ -1,0 +1,9 @@
+export function isToolkitContributorSandboxRoute(
+  mode: string,
+  search: string
+): boolean {
+  return (
+    mode === 'development' &&
+    new URLSearchParams(search).get('toolkitSandbox') === '1'
+  );
+}


### PR DESCRIPTION
Development-only toolkit contributor sandbox:

- Fixed the dev/query gate and production exclusion.
- Immutable Fighter/Barbarian clients.
- Injected one-template Dungeon Builder.
- Four RPC-only lobby flows with normal GameView links.
- Provider PRs: rpg-api#792 and game-dev#60.
- Tests: 99 focused and 2545 full, plus lint, typecheck, build, and the production artifact guard.
- Live WSL2/Docker/browser verification deferred to Unit D.

Closes #746
