### PR TITLE
feat(authoring): deliver region-union floor Wave A

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@
 # src/concepts/dungeon-builder/ to src/author/ (rpg-project#194 graduation).
 src/author/specimens/*.yaml
 src/author/specimens/*.json
+
+# Immutable provider-boundary regression input; must remain byte-identical to /home/kirk/Downloads/simple-room.yaml.
+src/author/testdata/simple-room-legacy.yaml

--- a/docs/evidence/dungeon-yaml-v04-wave-a-735.md
+++ b/docs/evidence/dungeon-yaml-v04-wave-a-735.md
@@ -1,0 +1,66 @@
+# Dungeon YAML v0.4 Wave A web checkpoint (#735)
+
+Outside-in checkpoint against RATIFIED rpg-project PR #203 at
+`40a3938fff9093ae2913da9ea100d8ab63193cb3`.
+
+## What this proves
+
+- The YAML model distinguishes omitted `canvas.floor_source`, explicit `bounds`,
+  and exact `regions`; invalid values reject instead of becoming bounds.
+- An exact region-floor candidate stays byte-for-byte unchanged. The legacy
+  subset projection and bounds-derived preview both hard-stop rather than strip
+  or downgrade it.
+- A future authoring projection consumer renders/hit-tests only returned
+  `floor_cells`, uses membership rather than pair orientation to identify edge
+  ownership (including center void and off-canvas endpoints), accepts an absent
+  draft entrance, and invents no envelope pairs.
+- A runtime seam exposes only authorized returned hex records and the edges
+  attached to them; it has no canvas/region input from which hidden floor or
+  topology could be recreated.
+
+The 5x5 ring fixture has exactly eight returned floor cells. Its in-bounds
+`[2,2]` center remains non-floor. Tiny draft coverage preserves an absent
+entrance. These are consumer contract tests, not provider rules implemented in
+TypeScript.
+
+## Exact dependency discovered
+
+Released TypeScript protos at `@kirkdiggler/rpg-api-protos` `v0.1.120`
+(`ba7eda1f1833a713afa4f7772b3a39955de9f7b2`) provide
+`FloorPlan.floor_cells`, `FloorPlan.edges`, and optional `FloorPlan.entrance`,
+but **do not provide resolved `FloorPlan.floor_source`**. The web cannot
+honestly distinguish:
+
+- a valid empty `regions` structural draft from an older producer's unset
+  repeated `floor_cells`; or
+- an explicit region-floor response from a bounds response that happens to
+  contain the same cells.
+
+The additive contract rail therefore needs:
+
+1. a generated authoring `FloorPlan.floor_source` field with discriminable
+   `bounds` and `regions` values (an enum is preferable; exact naming belongs to
+   the proto owner), present/resolved even when YAML omitted to bounds;
+2. the provider to populate it together with the complete canonical
+   `floor_cells`, existing flat pair `edges` (including void/off-canvas
+   endpoints), and presence-aware optional `entrance` on every successful
+   validate-only response; and
+3. the provider to accept the exact `floor_source: regions` candidate for
+   validate-only structural drafts, while strict writes/starts return the
+   provider's runnable-validity failure without mutating authored state.
+
+No generated code or runtime rules are patched on this branch. Once the
+released immutable proto exists, the structural concept type in
+`regionFloorContract.ts` must be replaced at the RPC adapter boundary by that
+generated type. The real game adapter also needs a bounded follow-through:
+`EncounterMap` currently calls `computeWallRuns` over zone bounding boxes when
+any wall exists. Region-union topology cannot use that synthetic envelope; its
+run rendering must be driven only by returned `HexRecord.edges`, while retaining
+the existing bounds/room-chain regression path. Then the Builder preview/save
+and game-route E2E can be wired and the remaining #735 acceptance run against
+delivered providers.
+
+## Local evidence
+
+- `npx vitest run src/author/regionFloorContract.test.ts`
+- `npm run ci-check`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.121",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.123",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#ba7eda1f1833a713afa4f7772b3a39955de9f7b2",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#a6648cecf193894231bf55df1fc28b3eb42cf32e",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.121",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.123",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -17,8 +17,14 @@
  * broken text intact and editable, never a thrown render exception and
  * never a silently-discarded draft.
  */
+import { create } from '@bufbuild/protobuf';
 import { Code, ConnectError } from '@connectrpc/connect';
