### PR TITLE
fix(session): wall corners close by construction (#793)

### DIFF
--- a/src/components/session/atlasWallRuns.test.ts
+++ b/src/components/session/atlasWallRuns.test.ts
@@ -569,6 +569,130 @@ describe('boundariesToWallRuns — an L-shaped interior seam', () => {
   });
 });
 
+describe('boundariesToWallRuns — corners close by construction (rpg-dnd5e-web#793)', () => {
+  /** A real interior L-shaped partition (region B a plain rectangle,
+   * region A its complement within the floor -- the exact construction
+   * the merged L-shaped-seam test above already proves produces a
+   * genuine two-leg bend) with `mirrored` flipping which side is B, so
+   * the corner bends the other way -- "both orientations of the
+   * corner" per the issue. */
+  function lShapedScene(mirrored: boolean) {
+    const cells: unknown[] = [];
+    for (let q = 0; q <= 8; q++) {
+      for (let r = 0; r <= 7; r++) cells.push(pos(q, r));
+    }
+    const inB = mirrored
+      ? (q: number, r: number) => q <= 5 && r >= 4
+      : (q: number, r: number) => q >= 3 && r >= 4;
+    const edges: Array<[number, number, number, number]> = [];
+    const seen = new Set<string>();
+    for (let q = 0; q <= 8; q++) {
+      for (let r = 0; r <= 7; r++) {
+        const neighbors: Array<[number, number]> = [
+          [q + 1, r - 1],
+          [q + 1, r],
+          [q, r - 1],
+          [q - 1, r],
+          [q - 1, r + 1],
+          [q, r + 1],
+        ];
+        for (const [nq, nr] of neighbors) {
+          if (nq < 0 || nq > 8 || nr < 0 || nr > 7) continue;
+          if (inB(q, r) === inB(nq, nr)) continue;
+          const key = [q, r, nq, nr].sort().join(',');
+          if (seen.has(key)) continue;
+          seen.add(key);
+          edges.push([q, r, nq, nr]);
+        }
+      }
+    }
+    const boundaries = edges.map(([q, r, nq, nr]) => ({
+      from: pos(q, r),
+      to: pos(nq, nr),
+      blocksMovement: true,
+      blocksLineOfSight: true,
+    }));
+    return boundariesToWallRuns(
+      {
+        cells: cells as never,
+        boundaries: boundaries as never,
+        doorways: [] as never,
+      },
+      1
+    );
+  }
+
+  const CORNER_OVERLAP_MARGIN = 0.16;
+
+  /** Finds the one pair of runs whose endpoints sit close together (a
+   * real corner join, post-margin) and, for each, the TRUE corner point
+   * its own margin extension was measured from -- pulling the final
+   * endpoint back by the margin along that run's own direction.
+   * Independent of `atlasWallRuns.ts`'s own internals: this is exactly
+   * what "the joint closes, then gets a visual margin on top" means
+   * from the outside. */
+  function findCornerJoin(runs: readonly AuthoredWallRun[]) {
+    for (let i = 0; i < runs.length; i++) {
+      for (let j = i + 1; j < runs.length; j++) {
+        for (const iEnd of ['start', 'end'] as const) {
+          for (const jEnd of ['start', 'end'] as const) {
+            const pi = runs[i]![iEnd];
+            const pj = runs[j]![jEnd];
+            if (distanceBetween(pi, pj) >= 0.5) continue;
+            const farI = iEnd === 'start' ? runs[i]!.end : runs[i]!.start;
+            const farJ = jEnd === 'start' ? runs[j]!.end : runs[j]!.start;
+            const dirI = unitDir(farI, pi);
+            const dirJ = unitDir(farJ, pj);
+            const trueCornerI = {
+              x: pi.x - dirI.x * CORNER_OVERLAP_MARGIN,
+              z: pi.z - dirI.z * CORNER_OVERLAP_MARGIN,
+            };
+            const trueCornerJ = {
+              x: pj.x - dirJ.x * CORNER_OVERLAP_MARGIN,
+              z: pj.z - dirJ.z * CORNER_OVERLAP_MARGIN,
+            };
+            return { pi, pj, dirI, dirJ, trueCornerI, trueCornerJ };
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+
+  it.each([false, true])(
+    'the true corner point coincides exactly, mirrored=%s',
+    (mirrored) => {
+      const scene = lShapedScene(mirrored);
+      const join = findCornerJoin(scene.wallRuns);
+      expect(join).toBeDefined(); // a real corner exists in this fixture
+      // Kirk's own finding: one side gapped, the other overlapped. The
+      // fix is distance(true corner, true corner) === 0 -- not "close",
+      // exact, the same way every other join in this module closes.
+      expect(
+        distanceBetween(join!.trueCornerI, join!.trueCornerJ)
+      ).toBeLessThan(1e-6);
+    }
+  );
+
+  it.each([false, true])(
+    'each run extends exactly the named overlap margin past the true corner, mirrored=%s',
+    (mirrored) => {
+      const scene = lShapedScene(mirrored);
+      const join = findCornerJoin(scene.wallRuns);
+      expect(join).toBeDefined();
+      // The visual-closure margin assertion: each run's own FINAL
+      // corner endpoint sits CORNER_OVERLAP_MARGIN past the shared true
+      // corner, along its OWN direction -- real wall-piece thickness
+      // overlapping the joint's outside face, not a coincidence of the
+      // fit.
+      const distI = distanceBetween(join!.pi, join!.trueCornerI);
+      const distJ = distanceBetween(join!.pj, join!.trueCornerJ);
+      expect(distI).toBeCloseTo(CORNER_OVERLAP_MARGIN, 6);
+      expect(distJ).toBeCloseTo(CORNER_OVERLAP_MARGIN, 6);
+    }
+  );
+});
+
 describe('boundariesToWallRuns — a horizontal seam (chambers stacked in rows)', () => {
   it('renders along the row boundary’s own midline, not slanted (the old bug: connector geometry only modeled a vertical, column-separating seam)', () => {
     // The real boundary between row-band r<=1 and row-band r>=2 across a

--- a/src/components/session/atlasWallRuns.test.ts
+++ b/src/components/session/atlasWallRuns.test.ts
@@ -36,7 +36,7 @@ import { hexEdgeBetween, type CubeCoord } from '@/components/hex-grid/hexMath';
 import type { AuthoredWallRun } from '@/hooks/authoredWallRuns';
 import { describe, expect, it } from 'vitest';
 import referenceTombCells from '../../concepts/session-tomb/referenceTombCells.json';
-import { boundariesToWallRuns } from './atlasWallRuns';
+import { boundariesToWallRuns, cornerJoint } from './atlasWallRuns';
 import { positionToCube } from './positionBridge';
 
 const pos = (x: number, y: number) => ({ x, y }) as never;
@@ -622,55 +622,183 @@ describe('boundariesToWallRuns — corners close by construction (rpg-dnd5e-web#
     );
   }
 
-  const CORNER_OVERLAP_MARGIN = 0.16;
-
-  /** Finds the one pair of runs whose endpoints sit close together (a
-   * real corner join, post-margin) and, for each, the TRUE corner point
-   * its own margin extension was measured from -- pulling the final
-   * endpoint back by the margin along that run's own direction.
-   * Independent of `atlasWallRuns.ts`'s own internals: this is exactly
-   * what "the joint closes, then gets a visual margin on top" means
-   * from the outside. */
-  function findCornerJoin(runs: readonly AuthoredWallRun[]) {
-    for (let i = 0; i < runs.length; i++) {
-      for (let j = i + 1; j < runs.length; j++) {
-        for (const iEnd of ['start', 'end'] as const) {
-          for (const jEnd of ['start', 'end'] as const) {
-            const pi = runs[i]![iEnd];
-            const pj = runs[j]![jEnd];
-            if (distanceBetween(pi, pj) >= 0.5) continue;
-            const farI = iEnd === 'start' ? runs[i]!.end : runs[i]!.start;
-            const farJ = jEnd === 'start' ? runs[j]!.end : runs[j]!.start;
-            const dirI = unitDir(farI, pi);
-            const dirJ = unitDir(farJ, pj);
-            const trueCornerI = {
-              x: pi.x - dirI.x * CORNER_OVERLAP_MARGIN,
-              z: pi.z - dirI.z * CORNER_OVERLAP_MARGIN,
-            };
-            const trueCornerJ = {
-              x: pj.x - dirJ.x * CORNER_OVERLAP_MARGIN,
-              z: pj.z - dirJ.z * CORNER_OVERLAP_MARGIN,
-            };
-            return { pi, pj, dirI, dirJ, trueCornerI, trueCornerJ };
-          }
+  /** A genuine T-junction: three regions tiled by cube-axis dominance
+   * (region = whichever of a cell's own cube x/y/z is the strict
+   * maximum) around one small patch of floor -- a standard hex-grid
+   * tri-coloring, not a hand-picked shape, that reliably produces
+   * exactly one raw vertex where all three regions meet (verified: at
+   * this N, exactly one endpoint cluster of size 3 exists, and every
+   * other genuine corner in the fixture clusters at size 2).
+   * `computeAuthoredWallRuns` explicitly supports a branch vertex with
+   * 3+ runs meeting it (this module's own header doc, corners
+   * section) -- this is that shape. */
+  function tJunctionScene() {
+    const N = 2;
+    const regionOf = (q: number, r: number): 0 | 1 | 2 => {
+      const x = q;
+      const y = -q - r;
+      const z = r;
+      if (x >= y && x >= z) return 0;
+      if (y > x && y >= z) return 1;
+      return 2;
+    };
+    const inRange = (q: number, r: number) =>
+      Math.abs(q) <= N && Math.abs(r) <= N && Math.abs(-q - r) <= N;
+    const cells: unknown[] = [];
+    for (let q = -N; q <= N; q++) {
+      for (let r = -N; r <= N; r++) if (inRange(q, r)) cells.push(pos(q, r));
+    }
+    const boundaries: Array<{
+      from: unknown;
+      to: unknown;
+      blocksMovement: boolean;
+      blocksLineOfSight: boolean;
+    }> = [];
+    const seen = new Set<string>();
+    for (let q = -N; q <= N; q++) {
+      for (let r = -N; r <= N; r++) {
+        if (!inRange(q, r)) continue;
+        const neighbors: Array<[number, number]> = [
+          [q + 1, r - 1],
+          [q + 1, r],
+          [q, r - 1],
+          [q - 1, r],
+          [q - 1, r + 1],
+          [q, r + 1],
+        ];
+        for (const [nq, nr] of neighbors) {
+          if (!inRange(nq, nr)) continue;
+          if (regionOf(q, r) === regionOf(nq, nr)) continue;
+          const key = [q, r, nq, nr].sort().join(',');
+          if (seen.has(key)) continue;
+          seen.add(key);
+          boundaries.push({
+            from: pos(q, r),
+            to: pos(nq, nr),
+            blocksMovement: true,
+            blocksLineOfSight: true,
+          });
         }
       }
     }
+    return boundariesToWallRuns(
+      {
+        cells: cells as never,
+        boundaries: boundaries as never,
+        doorways: [] as never,
+      },
+      1
+    );
+  }
+
+  const CORNER_OVERLAP_MARGIN = 0.16;
+  const JOIN_RADIUS = 0.5;
+  // A real bend's two directions are never anywhere near parallel (the
+  // shallowest authored corner this codebase's hex geometry produces
+  // is still a clear angle change); a straight fragment-to-fragment
+  // join has directions pointing the SAME or OPPOSITE way. 0.9 sits
+  // well below any genuine corner's dot product and well above a
+  // collinear join's -- see the describe block's own header doc,
+  // Copilot review finding, for why this check exists at all.
+  const COLLINEAR_DOT_LIMIT = 0.9;
+
+  interface EndpointRef {
+    runIndex: number;
+    end: 'start' | 'end';
+    point: P;
+    dir: P;
+  }
+
+  /** Groups every run endpoint (both ends of every run) with every
+   * OTHER endpoint within `JOIN_RADIUS`, transitively (single-linkage,
+   * like the production clustering this test is verifying from the
+   * outside) -- then only accepts a group as real evidence of a
+   * corner/junction if EVERY pair of its members' directions forms a
+   * genuine bend (Copilot review, PR #794: a bare distance threshold
+   * alone can also match two independent fragments of what's
+   * geometrically one straight run -- the production margin is 0.16,
+   * so a straight tolerance-split join can land only 0.32 apart, well
+   * inside the old 0.5 radius, with no bend at all). Returns the one
+   * group of exactly `size` members satisfying both, or undefined if
+   * none exists -- callers assert a corner/junction actually exists
+   * before trusting anything about it. */
+  function findJunctionCluster(runs: readonly AuthoredWallRun[], size: number) {
+    const refs: EndpointRef[] = [];
+    for (let i = 0; i < runs.length; i++) {
+      refs.push({
+        runIndex: i,
+        end: 'start',
+        point: runs[i]!.start,
+        dir: unitDir(runs[i]!.end, runs[i]!.start),
+      });
+      refs.push({
+        runIndex: i,
+        end: 'end',
+        point: runs[i]!.end,
+        dir: unitDir(runs[i]!.start, runs[i]!.end),
+      });
+    }
+    const parent = refs.map((_, i) => i);
+    const find = (x: number): number =>
+      parent[x] === x ? x : (parent[x] = find(parent[x]!));
+    const union = (a: number, b: number) => {
+      const ra = find(a);
+      const rb = find(b);
+      if (ra !== rb) parent[ra] = rb;
+    };
+    for (let i = 0; i < refs.length; i++) {
+      for (let j = i + 1; j < refs.length; j++) {
+        if (refs[i]!.runIndex === refs[j]!.runIndex) continue; // never join a run to its own other end
+        if (distanceBetween(refs[i]!.point, refs[j]!.point) < JOIN_RADIUS) {
+          union(i, j);
+        }
+      }
+    }
+    const groups = new Map<number, EndpointRef[]>();
+    for (let i = 0; i < refs.length; i++) {
+      const root = find(i);
+      const list = groups.get(root) ?? [];
+      list.push(refs[i]!);
+      groups.set(root, list);
+    }
+    for (const group of groups.values()) {
+      if (group.length !== size) continue;
+      const allBend = group.every((a, gi) =>
+        group.every(
+          (b, gj) =>
+            gi === gj ||
+            Math.abs(a.dir.x * b.dir.x + a.dir.z * b.dir.z) <
+              COLLINEAR_DOT_LIMIT
+        )
+      );
+      if (allBend) return group;
+    }
     return undefined;
+  }
+
+  /** Each member's own TRUE corner/junction point -- the final
+   * endpoint pulled back by the named overlap margin along that run's
+   * OWN direction. Independent of `atlasWallRuns.ts`'s own internals:
+   * this is exactly what "the joint closes, then gets a visual margin
+   * on top" means from the outside. */
+  function trueCornersOf(group: readonly EndpointRef[]) {
+    return group.map((m) => ({
+      x: m.point.x - m.dir.x * CORNER_OVERLAP_MARGIN,
+      z: m.point.z - m.dir.z * CORNER_OVERLAP_MARGIN,
+    }));
   }
 
   it.each([false, true])(
     'the true corner point coincides exactly, mirrored=%s',
     (mirrored) => {
       const scene = lShapedScene(mirrored);
-      const join = findCornerJoin(scene.wallRuns);
-      expect(join).toBeDefined(); // a real corner exists in this fixture
+      const group = findJunctionCluster(scene.wallRuns, 2);
+      expect(group).toBeDefined(); // a real corner exists in this fixture
+      const [trueCornerI, trueCornerJ] = trueCornersOf(group!);
       // Kirk's own finding: one side gapped, the other overlapped. The
       // fix is distance(true corner, true corner) === 0 -- not "close",
       // exact, the same way every other join in this module closes.
-      expect(
-        distanceBetween(join!.trueCornerI, join!.trueCornerJ)
-      ).toBeLessThan(1e-6);
+      expect(distanceBetween(trueCornerI!, trueCornerJ!)).toBeLessThan(1e-6);
     }
   );
 
@@ -678,19 +806,123 @@ describe('boundariesToWallRuns — corners close by construction (rpg-dnd5e-web#
     'each run extends exactly the named overlap margin past the true corner, mirrored=%s',
     (mirrored) => {
       const scene = lShapedScene(mirrored);
-      const join = findCornerJoin(scene.wallRuns);
-      expect(join).toBeDefined();
+      const group = findJunctionCluster(scene.wallRuns, 2);
+      expect(group).toBeDefined();
+      const trueCorners = trueCornersOf(group!);
       // The visual-closure margin assertion: each run's own FINAL
       // corner endpoint sits CORNER_OVERLAP_MARGIN past the shared true
       // corner, along its OWN direction -- real wall-piece thickness
       // overlapping the joint's outside face, not a coincidence of the
       // fit.
-      const distI = distanceBetween(join!.pi, join!.trueCornerI);
-      const distJ = distanceBetween(join!.pj, join!.trueCornerJ);
-      expect(distI).toBeCloseTo(CORNER_OVERLAP_MARGIN, 6);
-      expect(distJ).toBeCloseTo(CORNER_OVERLAP_MARGIN, 6);
+      for (let i = 0; i < group!.length; i++) {
+        expect(distanceBetween(group![i]!.point, trueCorners[i]!)).toBeCloseTo(
+          CORNER_OVERLAP_MARGIN,
+          6
+        );
+      }
     }
   );
+
+  /** The center and radius of the unique circle through 3 non-
+   * collinear points -- used below because, unlike a two-run corner
+   * (where the shared joint sits EXACTLY on both runs' own fitted
+   * lines, so pulling a final endpoint back by the margin along that
+   * run's own recomputed direction exactly recovers the joint), a
+   * three-run T-junction's least-squares joint generally does NOT sit
+   * exactly on any ONE of the three individual fitted lines (that's
+   * inherent to fitting 3 lines that don't happen to be exactly
+   * concurrent) -- each run's own final segment gets a tiny genuine
+   * bend over just its last `CORNER_OVERLAP_MARGIN` of length, so
+   * "pull back along the run's own direction" no longer exactly
+   * reconstructs the shared joint for 3+ runs the way it does for 2.
+   * What IS still exactly true by construction, for any number of
+   * runs: every final endpoint is `joint + unitDir * margin`, so every
+   * final endpoint sits at EXACTLY distance `margin` from `joint` --
+   * i.e., all of them lie on one common circle of that exact radius
+   * centered at `joint`. Three non-collinear points determine a unique
+   * circle, so recovering that circle from the three FINAL endpoints
+   * and checking its radius is `margin` is an exact, external proof
+   * that all three really did close to the same one shared joint,
+   * without needing to know that joint's coordinates independently. */
+  function circumcircle(p0: P, p1: P, p2: P): { center: P; radius: number } {
+    const d =
+      2 * (p0.x * (p1.z - p2.z) + p1.x * (p2.z - p0.z) + p2.x * (p0.z - p1.z));
+    const sq = (p: P) => p.x * p.x + p.z * p.z;
+    const ux =
+      (sq(p0) * (p1.z - p2.z) +
+        sq(p1) * (p2.z - p0.z) +
+        sq(p2) * (p0.z - p1.z)) /
+      d;
+    const uz =
+      (sq(p0) * (p2.x - p1.x) +
+        sq(p1) * (p0.x - p2.x) +
+        sq(p2) * (p1.x - p0.x)) /
+      d;
+    const center = { x: ux, z: uz };
+    return { center, radius: distanceBetween(center, p0) };
+  }
+
+  it('a T-junction (three runs meeting at one raw vertex) closes to one shared point, not three (Copilot review, PR #794)', () => {
+    // The pairwise-only version of this fix rewrote the same endpoint
+    // once per pair it appeared in -- order-dependent, and the three
+    // fitted centerlines never ended up sharing one joint. Grouping by
+    // raw vertex first closes the whole junction in one shot.
+    const scene = tJunctionScene();
+    const group = findJunctionCluster(scene.wallRuns, 3);
+    expect(group).toBeDefined(); // a real T-junction exists in this fixture
+    const [p0, p1, p2] = group!.map((m) => m.point);
+    const circle = circumcircle(p0!, p1!, p2!);
+    // All three final endpoints sit on ONE circle of exactly the named
+    // margin's radius -- possible only if all three really were
+    // extended `margin` past the SAME shared joint (see this helper's
+    // own doc comment for why this, not a per-run pull-back, is the
+    // exact invariant for 3+ runs).
+    expect(circle.radius).toBeCloseTo(CORNER_OVERLAP_MARGIN, 6);
+    expect(distanceBetween(circle.center, p0!)).toBeCloseTo(
+      CORNER_OVERLAP_MARGIN,
+      6
+    );
+    expect(distanceBetween(circle.center, p1!)).toBeCloseTo(
+      CORNER_OVERLAP_MARGIN,
+      6
+    );
+    expect(distanceBetween(circle.center, p2!)).toBeCloseTo(
+      CORNER_OVERLAP_MARGIN,
+      6
+    );
+  });
+
+  describe('cornerJoint — the near-parallel fallback (Copilot review, PR #794)', () => {
+    it('falls back to the shared raw vertex when two lines are too close to parallel to intersect reliably', () => {
+      // A first version of this fallback branch `continue`d without
+      // assigning anything, so the documented fallback was dead code:
+      // each endpoint stayed at its independently-fitted (disagreeing)
+      // position. This constructs the case directly -- unreachable
+      // through any real authored corner's own geometry (a genuine
+      // corner's two legs are never this close to parallel) -- rather
+      // than trying to coax it out of the full atlas pipeline.
+      const rawVertex: P = { x: 3, z: 5 };
+      const nearlyParallel = [
+        { point: { x: 0, z: 0 }, dir: { x: 1, z: 0 } },
+        {
+          point: { x: 1, z: 1 },
+          dir: { x: Math.cos(1e-10), z: Math.sin(1e-10) },
+        },
+      ];
+      expect(cornerJoint(rawVertex, nearlyParallel)).toEqual(rawVertex);
+    });
+
+    it('still returns the exact intersection for two genuinely non-parallel lines (unchanged happy path)', () => {
+      const rawVertex: P = { x: 3, z: 5 }; // never used -- provided for signature only
+      const perpendicular = [
+        { point: { x: 0, z: 2 }, dir: { x: 1, z: 0 } }, // line z=2
+        { point: { x: 4, z: 0 }, dir: { x: 0, z: 1 } }, // line x=4
+      ];
+      const joint = cornerJoint(rawVertex, perpendicular);
+      expect(joint.x).toBeCloseTo(4, 9);
+      expect(joint.z).toBeCloseTo(2, 9);
+    });
+  });
 });
 
 describe('boundariesToWallRuns — a horizontal seam (chambers stacked in rows)', () => {

--- a/src/components/session/atlasWallRuns.ts
+++ b/src/components/session/atlasWallRuns.ts
@@ -149,18 +149,40 @@
  * point after fitting, so the shared vertex opens into a gap or an
  * overlap depending on which side of each line it happened to fall.
  * Fixed the same way every other seam in this module closes: not by
- * tuning, by construction. Two runs whose RAW (pre-fit) endpoints
- * coincide share an authored corner; both runs' corner endpoints are
- * overwritten with the exact intersection of their two FITTED lines
- * (`lineIntersection`, reused from `wallRuns.ts` rather than
- * reimplemented) — falling back to the shared raw vertex, unchanged,
- * when the two lines are too close to parallel to intersect reliably
- * (not reachable for a real corner, but a defensive floor rather than
- * a division by ~0). Each run is then extended a further
+ * tuning, by construction. Every run endpoint is clustered with every
+ * OTHER run endpoint whose RAW (pre-fit) position coincides — two
+ * clustered endpoints share an ordinary authored corner; three or more
+ * share a T-junction (`computeAuthoredWallRuns` explicitly supports a
+ * branch vertex with 3+ runs meeting it, see its own doc comment). A
+ * first version of this fix closed corners PAIRWISE instead of by
+ * cluster (Copilot review, PR #794): at a T-junction that rewrites the
+ * same endpoint once per pair it appears in — A/B moves A, then A/C
+ * moves A again, then B/C moves B and C — order-dependent, and the
+ * three fitted centerlines never end up sharing one joint. Clustering
+ * first, then closing the WHOLE cluster in one shot, removes the
+ * order-dependence entirely: a two-member cluster's shared joint is
+ * the exact intersection of its two fitted lines (`lineIntersection`,
+ * reused from `wallRuns.ts` rather than reimplemented); a three-or-
+ * more-member cluster's shared joint is the single point minimizing
+ * total squared perpendicular distance to every member's fitted line
+ * (`leastSquaresLineJoint` below — a deliberate, justified choice: it
+ * is the natural generalization of "the one point every line agrees
+ * on" when no single point is exactly on all of them, and it reduces
+ * to the same answer `lineIntersection` gives for exactly two
+ * non-parallel lines, since their exact crossing already has zero
+ * total squared distance). Either path falls back to the shared RAW
+ * vertex, unchanged, when the participating lines are too close to
+ * parallel (or otherwise degenerate) to solve reliably (not reachable
+ * for a real corner or T-junction, but a defensive floor rather than a
+ * division by ~0 — Copilot review, PR #794: an earlier version of this
+ * fallback `continue`d without assigning anything, so the documented
+ * fallback was dead code; it now explicitly assigns every member to
+ * the shared raw vertex, margin included, same as the solved case).
+ * Each run is then extended a further
  * `DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN` (also reused from
  * `wallRuns.ts` — a named constant derived from real wall-piece
- * thickness, not a tuning knob hidden in this module) past that exact
- * intersection, along its OWN direction, so the OUTSIDE face of the
+ * thickness, not a tuning knob hidden in this module) past that
+ * shared joint, along its OWN direction, so the OUTSIDE face of the
  * corner has real wall-piece thickness overlapping the joint instead
  * of a thickness-sized notch peeking through it — the same
  * "overlap-miter" convention `WallRunMesh`'s own doc comment already
@@ -244,6 +266,96 @@ function unitDirection(a: WorldPos, b: WorldPos): WorldPos {
   const len = distance(a, b);
   if (len === 0) return { x: 0, z: 0 };
   return { x: (b.x - a.x) / len, z: (b.z - a.z) / len };
+}
+
+/**
+ * The single point minimizing the sum of squared perpendicular
+ * distances to every line in `lines` -- used below to close a
+ * T-junction (rpg-dnd5e-web#793, Copilot review PR #794) where three
+ * or more runs' fitted lines all pass NEAR one shared raw vertex but,
+ * after independent least-squares fitting, no longer pass through any
+ * single common point exactly. Standard least-squares line
+ * intersection: for each line, its unit NORMAL `n` (perpendicular to
+ * `dir`) and the scalar `c = n . point` describe every point ON that
+ * line as `{p : n . p = c}`; the minimizer of `sum((n_k . p - c_k)^2)`
+ * solves the 2x2 normal-equations system
+ * `sum(n_k n_k^T) * p = sum(c_k * n_k)` (Cramer's rule below). For
+ * exactly two non-parallel lines this is IDENTICAL to
+ * `lineIntersection` (their exact crossing has zero total squared
+ * distance, the global minimum), which is why corner-closure below
+ * only calls this for three-or-more-member clusters and keeps using
+ * the already-proven `lineIntersection` for the common two-run corner
+ * case. Returns undefined when the system is singular (every
+ * participating line the same direction) -- not reachable for a real
+ * corner or T-junction, but a defensive floor rather than a division
+ * by ~0. Note the least-squares joint generally does NOT sit exactly
+ * ON any one of the individual lines when 3+ of them aren't exactly
+ * concurrent (real hex-grid corners at a T-junction usually aren't) --
+ * each run's own final segment therefore gets a tiny genuine bend over
+ * just its last `DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN` of length,
+ * negligible visually (well inside the same margin already designed
+ * to absorb corner-joint slop) and NOT a defect: forcing every run's
+ * whole line to re-fit through one shared point would fight the
+ * per-run least-squares fit finding 3 already relies on.
+ */
+function leastSquaresLineJoint(
+  lines: ReadonlyArray<{ point: WorldPos; dir: WorldPos }>
+): WorldPos | undefined {
+  let sxx = 0;
+  let sxz = 0;
+  let szz = 0;
+  let bx = 0;
+  let bz = 0;
+  for (const { point, dir } of lines) {
+    const nx = -dir.z;
+    const nz = dir.x;
+    sxx += nx * nx;
+    sxz += nx * nz;
+    szz += nz * nz;
+    const c = nx * point.x + nz * point.z;
+    bx += c * nx;
+    bz += c * nz;
+  }
+  const det = sxx * szz - sxz * sxz;
+  if (Math.abs(det) < 1e-9) return undefined;
+  return {
+    x: (szz * bx - sxz * bz) / det,
+    z: (sxx * bz - sxz * bx) / det,
+  };
+}
+
+/**
+ * The single point two or more run endpoints sharing one raw vertex
+ * should close to: the exact line intersection for two members, the
+ * least-squares joint for three or more (a T-junction), falling back
+ * to `rawPoint` itself -- UNCONDITIONALLY, this always returns a
+ * point, never leaves a caller to decide whether "nothing changed" is
+ * an acceptable answer -- when the participating lines are too close
+ * to parallel to solve reliably. Exported (like
+ * `lineIntersection`/`DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN`, which
+ * this builds on) so the fallback path -- unreachable through any
+ * real authored corner's own geometry, by design, since a genuine
+ * corner's two legs are never near-parallel -- can still be pinned
+ * directly with a synthetic near-parallel pair rather than left
+ * untested (rpg-dnd5e-web#793, Copilot review PR #794: an earlier
+ * version of this fallback `continue`d without assigning anything,
+ * silently leaving the documented behavior unimplemented).
+ */
+export function cornerJoint(
+  rawPoint: WorldPos,
+  lines: ReadonlyArray<{ point: WorldPos; dir: WorldPos }>
+): WorldPos {
+  if (lines.length === 2) {
+    return (
+      lineIntersection(
+        lines[0]!.point,
+        lines[0]!.dir,
+        lines[1]!.point,
+        lines[1]!.dir
+      ) ?? rawPoint
+    );
+  }
+  return leastSquaresLineJoint(lines) ?? rawPoint;
 }
 
 /** A stable, order-independent key for an unordered pair of hex
@@ -657,50 +769,76 @@ export function boundariesToWallRuns(
     };
   });
 
-  // Corner closure (rpg-dnd5e-web#793): two runs whose RAW (pre-fit)
-  // endpoints coincide share a real authored corner vertex -- each got
-  // its own independent least-squares fit above (finding 3's
-  // door-link-only grouping deliberately never merges a genuine
-  // corner's two legs into one fit), so nothing yet constrains their
-  // two fitted lines to still cross at that same point. Overwrite BOTH
-  // runs' corner endpoint with the exact intersection of their fitted
-  // lines -- closes by construction, not by tuning -- then extend each
-  // a further DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN past it, along its
-  // own direction, so real wall-piece thickness overlaps the joint on
-  // the corner's outside face (see this module's own header doc,
-  // corners section, for the full "why", including why this can never
-  // compete with door force-closure for the same endpoint).
+  // Corner closure (rpg-dnd5e-web#793, and its T-junction fix from
+  // Copilot review on PR #794 -- see this module's own header doc,
+  // corners section, for the full "why"). Cluster every run endpoint
+  // (both ends of every run) by shared RAW (pre-fit) vertex position
+  // FIRST, then close each cluster of 2+ members in ONE shot -- the
+  // previous pairwise version rewrote the same endpoint once per pair
+  // it appeared in, which is order-dependent and never converges to
+  // one shared joint at a T-junction (3+ runs meeting one vertex,
+  // explicitly supported by computeAuthoredWallRuns). Each member's
+  // own fitted corner position and direction (toward the corner, from
+  // its run's OTHER/far endpoint) is captured HERE, before any
+  // cluster's joint is applied -- so a run whose far endpoint is
+  // itself part of a DIFFERENT cluster never has its direction
+  // computed from an already-moved neighbor.
   const CORNER_EPS = 1e-6;
   const cornerEnds: Array<'start' | 'end'> = ['start', 'end'];
+  interface CornerEndpointSnapshot {
+    runIndex: number;
+    end: 'start' | 'end';
+    corner: WorldPos;
+    dir: WorldPos;
+  }
+  const clusters: Array<{
+    rawPoint: WorldPos;
+    members: CornerEndpointSnapshot[];
+  }> = [];
   for (let i = 0; i < rawRuns.length; i++) {
-    for (let j = i + 1; j < rawRuns.length; j++) {
-      for (const iEnd of cornerEnds) {
-        for (const jEnd of cornerEnds) {
-          if (distance(rawRuns[i]![iEnd], rawRuns[j]![jEnd]) >= CORNER_EPS) {
-            continue;
-          }
-          const runI = runs[i]!;
-          const runJ = runs[j]!;
-          const cornerI = runI[iEnd];
-          const farI = iEnd === 'start' ? runI.end : runI.start;
-          const dirI = unitDirection(farI, cornerI); // toward the corner
-          const cornerJ = runJ[jEnd];
-          const farJ = jEnd === 'start' ? runJ.end : runJ.start;
-          const dirJ = unitDirection(farJ, cornerJ);
-
-          const intersection = lineIntersection(cornerI, dirI, cornerJ, dirJ);
-          if (!intersection) continue; // near-parallel: leave the shared raw vertex position unchanged
-
-          runI[iEnd] = {
-            x: intersection.x + dirI.x * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
-            z: intersection.z + dirI.z * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
-          };
-          runJ[jEnd] = {
-            x: intersection.x + dirJ.x * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
-            z: intersection.z + dirJ.z * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
-          };
-        }
+    for (const end of cornerEnds) {
+      const rawPoint = rawRuns[i]![end];
+      let cluster = clusters.find(
+        (c) => distance(c.rawPoint, rawPoint) < CORNER_EPS
+      );
+      if (!cluster) {
+        cluster = { rawPoint, members: [] };
+        clusters.push(cluster);
       }
+      const run = runs[i]!;
+      const corner = run[end];
+      const far = end === 'start' ? run.end : run.start;
+      cluster.members.push({
+        runIndex: i,
+        end,
+        corner,
+        dir: unitDirection(far, corner), // toward the corner
+      });
+    }
+  }
+
+  for (const cluster of clusters) {
+    if (cluster.members.length < 2) continue; // no corner/junction at this endpoint
+
+    // `cornerJoint` always returns a point -- the already-proven exact
+    // line intersection for a two-run corner, the least-squares joint
+    // for a three-or-more-run T-junction, or the shared RAW vertex
+    // itself when the lines are too close to parallel to solve
+    // reliably. Every member of the cluster gets assigned relative to
+    // THAT joint, unconditionally -- including the fallback case, so
+    // a near-parallel pair still closes as documented instead of
+    // silently keeping its independently-fitted (disagreeing)
+    // position.
+    const joint = cornerJoint(
+      cluster.rawPoint,
+      cluster.members.map((m) => ({ point: m.corner, dir: m.dir }))
+    );
+
+    for (const m of cluster.members) {
+      runs[m.runIndex]![m.end] = {
+        x: joint.x + m.dir.x * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+        z: joint.z + m.dir.z * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+      };
     }
   }
 

--- a/src/components/session/atlasWallRuns.ts
+++ b/src/components/session/atlasWallRuns.ts
@@ -136,6 +136,49 @@
  * is a door with no state) falls back to its own raw `hexEdgeBetween`
  * geometry, since nothing straighter exists to align or close against.
  *
+ * # Corners: closed by construction too (rpg-dnd5e-web#793)
+ *
+ * Kirk, walking an authored dungeon on `dev` right after #788 merged:
+ * "the corners do not close consistently" — a screenshot of one walled
+ * room whose top wall gapped open against one side wall and overlapped
+ * past the other. Root cause: two runs of one chain that share a real
+ * authored corner vertex each get their OWN independent least-squares
+ * fit (finding 3's fit grouping is deliberately door-link-only, so a
+ * genuine corner's two legs are never merged into one fit) — nothing
+ * constrained the two fitted lines to still pass through the same
+ * point after fitting, so the shared vertex opens into a gap or an
+ * overlap depending on which side of each line it happened to fall.
+ * Fixed the same way every other seam in this module closes: not by
+ * tuning, by construction. Two runs whose RAW (pre-fit) endpoints
+ * coincide share an authored corner; both runs' corner endpoints are
+ * overwritten with the exact intersection of their two FITTED lines
+ * (`lineIntersection`, reused from `wallRuns.ts` rather than
+ * reimplemented) — falling back to the shared raw vertex, unchanged,
+ * when the two lines are too close to parallel to intersect reliably
+ * (not reachable for a real corner, but a defensive floor rather than
+ * a division by ~0). Each run is then extended a further
+ * `DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN` (also reused from
+ * `wallRuns.ts` — a named constant derived from real wall-piece
+ * thickness, not a tuning knob hidden in this module) past that exact
+ * intersection, along its OWN direction, so the OUTSIDE face of the
+ * corner has real wall-piece thickness overlapping the joint instead
+ * of a thickness-sized notch peeking through it — the same
+ * "overlap-miter" convention `WallRunMesh`'s own doc comment already
+ * documents for the OLD wire's chamber-based corners, reused here
+ * rather than invented fresh.
+ *
+ * Precedence where a corner and a door could ever compete for the same
+ * run endpoint: they never do, by construction, not by ordering — a
+ * door-adjacent endpoint is `computeAuthoredWallRuns`'s own
+ * `DOOR_TRIM`-inward trim from the door's corner, unique to that one
+ * run (finding 1's own doc comment), so it never coincides with
+ * ANOTHER run's raw endpoint the way a genuine corner's shared vertex
+ * does; corner-closure below only ever touches endpoints door
+ * force-closure never looks at, and vice versa. This pass still runs
+ * BEFORE door force-closure regardless, so if that invariant is ever
+ * wrong for some future wire shape, the door's own gap boundary is the
+ * one that wins (overwrites last).
+ *
  * Double-sided walls themselves (Kirk: "I think our walls should be
  * double sided") are explicitly OUT of scope here — filed as a
  * follow-up; this fix only makes the single face every run already has
@@ -154,6 +197,10 @@ import {
   type AuthoredWallEdgeInput,
   type AuthoredWallRun,
 } from '@/hooks/authoredWallRuns';
+import {
+  DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+  lineIntersection,
+} from '@/hooks/wallRuns';
 import type { GetAtlasResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/service_pb';
 import type {
   AtlasBoundary,
@@ -609,6 +656,53 @@ export function boundariesToWallRuns(
       facing: r.facing,
     };
   });
+
+  // Corner closure (rpg-dnd5e-web#793): two runs whose RAW (pre-fit)
+  // endpoints coincide share a real authored corner vertex -- each got
+  // its own independent least-squares fit above (finding 3's
+  // door-link-only grouping deliberately never merges a genuine
+  // corner's two legs into one fit), so nothing yet constrains their
+  // two fitted lines to still cross at that same point. Overwrite BOTH
+  // runs' corner endpoint with the exact intersection of their fitted
+  // lines -- closes by construction, not by tuning -- then extend each
+  // a further DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN past it, along its
+  // own direction, so real wall-piece thickness overlaps the joint on
+  // the corner's outside face (see this module's own header doc,
+  // corners section, for the full "why", including why this can never
+  // compete with door force-closure for the same endpoint).
+  const CORNER_EPS = 1e-6;
+  const cornerEnds: Array<'start' | 'end'> = ['start', 'end'];
+  for (let i = 0; i < rawRuns.length; i++) {
+    for (let j = i + 1; j < rawRuns.length; j++) {
+      for (const iEnd of cornerEnds) {
+        for (const jEnd of cornerEnds) {
+          if (distance(rawRuns[i]![iEnd], rawRuns[j]![jEnd]) >= CORNER_EPS) {
+            continue;
+          }
+          const runI = runs[i]!;
+          const runJ = runs[j]!;
+          const cornerI = runI[iEnd];
+          const farI = iEnd === 'start' ? runI.end : runI.start;
+          const dirI = unitDirection(farI, cornerI); // toward the corner
+          const cornerJ = runJ[jEnd];
+          const farJ = jEnd === 'start' ? runJ.end : runJ.start;
+          const dirJ = unitDirection(farJ, cornerJ);
+
+          const intersection = lineIntersection(cornerI, dirI, cornerJ, dirJ);
+          if (!intersection) continue; // near-parallel: leave the shared raw vertex position unchanged
+
+          runI[iEnd] = {
+            x: intersection.x + dirI.x * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+            z: intersection.z + dirI.z * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+          };
+          runJ[jEnd] = {
+            x: intersection.x + dirJ.x * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+            z: intersection.z + dirJ.z * DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN,
+          };
+        }
+      }
+    }
+  }
 
   // Pass 1: finalize every door's gap geometry against the FITTED
   // `runs` (the run INDEX each `DoorInfo` found is valid against both


### PR DESCRIPTION
## Root cause

Kirk, walking an authored dungeon on `dev` right after PR #788 merged: "the corners do not close consistently." Screenshot: a walled room whose top wall gapped open against one side wall, and overlapped past the other.

Two runs of one chain that share a real authored corner vertex each get their **own independent least-squares fit** (#788's own fit grouping is deliberately door-link-only, so a genuine corner's two legs are never merged into one fit — correctly so, since merging them would average two different real directions into one wrong one). Nothing constrained the two resulting fitted lines to still cross at the shared vertex after fitting, so the corner opened into a gap or closed into an overlap depending on which side of each line the vertex fell.

## Fix

Two runs whose RAW (pre-fit) endpoints coincide share an authored corner. Both runs' corner endpoints are overwritten with the **exact intersection of their two fitted lines** (`lineIntersection`, reused from `wallRuns.ts`, not reimplemented) — falling back to the shared raw vertex, unchanged, when the two lines are too close to parallel to intersect reliably (not reachable for a real corner, a defensive floor rather than a division by ~0).

Each run is then extended a further `DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN` (also reused from `wallRuns.ts` — a named constant derived from real wall-piece thickness, not a tuning knob hidden in this module) past that exact intersection, along its own direction, so real wall-piece thickness overlaps the joint on the corner's outside face — the same "overlap-miter" convention `WallRunMesh`'s own doc comment already documents for the OLD wire's chamber-based corners.

**Precedence with doors:** a corner and a door can never compete for the same run endpoint, by construction — a door-adjacent endpoint is `computeAuthoredWallRuns`'s own `DOOR_TRIM`-inward trim from the door's corner, unique to that one run, so it never coincides with another run's raw endpoint the way a genuine corner's shared vertex does. Corner-closure still runs *before* door force-closure regardless, so the door's own gap boundary is the one that wins if that invariant is ever wrong for some future wire shape.

## Test evidence

- `npm run ci-check` passes (format, lint, typecheck, build, tests).
- New tests in `atlasWallRuns.test.ts` (verified against a real interior L-shaped partition built from a genuine region complement, in **both** corner orientations):
  - `distance(true corner, true corner) === 0` (within 1e-6) — the exact intersection both runs converge to, recovered independently by pulling each run's final endpoint back by the margin along its own direction.
  - each run's own final endpoint sits exactly `DEFAULT_ENVELOPE_CORNER_OVERLAP_MARGIN` (0.16) past that true corner, along its own direction — the visual-closure margin assertion.
- Full existing suite (57 prior tests across the affected files) still passes unchanged, including the door exact-closure, rotation, and facing pins from #788 — confirming corner-closure and door force-closure never conflict.

## Evidence screenshot

Skipped this round: I wasn't able to reach Kirk's own authored room (only `reference-tomb`, `toolkit-contributor-sandbox`, and a blank `new-dungeon` are available locally, and none has a real L-corner to render), and authoring a fresh one interactively through the builder's canvas wasn't reachable in reasonable time via this scratch tool's automation. The unit tests above pin the exact geometric claim directly (both the zero-distance join and the named margin), which is the stronger evidence for this specific fix. Worth a look on Kirk's real walk.

Closes #793.

— world-builder lane, on behalf of KirkDiggler

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017MbNn6jFLjJwzTw6ZbY5M1