### PR TITLE
docs: align class animation contract with townfolk roster (#225)

### DIFF
--- a/src/components/hex-grid/ClassCharacterModel.tsx
+++ b/src/components/hex-grid/ClassCharacterModel.tsx
@@ -26,16 +26,11 @@
  * fetched 200 OK, nothing rendered). `SkeletonUtils.clone()` fixed this
  * and shipped separately via #517; this file wires up the animation
  * playback on top of that already-landed fix, not the clone itself.
- * Current asset reality (re-verified against assets#4-#10, then again
- * post rpg-game-assets#11): fighter/barbarian.glb ship 0 baked clips
- * (junk stripped; Big-Rig retarget pending) — `resolveIdleClipName`
- * returning undefined for a clip-less model is a normal, expected case,
- * not an error; the animation effects below and the frameloop-invalidate
- * heartbeat all no-op cleanly for it. monk/rogue.glb now ship 3 idle
- * clips each (rpg-game-assets#11, closing rpg-dnd5e-web#522) and play
- * one on loop. Downed variants ship with no animation data at all —
- * `SkeletonUtils.clone()` still works for a static mesh, so one clone
- * path covers both cases.
+ * Merged Townfolk contract (provider PR #61, merge commit 4fac080): every
+ * standing Fighter/Monk/Rogue/Barbarian class alias ships exactly two baked
+ * clips, in order: `Idle_Relaxed`, then `Walk_Forward`. Every downed variant
+ * is static and ships zero animation clips. `SkeletonUtils.clone()` works
+ * for both animated and static meshes, so one clone path covers both cases.
  *
  * `isMoving` (rpg-dnd5e-web#542): HexEntity computes this from whether it's
  * currently stepping the entity's rendered position through a real
@@ -203,10 +198,10 @@ export function ClassCharacterModel({
   // prefer a `Walk_*` clip (resolveWalkClipName), falling back to idle if
   // this model has no walk clip yet; stationary always plays idle
   // (resolveIdleClipName — prefers an "idle"-named clip, falls back to the
-  // first available). Today's `main` fighter/barbarian/monk/rogue.glb all
-  // ship 4 clips (3 idle variants + Walk_Forward, rpg-game-assets#20);
-  // downed variants ship 0, so `names` is empty and `resolvedClipName` is
-  // undefined — this effect no-ops cleanly for those, same as before #542.
+  // first available). The merged standing Townfolk files all ship exactly
+  // `Idle_Relaxed`, then `Walk_Forward`; downed variants ship 0 clips, so
+  // `names` is empty and `resolvedClipName` is undefined — this effect
+  // no-ops cleanly for those, same as before #542.
   const { actions, names } = useAnimations(animations, cloned);
   const resolvedClipName = isMoving
     ? (resolveWalkClipName(names) ?? resolveIdleClipName(names))

--- a/src/components/hex-grid/classCharacterModels.test.ts
+++ b/src/components/hex-grid/classCharacterModels.test.ts
@@ -61,30 +61,23 @@ describe('resolveIdleClipName', () => {
     expect(resolveIdleClipName(['Walk', 'Run', 'Attack'])).toBe('Walk');
   });
 
-  it("returns undefined for an empty clip list — today's real case for main's fighter/barbarian.glb (0 clips shipped) and every downed variant", () => {
+  it('returns undefined for an empty clip list', () => {
     expect(resolveIdleClipName([])).toBeUndefined();
   });
 
-  it('picks the first idle-named clip when every clip is idle-named (monk/rogue\'s real multi-clip shape on main since rpg-game-assets#11 — all variants match "idle", so the "first available" fallback effectively decides)', () => {
-    expect(
-      resolveIdleClipName(['Idle_Drinking', 'Idle_Meditative', 'Idle_Relaxed'])
-    ).toBe('Idle_Drinking');
-    expect(
-      resolveIdleClipName(['Idle_CheckWatch', 'Idle_Drinking', 'Idle_Relaxed'])
-    ).toBe('Idle_CheckWatch');
+  it('picks the first idle-named clip when multiple clips are idle-named', () => {
+    expect(resolveIdleClipName(['Idle_Alert', 'Idle_Relaxed'])).toBe(
+      'Idle_Alert'
+    );
   });
 });
 
 describe('resolveWalkClipName', () => {
-  it('picks the clip whose name contains "walk" — today\'s real 4-class shape on main since rpg-game-assets#20', () => {
-    expect(
-      resolveWalkClipName([
-        'Idle_Drinking',
-        'Idle_Meditative',
-        'Idle_Relaxed',
-        'Walk_Forward',
-      ])
-    ).toBe('Walk_Forward');
+  it('resolves the exact merged Townfolk standing release shape', () => {
+    const releaseClipNames = ['Idle_Relaxed', 'Walk_Forward'];
+
+    expect(resolveIdleClipName(releaseClipNames)).toBe('Idle_Relaxed');
+    expect(resolveWalkClipName(releaseClipNames)).toBe('Walk_Forward');
   });
 
   it('matches "walk" case-insensitively', () => {

--- a/src/components/hex-grid/classCharacterModels.ts
+++ b/src/components/hex-grid/classCharacterModels.ts
@@ -60,29 +60,18 @@ export function resolveClassCharacterModelUrl(
  * for a downed variant or any model with no baked animation at all —
  * callers treat that as "leave the static pose alone", never a crash.
  *
- * Re-verified against current asset reality (rebased post assets#4-#10,
- * then re-checked again post rpg-game-assets#11): on `main` today,
- * fighter/barbarian.glb ship 0 animation clips (junk stripped during the
- * asset cleanup; a Big-Rig retarget is pending) — `resolveIdleClipName`
- * returns undefined for both, which is the correct, expected,
- * no-op-the-animation behavior for clip-less models, not a gap.
- * monk.glb/rogue.glb, following the merge of rpg-game-assets#11 (idle
- * retarget for rpg-dnd5e-web#522), now ship 3 clips each — monk:
- * `Idle_Drinking`/`Idle_Meditative`/`Idle_Relaxed`; rogue:
- * `Idle_CheckWatch`/`Idle_Drinking`/`Idle_Relaxed`. Every clip in that set
- * matches the `/idle/i` filter, so this function picks whichever comes
- * first in the GLB's animation array — an arbitrary but always-correct
- * choice among interchangeable idle variants. Naming a *specific*
- * preferred variant (e.g. always "Relaxed") is out of scope for this PR;
- * that's the char-creation animation-picker slice's job.
+ * The merged Townfolk provider contract (provider PR #61, merge commit
+ * 4fac080) gives every standing Fighter/Monk/Rogue/Barbarian class alias
+ * exactly two clips in this order: `Idle_Relaxed`, then `Walk_Forward`.
+ * This resolver therefore returns `Idle_Relaxed` for every standing file.
+ * Every downed variant is static with zero clips, so it returns undefined.
  *
  * @example
  * ```typescript
- * resolveIdleClipName(['Idle_Drinking', 'Idle_Meditative', 'Idle_Relaxed']);
- * // 'Idle_Drinking' — first idle-matching clip, current monk/rogue reality
+ * resolveIdleClipName(['Idle_Relaxed', 'Walk_Forward']);
+ * // 'Idle_Relaxed' — exact merged standing Townfolk release shape
  * resolveIdleClipName(['Walk', 'Idle_Loop']); // 'Idle_Loop'
- * resolveIdleClipName([]); // undefined — today's fighter/barbarian on
- *                          // `main` (0 clips), and every downed variant
+ * resolveIdleClipName([]); // undefined — static downed Townfolk variant
  * ```
  */
 export function resolveIdleClipName(names: string[]): string | undefined {
@@ -102,16 +91,15 @@ export function resolveIdleClipName(names: string[]): string | undefined {
  * than just staying on the resolved idle clip, which is what callers should
  * fall back to instead (see `ClassCharacterModel.tsx`'s usage: `isMoving`
  * prefers `resolveWalkClipName`, falling back to `resolveIdleClipName` only
- * if that's undefined — e.g. fighter/barbarian before a Walk_* clip ships
- * for them, or any future clip-less model).
+ * if that's undefined — e.g. a future model without a Walk_* clip, or a
+ * static downed variant with no clips).
  *
  * @example
  * ```typescript
- * resolveWalkClipName(['Idle_Relaxed', 'Idle_Drinking', 'Walk_Forward']);
- * // 'Walk_Forward'
- * resolveWalkClipName(['Idle_Relaxed', 'Idle_Drinking']);
- * // undefined — no Walk_* clip shipped for this model yet; caller falls
- * //             back to resolveIdleClipName instead of guessing
+ * resolveWalkClipName(['Idle_Relaxed', 'Walk_Forward']);
+ * // 'Walk_Forward' — exact merged standing Townfolk release shape
+ * resolveWalkClipName(['Idle_Relaxed']);
+ * // undefined — no Walk_* clip; caller falls back to resolveIdleClipName
  * ```
  */
 export function resolveWalkClipName(names: string[]): string | undefined {


### PR DESCRIPTION
## Summary
- update class-animation documentation to the merged two-clip Townfolk standing contract and static downed contract
- update the real-shape resolver fixture to assert `Idle_Relaxed` and `Walk_Forward` from the exact release order
- preserve URL resolution, clip selection, animation playback, and all runtime assets; behavior is unchanged

## Contract sources
- Tracks KirkDiggler/rpg-project#225
- Aligns with merged provider PR KirkDiggler/rpg-game-assets#61, merge commit `4fac08068ccfc7e752ac43a6edcbed6ecd18c9e4`

## Validation
- `npx vitest run src/components/hex-grid/classCharacterModels.test.ts` — 23/23 passed
- `npm run ci-check` — formatting, lint, typecheck, build, and tests passed
- `git diff --check` — passed

Licensed runtime files added = 0.

— asset-pipeline agent, on behalf of KirkDiggler
