### PR TITLE
feat: sighted players render as players, not goblins (Sighting.kind)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.136",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.138",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#e641db24c65081c033a0070cb73e640e3b9493cf",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#930fa762e34785cbe2e1f124f9f643b0a0b01e04",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.136",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.138",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/components/session/SessionCanvas.test.tsx
+++ b/src/components/session/SessionCanvas.test.tsx
@@ -6,7 +6,10 @@
  * rather than nesting a second `<Canvas>` inside it.
  */
 import type { AuthoredWallRun } from '@/hooks/authoredWallRuns';
-import { Standing } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
+import {
+  MemberKind,
+  Standing,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import * as THREE from 'three';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -432,6 +435,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,
@@ -461,6 +465,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: true,
               standing: Standing.UP,
@@ -486,6 +491,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.DOWNED,
@@ -493,6 +499,89 @@ describe('SessionScene', () => {
           ]}
         />
       );
+      expect(renderer.scene.children.length).toBeGreaterThan(0);
+    });
+
+    it('a MONSTER-kind member renders via the monster path -- its resolved npc GLB mounts', async () => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <SessionScene
+          scene={scene()}
+          hexSize={1}
+          characterId="char-1"
+          characterName="Toolkit Sandbox Fighter"
+          character={undefined}
+          classRefId={undefined}
+          myPosition={{ x: 0, y: 0, z: 0 }}
+          otherMembers={[
+            {
+              subject: 'skeleton-1',
+              name: 'skeleton-1',
+              monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
+              position: { x: 1, y: -1, z: 0 },
+              remembered: false,
+              standing: Standing.UP,
+            },
+          ]}
+        />
+      );
+      // The mocked useGLTF (top of file) names its mesh after the resolved
+      // URL -- resolveMonsterModelUrl('skeleton', ...) resolves a real npc
+      // GLB under monsterModels.ts's own MONSTER_MODEL_BASE, so its path
+      // shows up somewhere in the tree only when ClassCharacterModel
+      // actually mounted it.
+      const monsterGlbMeshes = renderer.scene.findAll(
+        (node) =>
+          node.type === 'Mesh' &&
+          (node.instance as THREE.Mesh).name.includes(
+            '/models/synty/npcs/skeleton'
+          )
+      );
+      expect(monsterGlbMeshes.length).toBeGreaterThan(0);
+    });
+
+    it('a PLAYER-kind member renders via the player path -- no monster ref is derived, and no monster GLB mounts', async () => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <SessionScene
+          scene={scene()}
+          hexSize={1}
+          characterId="char-1"
+          characterName="Toolkit Sandbox Fighter"
+          character={undefined}
+          classRefId={undefined}
+          myPosition={{ x: 0, y: 0, z: 0 }}
+          otherMembers={[
+            {
+              // A player subject id looks nothing like a monster ref --
+              // sightingEntities.ts already leaves monsterRefId undefined
+              // for PLAYER kind, so this member carries none, unlike every
+              // other case in this describe block.
+              subject: 'char-2',
+              name: 'Second Barbarian',
+              monsterRefId: undefined,
+              kind: MemberKind.PLAYER,
+              position: { x: 1, y: -1, z: 0 },
+              remembered: false,
+              standing: Standing.UP,
+            },
+          ]}
+        />
+      );
+      // No classRefId/character is known for a sighted player (rpg-api#814:
+      // GetCharacterData is owner-gated), so the player path's own class-GLB
+      // resolution falls through to undefined and this entity mounts the
+      // MediumHumanoid placeholder instead. Scoped to the npc GLB base path
+      // (monsterModels.ts's MONSTER_MODEL_BASE) rather than "any named
+      // mesh" -- the floor/walls in `scene()` mount their own real GLBs via
+      // this same useGLTF mock, so a blanket non-empty-name check would
+      // false-fail on those, unrelated to this entity's own render path.
+      const monsterGlbMeshes = renderer.scene.findAll(
+        (node) =>
+          node.type === 'Mesh' &&
+          (node.instance as THREE.Mesh).name.includes('/models/synty/npcs/')
+      );
+      expect(monsterGlbMeshes).toHaveLength(0);
+      // Still mounts something -- the neutral fallback, not a blank void.
       expect(renderer.scene.children.length).toBeGreaterThan(0);
     });
   });
