### PR TITLE
fix(dev): the UI's player id must be the id the auth header sends

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { lazy, Suspense, useEffect, useState } from 'react';
+import { getPlayerId } from './api/auth';
 import { useListCharacters, useListDrafts } from './api/hooks';
 import { useDevPlayerIdAuth } from './api/useDevPlayerIdAuth';
 import { useMyActiveLobby } from './api/useMyActiveLobby';
@@ -101,9 +102,16 @@ function AppContent() {
   // Sync dev override into gRPC auth store so outbound RPCs carry the right
   // player ID. useLayoutEffect fires before child effects, preventing races.
   useDevPlayerIdAuth(devPlayerIdOverride);
+  // The UI's identity must be the SAME id the auth interceptor sends, or the
+  // lobby roster can't find "me": the server stamps members with the header
+  // id, and a UI that believes it is someone else hides Ready state and the
+  // host's Start button. getPlayerId() already falls back to
+  // VITE_DEV_PLAYER_ID the way the interceptor does, so ask it rather than
+  // re-deriving a second (and previously disagreeing) fallback here.
   const playerId =
     discord.user?.id ||
     devPlayerIdOverride ||
+    getPlayerId() ||
     (isDevelopment ? 'test-player' : null);
 
   // Resume-after-refresh (#444): ask the server, once, whether this player


### PR DESCRIPTION
## What

In local dev with `VITE_DEV_PLAYER_ID` set and no `?playerId=` override, the gRPC auth interceptor authenticated as that id while `App.tsx` derived the UI's identity as `'test-player'`. The server stamped the lobby member (host, ready) with the header id; the roster could not find "me", so the Ready button never flipped to "✓ Ready!" and the host's **Start** button never rendered.

Found by Kirk the first time a human walked the session route (#764) on `dev` — Playwright runs always passed `?playerId=`, which masks it.

## Fix

`getPlayerId()` already carries the interceptor's fallback chain, so the UI asks it instead of keeping a second, disagreeing default. One hunk in `App.tsx`; precedence is unchanged for Discord and for the explicit override.

## Checks

`npm run ci-check`: format, lint, typecheck, build, tests — all green locally; pre-push hook ran the same.

— asset-pipeline agent, on behalf of KirkDiggler