-import type { PutDungeonResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import {
+  FloorPlanEdgeKind,
+  FloorPlanFloorSource,
+  FloorPlanSchema,
+  type PutDungeonResponse,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import {
   act,
   fireEvent,
@@ -26,6 +32,8 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TOOLKIT_SANDBOX_YAML } from '../toolkit-contributor-sandbox/constants';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
@@ -39,6 +47,7 @@ vi.mock('@/api/client', () => ({
 }));
 
 import { DungeonBuilderConcept } from './DungeonBuilderConcept';
+import type { AuthoringUnaryClient } from './useSaveDungeon';
 
 /** `DungeonBuilderConcept.tsx`'s own `APPLY_DEBOUNCE_MS` (not exported —
  * this is the pane's debounced-reparse delay the two-way-pane tests below
@@ -46,6 +55,29 @@ import { DungeonBuilderConcept } from './DungeonBuilderConcept';
 const APPLY_DEBOUNCE_MS = 700;
 
 const DRAFT_KEY = 'dungeon-builder:draft:create';
+
+const regionFixture = (name: string): string =>
+  readFileSync(join(__dirname, 'testdata', name), 'utf8');
+
+const canonicalRegionFloorPlan = () =>
+  create(FloorPlanSchema, {
+    width: 20,
+    height: 30,
+    floorSource: FloorPlanFloorSource.REGIONS,
+    floorCells: [
+      { column: 0, row: 0 },
+      { column: 0, row: 1 },
+      { column: 1, row: 1 },
+    ],
+    edges: [
+      {
+        from: { column: 0, row: 0 },
+        to: { column: -1, row: 0 },
+        kind: FloorPlanEdgeKind.SOLID,
+      },
+    ],
+    entrance: { column: 0, row: 0 },
+  });
 
 /** Kirk's exact repro: a `walls:` entry shaped like `wallLines:` instead
  * — `{cell, corner}` where a real `[col, row]` `from` belongs. Genuinely
@@ -68,6 +100,137 @@ function seedBrokenDraft() {
     JSON.stringify({ yamlText: BROKEN_WALLS_YAML, savedAt: Date.now() })
   );
 }
+
+describe('DungeonBuilderConcept — exact region-floor hard stops', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  function liveClient(
+    validate: (
+      request: Parameters<AuthoringUnaryClient['putDungeon']>[0]
+    ) => PutDungeonResponse
+  ) {
+    const putDungeon = vi.fn(
+      async (request: Parameters<AuthoringUnaryClient['putDungeon']>[0]) => {
+        if (request.key === '') {
+          throw new ConnectError('bad key', Code.InvalidArgument);
+        }
+        if ((request.key ?? '').startsWith('capprobe-')) {
+          return {
+            success: true,
+            fieldErrors: [],
+          } as unknown as PutDungeonResponse;
+        }
+        return validate(request);
+      }
+    );
+    return { putDungeon };
+  }
+
+  it('keeps the immutable legacy source visible, surfaces the exact spec source-path failure, and disables Save & Play', async () => {
+    const source = regionFixture('simple-room-legacy.yaml');
+    const client = liveClient(
+      () =>
+        ({
+          success: false,
+          fieldErrors: [
+            {
+              field: 'spec',
+              message:
+                'decode dungeon spec: line 2: spec is not a supported field',
+            },
+          ],
+        }) as unknown as PutDungeonResponse
+    );
+
+    render(
+      <DungeonBuilderConcept
+        initialYaml={source}
+        authoringClient={client}
+        persistDraft={false}
+        allowNewCanvas={false}
+      />
+    );
+
+    await screen.findByText(
+      'spec: decode dungeon spec: line 2: spec is not a supported field',
+      undefined,
+      { timeout: 4000 }
+    );
+    expect(
+      (screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement).value
+    ).toBe(source);
+    expect(
+      (screen.getByRole('button', { name: /^Save/ }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+    expect(
+      client.putDungeon.mock.calls.some(
+        ([request]) =>
+          request.key === 'simple-room' &&
+          request.validateOnly === true &&
+          request.yaml === source
+      )
+    ).toBe(true);
+    expect(source).toMatch(/spec: ['"]0\.3['"]/);
+    expect(source).not.toContain('floor_source');
+  });
+
+  it('enables Save & Play only after the byte-exact canonical candidate receives a valid REGIONS plan, then saves that same candidate', async () => {
+    const source = regionFixture('simple-room-v04-regions.yaml');
+    const client = liveClient(
+      (request) =>
+        ({
+          success: true,
+          fieldErrors: [],
+          floorPlan: request.validateOnly
+            ? canonicalRegionFloorPlan()
+            : undefined,
+        }) as unknown as PutDungeonResponse
+    );
+
+    render(
+      <DungeonBuilderConcept
+        initialYaml={source}
+        authoringClient={client}
+        persistDraft={false}
+        allowNewCanvas={false}
+      />
+    );
+
+    await waitFor(
+      () =>
+        expect(
+          (
+            screen.getByRole('button', {
+              name: 'Save & Play',
+            }) as HTMLButtonElement
+          ).disabled
+        ).toBe(false),
+      { timeout: 4000 }
+    );
+    expect(
+      (screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement).value
+    ).toBe(source);
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Play' }));
+
+    await waitFor(() =>
+      expect(
+        client.putDungeon.mock.calls.some(
+          ([request]) =>
+            request.key === 'simple-room' &&
+            request.validateOnly === false &&
+            request.yaml === source
+        )
+      ).toBe(true)
+    );
+  });
+});
 
 describe('DungeonBuilderConcept — crash-proof draft restore (Kirk incident regression)', () => {
   beforeEach(() => {

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -41,6 +41,8 @@ import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 const hoisted = vi.hoisted(() => ({
   globalPutDungeon: vi.fn(),
   previewProps: null as Record<string, unknown> | null,
+  compilableRenders: [] as boolean[],
+  saveRenderAttempts: [] as Array<() => void>,
 }));
 
 vi.mock('@/api/client', () => ({
@@ -53,6 +55,20 @@ vi.mock('./preview3d/DungeonPreview3D', () => ({
     return null;
   },
 }));
+
+vi.mock('./YamlPane', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./YamlPane')>();
+  return {
+    ...actual,
+    SaveAndPlayButton: (
+      props: Parameters<typeof actual.SaveAndPlayButton>[0]
+    ) => {
+      hoisted.compilableRenders.push(props.v1Compilable);
+      hoisted.saveRenderAttempts.push(props.onSaveAndPlay);
+      return actual.SaveAndPlayButton(props);
+    },
+  };
+});
 
 import { DungeonBuilderConcept } from './DungeonBuilderConcept';
 import type { AuthoringUnaryClient } from './useSaveDungeon';
@@ -113,6 +129,8 @@ describe('DungeonBuilderConcept — exact region-floor hard stops', () => {
   beforeEach(() => {
     localStorage.clear();
     hoisted.previewProps = null;
+    hoisted.compilableRenders.length = 0;
+    hoisted.saveRenderAttempts.length = 0;
   });
   afterEach(() => {
     localStorage.clear();
@@ -249,6 +267,74 @@ describe('DungeonBuilderConcept — exact region-floor hard stops', () => {
         )
       ).toBe(true)
     );
+  });
+
+  it('synchronously revokes an accepted candidate when the current YAML/key changes, before Save & Play can reuse stale YAML', async () => {
+    const source = regionFixture('simple-room-v04-regions.yaml');
+    const editedSource = source.replace(
+      'key: simple-room',
+      'key: simple-room-edited'
+    );
+    const floorPlan = canonicalRegionFloorPlan();
+    const client = liveClient(
+      (request) =>
+        ({
+          success: true,
+          fieldErrors: [],
+          floorPlan: request.validateOnly ? floorPlan : undefined,
+        }) as unknown as PutDungeonResponse
+    );
+
+    render(
+      <DungeonBuilderConcept
+        initialYaml={source}
+        authoringClient={client}
+        persistDraft={false}
+        allowNewCanvas={false}
+      />
+    );
+
+    const saveButton = await screen.findByRole(
+      'button',
+      { name: 'Save & Play' },
+      { timeout: 4000 }
+    );
+    await waitFor(() =>
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false)
+    );
+    fireEvent.click(screen.getByRole('button', { name: '3D' }));
+    await waitFor(() =>
+      expect(hoisted.previewProps?.floorPlan).toBe(floorPlan)
+    );
+
+    hoisted.previewProps = null;
+    hoisted.compilableRenders.length = 0;
+    hoisted.saveRenderAttempts.length = 0;
+    fireEvent.change(screen.getByLabelText('Dungeon YAML'), {
+      target: { value: editedSource },
+    });
+
+    // Exercise every callback committed for the edit. Before the fix, the
+    // first render still advertised `compilable: true`, and its callback
+    // could persist the prior accepted YAML before the passive cleanup render.
+    act(() => {
+      hoisted.saveRenderAttempts.forEach((attempt) => attempt());
+    });
+    expect(
+      client.putDungeon.mock.calls.filter(
+        ([request]) => request.validateOnly === false
+      )
+    ).toEqual([]);
+    expect(hoisted.compilableRenders).not.toContain(true);
+    expect(hoisted.compilableRenders.at(-1)).toBe(false);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+    expect(hoisted.previewProps).toBeNull();
+    fireEvent.click(saveButton);
+    expect(
+      client.putDungeon.mock.calls.filter(
+        ([request]) => request.validateOnly === false
+      )
+    ).toEqual([]);
   });
 });
 

--- a/src/author/DungeonBuilderConcept.test.tsx
+++ b/src/author/DungeonBuilderConcept.test.tsx
@@ -40,10 +40,18 @@ import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 
 const hoisted = vi.hoisted(() => ({
   globalPutDungeon: vi.fn(),
+  previewProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock('@/api/client', () => ({
   authoringClient: { putDungeon: hoisted.globalPutDungeon },
+}));
+
+vi.mock('./preview3d/DungeonPreview3D', () => ({
+  DungeonPreview3D: (props: Record<string, unknown>) => {
+    hoisted.previewProps = props;
+    return null;
+  },
 }));
 
 import { DungeonBuilderConcept } from './DungeonBuilderConcept';
@@ -104,6 +112,7 @@ function seedBrokenDraft() {
 describe('DungeonBuilderConcept — exact region-floor hard stops', () => {
   beforeEach(() => {
     localStorage.clear();
+    hoisted.previewProps = null;
   });
   afterEach(() => {
     localStorage.clear();
@@ -181,16 +190,15 @@ describe('DungeonBuilderConcept — exact region-floor hard stops', () => {
     expect(source).not.toContain('floor_source');
   });
 
-  it('enables Save & Play only after the byte-exact canonical candidate receives a valid REGIONS plan, then saves that same candidate', async () => {
+  it('enables Save & Play only after the byte-exact canonical candidate receives a valid REGIONS plan, renders its envelope/entrance, then saves that same candidate', async () => {
     const source = regionFixture('simple-room-v04-regions.yaml');
+    const floorPlan = canonicalRegionFloorPlan();
     const client = liveClient(
       (request) =>
         ({
           success: true,
           fieldErrors: [],
-          floorPlan: request.validateOnly
-            ? canonicalRegionFloorPlan()
-            : undefined,
+          floorPlan: request.validateOnly ? floorPlan : undefined,
         }) as unknown as PutDungeonResponse
     );
 
@@ -217,6 +225,18 @@ describe('DungeonBuilderConcept — exact region-floor hard stops', () => {
     expect(
       (screen.getByLabelText('Dungeon YAML') as HTMLTextAreaElement).value
     ).toBe(source);
+
+    fireEvent.click(screen.getByRole('button', { name: '3D' }));
+    await waitFor(() =>
+      expect(hoisted.previewProps?.floorPlan).toBe(floorPlan)
+    );
+    const renderedPlan = hoisted.previewProps?.floorPlan as ReturnType<
+      typeof canonicalRegionFloorPlan
+    >;
+    expect(renderedPlan.edges).toEqual(floorPlan.edges);
+    expect(renderedPlan.entrance).toEqual(floorPlan.entrance);
+    expect(renderedPlan.edges).toHaveLength(1);
+
     fireEvent.click(screen.getByRole('button', { name: 'Save & Play' }));
 
     await waitFor(() =>

--- a/src/author/DungeonBuilderConcept.tsx
+++ b/src/author/DungeonBuilderConcept.tsx
@@ -37,6 +37,7 @@
  * interactive drag actually calls) are untouched.
  */
 import { ErrorBoundary } from '@/components/ui/Feedback/ErrorBoundary';
+import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import {
   useEffect,
   useMemo,
@@ -45,6 +46,7 @@ import {
   type MutableRefObject,
 } from 'react';
 import { BoardCrashRecovery } from './BoardCrashRecovery';
+import { validateRegionFloorCandidate } from './capabilityProbe';
 import { CreationConcept } from './creation/CreationConcept';
 import { DEFAULT_CANVAS, emptyCanvasYaml } from './creation/emptyCanvasDoc';
 import type { CornerRef } from './creation/hexCorner';
@@ -74,6 +76,7 @@ import {
   type DungeonDoc,
   type WallKind,
 } from './dungeonYaml';
+import { hasRegionFloorIntent } from './regionFloorContract';
 import { buildSpecCompatReport } from './specCompat';
 import type { BoardTool } from './types';
 import { useBoardEditing } from './useBoardEditing';
@@ -97,6 +100,12 @@ interface CreationCrash {
   message: string;
   yamlText: string;
 }
+
+type RegionFloorState =
+  | { kind: 'inactive' }
+  | { kind: 'validating' }
+  | { kind: 'blocked'; reason: string }
+  | { kind: 'accepted'; yaml: string; floorPlan: FloorPlan };
 
 /** `draftDiffersFromFreshSeed`'s canonicalize function — the real
  * parse+serialize round trip, module-level since it needs nothing from
@@ -269,6 +278,63 @@ export function DungeonBuilderConcept({
     null
   );
   const createAutosaveRef = useRef<DraftAutosave | null>(null);
+  const regionFloorIntent = hasRegionFloorIntent(creationDoc);
+  const [regionFloorState, setRegionFloorState] = useState<RegionFloorState>({
+    kind: 'inactive',
+  });
+
+  // A region floor is accepted by its normal exact validate-only request,
+  // never by the legacy per-field capability strip. Keep the request payload
+  // separate from the editable source: lossless wallLines sugar may compile on
+  // a fresh CST, while failures always leave the textarea byte-for-byte intact.
+  useEffect(() => {
+    if (!regionFloorIntent) {
+      setRegionFloorState({ kind: 'inactive' });
+      return;
+    }
+    if (preview.serverState === 'probing') {
+      setRegionFloorState({ kind: 'validating' });
+      return;
+    }
+    if (preview.serverState !== 'live') {
+      setRegionFloorState({
+        kind: 'blocked',
+        reason:
+          'canvas.floor_source: regions requires a reachable authoring provider for exact validate-only acceptance',
+      });
+      return;
+    }
+
+    let cancelled = false;
+    setRegionFloorState({ kind: 'validating' });
+    const timer = setTimeout(() => {
+      validateRegionFloorCandidate(creationYamlText, {
+        capabilities: preview.capabilities,
+        client: authoringClient,
+      }).then((result) => {
+        if (cancelled) return;
+        setRegionFloorState(
+          result.accepted
+            ? {
+                kind: 'accepted',
+                yaml: result.yaml,
+                floorPlan: result.floorPlan,
+              }
+            : { kind: 'blocked', reason: result.reason }
+        );
+      });
+    }, 500);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [
+    authoringClient,
+    creationYamlText,
+    preview.capabilities,
+    preview.serverState,
+    regionFloorIntent,
+  ]);
 
   // Creation mode's own live FloorPlan preview (v0.3 wire consumption
   // unit, 2026-08-05) — same "reuse the shared serverState/capabilities,
@@ -282,7 +348,7 @@ export function DungeonBuilderConcept({
   // Wave 0/1 lands, not a behavior change against any server reachable
   // right now.
   const creationFloorPreview = useCreationFloorPlanPreview(
-    creationDoc,
+    regionFloorIntent ? null : creationDoc,
     creationYamlText,
     preview.serverState,
     preview.capabilities,
@@ -296,6 +362,16 @@ export function DungeonBuilderConcept({
   // strip too — no second probe needed.
   const creationSave = useSaveDungeon(authoringClient, onSaveSucceeded);
   const creationV1Subset = useMemo(() => {
+    if (regionFloorIntent) {
+      if (regionFloorState.kind !== 'accepted') return null;
+      return {
+        yaml: regionFloorState.yaml,
+        dropped: [],
+        compiling: ['exact region floor'],
+        compilable: true,
+        compilableBlockers: [],
+      };
+    }
     try {
       return stripToV1Subset(
         creationYamlText,
@@ -304,7 +380,12 @@ export function DungeonBuilderConcept({
     } catch {
       return null;
     }
-  }, [creationYamlText, preview.capabilities]);
+  }, [
+    creationYamlText,
+    preview.capabilities,
+    regionFloorIntent,
+    regionFloorState,
+  ]);
 
   // Local drafts + versioned save/load — creation mode's own spec-compat
   // report.
@@ -314,6 +395,11 @@ export function DungeonBuilderConcept({
   );
 
   const handleCreationSaveAndPlay = () => {
+    if (regionFloorIntent) {
+      if (regionFloorState.kind !== 'accepted') return;
+      creationSave.save(creationDoc.key, regionFloorState.yaml);
+      return;
+    }
     creationSave.save(
       creationDoc.key,
       creationV1Subset?.yaml ?? creationYamlText
@@ -619,7 +705,12 @@ export function DungeonBuilderConcept({
           <CreationConcept
             doc={creationDoc}
             yamlText={creationYamlText}
-            yamlParseError={creationParseError}
+            yamlParseError={
+              creationParseError ??
+              (regionFloorState.kind === 'blocked'
+                ? regionFloorState.reason
+                : null)
+            }
             onChangeYamlText={handleChangeCreationText}
             edit={creationEdit}
             selectedTool={creationSelectedTool}
@@ -642,15 +733,37 @@ export function DungeonBuilderConcept({
             serverState={preview.serverState}
             capabilities={preview.capabilities}
             onRefreshCapabilities={preview.refreshCapabilities}
-            liveFloorPlan={creationFloorPreview.floorPlan}
+            liveFloorPlan={
+              regionFloorState.kind === 'accepted'
+                ? regionFloorState.floorPlan
+                : creationFloorPreview.floorPlan
+            }
             v1Subset={creationV1Subset}
             onSaveAndPlay={handleCreationSaveAndPlay}
             saveState={creationSave.state}
             savedKey={creationSave.savedKey}
             saveFieldErrors={creationSave.fieldErrors}
             saveErrorMessage={creationSave.errorMessage}
-            boardDim={createBoardDim}
-            onSetBoardDim={setCreateBoardDim}
+            boardDim={
+              regionFloorIntent && regionFloorState.kind !== 'accepted'
+                ? '2d'
+                : createBoardDim
+            }
+            onSetBoardDim={(dim) => {
+              if (
+                dim === '3d' &&
+                regionFloorIntent &&
+                regionFloorState.kind !== 'accepted'
+              ) {
+                flashToast(
+                  regionFloorState.kind === 'blocked'
+                    ? regionFloorState.reason
+                    : 'Validating the exact region-floor candidate before preview.'
+                );
+                return;
+              }
+              setCreateBoardDim(dim);
+            }}
             yamlDownloadFilename={creationDownloadFilename}
             onLoadYamlFile={handleLoadCreationYamlFile}
             onLoadYamlFileError={handleLoadCreationYamlFileError}

--- a/src/author/DungeonBuilderConcept.tsx
+++ b/src/author/DungeonBuilderConcept.tsx
@@ -105,7 +105,13 @@ type RegionFloorState =
   | { kind: 'inactive' }
   | { kind: 'validating' }
   | { kind: 'blocked'; reason: string }
-  | { kind: 'accepted'; yaml: string; floorPlan: FloorPlan };
+  | {
+      kind: 'accepted';
+      sourceYaml: string;
+      key: string;
+      yaml: string;
+      floorPlan: FloorPlan;
+    };
 
 /** `draftDiffersFromFreshSeed`'s canonicalize function — the real
  * parse+serialize round trip, module-level since it needs nothing from
@@ -317,6 +323,8 @@ export function DungeonBuilderConcept({
           result.accepted
             ? {
                 kind: 'accepted',
+                sourceYaml: creationYamlText,
+                key: result.key,
                 yaml: result.yaml,
                 floorPlan: result.floorPlan,
               }
@@ -335,6 +343,17 @@ export function DungeonBuilderConcept({
     preview.serverState,
     regionFloorIntent,
   ]);
+
+  // Acceptance belongs to one exact editable source and request key. This
+  // match is render-time safety, not effect cleanup: a source edit revokes
+  // compile, preview, and save access in the same render even while the old
+  // accepted state is still waiting for the passive effect above to clean up.
+  const acceptedRegionFloor =
+    regionFloorState.kind === 'accepted' &&
+    regionFloorState.sourceYaml === creationYamlText &&
+    regionFloorState.key === creationDoc.key
+      ? regionFloorState
+      : null;
 
   // Creation mode's own live FloorPlan preview (v0.3 wire consumption
   // unit, 2026-08-05) — same "reuse the shared serverState/capabilities,
@@ -363,9 +382,9 @@ export function DungeonBuilderConcept({
   const creationSave = useSaveDungeon(authoringClient, onSaveSucceeded);
   const creationV1Subset = useMemo(() => {
     if (regionFloorIntent) {
-      if (regionFloorState.kind !== 'accepted') return null;
+      if (!acceptedRegionFloor) return null;
       return {
-        yaml: regionFloorState.yaml,
+        yaml: acceptedRegionFloor.yaml,
         dropped: [],
         compiling: ['exact region floor'],
         compilable: true,
@@ -381,10 +400,10 @@ export function DungeonBuilderConcept({
       return null;
     }
   }, [
+    acceptedRegionFloor,
     creationYamlText,
     preview.capabilities,
     regionFloorIntent,
-    regionFloorState,
   ]);
 
   // Local drafts + versioned save/load — creation mode's own spec-compat
@@ -396,8 +415,8 @@ export function DungeonBuilderConcept({
 
   const handleCreationSaveAndPlay = () => {
     if (regionFloorIntent) {
-      if (regionFloorState.kind !== 'accepted') return;
-      creationSave.save(creationDoc.key, regionFloorState.yaml);
+      if (!acceptedRegionFloor) return;
+      creationSave.save(acceptedRegionFloor.key, acceptedRegionFloor.yaml);
       return;
     }
     creationSave.save(
@@ -734,8 +753,8 @@ export function DungeonBuilderConcept({
             capabilities={preview.capabilities}
             onRefreshCapabilities={preview.refreshCapabilities}
             liveFloorPlan={
-              regionFloorState.kind === 'accepted'
-                ? regionFloorState.floorPlan
+              acceptedRegionFloor
+                ? acceptedRegionFloor.floorPlan
                 : creationFloorPreview.floorPlan
             }
             v1Subset={creationV1Subset}
@@ -745,16 +764,10 @@ export function DungeonBuilderConcept({
             saveFieldErrors={creationSave.fieldErrors}
             saveErrorMessage={creationSave.errorMessage}
             boardDim={
-              regionFloorIntent && regionFloorState.kind !== 'accepted'
-                ? '2d'
-                : createBoardDim
+              regionFloorIntent && !acceptedRegionFloor ? '2d' : createBoardDim
             }
             onSetBoardDim={(dim) => {
-              if (
-                dim === '3d' &&
-                regionFloorIntent &&
-                regionFloorState.kind !== 'accepted'
-              ) {
+              if (dim === '3d' && regionFloorIntent && !acceptedRegionFloor) {
                 flashToast(
                   regionFloorState.kind === 'blocked'
                     ? regionFloorState.reason

--- a/src/author/capabilityProbe.test.ts
+++ b/src/author/capabilityProbe.test.ts
@@ -1,4 +1,12 @@
-import type { PutDungeonRequest } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanEdgeKind,
+  FloorPlanFloorSource,
+  FloorPlanSchema,
+  type PutDungeonRequest,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => ({
@@ -17,12 +25,132 @@ import {
   probeAllCapabilities,
   V03_CUT_FIELDS,
   v03CutFullySupported,
+  validateRegionFloorCandidate,
   type DialectField,
   type ServerCapabilities,
 } from './capabilityProbe';
 
 beforeEach(() => {
   hoisted.putDungeonFn.mockReset();
+});
+
+const regionFixture = (name: string): string =>
+  readFileSync(join(__dirname, 'testdata', name), 'utf8');
+
+function canonicalRegionFloorPlan() {
+  return create(FloorPlanSchema, {
+    width: 20,
+    height: 30,
+    floorSource: FloorPlanFloorSource.REGIONS,
+    floorCells: [
+      { column: 0, row: 0 },
+      { column: 0, row: 1 },
+      { column: 1, row: 1 },
+    ],
+    edges: [
+      {
+        from: { column: 0, row: 0 },
+        to: { column: -1, row: 0 },
+        kind: FloorPlanEdgeKind.SOLID,
+      },
+    ],
+    entrance: { column: 0, row: 0 },
+  });
+}
+
+describe('validateRegionFloorCandidate — exact normal PutDungeon acceptance', () => {
+  it('sends the immutable legacy source byte-for-byte and surfaces the provider strict-decode source path for spec', async () => {
+    const source = regionFixture('simple-room-legacy.yaml');
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: false,
+      fieldErrors: [
+        {
+          field: 'spec',
+          message: 'decode dungeon spec: line 2: spec is not a supported field',
+        },
+      ],
+    });
+
+    const result = await validateRegionFloorCandidate(source);
+
+    expect(result).toEqual({
+      accepted: false,
+      reason:
+        'spec: decode dungeon spec: line 2: spec is not a supported field',
+    });
+    expect(hoisted.putDungeonFn).toHaveBeenCalledOnce();
+    expect(hoisted.putDungeonFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'simple-room',
+        yaml: source,
+        validateOnly: true,
+      })
+    );
+    expect(source).toMatch(/spec: ['"]0\.3['"]/);
+    expect(source).not.toContain('floor_source');
+  });
+
+  it('submits the simplified canonical fixture byte-for-byte and accepts only a generated REGIONS response', async () => {
+    const source = regionFixture('simple-room-v04-regions.yaml');
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: true,
+      fieldErrors: [],
+      floorPlan: canonicalRegionFloorPlan(),
+    });
+
+    const result = await validateRegionFloorCandidate(source);
+
+    expect(result.accepted).toBe(true);
+    if (!result.accepted) throw new Error(result.reason);
+    expect(result.yaml).toBe(source);
+    expect(result.floorPlan.floorSource).toBe(FloorPlanFloorSource.REGIONS);
+    expect(hoisted.putDungeonFn).toHaveBeenCalledWith(
+      expect.objectContaining({ yaml: source, validateOnly: true })
+    );
+  });
+
+  it('blocks preview/save with the exact validate-only server reason', async () => {
+    const source = regionFixture('simple-room-v04-regions.yaml');
+    hoisted.putDungeonFn.mockResolvedValue({
+      success: false,
+      fieldErrors: [
+        {
+          field: 'regions[0].cells',
+          message: 'region-union floor must be connected in strict mode',
+        },
+      ],
+    });
+
+    await expect(validateRegionFloorCandidate(source)).resolves.toEqual({
+      accepted: false,
+      reason:
+        'regions[0].cells: region-union floor must be connected in strict mode',
+    });
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['UNSPECIFIED', FloorPlanFloorSource.UNSPECIFIED],
+    ['BOUNDS', FloorPlanFloorSource.BOUNDS],
+  ])(
+    'rejects a successful response whose floor source is %s',
+    async (_label, floorSource) => {
+      const source = regionFixture('simple-room-v04-regions.yaml');
+      hoisted.putDungeonFn.mockResolvedValue({
+        success: true,
+        fieldErrors: [],
+        floorPlan: create(FloorPlanSchema, {
+          ...canonicalRegionFloorPlan(),
+          floorSource,
+        }),
+      });
+
+      const result = await validateRegionFloorCandidate(source);
+      expect(result.accepted).toBe(false);
+      if (result.accepted) throw new Error('unexpected acceptance');
+      expect(result.reason).toMatch(/FloorPlan\.floor_source/);
+    }
+  );
 });
 
 describe('DIALECT_FIELDS', () => {

--- a/src/author/capabilityProbe.test.ts
+++ b/src/author/capabilityProbe.test.ts
@@ -128,6 +128,49 @@ describe('validateRegionFloorCandidate — exact normal PutDungeon acceptance', 
     });
   });
 
+  it('never accepts incomplete or non-adjacent generated REGIONS projections', async () => {
+    const source = regionFixture('simple-room-v04-regions.yaml');
+    const invalidPlans = [
+      create(FloorPlanSchema, {
+        floorSource: FloorPlanFloorSource.REGIONS,
+        floorCells: [],
+        edges: [
+          {
+            from: { column: 0, row: 0 },
+            to: { column: -1, row: 0 },
+            kind: FloorPlanEdgeKind.SOLID,
+          },
+        ],
+      }),
+      create(FloorPlanSchema, {
+        floorSource: FloorPlanFloorSource.REGIONS,
+        floorCells: [{ column: 0, row: 0 }],
+        edges: [],
+      }),
+      create(FloorPlanSchema, {
+        floorSource: FloorPlanFloorSource.REGIONS,
+        floorCells: [{ column: 0, row: 0 }],
+        edges: [
+          {
+            from: { column: 0, row: 0 },
+            to: { column: 4, row: 4 },
+            kind: FloorPlanEdgeKind.SOLID,
+          },
+        ],
+      }),
+    ];
+
+    for (const floorPlan of invalidPlans) {
+      hoisted.putDungeonFn.mockResolvedValueOnce({
+        success: true,
+        fieldErrors: [],
+        floorPlan,
+      });
+      const result = await validateRegionFloorCandidate(source);
+      expect(result.accepted).toBe(false);
+    }
+  });
+
   it.each([
     ['absent', undefined],
     ['UNSPECIFIED', FloorPlanFloorSource.UNSPECIFIED],

--- a/src/author/capabilityProbe.ts
+++ b/src/author/capabilityProbe.ts
@@ -98,8 +98,17 @@
  */
 import { authoringClient } from '@/api/client';
 import { create } from '@bufbuild/protobuf';
-import type { PutDungeonResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import type {
+  FloorPlan,
+  PutDungeonResponse,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { PutDungeonRequestSchema } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import { parseDungeon } from './dungeonYaml';
+import {
+  consumeRegionFloorProjection,
+  hasRegionFloorIntent,
+  prepareExactRegionFloorCandidate,
+} from './regionFloorContract';
 import type { AuthoringUnaryClient } from './useSaveDungeon';
 
 /** One entry per target-dialect construct `stripToV1Subset` knows how to
@@ -565,6 +574,128 @@ function classify(response: PutDungeonResponse): CapabilityResult {
  *   Not re-derived here — threaded verbatim from the server either way,
  *   per this module's own rule.
  */
+export type RegionFloorCandidateValidation =
+  | {
+      accepted: true;
+      /** Exact request payload accepted by validate-only and used for save. */
+      yaml: string;
+      floorPlan: FloorPlan;
+    }
+  | { accepted: false; reason: string };
+
+export interface ValidateRegionFloorCandidateOptions {
+  capabilities?: ServerCapabilities | null;
+  client?: AuthoringUnaryClient;
+}
+
+function formatCandidateFailure(response: PutDungeonResponse): string {
+  const reasons = response.fieldErrors.map((error) =>
+    error.field ? `${error.field}: ${error.message}` : error.message
+  );
+  return (
+    reasons.join('; ') ||
+    'validate-only rejected the candidate without a reason'
+  );
+}
+
+/**
+ * Validates one region-floor candidate through the normal PutDungeon RPC. This
+ * is intentionally not another capability bit: successful validate-only output
+ * plus the generated REGIONS projection is the acceptance signal. Legacy input
+ * carrying `spec` is attempted byte-for-byte so the provider's strict-decode
+ * source path remains visible; no client code deletes `spec` or adds a floor
+ * source on its behalf.
+ */
+export async function validateRegionFloorCandidate(
+  yaml: string,
+  options: ValidateRegionFloorCandidateOptions = {}
+): Promise<RegionFloorCandidateValidation> {
+  let parsed;
+  try {
+    parsed = parseDungeon(yaml);
+  } catch (error) {
+    return {
+      accepted: false,
+      reason: error instanceof Error ? error.message : 'invalid dungeon YAML',
+    };
+  }
+  if (!hasRegionFloorIntent(parsed.doc)) {
+    return {
+      accepted: false,
+      reason: 'regions: no region-floor candidate is present',
+    };
+  }
+
+  let candidateYaml = yaml;
+  // `spec` is provider grammar evidence: send the immutable source exactly so
+  // its real strict-decode path is surfaced. Every valid v0.4 candidate takes
+  // the explicit/lossless preparation path below.
+  if (parsed.doc.spec === null) {
+    try {
+      candidateYaml = prepareExactRegionFloorCandidate(yaml, {
+        wallsCapability: options.capabilities?.walls,
+      }).yaml;
+    } catch (error) {
+      return {
+        accepted: false,
+        reason:
+          error instanceof Error
+            ? error.message
+            : 'region-floor candidate preparation failed',
+      };
+    }
+  }
+
+  const client = options.client ?? authoringClient;
+  let response: PutDungeonResponse;
+  try {
+    response = await client.putDungeon(
+      create(PutDungeonRequestSchema, {
+        key: parsed.doc.key,
+        yaml: candidateYaml,
+        validateOnly: true,
+      })
+    );
+  } catch (error) {
+    return {
+      accepted: false,
+      reason:
+        error instanceof Error ? error.message : 'PutDungeon request failed',
+    };
+  }
+  if (!response.success) {
+    return { accepted: false, reason: formatCandidateFailure(response) };
+  }
+  if (parsed.doc.spec !== null) {
+    return {
+      accepted: false,
+      reason: 'spec: legacy authoring metadata is not provider grammar',
+    };
+  }
+  if (!response.floorPlan) {
+    return {
+      accepted: false,
+      reason: 'validate-only succeeded without a FloorPlan',
+    };
+  }
+  try {
+    consumeRegionFloorProjection(response.floorPlan);
+  } catch (error) {
+    return {
+      accepted: false,
+      reason:
+        error instanceof Error
+          ? error.message
+          : 'invalid region-floor projection',
+    };
+  }
+  return {
+    accepted: true,
+    yaml: candidateYaml,
+    floorPlan: response.floorPlan,
+  };
+}
+
 export async function probeAllCapabilities(
   client: AuthoringUnaryClient = authoringClient
 ): Promise<ServerCapabilities> {

--- a/src/author/capabilityProbe.ts
+++ b/src/author/capabilityProbe.ts
@@ -577,6 +577,8 @@ function classify(response: PutDungeonResponse): CapabilityResult {
 export type RegionFloorCandidateValidation =
   | {
       accepted: true;
+      /** Key sent with the exact validate-only request. */
+      key: string;
       /** Exact request payload accepted by validate-only and used for save. */
       yaml: string;
       floorPlan: FloorPlan;
@@ -691,6 +693,7 @@ export async function validateRegionFloorCandidate(
   }
   return {
     accepted: true,
+    key: parsed.doc.key,
     yaml: candidateYaml,
     floorPlan: response.floorPlan,
   };

--- a/src/author/creation/CreationConcept.tsx
+++ b/src/author/creation/CreationConcept.tsx
@@ -426,9 +426,11 @@ export function CreationConcept({
             // tool (region/wall/hole/start/end) armed while the author
             // clicks in 3D gets an honest "switch to 2D" message instead
             // of the generic "pick a palette item" one.
-            // `floorPlan` stays unset — a canvas has none — so
-            // `floorCells` (this component's own derivation above) is
-            // the only floor input; `onPlace`'s `roomId` argument is
+            // `floorCells` remains the canvas tile mask. When exact live
+            // provider truth exists, the full `floorPlan` is also passed so
+            // DungeonPreview3D renders its returned envelope/door pairs and
+            // presence-aware entrance; it never derives replacements.
+            // `onPlace`'s `roomId` argument is
             // always `null` on this path (`DungeonPreview3D.tsx`'s own
             // `handleClickCell` doc comment) — the same top-level shape
             // `CreationBoard.tsx`'s 2D brush already produces via
@@ -436,6 +438,7 @@ export function CreationConcept({
             // itself stays out of scope this round — see CONTRACT.md.
             <div style={{ flex: 1, minHeight: 0 }}>
               <DungeonPreview3D
+                floorPlan={liveFloorPlan ?? undefined}
                 floorCells={floorCells}
                 floorSource={resolvedFloor.source}
                 doc={doc}

--- a/src/author/creation/canvasFloor.test.ts
+++ b/src/author/creation/canvasFloor.test.ts
@@ -1,5 +1,7 @@
 import { create } from '@bufbuild/protobuf';
 import {
+  FloorPlanEdgeKind,
+  FloorPlanFloorSource,
   FloorPlanSchema,
   type FloorPlan,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
@@ -77,6 +79,68 @@ describe('deriveCanvasFloorCells', () => {
       holes: [[0, 0]],
     });
     expect(cells).toEqual([]);
+  });
+});
+
+describe('resolveCanvasFloor — exact region floor', () => {
+  const doc = {
+    canvas: { width: 5, height: 5, floorSource: 'regions' as const },
+    holes: [] as [number, number][],
+  };
+
+  const regionPlan = (floorSource: FloorPlanFloorSource | undefined) =>
+    create(FloorPlanSchema, {
+      width: 5,
+      height: 5,
+      floorSource,
+      floorCells: [
+        { column: 1, row: 1 },
+        { column: 1, row: 2 },
+        { column: 2, row: 1 },
+      ],
+      edges: [
+        {
+          from: { column: 0, row: 1 },
+          to: { column: 1, row: 1 },
+          kind: FloorPlanEdgeKind.SOLID,
+        },
+      ],
+      entrance: { column: 1, row: 1 },
+    });
+
+  it('requires a real generated REGIONS plan and never renders a client-derived bounds rectangle', () => {
+    const result = resolveCanvasFloor(
+      doc,
+      regionPlan(FloorPlanFloorSource.REGIONS)
+    );
+
+    expect(result.source).toBe('server');
+    expect(result.floorSource).toBe(FloorPlanFloorSource.REGIONS);
+    expect(result.cells).toEqual([
+      [1, 1],
+      [1, 2],
+      [2, 1],
+    ]);
+    expect(result.cells).not.toContainEqual([0, 0]);
+    expect(result.entrance).toEqual([1, 1]);
+    expect(result.edges).toEqual([
+      expect.objectContaining({
+        from: [0, 1],
+        to: [1, 1],
+        floorOwners: [[1, 1]],
+      }),
+    ]);
+  });
+
+  it.each([
+    ['no plan', null],
+    ['absent source', regionPlan(undefined)],
+    ['unspecified source', regionPlan(FloorPlanFloorSource.UNSPECIFIED)],
+    ['bounds source', regionPlan(FloorPlanFloorSource.BOUNDS)],
+  ])('hard-stops for %s instead of deriving bounds', (_label, floorPlan) => {
+    expect(() => resolveCanvasFloor(doc, floorPlan)).toThrow(
+      /FloorPlan\.floor_source|requires a successful validate-only FloorPlan/
+    );
   });
 });
 

--- a/src/author/creation/canvasFloor.ts
+++ b/src/author/creation/canvasFloor.ts
@@ -37,7 +37,10 @@ import type {
   FloorPlanCell,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { isCellOccupied } from '../boardGeometry';
-import type { DungeonDoc } from '../dungeonYaml';
+import {
+  UnsupportedRegionFloorContractError,
+  type DungeonDoc,
+} from '../dungeonYaml';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
 
 export type Cell = [number, number];
@@ -126,6 +129,11 @@ export function resolveCanvasFloor(
   doc: Pick<DungeonDoc, 'canvas' | 'holes'>,
   floorPlan: FloorPlan | null
 ): ResolvedCanvasFloor {
+  if (doc.canvas?.floorSource === 'regions') {
+    throw new UnsupportedRegionFloorContractError(
+      'FloorPlan.floor_source is not present in the released proto; refusing to infer or downgrade a region-union floor'
+    );
+  }
   if (floorPlan && floorPlan.floorCells.length > 0) {
     return {
       cells: sortCellsLexicographic(

--- a/src/author/creation/canvasFloor.ts
+++ b/src/author/creation/canvasFloor.ts
@@ -32,15 +32,20 @@
  * against every live server today — verified by the
  * rpg-api-protos#214 conformance review's finding A4).
  */
-import type {
-  FloorPlan,
-  FloorPlanCell,
+import {
+  FloorPlanFloorSource,
+  type FloorPlan,
+  type FloorPlanCell,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { isCellOccupied } from '../boardGeometry';
 import {
   UnsupportedRegionFloorContractError,
   type DungeonDoc,
 } from '../dungeonYaml';
+import {
+  consumeRegionFloorProjection,
+  type ConsumedRegionFloorEdge,
+} from '../regionFloorContract';
 import { DEFAULT_CANVAS } from './emptyCanvasDoc';
 
 export type Cell = [number, number];
@@ -91,10 +96,14 @@ function floorPlanCellToTuple(cell: FloorPlanCell): Cell {
 export type CanvasFloorSource = 'server' | 'derived';
 
 export interface ResolvedCanvasFloor {
-  /** Ascending-lexicographic-normalized (see `sortCellsLexicographic`),
-   * regardless of source. */
+  /** Provider order for REGIONS; normalized legacy order for bounds fallback. */
   cells: Cell[];
   source: CanvasFloorSource;
+  floorSource?: FloorPlanFloorSource;
+  /** Present only for exact REGIONS output; never client-invented. */
+  edges?: readonly ConsumedRegionFloorEdge[];
+  /** Presence-aware provider anchor, including a real [0,0]. */
+  entrance?: Cell;
 }
 
 /**
@@ -130,9 +139,21 @@ export function resolveCanvasFloor(
   floorPlan: FloorPlan | null
 ): ResolvedCanvasFloor {
   if (doc.canvas?.floorSource === 'regions') {
-    throw new UnsupportedRegionFloorContractError(
-      'FloorPlan.floor_source is not present in the released proto; refusing to infer or downgrade a region-union floor'
-    );
+    if (!floorPlan) {
+      throw new UnsupportedRegionFloorContractError(
+        'canvas.floor_source: regions requires a successful validate-only FloorPlan; refusing to derive bounds'
+      );
+    }
+    const projection = consumeRegionFloorProjection(floorPlan);
+    return {
+      cells: projection.floorCells.map(([column, row]) => [column, row]),
+      source: 'server',
+      floorSource: projection.floorSource,
+      edges: projection.edges,
+      entrance: projection.entrance
+        ? [projection.entrance[0], projection.entrance[1]]
+        : undefined,
+    };
   }
   if (floorPlan && floorPlan.floorCells.length > 0) {
     return {

--- a/src/author/dungeonYaml.test.ts
+++ b/src/author/dungeonYaml.test.ts
@@ -1,4 +1,5 @@
 import { hexDistance } from '@/components/hex-grid/hexMath';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -70,6 +71,21 @@ const regionFixture = (name: string): string =>
   readFileSync(join(__dirname, 'testdata', name), 'utf8');
 
 describe('Dungeon YAML v0.4 exact region-floor candidates', () => {
+  it('pins the legacy fixture byte-for-byte to the immutable downloaded source and its SHA-256', () => {
+    const immutable = readFileSync('/home/kirk/Downloads/simple-room.yaml');
+    const fixture = readFileSync(
+      join(__dirname, 'testdata', 'simple-room-legacy.yaml')
+    );
+    const sha256 = (bytes: Buffer): string =>
+      createHash('sha256').update(bytes).digest('hex');
+
+    expect(fixture.equals(immutable)).toBe(true);
+    expect(sha256(immutable)).toBe(
+      '85c9b6e27cfb4a09ff1ef764f4a923056586eabf1bdd2585b36206d19c41d620'
+    );
+    expect(sha256(fixture)).toBe(sha256(immutable));
+  });
+
   it('keeps the immutable legacy source exact and refuses the legacy subset path instead of deleting spec or inferring floor_source', () => {
     const source = regionFixture('simple-room-legacy.yaml');
     const before = source;

--- a/src/author/dungeonYaml.test.ts
+++ b/src/author/dungeonYaml.test.ts
@@ -60,7 +60,84 @@ import {
 } from './dungeonYaml';
 import { SHOWCASE_YAML } from './fixtures';
 import { cubeAtColRow } from './hexLayout';
+import {
+  prepareExactRegionFloorCandidate,
+  UnsupportedRegionFloorContractError,
+} from './regionFloorContract';
 import { OVERLAP_SAMPLE_CELLS } from './regionTree';
+
+const regionFixture = (name: string): string =>
+  readFileSync(join(__dirname, 'testdata', name), 'utf8');
+
+describe('Dungeon YAML v0.4 exact region-floor candidates', () => {
+  it('keeps the immutable legacy source exact and refuses the legacy subset path instead of deleting spec or inferring floor_source', () => {
+    const source = regionFixture('simple-room-legacy.yaml');
+    const before = source;
+    const parsed = parseDungeon(source);
+
+    expect(parsed.doc.spec).toBe('0.3');
+    expect(parsed.doc.canvas?.floorSource).toBeNull();
+    expect(source).toBe(before);
+    expect(() => stripToV1Subset(source)).toThrow(
+      /exact region-floor candidate/
+    );
+    expect(source).toMatch(/spec: ['"]0\.3['"]/);
+    expect(source).not.toContain('floor_source');
+  });
+
+  it('serializes an explicitly authored canvas.floor_source without inventing one when it was absent', () => {
+    const legacy = parseDungeon(regionFixture('simple-room-legacy.yaml'));
+    const canonical = parseDungeon(
+      regionFixture('simple-room-v04-regions.yaml')
+    );
+
+    expect(serializeDungeon(legacy.cst)).not.toContain('floor_source');
+    expect(serializeDungeon(canonical.cst)).toContain('floor_source: regions');
+  });
+
+  it('hard-stops the local v0.4 derivative non-destructively for both lossy perimeter wallLines and unsupported rotate_degrees', () => {
+    const source = regionFixture('simple-room-v04-lossy.yaml');
+    const before = source;
+
+    expect(() => prepareExactRegionFloorCandidate(source)).toThrowError(
+      new UnsupportedRegionFloorContractError(
+        'wallLines: perimeter rim edges cannot compile losslessly to walls; place[5].rotate_degrees: unsupported capability: fine rotation cannot be removed from an exact region-floor candidate; wallLines[3]: projection produced no canonical walls; exact region-floor candidate blocked'
+      )
+    );
+    expect(source).toBe(before);
+    expect(source).toContain('wallLines:');
+    expect(source).toContain('rotate_degrees: 30');
+  });
+
+  it('submits the simplified canonical fixture byte-for-byte because it needs no client-side wall sugar', () => {
+    const source = regionFixture('simple-room-v04-regions.yaml');
+    const candidate = prepareExactRegionFloorCandidate(source);
+
+    expect(candidate.yaml).toBe(source);
+    expect(candidate.doc.canvas?.floorSource).toBe('regions');
+    expect(candidate.doc.regions[0]?.cells).toHaveLength(53);
+    expect(candidate.doc.place).toHaveLength(6);
+    expect(candidate.doc.walls).toEqual([]);
+  });
+
+  it('blocks wallLines with the exact rejected walls capability reason before attempting a projection', () => {
+    const source = regionFixture('simple-room-v04-lossy.yaml').replace(
+      ', rotate_degrees: 30',
+      ''
+    );
+
+    expect(() =>
+      prepareExactRegionFloorCandidate(source, {
+        wallsCapability: {
+          accepted: false,
+          message: 'walls are disabled on this provider',
+        },
+      })
+    ).toThrow(
+      'walls: walls are disabled on this provider; wallLines cannot compile for an exact region-floor candidate'
+    );
+  });
+});
 
 describe('parseDungeon', () => {
   it('parses showcase.yaml into the expected room chain', () => {

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -678,8 +678,8 @@ export interface ParsedDungeon {
 
 export class DungeonParseError extends Error {}
 
-/** Hard stop for an exact `floor_source: regions` document while the
- * released FloorPlan proto cannot project the resolved discriminator. */
+/** Visible hard stop for a region-floor candidate that cannot be submitted
+ * and consumed without changing its authored semantics. */
 export class UnsupportedRegionFloorContractError extends Error {}
 
 /** Parse YAML text into both the CST (for mutation/round-trip) and a plain
@@ -2628,9 +2628,12 @@ export function stripToV1Subset(
   capabilities?: ServerCapabilities
 ): V1SubsetResult {
   const { cst, doc } = parseDungeon(yamlText);
-  if (doc.canvas?.floorSource === 'regions') {
+  if (
+    doc.canvas?.floorSource === 'regions' ||
+    (doc.canvas !== null && doc.rooms.length === 0 && doc.regions.length > 0)
+  ) {
     throw new UnsupportedRegionFloorContractError(
-      'canvas.floor_source: regions cannot be stripped or downgraded; wait for the additive FloorPlan.floor_source proto before preview/save/run'
+      'regions require an exact region-floor candidate; stripToV1Subset cannot remove spec, infer canvas.floor_source, drop regions, or approximate wallLines'
     );
   }
   const dropped: string[] = [];

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -441,9 +441,15 @@ export interface ConnectorDoc {
   locked: LockedDoc | null;
 }
 
+export type CanvasFloorSource = 'bounds' | 'regions';
+
 export interface CanvasDoc {
   width: number;
   height: number;
+  /** RATIFIED Dungeon YAML v0.4 topology discriminator. `null` preserves
+   * omission as authored; the provider resolves omission to `bounds` in its
+   * FloorPlan projection. The client must never rewrite `regions` to bounds. */
+  floorSource?: CanvasFloorSource | null;
 }
 
 /** Cell-authored semantic room region — target dialect, proposed
@@ -672,6 +678,10 @@ export interface ParsedDungeon {
 
 export class DungeonParseError extends Error {}
 
+/** Hard stop for an exact `floor_source: regions` document while the
+ * released FloorPlan proto cannot project the resolved discriminator. */
+export class UnsupportedRegionFloorContractError extends Error {}
+
 /** Parse YAML text into both the CST (for mutation/round-trip) and a plain
  * view model (for rendering). Throws `DungeonParseError` on YAML syntax
  * errors OR on structural shape mismatches (missing `rooms`, a room with
@@ -791,7 +801,24 @@ export function toDungeonDoc(cst: Document): DungeonDoc {
             `canvas: width/height must be numbers, got ${JSON.stringify(c)}`
           );
         }
-        return { width: c.width, height: c.height };
+        if (
+          c.floor_source !== undefined &&
+          c.floor_source !== 'bounds' &&
+          c.floor_source !== 'regions'
+        ) {
+          throw new DungeonParseError(
+            `canvas.floor_source: expected "bounds" or "regions", got ${JSON.stringify(c.floor_source)}`
+          );
+        }
+        const floorSource: CanvasFloorSource | null =
+          c.floor_source === 'bounds' || c.floor_source === 'regions'
+            ? c.floor_source
+            : null;
+        return {
+          width: c.width,
+          height: c.height,
+          floorSource,
+        };
       })()
     : null;
 
@@ -2601,6 +2628,11 @@ export function stripToV1Subset(
   capabilities?: ServerCapabilities
 ): V1SubsetResult {
   const { cst, doc } = parseDungeon(yamlText);
+  if (doc.canvas?.floorSource === 'regions') {
+    throw new UnsupportedRegionFloorContractError(
+      'canvas.floor_source: regions cannot be stripped or downgraded; wait for the additive FloorPlan.floor_source proto before preview/save/run'
+    );
+  }
   const dropped: string[] = [];
   const compiling: string[] = [];
   const accepted = (field: DialectField): boolean =>

--- a/src/author/preview3d/DungeonPreview3D.test.ts
+++ b/src/author/preview3d/DungeonPreview3D.test.ts
@@ -17,6 +17,12 @@
  */
 import { HEX_SIZE } from '@/components/hex-grid/hexMath';
 import { WALL_HEIGHT } from '@/rendering/calibrationConstants';
+import { create } from '@bufbuild/protobuf';
+import {
+  FloorPlanEdgeKind,
+  FloorPlanFloorSource,
+  FloorPlanSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -35,6 +41,7 @@ import {
   setPlacementMount,
   setPlacementRotationDegrees,
   setRefDefault,
+  setWallEdge,
   toDungeonDoc,
   toggleWallLineDoorAt,
 } from '../dungeonYaml';
@@ -50,6 +57,7 @@ import {
   buildWallLineSegments,
   CANVAS_ROOM_ID,
   ORBIT_INITIAL_CAMERA_POSITION,
+  selectPreviewSourceWalls,
 } from './DungeonPreview3D';
 import { azimuthOf, INITIAL_AZIMUTH } from './playCameraRig';
 
@@ -162,6 +170,74 @@ describe('buildOnePlacement — resolved facing × fine-rotation composition', (
 // comment describes. `buildFloorTiles`/`buildStandableWallLineFootprint` are pure
 // math with no Canvas/GLB dependency (same reasoning `buildOnePlacement`'s
 // own doc comment above gives for being exported and tested directly).
+describe('provider-backed region preview wall truth', () => {
+  it('renders source walls before acceptance, then only provider edges for a wall-bearing accepted candidate without dropping placements', () => {
+    const source = emptyCanvasYaml(6, 6).replace(
+      '  height: 6\nrooms:',
+      '  height: 6\n  floor_source: regions\nrooms:'
+    );
+    const { cst } = parseDungeon(source);
+    setWallEdge(cst, [1, 1], [1, 2], 'solid', true);
+    addWallLine(cst, { cell: [3, 3], corner: 2 }, { cell: [3, 3], corner: 5 });
+    placeItem(cst, null, 'dnd5e:props:pillar', [2, 1]);
+    const doc = toDungeonDoc(cst);
+    const floorCells: [number, number][] = [
+      [1, 1],
+      [1, 2],
+      [2, 1],
+    ];
+    const acceptedPlan = create(FloorPlanSchema, {
+      width: 6,
+      height: 6,
+      floorSource: FloorPlanFloorSource.REGIONS,
+      floorCells: floorCells.map(([column, row]) => ({ column, row })),
+      edges: [
+        {
+          from: { column: 1, row: 1 },
+          to: { column: 1, row: 2 },
+          kind: FloorPlanEdgeKind.SOLID,
+        },
+      ],
+    });
+
+    expect(doc.walls).toHaveLength(1);
+    expect(doc.wallLines).toHaveLength(1);
+    expect(doc.place).toHaveLength(1);
+
+    const beforeAcceptance = selectPreviewSourceWalls(
+      undefined,
+      floorCells,
+      doc
+    );
+    expect(beforeAcceptance.enabled).toBe(true);
+    expect(beforeAcceptance.walls).toBe(doc.walls);
+    expect(beforeAcceptance.wallLines).toBe(doc.wallLines);
+
+    const afterAcceptance = selectPreviewSourceWalls(
+      acceptedPlan,
+      floorCells,
+      doc
+    );
+    expect(acceptedPlan.edges).toHaveLength(1);
+    expect(afterAcceptance).toEqual({
+      enabled: false,
+      walls: [],
+      wallLines: [],
+    });
+    expect(
+      buildOnePlacement(
+        doc,
+        doc.place[0],
+        doc.place[0].at[0],
+        doc.place[0].at[1],
+        { roomId: null, index: 0 },
+        'accepted:placement'
+      ).prop
+    ).toBeDefined();
+    expect(doc.place).toHaveLength(1);
+  });
+});
+
 describe('buildFloorTiles — the floorCells alternate input path (creation mode)', () => {
   it('builds one tile per supplied cell, tagged with the canvas room-id sentinel', () => {
     const tiles = buildFloorTiles(

--- a/src/author/preview3d/DungeonPreview3D.tsx
+++ b/src/author/preview3d/DungeonPreview3D.tsx
@@ -1252,6 +1252,10 @@ export function DungeonPreview3D({
   selectedTool,
   placementPreviewOverride,
 }: DungeonPreview3DProps) {
+  // A canvas can now carry both its exact floorCells mask and a full provider
+  // FloorPlan for returned envelope/entrance truth. Tile input, not FloorPlan
+  // presence, distinguishes canvas placement semantics from a room chain.
+  const isCanvasFloor = floorCells !== undefined;
   const floorTiles = useMemo(
     () => buildFloorTiles(floorPlan, doc.holes, floorCells),
     [floorPlan, doc.holes, floorCells]
@@ -1323,16 +1327,22 @@ export function DungeonPreview3D({
     [floorPlan, doc]
   );
   // Click-to-place (Kirk's "3D editing" arc, part 3) now covers creation
-  // mode too (rpg-project#169's creation-3D-editing unit) — `floorPlan`
-  // presence still decides WHICH legality rule applies (room-scoped vs.
-  // top-level canvas), but `placeableCells` is no longer gated to "empty
-  // without floorPlan": `floorTiles` already carries the right cell set
+  // mode too (rpg-project#169's creation-3D-editing unit) — `floorCells`
+  // presence selects top-level canvas legality even when a provider
+  // FloorPlan is also present for envelope/entrance rendering. Otherwise
+  // the room-scoped plan path applies. `floorTiles` carries the right set
   // for either mode (`buildFloorTiles`'s own doc comment), and
   // `buildPlaceableCells` now branches internally per-cell instead of the
   // caller branching on the whole set.
   const placeableCells = useMemo(
-    () => buildPlaceableCells(floorPlan, doc, floorTiles, wallLineFootprint),
-    [floorPlan, doc, floorTiles, wallLineFootprint]
+    () =>
+      buildPlaceableCells(
+        isCanvasFloor ? undefined : floorPlan,
+        doc,
+        floorTiles,
+        wallLineFootprint
+      ),
+    [isCanvasFloor, floorPlan, doc, floorTiles, wallLineFootprint]
   );
   const hitShape = useMemo(() => buildHexHitShape(), []);
 
@@ -1489,12 +1499,12 @@ export function DungeonPreview3D({
     : onSelectConnector;
 
   // Mirrors Board.tsx's own click-to-place cell handler for the edit-mode
-  // (floorPlan present) branch — same messages, same boss/occupied rules,
-  // still silent on `occupied` there (no toast, matching Board.tsx's own
-  // click-to-place precedent exactly — `if (occupied) return;`).
+  // (room-chain floorPlan without floorCells) branch — same messages,
+  // same boss/occupied rules, still silent on `occupied` there (no toast,
+  // matching Board.tsx's own click-to-place precedent exactly).
   //
-  // The `!floorPlan` branch (creation mode's from-scratch canvas, this
-  // unit) is a genuinely different placement shape: TOP-LEVEL
+  // The `isCanvasFloor` branch (floorCells, optionally with provider plan
+  // truth) is a genuinely different placement shape: TOP-LEVEL
   // (`roomId: null`, absolute `[col, row]`, no room to resolve a
   // room-local column against) — the exact shape `CreationBoard.tsx`'s
   // own 2D brush already produces via `edit.handlePlace(null, cell)`.
@@ -1513,7 +1523,7 @@ export function DungeonPreview3D({
       return;
     }
     const onPlace = effectiveOnPlace;
-    if (!floorPlan) {
+    if (isCanvasFloor) {
       // Boss stays room-scoped even in the target dialect (dungeonspec's
       // validateBossCardinality needs an owning archetype:boss room) — a
       // from-scratch canvas has zero rooms, same guard
@@ -1548,6 +1558,10 @@ export function DungeonPreview3D({
         return;
       }
       onPlace(null, [cell.col, cell.row]);
+      return;
+    }
+    if (!floorPlan) {
+      onReject?.('No compiled floor plan is available for this cell.');
       return;
     }
     // The connector-band fix above (`buildFloorTiles`) gives the door its

--- a/src/author/preview3d/DungeonPreview3D.tsx
+++ b/src/author/preview3d/DungeonPreview3D.tsx
@@ -142,7 +142,10 @@ import {
   CUTAWAY_STUB_WALL_HEIGHT,
   WALL_HEIGHT,
 } from '@/rendering/calibrationConstants';
-import type { FloorPlan } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
+import {
+  FloorPlanFloorSource,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import { Billboard, Bounds, OrbitControls, Text } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import { Suspense, useMemo, useState } from 'react';
@@ -558,6 +561,36 @@ function buildWalls(
       edgeA,
     };
   });
+}
+
+export interface PreviewSourceWalls {
+  enabled: boolean;
+  walls: DungeonDoc['walls'];
+  wallLines: DungeonDoc['wallLines'];
+}
+
+/**
+ * Chooses whether doc-native wall topology participates in the preview.
+ * Before provider acceptance, source walls and straight-wall sugar remain
+ * visible and editable. Once a canvas carries an accepted REGIONS plan with
+ * canonical provider edges, only those edges render; the unchanged source
+ * remains the authoring record, not a second post-acceptance topology layer.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function selectPreviewSourceWalls(
+  floorPlan: FloorPlan | undefined,
+  floorCells: readonly [number, number][] | undefined,
+  doc: DungeonDoc
+): PreviewSourceWalls {
+  const providerBackedRegionCanvas =
+    floorCells !== undefined &&
+    floorPlan !== undefined &&
+    floorPlan.floorSource === FloorPlanFloorSource.REGIONS &&
+    hasServerEdges(floorPlan);
+
+  return providerBackedRegionCanvas
+    ? { enabled: false, walls: [], wallLines: [] }
+    : { enabled: true, walls: doc.walls, wallLines: doc.wallLines };
 }
 
 /** `DoorGap`'s `onSelectDoor` for one `PlacedWall` — `undefined` unless
@@ -1276,9 +1309,13 @@ export function DungeonPreview3D({
       ),
     [baseProps, placementPreviewOverride]
   );
+  const sourceWalls = useMemo(
+    () => selectPreviewSourceWalls(floorPlan, floorCells, doc),
+    [floorPlan, floorCells, doc]
+  );
   const authoredWalls = useMemo(
-    () => buildWalls(doc.walls, 'authored'),
-    [doc.walls]
+    () => buildWalls(sourceWalls.walls, 'authored'),
+    [sourceWalls.walls]
   );
   // Server-truth wall/door edges (rpg-project#169's wire-edges unit) — see
   // this file's own header doc comment. Empty whenever `floorPlan` is
@@ -1293,29 +1330,27 @@ export function DungeonPreview3D({
         : [],
     [floorPlan]
   );
-  // A straight wall's (`doc.wallLines`) footprint — doc-native, renders
-  // identically regardless of `floorPlan`/`floorCells`. `wallLineFootprint`
-  // is the STANDABLE subset (coverage-based, rpg-project#169's live-design
-  // follow-up) — every existing consumer below (`buildPlaceableCells`,
-  // `buildWalkContext`, `handleClickCell`) already only ever needed "is
-  // this cell blocked for STANDING," so none of them changed; only what
-  // this variable itself means did. `wallLineFootprintCoverage` is the
-  // FULL touched-at-all map (every footprint cell, any coverage), needed
-  // separately for the dim overlay's own light/full de-emphasis below —
-  // see `buildWallLineFootprintCoverage`/`buildStandableWallLineFootprint`'s
-  // own doc comments.
+  // A straight wall's (`doc.wallLines`) footprint is source-native before
+  // acceptance. An accepted provider-backed REGIONS canvas suppresses it
+  // alongside source wall geometry so provider edges remain the sole preview
+  // topology; the source document itself and its placements stay unchanged.
   const wallLineFootprintCoverage = useMemo(
-    () => buildWallLineFootprintCoverage(doc),
-    [doc]
+    () =>
+      sourceWalls.enabled
+        ? buildWallLineFootprintCoverage(doc)
+        : new Map<string, number>(),
+    [doc, sourceWalls.enabled]
   );
   const wallLineFootprint = useMemo(
     () => standableFootprintKeys(wallLineFootprintCoverage),
     [wallLineFootprintCoverage]
   );
-  // The straight wall's own real geometry (this unit) — doc-native too,
-  // same reasoning as the footprint above. See `buildWallLineSegments`'s
-  // own doc comment.
-  const wallLineSegments = useMemo(() => buildWallLineSegments(doc), [doc]);
+  // The straight wall's own real geometry follows the same source/provider
+  // selection as its footprint. See `buildWallLineSegments`'s own doc comment.
+  const wallLineSegments = useMemo(
+    () => (sourceWalls.enabled ? buildWallLineSegments(doc) : []),
+    [doc, sourceWalls.enabled]
+  );
   // The generator-chosen entrance marker has no creation-mode analog at
   // all (CONTRACT.md's "Start/end: authored, in real tension with the
   // generator-chosen entrance" finding — a freeform canvas has no

--- a/src/author/regionFloorContract.test.ts
+++ b/src/author/regionFloorContract.test.ts
@@ -1,0 +1,222 @@
+import { create } from '@bufbuild/protobuf';
+import {
+  HexRecordSchema,
+  PositionSchema,
+  WallKind,
+  WallSchema,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { describe, expect, it } from 'vitest';
+import { resolveCanvasFloor } from './creation/canvasFloor';
+import { parseDungeon, serializeDungeon, stripToV1Subset } from './dungeonYaml';
+import {
+  consumeAuthorizedRuntimeHexes,
+  consumeRegionFloorProjection,
+  prepareExactRegionFloorCandidate,
+  UnsupportedRegionFloorContractError,
+  type RegionFloorCell,
+  type RegionFloorProjection,
+} from './regionFloorContract';
+
+const RING_CELLS = [
+  [1, 1],
+  [1, 2],
+  [1, 3],
+  [2, 1],
+  [2, 3],
+  [3, 1],
+  [3, 2],
+  [3, 3],
+] as const satisfies readonly RegionFloorCell[];
+
+const RING_YAML = `# preserve this exact candidate
+version: 1
+key: ring-room
+name: 'Ring Room'
+canvas: { width: 5, height: 5, floor_source: regions }
+rooms: []
+connectors: []
+regions:
+  - id: ring
+    archetype: chamber
+    cells: [[1,1], [1,2], [1,3], [2,1], [2,3], [3,1], [3,2], [3,3]]
+`;
+
+describe('Dungeon YAML v0.4 Wave A exact candidate', () => {
+  it('parses floor_source: regions and returns the byte-exact YAML instead of stripping or downgrading it', () => {
+    const candidate = prepareExactRegionFloorCandidate(RING_YAML);
+
+    expect(candidate.doc.canvas?.floorSource).toBe('regions');
+    expect(candidate.yaml).toBe(RING_YAML);
+    expect(candidate.yaml).toContain('floor_source: regions');
+    expect(candidate.yaml).toContain('# preserve this exact candidate');
+  });
+
+  it('keeps omission distinct from explicit bounds while preserving both CST shapes', () => {
+    const omitted = RING_YAML.replace(', floor_source: regions', '');
+    const bounds = RING_YAML.replace(
+      'floor_source: regions',
+      'floor_source: bounds'
+    );
+
+    const omittedParsed = parseDungeon(omitted);
+    const boundsParsed = parseDungeon(bounds);
+    expect(omittedParsed.doc.canvas?.floorSource).toBeNull();
+    expect(boundsParsed.doc.canvas?.floorSource).toBe('bounds');
+    expect(serializeDungeon(omittedParsed.cst)).not.toContain('floor_source');
+    expect(serializeDungeon(boundsParsed.cst)).toContain(
+      'floor_source: bounds'
+    );
+  });
+
+  it('rejects an unknown floor source instead of silently treating it as bounds', () => {
+    expect(() =>
+      parseDungeon(
+        RING_YAML.replace('floor_source: regions', 'floor_source: painted')
+      )
+    ).toThrow(/canvas\.floor_source: expected "bounds" or "regions"/);
+  });
+
+  it('hard-stops the region-floor path for a non-region candidate', () => {
+    expect(() =>
+      prepareExactRegionFloorCandidate(
+        RING_YAML.replace('floor_source: regions', 'floor_source: bounds')
+      )
+    ).toThrow(UnsupportedRegionFloorContractError);
+  });
+
+  it('never routes region semantics through the legacy subset strip or bounds-derived preview fallback', () => {
+    const doc = parseDungeon(RING_YAML).doc;
+
+    expect(() => stripToV1Subset(RING_YAML)).toThrow(
+      /cannot be stripped or downgraded/
+    );
+    expect(() => resolveCanvasFloor(doc, null)).toThrow(
+      /refusing to infer or downgrade/
+    );
+  });
+});
+
+describe('authoring projection consumer', () => {
+  function ringProjection(): RegionFloorProjection {
+    return {
+      floorSource: 'regions',
+      floorCells: RING_CELLS,
+      edges: [
+        // Interior void envelope. Pair orientation is intentionally reversed:
+        // ownership comes from floor membership, never `from`.
+        { from: [2, 2], to: [2, 1], kind: 'solid' },
+        // Outer envelope with an off-canvas endpoint.
+        { from: [1, 1], to: [0, 1], kind: 'solid' },
+        // An ordinary provider edge whose endpoints are both floor.
+        { from: [1, 2], to: [1, 3], kind: 'door', doorId: 'door-a' },
+      ],
+      entrance: [1, 1],
+    };
+  }
+
+  it('renders and hit-tests exactly the eight returned ring cells, leaving the in-bounds center void non-floor', () => {
+    const preview = consumeRegionFloorProjection(ringProjection());
+
+    expect(preview.floorCells).toEqual(RING_CELLS);
+    expect(preview.floorCells).toHaveLength(8);
+    expect(preview.contains([2, 2])).toBe(false);
+    expect(preview.contains([1, 1])).toBe(true);
+    // Only the three provider pairs exist; no rectangle/union envelope was
+    // recreated by this consumer.
+    expect(preview.edges).toHaveLength(3);
+  });
+
+  it('determines envelope ownership by returned floor membership, including reversed and off-canvas pairs', () => {
+    const preview = consumeRegionFloorProjection(ringProjection());
+
+    expect(preview.edges[0]?.floorOwners).toEqual([[2, 1]]);
+    expect(preview.edges[1]?.floorOwners).toEqual([[1, 1]]);
+    expect(preview.edges[2]?.floorOwners).toEqual([
+      [1, 2],
+      [1, 3],
+    ]);
+  });
+
+  it('previews a structurally valid tiny draft with an absent entrance', () => {
+    const preview = consumeRegionFloorProjection({
+      floorSource: 'regions',
+      floorCells: [
+        [1, 1],
+        [1, 2],
+      ],
+      edges: [{ from: [1, 1], to: [0, 1], kind: 'solid' }],
+      // entrance intentionally absent: strict runnable validity is provider-owned.
+    });
+
+    expect(preview.floorCells).toHaveLength(2);
+    expect(preview.entrance).toBeUndefined();
+  });
+
+  it('keeps both returned islands even when the provider returns an entrance only on the runnable-sized island', () => {
+    const islandA = [
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [1, 1],
+    ] as const;
+    const islandB = [4, 4] as const;
+    const preview = consumeRegionFloorProjection({
+      floorSource: 'regions',
+      floorCells: [...islandA, islandB],
+      edges: [
+        { from: [0, 0], to: [-1, 0], kind: 'solid' },
+        { from: islandB, to: [5, 4], kind: 'solid' },
+      ],
+      entrance: [0, 0],
+    });
+
+    expect(preview.floorCells).toEqual([...islandA, islandB]);
+    expect(preview.entrance).toEqual([0, 0]);
+    expect(preview.contains(islandB)).toBe(true);
+  });
+
+  it('hard-stops when the released projection cannot discriminate floor_source', () => {
+    expect(() =>
+      consumeRegionFloorProjection({
+        floorCells: RING_CELLS,
+        edges: [],
+      })
+    ).toThrow(/additive authoring proto is required/);
+  });
+
+  it('hard-stops malformed provider truth instead of inferring a repair', () => {
+    expect(() =>
+      consumeRegionFloorProjection({
+        floorSource: 'regions',
+        floorCells: RING_CELLS,
+        edges: [{ from: [0, 0], to: [0, 1], kind: 'solid' }],
+      })
+    ).toThrow(/has no returned floor owner/);
+  });
+});
+
+describe('authorized runtime consumer', () => {
+  it('exposes only returned HexRecords and their attached edges; hidden and center-void topology stays absent', () => {
+    const providerEdge = create(WallSchema, {
+      from: create(PositionSchema, { x: 1, y: -2, z: 1 }),
+      to: create(PositionSchema, { x: 2, y: -4, z: 2 }),
+      kind: WallKind.SOLID,
+    });
+    const runtime = consumeAuthorizedRuntimeHexes([
+      create(HexRecordSchema, {
+        position: create(PositionSchema, { x: 1, y: -2, z: 1 }),
+        edges: [providerEdge],
+      }),
+      create(HexRecordSchema, {
+        position: create(PositionSchema, { x: 2, y: -3, z: 1 }),
+        edges: [],
+      }),
+    ]);
+
+    expect([...runtime.floorKeys]).toEqual(['1,-2,1', '2,-3,1']);
+    expect(runtime.edges).toHaveLength(1);
+    expect(runtime.canHit([1, -2, 1])).toBe(true);
+    expect(runtime.canHit([2, -4, 2])).toBe(false);
+    expect(runtime.canHit([9, -9, 0])).toBe(false);
+  });
+});

--- a/src/author/regionFloorContract.test.ts
+++ b/src/author/regionFloorContract.test.ts
@@ -123,6 +123,32 @@ describe('generated authoring region-floor projection consumer', () => {
     }
   );
 
+  it('hard-stops incomplete REGIONS projections with an empty floor mask or empty provider envelope', () => {
+    expect(() =>
+      consumeRegionFloorProjection(ringFloorPlan({ floorCells: [] }))
+    ).toThrow(/FloorPlan\.floor_cells is empty/);
+
+    expect(() =>
+      consumeRegionFloorProjection(ringFloorPlan({ edges: [] }))
+    ).toThrow(/FloorPlan\.edges is empty/);
+  });
+
+  it('rejects a non-adjacent provider pair as an invalid canonical edge without deriving replacement topology', () => {
+    expect(() =>
+      consumeRegionFloorProjection(
+        ringFloorPlan({
+          edges: [
+            {
+              from: { column: 1, row: 1 },
+              to: { column: 4, row: 4 },
+              kind: FloorPlanEdgeKind.SOLID,
+            },
+          ],
+        })
+      )
+    ).toThrow(/endpoints are not adjacent/);
+  });
+
   it('rejects non-canonical floor-cell order instead of normalizing provider truth client-side', () => {
     expect(() =>
       consumeRegionFloorProjection(

--- a/src/author/regionFloorContract.test.ts
+++ b/src/author/regionFloorContract.test.ts
@@ -1,4 +1,10 @@
-import { create } from '@bufbuild/protobuf';
+import { create, type MessageInitShape } from '@bufbuild/protobuf';
+import {
+  FloorPlanEdgeKind,
+  FloorPlanFloorSource,
+  FloorPlanSchema,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import {
   HexRecordSchema,
   PositionSchema,
@@ -6,15 +12,11 @@ import {
   WallSchema,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
 import { describe, expect, it } from 'vitest';
-import { resolveCanvasFloor } from './creation/canvasFloor';
-import { parseDungeon, serializeDungeon, stripToV1Subset } from './dungeonYaml';
 import {
   consumeAuthorizedRuntimeHexes,
   consumeRegionFloorProjection,
-  prepareExactRegionFloorCandidate,
   UnsupportedRegionFloorContractError,
   type RegionFloorCell,
-  type RegionFloorProjection,
 } from './regionFloorContract';
 
 const RING_CELLS = [
@@ -28,170 +30,150 @@ const RING_CELLS = [
   [3, 3],
 ] as const satisfies readonly RegionFloorCell[];
 
-const RING_YAML = `# preserve this exact candidate
-version: 1
-key: ring-room
-name: 'Ring Room'
-canvas: { width: 5, height: 5, floor_source: regions }
-rooms: []
-connectors: []
-regions:
-  - id: ring
-    archetype: chamber
-    cells: [[1,1], [1,2], [1,3], [2,1], [2,3], [3,1], [3,2], [3,3]]
-`;
+function ringFloorPlan(
+  overrides: MessageInitShape<typeof FloorPlanSchema> = {}
+): FloorPlan {
+  return create(FloorPlanSchema, {
+    width: 5,
+    height: 5,
+    floorSource: FloorPlanFloorSource.REGIONS,
+    floorCells: RING_CELLS.map(([column, row]) => ({ column, row })),
+    edges: [
+      // Reversed interior-void pair: ownership must come from membership.
+      {
+        from: { column: 2, row: 2 },
+        to: { column: 2, row: 1 },
+        kind: FloorPlanEdgeKind.SOLID,
+      },
+      // Off-canvas endpoint, orientation deliberately nonsemantic.
+      {
+        from: { column: 1, row: 1 },
+        to: { column: 0, row: 1 },
+        kind: FloorPlanEdgeKind.SOLID,
+      },
+      {
+        from: { column: 1, row: 2 },
+        to: { column: 1, row: 3 },
+        kind: FloorPlanEdgeKind.DOOR,
+        doorId: 'door-a',
+      },
+    ],
+    entrance: { column: 1, row: 1 },
+    ...overrides,
+  } as never);
+}
 
-describe('Dungeon YAML v0.4 Wave A exact candidate', () => {
-  it('parses floor_source: regions and returns the byte-exact YAML instead of stripping or downgrading it', () => {
-    const candidate = prepareExactRegionFloorCandidate(RING_YAML);
+describe('generated authoring region-floor projection consumer', () => {
+  it('renders and hit-tests exactly the canonical returned mask, preserving voids and optional entrance', () => {
+    const preview = consumeRegionFloorProjection(ringFloorPlan());
 
-    expect(candidate.doc.canvas?.floorSource).toBe('regions');
-    expect(candidate.yaml).toBe(RING_YAML);
-    expect(candidate.yaml).toContain('floor_source: regions');
-    expect(candidate.yaml).toContain('# preserve this exact candidate');
-  });
-
-  it('keeps omission distinct from explicit bounds while preserving both CST shapes', () => {
-    const omitted = RING_YAML.replace(', floor_source: regions', '');
-    const bounds = RING_YAML.replace(
-      'floor_source: regions',
-      'floor_source: bounds'
-    );
-
-    const omittedParsed = parseDungeon(omitted);
-    const boundsParsed = parseDungeon(bounds);
-    expect(omittedParsed.doc.canvas?.floorSource).toBeNull();
-    expect(boundsParsed.doc.canvas?.floorSource).toBe('bounds');
-    expect(serializeDungeon(omittedParsed.cst)).not.toContain('floor_source');
-    expect(serializeDungeon(boundsParsed.cst)).toContain(
-      'floor_source: bounds'
-    );
-  });
-
-  it('rejects an unknown floor source instead of silently treating it as bounds', () => {
-    expect(() =>
-      parseDungeon(
-        RING_YAML.replace('floor_source: regions', 'floor_source: painted')
-      )
-    ).toThrow(/canvas\.floor_source: expected "bounds" or "regions"/);
-  });
-
-  it('hard-stops the region-floor path for a non-region candidate', () => {
-    expect(() =>
-      prepareExactRegionFloorCandidate(
-        RING_YAML.replace('floor_source: regions', 'floor_source: bounds')
-      )
-    ).toThrow(UnsupportedRegionFloorContractError);
-  });
-
-  it('never routes region semantics through the legacy subset strip or bounds-derived preview fallback', () => {
-    const doc = parseDungeon(RING_YAML).doc;
-
-    expect(() => stripToV1Subset(RING_YAML)).toThrow(
-      /cannot be stripped or downgraded/
-    );
-    expect(() => resolveCanvasFloor(doc, null)).toThrow(
-      /refusing to infer or downgrade/
-    );
-  });
-});
-
-describe('authoring projection consumer', () => {
-  function ringProjection(): RegionFloorProjection {
-    return {
-      floorSource: 'regions',
-      floorCells: RING_CELLS,
-      edges: [
-        // Interior void envelope. Pair orientation is intentionally reversed:
-        // ownership comes from floor membership, never `from`.
-        { from: [2, 2], to: [2, 1], kind: 'solid' },
-        // Outer envelope with an off-canvas endpoint.
-        { from: [1, 1], to: [0, 1], kind: 'solid' },
-        // An ordinary provider edge whose endpoints are both floor.
-        { from: [1, 2], to: [1, 3], kind: 'door', doorId: 'door-a' },
-      ],
-      entrance: [1, 1],
-    };
-  }
-
-  it('renders and hit-tests exactly the eight returned ring cells, leaving the in-bounds center void non-floor', () => {
-    const preview = consumeRegionFloorProjection(ringProjection());
-
+    expect(preview.floorSource).toBe(FloorPlanFloorSource.REGIONS);
     expect(preview.floorCells).toEqual(RING_CELLS);
     expect(preview.floorCells).toHaveLength(8);
     expect(preview.contains([2, 2])).toBe(false);
     expect(preview.contains([1, 1])).toBe(true);
-    // Only the three provider pairs exist; no rectangle/union envelope was
-    // recreated by this consumer.
+    expect(preview.entrance).toEqual([1, 1]);
     expect(preview.edges).toHaveLength(3);
   });
 
-  it('determines envelope ownership by returned floor membership, including reversed and off-canvas pairs', () => {
-    const preview = consumeRegionFloorProjection(ringProjection());
+  it('preserves provider pair orientation and derives one-sided envelope ownership only from returned floor membership', () => {
+    const preview = consumeRegionFloorProjection(ringFloorPlan());
 
-    expect(preview.edges[0]?.floorOwners).toEqual([[2, 1]]);
-    expect(preview.edges[1]?.floorOwners).toEqual([[1, 1]]);
-    expect(preview.edges[2]?.floorOwners).toEqual([
-      [1, 2],
-      [1, 3],
-    ]);
+    expect(preview.edges[0]).toMatchObject({
+      from: [2, 2],
+      to: [2, 1],
+      kind: FloorPlanEdgeKind.SOLID,
+      floorOwners: [[2, 1]],
+    });
+    expect(preview.edges[1]).toMatchObject({
+      from: [1, 1],
+      to: [0, 1],
+      kind: FloorPlanEdgeKind.SOLID,
+      floorOwners: [[1, 1]],
+    });
+    expect(preview.edges[2]).toMatchObject({
+      from: [1, 2],
+      to: [1, 3],
+      kind: FloorPlanEdgeKind.DOOR,
+      doorId: 'door-a',
+      floorOwners: [
+        [1, 2],
+        [1, 3],
+      ],
+    });
   });
 
-  it('previews a structurally valid tiny draft with an absent entrance', () => {
-    const preview = consumeRegionFloorProjection({
-      floorSource: 'regions',
-      floorCells: [
-        [1, 1],
-        [1, 2],
-      ],
-      edges: [{ from: [1, 1], to: [0, 1], kind: 'solid' }],
-      // entrance intentionally absent: strict runnable validity is provider-owned.
-    });
-
-    expect(preview.floorCells).toHaveLength(2);
+  it('preserves an absent entrance for a structurally valid draft', () => {
+    const preview = consumeRegionFloorProjection(
+      ringFloorPlan({ entrance: undefined })
+    );
     expect(preview.entrance).toBeUndefined();
   });
 
-  it('keeps both returned islands even when the provider returns an entrance only on the runnable-sized island', () => {
-    const islandA = [
-      [0, 0],
-      [0, 1],
-      [1, 0],
-      [1, 1],
-    ] as const;
-    const islandB = [4, 4] as const;
-    const preview = consumeRegionFloorProjection({
-      floorSource: 'regions',
-      floorCells: [...islandA, islandB],
-      edges: [
-        { from: [0, 0], to: [-1, 0], kind: 'solid' },
-        { from: islandB, to: [5, 4], kind: 'solid' },
-      ],
-      entrance: [0, 0],
-    });
+  it.each([
+    ['absent', undefined],
+    ['UNSPECIFIED', FloorPlanFloorSource.UNSPECIFIED],
+    ['BOUNDS', FloorPlanFloorSource.BOUNDS],
+  ])(
+    'hard-stops when generated FloorPlan.floorSource is %s instead of present REGIONS',
+    (_label, floorSource) => {
+      expect(() =>
+        consumeRegionFloorProjection(ringFloorPlan({ floorSource }))
+      ).toThrow(UnsupportedRegionFloorContractError);
+    }
+  );
 
-    expect(preview.floorCells).toEqual([...islandA, islandB]);
-    expect(preview.entrance).toEqual([0, 0]);
-    expect(preview.contains(islandB)).toBe(true);
+  it('rejects non-canonical floor-cell order instead of normalizing provider truth client-side', () => {
+    expect(() =>
+      consumeRegionFloorProjection(
+        ringFloorPlan({
+          floorCells: [
+            { column: 3, row: 3 },
+            { column: 1, row: 1 },
+          ],
+        })
+      )
+    ).toThrow(/canonical ascending order/);
   });
 
-  it('hard-stops when the released projection cannot discriminate floor_source', () => {
+  it('rejects a canonical edge with no returned floor owner instead of inventing or clipping an envelope', () => {
     expect(() =>
-      consumeRegionFloorProjection({
-        floorCells: RING_CELLS,
-        edges: [],
-      })
-    ).toThrow(/additive authoring proto is required/);
-  });
-
-  it('hard-stops malformed provider truth instead of inferring a repair', () => {
-    expect(() =>
-      consumeRegionFloorProjection({
-        floorSource: 'regions',
-        floorCells: RING_CELLS,
-        edges: [{ from: [0, 0], to: [0, 1], kind: 'solid' }],
-      })
+      consumeRegionFloorProjection(
+        ringFloorPlan({
+          edges: [
+            {
+              from: { column: 0, row: 0 },
+              to: { column: 0, row: 1 },
+              kind: FloorPlanEdgeKind.SOLID,
+            },
+          ],
+        })
+      )
     ).toThrow(/has no returned floor owner/);
+  });
+
+  it('rejects missing endpoints and unsupported edge kinds with the provider pair intact', () => {
+    expect(() =>
+      consumeRegionFloorProjection(
+        ringFloorPlan({
+          edges: [{ to: { column: 1, row: 1 }, kind: FloorPlanEdgeKind.SOLID }],
+        })
+      )
+    ).toThrow(/missing from or to/);
+
+    expect(() =>
+      consumeRegionFloorProjection(
+        ringFloorPlan({
+          edges: [
+            {
+              from: { column: 1, row: 1 },
+              to: { column: 1, row: 2 },
+              kind: FloorPlanEdgeKind.UNSPECIFIED,
+            },
+          ],
+        })
+      )
+    ).toThrow(/unsupported kind/);
   });
 });
 

--- a/src/author/regionFloorContract.ts
+++ b/src/author/regionFloorContract.ts
@@ -1,0 +1,168 @@
+/**
+ * Outside-in consumer seam for RATIFIED Dungeon YAML v0.4 Wave A.
+ *
+ * This deliberately does not extend generated protobuf types. The released
+ * authoring FloorPlan has no floor_source field yet, so integrating this seam
+ * with the RPC would hide that contract gap. Fixtures can exercise the exact
+ * future projection while production hard-stops until the additive proto is
+ * published.
+ */
+import type {
+  HexRecord,
+  Wall,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import {
+  parseDungeon,
+  UnsupportedRegionFloorContractError,
+  type DungeonDoc,
+} from './dungeonYaml';
+
+export { UnsupportedRegionFloorContractError } from './dungeonYaml';
+
+export type RegionFloorCell = readonly [column: number, row: number];
+
+export interface RegionFloorEdge {
+  from: RegionFloorCell;
+  to: RegionFloorCell;
+  kind: 'solid' | 'door';
+  doorId?: string;
+}
+
+/** Structural future-contract shape, intentionally not a generated-proto shim. */
+export interface RegionFloorProjection {
+  floorSource?: 'bounds' | 'regions';
+  floorCells: readonly RegionFloorCell[];
+  edges: readonly RegionFloorEdge[];
+  entrance?: RegionFloorCell;
+}
+
+export interface ConsumedRegionFloor {
+  floorSource: 'regions';
+  floorCells: readonly RegionFloorCell[];
+  edges: readonly (RegionFloorEdge & {
+    /** Membership-derived owners; pair orientation is nonsemantic. */
+    floorOwners: readonly RegionFloorCell[];
+  })[];
+  entrance?: RegionFloorCell;
+  contains(cell: RegionFloorCell): boolean;
+}
+
+function cellKey([column, row]: RegionFloorCell): string {
+  return `${column},${row}`;
+}
+
+function edgeKey(edge: RegionFloorEdge): string {
+  const from = cellKey(edge.from);
+  const to = cellKey(edge.to);
+  return from < to ? `${from}|${to}` : `${to}|${from}`;
+}
+
+/**
+ * Keeps an authored region-floor request byte-for-byte exact. This is the
+ * capability attempt payload: callers may submit it with validate_only=true,
+ * but may not route it through the legacy subset stripper.
+ */
+export function prepareExactRegionFloorCandidate(yaml: string): {
+  yaml: string;
+  doc: DungeonDoc;
+} {
+  const { doc } = parseDungeon(yaml);
+  if (doc.canvas?.floorSource !== 'regions') {
+    throw new UnsupportedRegionFloorContractError(
+      'canvas.floor_source: regions is required for a Wave A region-floor candidate'
+    );
+  }
+  return { yaml, doc };
+}
+
+/**
+ * Consumes provider truth without deriving a rectangle, a region union, or
+ * competing envelope edges. Producer-contract violations hard-stop instead of
+ * falling back to bounds.
+ */
+export function consumeRegionFloorProjection(
+  projection: RegionFloorProjection
+): ConsumedRegionFloor {
+  if (projection.floorSource !== 'regions') {
+    throw new UnsupportedRegionFloorContractError(
+      projection.floorSource === undefined
+        ? 'FloorPlan.floor_source is absent; the additive authoring proto is required before region-floor preview can render'
+        : `FloorPlan.floor_source resolved to ${projection.floorSource}, not regions`
+    );
+  }
+
+  const floorKeys = new Set<string>();
+  for (const cell of projection.floorCells) {
+    const key = cellKey(cell);
+    if (floorKeys.has(key)) {
+      throw new UnsupportedRegionFloorContractError(
+        `FloorPlan.floor_cells contains duplicate ${key}`
+      );
+    }
+    floorKeys.add(key);
+  }
+
+  const seenEdges = new Set<string>();
+  const edges = projection.edges.map((edge) => {
+    const key = edgeKey(edge);
+    if (seenEdges.has(key)) {
+      throw new UnsupportedRegionFloorContractError(
+        `FloorPlan.edges contains duplicate pair ${key}`
+      );
+    }
+    seenEdges.add(key);
+
+    const floorOwners = [edge.from, edge.to].filter((cell) =>
+      floorKeys.has(cellKey(cell))
+    );
+    if (floorOwners.length === 0) {
+      throw new UnsupportedRegionFloorContractError(
+        `FloorPlan edge ${key} has no returned floor owner`
+      );
+    }
+    return { ...edge, floorOwners };
+  });
+
+  if (
+    projection.entrance !== undefined &&
+    !floorKeys.has(cellKey(projection.entrance))
+  ) {
+    throw new UnsupportedRegionFloorContractError(
+      `FloorPlan.entrance ${cellKey(projection.entrance)} is not returned floor`
+    );
+  }
+
+  return {
+    floorSource: 'regions',
+    floorCells: [...projection.floorCells],
+    edges,
+    entrance: projection.entrance,
+    contains: (cell) => floorKeys.has(cellKey(cell)),
+  };
+}
+
+/**
+ * Runtime/fog seam over the released generated HexRecord/Wall contract:
+ * hit-testing and edge rendering are built only from authorized records. It
+ * intentionally knows no canvas dimensions or authored regions from which
+ * topology could be rebuilt.
+ */
+export function consumeAuthorizedRuntimeHexes(hexes: readonly HexRecord[]): {
+  floorKeys: ReadonlySet<string>;
+  edges: readonly Wall[];
+  canHit(position: readonly [number, number, number]): boolean;
+} {
+  const floorKeys = new Set(
+    hexes.flatMap((hex) =>
+      hex.position
+        ? [`${hex.position.x},${hex.position.y},${hex.position.z}`]
+        : []
+    )
+  );
+  const edges = hexes.flatMap((hex) => [...hex.edges]);
+  return {
+    floorKeys,
+    edges,
+    canHit: (position) => floorKeys.has(position.join(',')),
+  };
+}

--- a/src/author/regionFloorContract.ts
+++ b/src/author/regionFloorContract.ts
@@ -1,3 +1,4 @@
+import { hexDistance } from '@/components/hex-grid/hexMath';
 import {
   FloorPlanEdgeKind,
   FloorPlanFloorSource,
@@ -16,6 +17,7 @@ import {
   type DungeonDoc,
   type WallDoc,
 } from './dungeonYaml';
+import { cubeAtColRow } from './hexLayout';
 
 export { UnsupportedRegionFloorContractError } from './dungeonYaml';
 
@@ -228,6 +230,17 @@ export function consumeRegionFloorProjection(
     );
   }
 
+  if (floorPlan.floorCells.length === 0) {
+    throw new UnsupportedRegionFloorContractError(
+      'FloorPlan.floor_cells is empty for a REGIONS projection'
+    );
+  }
+  if (floorPlan.edges.length === 0) {
+    throw new UnsupportedRegionFloorContractError(
+      'FloorPlan.edges is empty for a REGIONS projection'
+    );
+  }
+
   const floorCells: RegionFloorCell[] = [];
   const floorKeys = new Set<string>();
   let previous: RegionFloorCell | undefined;
@@ -268,6 +281,18 @@ export function consumeRegionFloorProjection(
       if (cellKey(from) === cellKey(to)) {
         throw new UnsupportedRegionFloorContractError(
           `FloorPlan edge ${key} has identical endpoints`
+        );
+      }
+      // Producer-contract validation only: reject an invalid returned pair.
+      // This does not derive, orient, repair, or add any topology.
+      if (
+        hexDistance(
+          cubeAtColRow(from[0], from[1]),
+          cubeAtColRow(to[0], to[1])
+        ) !== 1
+      ) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan edge ${key} endpoints are not adjacent`
         );
       }
       if (seenEdges.has(key)) {

--- a/src/author/regionFloorContract.ts
+++ b/src/author/regionFloorContract.ts
@@ -1,152 +1,347 @@
-/**
- * Outside-in consumer seam for RATIFIED Dungeon YAML v0.4 Wave A.
- *
- * This deliberately does not extend generated protobuf types. The released
- * authoring FloorPlan has no floor_source field yet, so integrating this seam
- * with the RPC would hide that contract gap. Fixtures can exercise the exact
- * future projection while production hard-stops until the additive proto is
- * published.
- */
+import {
+  FloorPlanEdgeKind,
+  FloorPlanFloorSource,
+  type FloorPlan,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/authoring/v1alpha1/service_pb';
 import type {
   HexRecord,
   Wall,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha2/encounter/types_pb';
+import { DEFAULT_CANVAS } from './creation/emptyCanvasDoc';
+import { projectWallLineToEdges } from './creation/straightWallGeometry';
 import {
   parseDungeon,
+  serializeDungeon,
   UnsupportedRegionFloorContractError,
   type DungeonDoc,
+  type WallDoc,
 } from './dungeonYaml';
 
 export { UnsupportedRegionFloorContractError } from './dungeonYaml';
 
 export type RegionFloorCell = readonly [column: number, row: number];
 
-export interface RegionFloorEdge {
+export interface ConsumedRegionFloorEdge {
   from: RegionFloorCell;
   to: RegionFloorCell;
-  kind: 'solid' | 'door';
+  kind: FloorPlanEdgeKind.SOLID | FloorPlanEdgeKind.DOOR;
   doorId?: string;
-}
-
-/** Structural future-contract shape, intentionally not a generated-proto shim. */
-export interface RegionFloorProjection {
-  floorSource?: 'bounds' | 'regions';
-  floorCells: readonly RegionFloorCell[];
-  edges: readonly RegionFloorEdge[];
-  entrance?: RegionFloorCell;
+  /** Membership-derived owners. Endpoint orientation is nonsemantic. */
+  floorOwners: readonly RegionFloorCell[];
 }
 
 export interface ConsumedRegionFloor {
-  floorSource: 'regions';
+  floorSource: FloorPlanFloorSource.REGIONS;
   floorCells: readonly RegionFloorCell[];
-  edges: readonly (RegionFloorEdge & {
-    /** Membership-derived owners; pair orientation is nonsemantic. */
-    floorOwners: readonly RegionFloorCell[];
-  })[];
+  edges: readonly ConsumedRegionFloorEdge[];
   entrance?: RegionFloorCell;
   contains(cell: RegionFloorCell): boolean;
+}
+
+export interface RegionFloorCandidateOptions {
+  wallsCapability?: {
+    accepted: boolean;
+    message?: string;
+  };
+}
+
+export interface ExactRegionFloorCandidate {
+  /** Request payload. Equal to the source unless lossless wallLines sugar was compiled. */
+  yaml: string;
+  doc: DungeonDoc;
+}
+
+export function hasRegionFloorIntent(
+  doc: Pick<DungeonDoc, 'canvas' | 'regions' | 'rooms'>
+): boolean {
+  return (
+    doc.canvas?.floorSource === 'regions' ||
+    (doc.canvas !== null && doc.rooms.length === 0 && doc.regions.length > 0)
+  );
 }
 
 function cellKey([column, row]: RegionFloorCell): string {
   return `${column},${row}`;
 }
 
-function edgeKey(edge: RegionFloorEdge): string {
-  const from = cellKey(edge.from);
-  const to = cellKey(edge.to);
-  return from < to ? `${from}|${to}` : `${to}|${from}`;
+function wallEdgeKey(a: RegionFloorCell, b: RegionFloorCell): string {
+  const aKey = cellKey(a);
+  const bKey = cellKey(b);
+  return aKey <= bKey ? `${aKey}|${bKey}` : `${bKey}|${aKey}`;
+}
+
+function rotationBlockers(doc: DungeonDoc): string[] {
+  const blockers: string[] = [];
+  doc.place.forEach((placement, index) => {
+    if (placement.rotationDegrees !== null) {
+      blockers.push(
+        `place[${index}].rotate_degrees: unsupported capability: fine rotation cannot be removed from an exact region-floor candidate`
+      );
+    }
+  });
+  doc.rooms.forEach((room, roomIndex) => {
+    room.place.forEach((placement, placementIndex) => {
+      if (placement.rotationDegrees !== null) {
+        blockers.push(
+          `rooms[${roomIndex}].place[${placementIndex}].rotate_degrees: unsupported capability: fine rotation cannot be removed from an exact region-floor candidate`
+        );
+      }
+    });
+  });
+  return blockers;
 }
 
 /**
- * Keeps an authored region-floor request byte-for-byte exact. This is the
- * capability attempt payload: callers may submit it with validate_only=true,
- * but may not route it through the legacy subset stripper.
+ * Builds the only request payload allowed for an explicit region floor.
+ * It never invokes the legacy subset stripper. The source is returned byte for
+ * byte when it already uses provider grammar. `wallLines` remains local sugar:
+ * it may be replaced on a fresh CST only when every implied pair is representable
+ * and no authored meaning conflicts. The caller's source string/CST is untouched.
  */
-export function prepareExactRegionFloorCandidate(yaml: string): {
-  yaml: string;
-  doc: DungeonDoc;
-} {
-  const { doc } = parseDungeon(yaml);
+export function prepareExactRegionFloorCandidate(
+  yaml: string,
+  options: RegionFloorCandidateOptions = {}
+): ExactRegionFloorCandidate {
+  const { cst, doc } = parseDungeon(yaml);
   if (doc.canvas?.floorSource !== 'regions') {
     throw new UnsupportedRegionFloorContractError(
-      'canvas.floor_source: regions is required for a Wave A region-floor candidate'
+      'canvas.floor_source: exact region-floor candidates must explicitly declare "regions"; the client will not infer it'
     );
   }
-  return { yaml, doc };
+
+  const blockers = rotationBlockers(doc);
+  const projected = new Map<string, WallDoc>();
+
+  if (doc.wallLines.length > 0) {
+    const wallsCapability = options.wallsCapability;
+    if (wallsCapability && !wallsCapability.accepted) {
+      blockers.unshift(
+        `walls: ${wallsCapability.message || 'rejected — no detail returned'}; wallLines cannot compile for an exact region-floor candidate`
+      );
+    } else {
+      const grid = doc.canvas ?? DEFAULT_CANVAS;
+      let hasRimEdges = false;
+      doc.wallLines.forEach((line, index) => {
+        const projection = projectWallLineToEdges(line, grid);
+        if (projection.rimEdgeCount > 0) hasRimEdges = true;
+        if (projection.edges.length === 0 && projection.rimEdgeCount === 0) {
+          blockers.push(
+            `wallLines[${index}]: projection produced no canonical walls; exact region-floor candidate blocked`
+          );
+        }
+        for (const edge of projection.edges) {
+          const key = wallEdgeKey(edge.from, edge.to);
+          const existing = projected.get(key);
+          if (existing && existing.kind !== edge.kind) {
+            blockers.push(
+              `wallLines[${index}]: conflicting wall kinds at ${key} cannot compile losslessly`
+            );
+            continue;
+          }
+          projected.set(key, edge);
+        }
+      });
+      if (hasRimEdges) {
+        blockers.unshift(
+          'wallLines: perimeter rim edges cannot compile losslessly to walls'
+        );
+      }
+
+      const explicit = new Map(
+        doc.walls.map(
+          (wall) => [wallEdgeKey(wall.from, wall.to), wall] as const
+        )
+      );
+      for (const [key, wall] of projected) {
+        const existing = explicit.get(key);
+        if (existing && existing.kind !== wall.kind) {
+          blockers.push(
+            `wallLines: projected ${wall.kind} conflicts with explicit ${existing.kind} at ${key}`
+          );
+        }
+      }
+    }
+  }
+
+  if (blockers.length > 0) {
+    throw new UnsupportedRegionFloorContractError(blockers.join('; '));
+  }
+
+  if (doc.wallLines.length === 0) {
+    return { yaml, doc };
+  }
+
+  const explicitKeys = new Set(
+    doc.walls.map((wall) => wallEdgeKey(wall.from, wall.to))
+  );
+  const walls = [
+    ...doc.walls,
+    ...[...projected.entries()]
+      .filter(([key]) => !explicitKeys.has(key))
+      .map(([, wall]) => ({
+        from: [...wall.from] as [number, number],
+        to: [...wall.to] as [number, number],
+        kind: wall.kind,
+      })),
+  ];
+  cst.set(
+    'walls',
+    walls.map((wall) => ({
+      from: wall.from,
+      to: wall.to,
+      kind: wall.kind,
+    }))
+  );
+  cst.delete('wallLines');
+  const candidateYaml = serializeDungeon(cst);
+  return { yaml: candidateYaml, doc: parseDungeon(candidateYaml).doc };
+}
+
+function tuple(cell: { column: number; row: number }): RegionFloorCell {
+  return [cell.column, cell.row];
+}
+
+function floorSourceFailure(floorSource: FloorPlan['floorSource']): string {
+  if (floorSource === undefined) {
+    return 'FloorPlan.floor_source is absent; refusing to infer a region floor from cells, bounds, or regions';
+  }
+  if (floorSource === FloorPlanFloorSource.UNSPECIFIED) {
+    return 'FloorPlan.floor_source is UNSPECIFIED; refusing to infer a region floor from cells, bounds, or regions';
+  }
+  if (floorSource === FloorPlanFloorSource.BOUNDS) {
+    return 'FloorPlan.floor_source resolved to BOUNDS, not REGIONS';
+  }
+  return `FloorPlan.floor_source has unsupported value ${floorSource}`;
 }
 
 /**
- * Consumes provider truth without deriving a rectangle, a region union, or
- * competing envelope edges. Producer-contract violations hard-stop instead of
- * falling back to bounds.
+ * Consumes the released generated FloorPlan directly. It validates producer
+ * contract rails but never derives a rectangle, region union, envelope, pair
+ * orientation, or replacement topology.
  */
 export function consumeRegionFloorProjection(
-  projection: RegionFloorProjection
+  floorPlan: FloorPlan
 ): ConsumedRegionFloor {
-  if (projection.floorSource !== 'regions') {
+  if (floorPlan.floorSource !== FloorPlanFloorSource.REGIONS) {
     throw new UnsupportedRegionFloorContractError(
-      projection.floorSource === undefined
-        ? 'FloorPlan.floor_source is absent; the additive authoring proto is required before region-floor preview can render'
-        : `FloorPlan.floor_source resolved to ${projection.floorSource}, not regions`
+      floorSourceFailure(floorPlan.floorSource)
     );
   }
 
+  const floorCells: RegionFloorCell[] = [];
   const floorKeys = new Set<string>();
-  for (const cell of projection.floorCells) {
+  let previous: RegionFloorCell | undefined;
+  for (const wireCell of floorPlan.floorCells) {
+    const cell = tuple(wireCell);
     const key = cellKey(cell);
     if (floorKeys.has(key)) {
       throw new UnsupportedRegionFloorContractError(
         `FloorPlan.floor_cells contains duplicate ${key}`
       );
     }
+    if (
+      previous &&
+      (cell[0] < previous[0] ||
+        (cell[0] === previous[0] && cell[1] < previous[1]))
+    ) {
+      throw new UnsupportedRegionFloorContractError(
+        `FloorPlan.floor_cells is not in canonical ascending order at ${key}`
+      );
+    }
+    previous = cell;
     floorKeys.add(key);
+    floorCells.push(cell);
   }
 
   const seenEdges = new Set<string>();
-  const edges = projection.edges.map((edge) => {
-    const key = edgeKey(edge);
-    if (seenEdges.has(key)) {
-      throw new UnsupportedRegionFloorContractError(
-        `FloorPlan.edges contains duplicate pair ${key}`
-      );
-    }
-    seenEdges.add(key);
+  const seenDoorIds = new Set<string>();
+  const edges: ConsumedRegionFloorEdge[] = floorPlan.edges.map(
+    (wireEdge, index) => {
+      if (!wireEdge.from || !wireEdge.to) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan.edges[${index}] is missing from or to`
+        );
+      }
+      const from = tuple(wireEdge.from);
+      const to = tuple(wireEdge.to);
+      const key = wallEdgeKey(from, to);
+      if (cellKey(from) === cellKey(to)) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan edge ${key} has identical endpoints`
+        );
+      }
+      if (seenEdges.has(key)) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan.edges contains duplicate pair ${key}`
+        );
+      }
+      seenEdges.add(key);
 
-    const floorOwners = [edge.from, edge.to].filter((cell) =>
-      floorKeys.has(cellKey(cell))
-    );
-    if (floorOwners.length === 0) {
-      throw new UnsupportedRegionFloorContractError(
-        `FloorPlan edge ${key} has no returned floor owner`
-      );
-    }
-    return { ...edge, floorOwners };
-  });
+      if (
+        wireEdge.kind !== FloorPlanEdgeKind.SOLID &&
+        wireEdge.kind !== FloorPlanEdgeKind.DOOR
+      ) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan edge ${key} has unsupported kind ${wireEdge.kind}`
+        );
+      }
+      if (
+        wireEdge.kind === FloorPlanEdgeKind.SOLID &&
+        wireEdge.doorId !== undefined
+      ) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan solid edge ${key} unexpectedly has door_id`
+        );
+      }
+      if (wireEdge.kind === FloorPlanEdgeKind.DOOR) {
+        if (!wireEdge.doorId) {
+          throw new UnsupportedRegionFloorContractError(
+            `FloorPlan door edge ${key} has no door_id`
+          );
+        }
+        if (seenDoorIds.has(wireEdge.doorId)) {
+          throw new UnsupportedRegionFloorContractError(
+            `FloorPlan.edges contains duplicate door_id ${wireEdge.doorId}`
+          );
+        }
+        seenDoorIds.add(wireEdge.doorId);
+      }
 
-  if (
-    projection.entrance !== undefined &&
-    !floorKeys.has(cellKey(projection.entrance))
-  ) {
+      const floorOwners = [from, to].filter((cell) =>
+        floorKeys.has(cellKey(cell))
+      );
+      if (floorOwners.length === 0) {
+        throw new UnsupportedRegionFloorContractError(
+          `FloorPlan edge ${key} has no returned floor owner`
+        );
+      }
+      return {
+        from,
+        to,
+        kind: wireEdge.kind,
+        doorId: wireEdge.doorId,
+        floorOwners,
+      };
+    }
+  );
+
+  const entrance = floorPlan.entrance ? tuple(floorPlan.entrance) : undefined;
+  if (entrance && !floorKeys.has(cellKey(entrance))) {
     throw new UnsupportedRegionFloorContractError(
-      `FloorPlan.entrance ${cellKey(projection.entrance)} is not returned floor`
+      `FloorPlan.entrance ${cellKey(entrance)} is not returned floor`
     );
   }
 
   return {
-    floorSource: 'regions',
-    floorCells: [...projection.floorCells],
+    floorSource: FloorPlanFloorSource.REGIONS,
+    floorCells,
     edges,
-    entrance: projection.entrance,
+    entrance,
     contains: (cell) => floorKeys.has(cellKey(cell)),
   };
 }
 
-/**
- * Runtime/fog seam over the released generated HexRecord/Wall contract:
- * hit-testing and edge rendering are built only from authorized records. It
- * intentionally knows no canvas dimensions or authored regions from which
- * topology could be rebuilt.
- */
+/** Runtime/fog seam: exposes only authorized HexRecords and attached edges. */
 export function consumeAuthorizedRuntimeHexes(hexes: readonly HexRecord[]): {
   floorKeys: ReadonlySet<string>;
   edges: readonly Wall[];

--- a/src/author/testdata/simple-room-legacy.yaml
+++ b/src/author/testdata/simple-room-legacy.yaml
@@ -1,7 +1,7 @@
 version: 1
-spec: '0.3'
+spec: "0.3"
 key: simple-room
-name: 'Simple Room'
+name: "Simple Room"
 theme: crypt
 height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads
 canvas:
@@ -10,122 +10,13 @@ canvas:
 rooms: []
 connectors: []
 walls: []
-wallLines:
-  [
-    { from: { cell: [0, 0], corner: 2 }, to: { cell: [0, 7], corner: 4 } },
-    { from: { cell: [6, 0], corner: 1 }, to: { cell: [6, 7], corner: 5 } },
-    {
-      from: { cell: [6, 7], corner: 5 },
-      to: { cell: [0, 7], corner: 4 },
-      doors: [{ cell: [3, 7] }],
-    },
-    { from: { cell: [6, 0], corner: 1 }, to: { cell: [0, 0], corner: 2 } },
-  ]
+wallLines: [ { from: { cell: [ 0, 0 ], corner: 2 }, to: { cell: [ 0, 7 ], corner: 4 } }, { from: { cell: [ 6, 0 ], corner: 1 }, to: { cell: [ 6, 7 ], corner: 5 } }, { from: { cell: [ 6, 7 ], corner: 5 }, to: { cell: [ 0, 7 ], corner: 4 }, doors: [ { cell: [ 3, 7 ] } ] }, { from: { cell: [ 6, 0 ], corner: 1 }, to: { cell: [ 0, 0 ], corner: 2 } } ]
 holes: []
 start: null
 end: null
-place:
-  [
-    {
-      ref: 'dnd5e:props:bookcase',
-      at: [6, 1],
-      blocks_movement: false,
-      blocks_los: false,
-      facing: SE,
-    },
-    {
-      ref: 'dnd5e:props:bookcase',
-      at: [6, 3],
-      blocks_movement: false,
-      blocks_los: false,
-      facing: SE,
-    },
-    {
-      ref: 'dnd5e:props:bookcase',
-      at: [6, 5],
-      blocks_movement: false,
-      blocks_los: false,
-      facing: SE,
-    },
-    {
-      ref: 'dnd5e:props:torch',
-      at: [6, 4],
-      blocks_movement: false,
-      blocks_los: false,
-    },
-    {
-      ref: 'dnd5e:props:torch',
-      at: [6, 2],
-      blocks_movement: false,
-      blocks_los: false,
-      height: 1,
-    },
-    {
-      ref: 'dnd5e:props:bookcase',
-      at: [5, 6],
-      blocks_movement: false,
-      blocks_los: false,
-      facing: SW,
-      rotate_degrees: 30,
-    },
-  ]
+place: [ { ref: "dnd5e:props:bookcase", at: [ 6, 1 ], blocks_movement: false, blocks_los: false, facing: SE }, { ref: "dnd5e:props:bookcase", at: [ 6, 3 ], blocks_movement: false, blocks_los: false, facing: SE }, { ref: "dnd5e:props:bookcase", at: [ 6, 5 ], blocks_movement: false, blocks_los: false, facing: SE }, { ref: "dnd5e:props:torch", at: [ 6, 4 ], blocks_movement: false, blocks_los: false }, { ref: "dnd5e:props:torch", at: [ 6, 2 ], blocks_movement: false, blocks_los: false, height: 1 }, { ref: "dnd5e:props:bookcase", at: [ 5, 6 ], blocks_movement: false, blocks_los: false, facing: SW, rotate_degrees: 30 } ]
 regions:
   - id: entrance
     name: Entryway
     archetype: entrance
-    cells:
-      [
-        [0, 0],
-        [0, 1],
-        [0, 2],
-        [0, 3],
-        [0, 4],
-        [0, 5],
-        [0, 6],
-        [1, 6],
-        [2, 6],
-        [3, 6],
-        [4, 6],
-        [5, 6],
-        [5, 5],
-        [5, 4],
-        [5, 3],
-        [5, 2],
-        [5, 1],
-        [5, 0],
-        [4, 0],
-        [3, 0],
-        [2, 0],
-        [1, 0],
-        [1, 1],
-        [1, 2],
-        [1, 3],
-        [1, 4],
-        [1, 5],
-        [2, 5],
-        [3, 5],
-        [4, 5],
-        [4, 4],
-        [4, 3],
-        [4, 2],
-        [4, 1],
-        [3, 1],
-        [3, 2],
-        [3, 3],
-        [3, 4],
-        [2, 4],
-        [2, 3],
-        [2, 2],
-        [2, 1],
-        [6, 0],
-        [6, 1],
-        [6, 2],
-        [6, 3],
-        [6, 4],
-        [6, 5],
-        [6, 6],
-        [0, 7],
-        [2, 7],
-        [4, 7],
-        [6, 7],
-      ]
+    cells: [ [ 0, 0 ], [ 0, 1 ], [ 0, 2 ], [ 0, 3 ], [ 0, 4 ], [ 0, 5 ], [ 0, 6 ], [ 1, 6 ], [ 2, 6 ], [ 3, 6 ], [ 4, 6 ], [ 5, 6 ], [ 5, 5 ], [ 5, 4 ], [ 5, 3 ], [ 5, 2 ], [ 5, 1 ], [ 5, 0 ], [ 4, 0 ], [ 3, 0 ], [ 2, 0 ], [ 1, 0 ], [ 1, 1 ], [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ], [ 2, 5 ], [ 3, 5 ], [ 4, 5 ], [ 4, 4 ], [ 4, 3 ], [ 4, 2 ], [ 4, 1 ], [ 3, 1 ], [ 3, 2 ], [ 3, 3 ], [ 3, 4 ], [ 2, 4 ], [ 2, 3 ], [ 2, 2 ], [ 2, 1 ], [ 6, 0 ], [ 6, 1 ], [ 6, 2 ], [ 6, 3 ], [ 6, 4 ], [ 6, 5 ], [ 6, 6 ], [ 0, 7 ], [ 2, 7 ], [ 4, 7 ], [ 6, 7 ] ]

--- a/src/author/testdata/simple-room-legacy.yaml
+++ b/src/author/testdata/simple-room-legacy.yaml
@@ -1,0 +1,131 @@
+version: 1
+spec: '0.3'
+key: simple-room
+name: 'Simple Room'
+theme: crypt
+height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads
+canvas:
+  width: 20
+  height: 30
+rooms: []
+connectors: []
+walls: []
+wallLines:
+  [
+    { from: { cell: [0, 0], corner: 2 }, to: { cell: [0, 7], corner: 4 } },
+    { from: { cell: [6, 0], corner: 1 }, to: { cell: [6, 7], corner: 5 } },
+    {
+      from: { cell: [6, 7], corner: 5 },
+      to: { cell: [0, 7], corner: 4 },
+      doors: [{ cell: [3, 7] }],
+    },
+    { from: { cell: [6, 0], corner: 1 }, to: { cell: [0, 0], corner: 2 } },
+  ]
+holes: []
+start: null
+end: null
+place:
+  [
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 1],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 3],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 5],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:torch',
+      at: [6, 4],
+      blocks_movement: false,
+      blocks_los: false,
+    },
+    {
+      ref: 'dnd5e:props:torch',
+      at: [6, 2],
+      blocks_movement: false,
+      blocks_los: false,
+      height: 1,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [5, 6],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SW,
+      rotate_degrees: 30,
+    },
+  ]
+regions:
+  - id: entrance
+    name: Entryway
+    archetype: entrance
+    cells:
+      [
+        [0, 0],
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [0, 4],
+        [0, 5],
+        [0, 6],
+        [1, 6],
+        [2, 6],
+        [3, 6],
+        [4, 6],
+        [5, 6],
+        [5, 5],
+        [5, 4],
+        [5, 3],
+        [5, 2],
+        [5, 1],
+        [5, 0],
+        [4, 0],
+        [3, 0],
+        [2, 0],
+        [1, 0],
+        [1, 1],
+        [1, 2],
+        [1, 3],
+        [1, 4],
+        [1, 5],
+        [2, 5],
+        [3, 5],
+        [4, 5],
+        [4, 4],
+        [4, 3],
+        [4, 2],
+        [4, 1],
+        [3, 1],
+        [3, 2],
+        [3, 3],
+        [3, 4],
+        [2, 4],
+        [2, 3],
+        [2, 2],
+        [2, 1],
+        [6, 0],
+        [6, 1],
+        [6, 2],
+        [6, 3],
+        [6, 4],
+        [6, 5],
+        [6, 6],
+        [0, 7],
+        [2, 7],
+        [4, 7],
+        [6, 7],
+      ]

--- a/src/author/testdata/simple-room-v04-lossy.yaml
+++ b/src/author/testdata/simple-room-v04-lossy.yaml
@@ -1,0 +1,131 @@
+version: 1
+key: simple-room
+name: 'Simple Room'
+theme: crypt
+height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads
+canvas:
+  width: 20
+  height: 30
+  floor_source: regions
+rooms: []
+connectors: []
+walls: []
+wallLines:
+  [
+    { from: { cell: [0, 0], corner: 2 }, to: { cell: [0, 7], corner: 4 } },
+    { from: { cell: [6, 0], corner: 1 }, to: { cell: [6, 7], corner: 5 } },
+    {
+      from: { cell: [6, 7], corner: 5 },
+      to: { cell: [0, 7], corner: 4 },
+      doors: [{ cell: [3, 7] }],
+    },
+    { from: { cell: [6, 0], corner: 1 }, to: { cell: [0, 0], corner: 2 } },
+  ]
+holes: []
+start: null
+end: null
+place:
+  [
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 1],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 3],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 5],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:torch',
+      at: [6, 4],
+      blocks_movement: false,
+      blocks_los: false,
+    },
+    {
+      ref: 'dnd5e:props:torch',
+      at: [6, 2],
+      blocks_movement: false,
+      blocks_los: false,
+      height: 1,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [5, 6],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SW,
+      rotate_degrees: 30,
+    },
+  ]
+regions:
+  - id: entrance
+    name: Entryway
+    archetype: entrance
+    cells:
+      [
+        [0, 0],
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [0, 4],
+        [0, 5],
+        [0, 6],
+        [1, 6],
+        [2, 6],
+        [3, 6],
+        [4, 6],
+        [5, 6],
+        [5, 5],
+        [5, 4],
+        [5, 3],
+        [5, 2],
+        [5, 1],
+        [5, 0],
+        [4, 0],
+        [3, 0],
+        [2, 0],
+        [1, 0],
+        [1, 1],
+        [1, 2],
+        [1, 3],
+        [1, 4],
+        [1, 5],
+        [2, 5],
+        [3, 5],
+        [4, 5],
+        [4, 4],
+        [4, 3],
+        [4, 2],
+        [4, 1],
+        [3, 1],
+        [3, 2],
+        [3, 3],
+        [3, 4],
+        [2, 4],
+        [2, 3],
+        [2, 2],
+        [2, 1],
+        [6, 0],
+        [6, 1],
+        [6, 2],
+        [6, 3],
+        [6, 4],
+        [6, 5],
+        [6, 6],
+        [0, 7],
+        [2, 7],
+        [4, 7],
+        [6, 7],
+      ]

--- a/src/author/testdata/simple-room-v04-regions.yaml
+++ b/src/author/testdata/simple-room-v04-regions.yaml
@@ -1,0 +1,116 @@
+version: 1
+key: simple-room
+name: 'Simple Room'
+theme: crypt
+height: 1 # unused placeholder — no compiled room chain exists yet; canvas.height below is what the board actually reads
+canvas:
+  width: 20
+  height: 30
+  floor_source: regions
+rooms: []
+connectors: []
+walls: []
+start: null
+place:
+  [
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 1],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 3],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [6, 5],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SE,
+    },
+    {
+      ref: 'dnd5e:props:torch',
+      at: [6, 4],
+      blocks_movement: false,
+      blocks_los: false,
+    },
+    {
+      ref: 'dnd5e:props:torch',
+      at: [6, 2],
+      blocks_movement: false,
+      blocks_los: false,
+    },
+    {
+      ref: 'dnd5e:props:bookcase',
+      at: [5, 6],
+      blocks_movement: false,
+      blocks_los: false,
+      facing: SW,
+    },
+  ]
+regions:
+  - id: entrance
+    name: Entryway
+    archetype: entrance
+    cells:
+      [
+        [0, 0],
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [0, 4],
+        [0, 5],
+        [0, 6],
+        [1, 6],
+        [2, 6],
+        [3, 6],
+        [4, 6],
+        [5, 6],
+        [5, 5],
+        [5, 4],
+        [5, 3],
+        [5, 2],
+        [5, 1],
+        [5, 0],
+        [4, 0],
+        [3, 0],
+        [2, 0],
+        [1, 0],
+        [1, 1],
+        [1, 2],
+        [1, 3],
+        [1, 4],
+        [1, 5],
+        [2, 5],
+        [3, 5],
+        [4, 5],
+        [4, 4],
+        [4, 3],
+        [4, 2],
+        [4, 1],
+        [3, 1],
+        [3, 2],
+        [3, 3],
+        [3, 4],
+        [2, 4],
+        [2, 3],
+        [2, 2],
+        [2, 1],
+        [6, 0],
+        [6, 1],
+        [6, 2],
+        [6, 3],
+        [6, 4],
+        [6, 5],
+        [6, 6],
+        [0, 7],
+        [2, 7],
+        [4, 7],
+        [6, 7],
+      ]


### PR DESCRIPTION
## Summary

- submit `canvas.floor_source: regions` through exact validate-only semantics without `stripToV1Subset` downgrade
- consume the server-provided floor mask, envelope edges, entrance, and resolved floor source as preview truth
- hard-stop legacy, lossy `wallLines`, unsupported fine rotation, and malformed provider projections without mutating source
- bind accepted projection state to the exact current YAML/key so edits synchronously revoke preview and Save & Play
- add the legacy, lossy, and canonical simple-room fixtures used for browser/server acceptance

## Verification

- `npm run test:run` — 152 files, 2,579 tests passed
- normal pre-push `npm run ci-check` — formatting, lint, typecheck, build, and tests passed
- real Chrome: legacy and lossy inputs remain unchanged with Save & Play disabled
- real Chrome: canonical 53-cell region validates and renders 58 provider envelope edges with zero authored walls
- actual Save & Play, byte-identical persistence, API restart, dungeon listing, lobby start, and viewer-authorized runtime projection passed
- independent final cross-repository review: MERGE_READY

Depends on KirkDiggler/rpg-api#782.

Closes #735

— asset-pipeline agent, on behalf of KirkDiggler