@@ -708,6 +797,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,
@@ -754,6 +844,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,
@@ -787,6 +878,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: true,
               standing: Standing.UP,
@@ -814,6 +906,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,
@@ -846,6 +939,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,
@@ -894,6 +988,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.DOWNED,
@@ -966,6 +1061,7 @@ describe('SessionScene', () => {
         subject: 'skeleton-1',
         name: 'skeleton-1',
         monsterRefId: 'skeleton',
+        kind: MemberKind.MONSTER,
         position: { x: 1, y: -1, z: 0 },
         remembered: false,
         standing: Standing.UP,
@@ -1155,6 +1251,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,
@@ -1187,6 +1284,7 @@ describe('SessionScene', () => {
               subject: 'skeleton-1',
               name: 'skeleton-1',
               monsterRefId: 'skeleton',
+              kind: MemberKind.MONSTER,
               position: { x: 1, y: -1, z: 0 },
               remembered: false,
               standing: Standing.UP,

--- a/src/components/session/SessionCanvas.tsx
+++ b/src/components/session/SessionCanvas.tsx
@@ -58,6 +58,7 @@
  */
 
 import { CAMERA_OFFSET } from '@/rendering/calibrationConstants';
+import { MemberKind } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { Canvas } from '@react-three/fiber';
 import {
@@ -169,12 +170,14 @@ export interface SessionCanvasProps {
    * dropped here since this route only ever animates the local player). */
   onMovementPresentationComplete?: (moveSeq: number) => void;
   /** Every OTHER member the local player currently perceives
-   * (`GetView.sightings`, mapped by `sightingsToEntities`). Drawn as
-   * monster `HexEntity`s with no `movePath`/`moveSeq` of their own:
-   * `useHexMovePath` already snaps an entity straight to a new `position`
-   * when `moveSeq` never advances, so a `GetView` refetch that moves one
-   * of these simply relocates it on the next render. Undefined/empty
-   * draws nothing extra. */
+   * (`GetView.sightings`, mapped by `sightingsToEntities`). Drawn as a
+   * player or monster `HexEntity` per `member.kind` (rpg-dnd5e-web#792 —
+   * see this component's render below for the split), with no
+   * `movePath`/`moveSeq` of their own either way: `useHexMovePath` already
+   * snaps an entity straight to a new `position` when `moveSeq` never
+   * advances, so a `GetView` refetch that moves one of these simply
+   * relocates it on the next render. Undefined/empty draws nothing
+   * extra. */
   otherMembers?: SightedMember[];
   /** Subject ids the caller currently offers as in-reach, AFFORDABLE
    * Attack candidates (rpg-project#249) — see this component's own doc
@@ -459,12 +462,27 @@ export function SessionScene({
         }
       />
       {otherMembers?.map((member) => (
+        // rpg-dnd5e-web#792: a PLAYER-kind sighting routes to HexEntity's
+        // player path — same path the local player renders through below,
+        // just with no `character`/`classRefId` of its own (sighted
+        // players carry neither; GetCharacterData is owner-gated per
+        // rpg-api#814, so this component never fetches another player's
+        // sheet). HexEntity's own class-model resolution already treats a
+        // missing classRefId as "no class GLB mapped" and falls back to
+        // its MediumHumanoid placeholder in the NEUTRAL 'human' variant —
+        // the same degrade-to-known-placeholder rule #479 already
+        // established for an unmapped class, reused here for a genuinely
+        // absent one. Everything else (MONSTER, and UNSPECIFIED per
+        // `SightedMember.kind`'s own doc comment) keeps the monster path,
+        // `monsterRefId` included — `sightingEntities.ts` already leaves
+        // that field undefined for a PLAYER subject, so passing it through
+        // unconditionally is safe for both branches.
         <HexEntity
           key={member.subject}
           entityId={member.subject}
           name={member.name}
           position={member.position}
-          type="monster"
+          type={member.kind === MemberKind.PLAYER ? 'player' : 'monster'}
           hexSize={hexSize}
           monsterRefId={member.monsterRefId}
           knowledgeState={member.remembered ? 'remembered' : undefined}

--- a/src/components/session/combatPanel.test.ts
+++ b/src/components/session/combatPanel.test.ts
@@ -76,6 +76,7 @@ function sightedMember(overrides: Partial<SightedMember> = {}): SightedMember {
   return {
     subject: 'skeleton-1',
     name: 'skeleton-1',
+    kind: MemberKind.MONSTER,
     monsterRefId: 'skeleton',
     position: { x: 0, y: 0, z: 0 },
     remembered: false,

--- a/src/components/session/sightingEntities.test.ts
+++ b/src/components/session/sightingEntities.test.ts
@@ -2,7 +2,10 @@ import type {
   Seen,
   Sighting,
 } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
-import { Standing } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
+import {
+  MemberKind,
+  Standing,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import { describe, expect, it } from 'vitest';
 import {
   isSightedDowned,
@@ -27,6 +30,7 @@ function sighting(overrides: Partial<Sighting> = {}): Sighting {
     currentVia: ['sight'],
     status: 'live',
     name: 'skeleton-1',
+    kind: MemberKind.MONSTER,
     ...overrides,
   } as Sighting;
 }
@@ -64,6 +68,7 @@ describe('sightingsToEntities', () => {
       {
         subject: 'skeleton-1',
         name: 'skeleton-1',
+        kind: MemberKind.MONSTER,
         monsterRefId: 'skeleton',
         // positionBridge.positionToCube(q=10, r=3): x=q, y=-q-r, z=r
         position: { x: 10, y: -13, z: 3 },
@@ -134,6 +139,42 @@ describe('sightingsToEntities', () => {
 
   it('an empty sightings list resolves to no entities', () => {
     expect(sightingsToEntities([], 'char-1')).toEqual([]);
+  });
+});
+
+describe('sightingsToEntities -- kind (rpg-dnd5e-web#792)', () => {
+  it('carries kind through verbatim for a MONSTER subject, and still derives a monster ref', () => {
+    const s = sighting({
+      subject: 'skeleton-1',
+      kind: MemberKind.MONSTER,
+      seen: seen({ position: { x: 0, y: 0 } as never }),
+    });
+    const entity = sightingsToEntities([s], 'char-1')[0]!;
+    expect(entity.kind).toBe(MemberKind.MONSTER);
+    expect(entity.monsterRefId).toBe('skeleton');
+  });
+
+  it('carries kind through verbatim for a PLAYER subject, and derives NO monster ref -- a character id has nothing to strip toward', () => {
+    const s = sighting({
+      subject: 'char-2',
+      name: 'Second Barbarian',
+      kind: MemberKind.PLAYER,
+      seen: seen({ position: { x: 0, y: 0 } as never }),
+    });
+    const entity = sightingsToEntities([s], 'char-1')[0]!;
+    expect(entity.kind).toBe(MemberKind.PLAYER);
+    expect(entity.monsterRefId).toBeUndefined();
+  });
+
+  it('MEMBER_KIND_UNSPECIFIED still derives a monster ref -- the ALREADY-ESTABLISHED default (this field predates kind), not a new one invented for the gap', () => {
+    const s = sighting({
+      subject: 'skeleton-1',
+      kind: MemberKind.UNSPECIFIED,
+      seen: seen({ position: { x: 0, y: 0 } as never }),
+    });
+    const entity = sightingsToEntities([s], 'char-1')[0]!;
+    expect(entity.kind).toBe(MemberKind.UNSPECIFIED);
+    expect(entity.monsterRefId).toBe('skeleton');
   });
 });
 

--- a/src/components/session/sightingEntities.ts
+++ b/src/components/session/sightingEntities.ts
@@ -25,13 +25,29 @@
  *     standing`). `STANDING_UNSPECIFIED` (an observer who has never
  *     resolved this) reads as `Standing.UP` for rendering purposes — see
  *     `standing`'s own field comment below.
+ *   - `Sighting.kind` (protos#245/toolkit#1231, rpg-dnd5e-web#792) is which
+ *     render path the caller routes a sighted member down — PLAYER goes to
+ *     `HexEntity`'s player path, everything else (including
+ *     `MEMBER_KIND_UNSPECIFIED`) to its monster path. UNSPECIFIED stays on
+ *     the monster path rather than flipping to player because that is the
+ *     behavior this module already had BEFORE `kind` existed — a producer
+ *     bug that leaves `kind` unset degrades to the known, already-shipped
+ *     fallback (goblin-if-unmapped) rather than a NEW untested one (a real
+ *     monster silently rendering as a neutral human, which would be a
+ *     worse and less discoverable lie in a combat context than the
+ *     original goblin bug this issue fixes). Once toolkit#1231 lands fully,
+ *     UNSPECIFIED should not occur for a live sighting at all — same
+ *     "defensive, not primary" status as `standing`'s own UNSPECIFIED case.
  *
  * `payload` is never read here — position/name/standing come only from
  * typed fields, per the review brief's "NEVER decode; render only from
  * typed data" rule.
  */
 import type { Sighting } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
-import { Standing } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
+import {
+  MemberKind,
+  Standing,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import type { CubeCoord } from '../hex-grid/hexMath';
 import { positionToCube } from './positionBridge';
 
@@ -41,10 +57,23 @@ export interface SightedMember {
   subject: string;
   /** Display name (`Sighting.name`) — never empty for a drawn entity. */
   name: string;
+  /** `Sighting.kind`, verbatim — which render path the caller routes this
+   * member down (rpg-dnd5e-web#792: a sighted PLAYER is a person, not a
+   * monster wearing that player's name). `MEMBER_KIND_UNSPECIFIED` reads as
+   * MONSTER for rendering purposes — see `monsterRefId`'s own doc comment
+   * below, the same "producer bug is the server's, not a reason to invent a
+   * new default" reasoning `standing`'s doc comment already gives. */
+  kind: MemberKind;
   /** The toolkit monster ref id derived from `subject` (strips the
    * trailing `-<ordinal>`) — feeds `resolveMonsterModelUrl` via
-   * `HexEntity.monsterRefId`. */
-  monsterRefId: string;
+   * `HexEntity.monsterRefId`. Undefined for a PLAYER-kind subject: a
+   * character id has no monster ref to strip toward, and deriving one
+   * anyway is exactly the bug #792 exists to fix. `MEMBER_KIND_UNSPECIFIED`
+   * still gets one derived, same as MONSTER — the least-presumptuous
+   * reading is the ALREADY-ESTABLISHED behavior (this field predates
+   * `kind` entirely), not a new one; see this module's own top-of-file
+   * doc comment for the full reasoning. */
+  monsterRefId: string | undefined;
   position: CubeCoord;
   /** True when `currentVia` was empty — a held memory, not a live
    * sighting. Feeds `HexEntity.knowledgeState="remembered"`. */
@@ -83,10 +112,14 @@ export function sightingsToEntities(
   for (const sighting of sightings) {
     if (sighting.subject === ownMember) continue;
     if (!sighting.seen?.position) continue;
+    const isPlayer = sighting.kind === MemberKind.PLAYER;
     entities.push({
       subject: sighting.subject,
       name: sighting.name || sighting.subject,
-      monsterRefId: monsterRefIdFromSubject(sighting.subject),
+      kind: sighting.kind,
+      monsterRefId: isPlayer
+        ? undefined
+        : monsterRefIdFromSubject(sighting.subject),
       position: positionToCube(sighting.seen.position),
       remembered: sighting.currentVia.length === 0,
       standing: sighting.seen.standing,


### PR DESCRIPTION
## Summary

Closes #792. Other members sighted in the 3D session route now route to the correct render path based on `Sighting.kind` (`MemberKind`: PLAYER vs MONSTER) instead of every sighted member unconditionally rendering as a monster.

- Bumps `@kirkdiggler/rpg-api-protos` to **v0.1.138** (not v0.1.137 — see note below).
- `sightingEntities.ts`: `SightedMember` gains `kind` (verbatim `Sighting.kind`). `monsterRefId` is now `string | undefined` and is only derived for a non-PLAYER subject — deriving one for a character id was the root cause of the goblin bug (stripping a character id's trailing ordinal never matches a monster manifest entry, so `resolveMonsterModelUrl` silently fell back to the default goblin GLB).
- `SessionCanvas.tsx`: `otherMembers` render now splits on `member.kind` — `MemberKind.PLAYER` → `HexEntity` `type="player"`, everything else (`MONSTER` and `UNSPECIFIED`) → `type="monster"` with `monsterRefId` as before. Click/hover/dead/remembered behavior is unchanged for both kinds.

### Note on the proto version

The brief specified v0.1.137, but I checked the generated `types_pb.ts` directly at that tag and `Sighting` stops at field 8 (`name`) — no `kind` field. `Sighting.kind = 9` only lands at **v0.1.138** (tagged today, contains protos#245's `MemberKind` on `Sighting`). Bumped to v0.1.138 instead, per "Git wins over prose."

### What the player path renders for a sighted player

No `character`/`classRefId` is available for a sighted player (`GetCharacterData` is owner-gated per rpg-api#814 — this PR does not fetch another player's sheet). `HexEntity`'s player path already treats a missing `classRefId` as "no class GLB mapped" (`resolveClassCharacterModelUrl` returns `undefined`) and falls back to the `MediumHumanoid` placeholder in its neutral `'human'` variant — the same rpg-dnd5e-web#479 degrade-to-known-placeholder rule already used for an unmapped class, just triggered here by a genuinely absent one instead. No new fetch, no blocker.

### The UNSPECIFIED decision

`MEMBER_KIND_UNSPECIFIED` stays on the monster path (same as before `kind` existed), not a new player-path default. Reasoning: this field predates `kind` entirely, so a producer bug/gap that leaves `kind` unset degrades to the ALREADY-SHIPPED fallback (goblin-if-unmapped) rather than a brand-new untested one — silently rendering an actual monster as a neutral, friendly-looking human would be a *worse* and less discoverable lie in a combat context than the original goblin bug this issue fixes. Once toolkit#1231 is fully live, UNSPECIFIED shouldn't occur for a live sighting at all — same "defensive, not primary" status `Sighting.seen.standing`'s own `UNSPECIFIED` case already has in this file.

Scope: render split only, per the brief. No appearance/class fidelity for sighted players (tracked as the recorded follow-up on #792), no wire changes, no new RPC calls.

## Test plan

- [x] `npm run ci-check` passes (format, lint, typecheck, build, tests)
- [x] `sightingEntities.test.ts`: extended — kind carried through verbatim (PLAYER/MONSTER/UNSPECIFIED), monster ref derived only for non-PLAYER
- [x] `SessionCanvas.test.tsx`: extended — a MONSTER-kind member mounts its resolved npc GLB; a PLAYER-kind member mounts neither a monster nor class GLB (falls to the MediumHumanoid placeholder)
- [ ] Manual two-browser walk (out of scope for this agent session — recommend before merge, same as the original bug report)

References protos#245, toolkit#1231, rpg-api#833.

— asset-pipeline agent, on behalf of KirkDiggler

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu