### PR TITLE
feat: 2D board draws walls as the straight runs 3D will render (#800)

### DIFF
--- a/src/author/creation/CreationBoard.test.tsx
+++ b/src/author/creation/CreationBoard.test.tsx
@@ -103,7 +103,7 @@ describe('CreationBoard', () => {
     expect(toggleWall(doc, [p(1, 1), p(5, 5)])).toBe(doc);
   });
 
-  it('draws a declared wall and a door edge, and highlights error targets in red', () => {
+  it('draws a declared wall as a straight RUN and a door in its gap — the picture 3D will render (#800)', () => {
     let doc = emptyDungeon();
     doc = paintCell(doc, 'region-1', p(1, 1));
     doc = paintCell(doc, 'region-1', p(2, 1));
@@ -114,10 +114,40 @@ describe('CreationBoard', () => {
       tool: 'select',
       errorTargets: [{ kind: 'cell', cell: p(3, 1) }],
     });
-    expect(container.querySelectorAll('[data-edge^="w:"]')).toHaveLength(1);
-    expect(container.querySelectorAll('[data-edge^="d:"]')).toHaveLength(1);
+    // The wall and door render as run geometry, not literal hex edges…
+    expect(container.querySelectorAll('[data-run]')).toHaveLength(1);
+    expect(container.querySelectorAll('[data-door-run]')).toHaveLength(1);
+    expect(container.querySelectorAll('[data-edge^="w:"]')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-edge^="d:"]')).toHaveLength(0);
+    // …and cell errors still highlight in red, as before.
     expect(cellEl(container, 3, 1).getAttribute('stroke')).toBe('#ff3b30');
     expect(cellEl(container, 2, 1).getAttribute('stroke')).not.toBe('#ff3b30');
+  });
+
+  it('an EDGE error stays a literal red hex edge on top of the runs — edge-scoped truth (#800)', () => {
+    let doc = emptyDungeon();
+    doc = paintCell(doc, 'region-1', p(1, 1));
+    doc = paintCell(doc, 'region-1', p(2, 1));
+    doc = toggleWall(doc, [p(1, 1), p(2, 1)]);
+    const { container } = mount(doc, {
+      errorTargets: [{ kind: 'edge', edge: [p(1, 1), p(2, 1)] }],
+    });
+    // The run still draws, and the literal error edge draws over it.
+    expect(container.querySelectorAll('[data-run]')).toHaveLength(1);
+    const literal = container.querySelectorAll('[data-edge^="w:"]');
+    expect(literal).toHaveLength(1);
+    expect(literal[0].getAttribute('stroke')).toBe('#ff3b30');
+  });
+
+  it('a flat-top document keeps the literal edge drawing — 3D refuses flat-top, so literal IS the honest picture (#763)', () => {
+    const f = (c: number, r: number) => fromOffset('flat', [c, r]);
+    let doc = emptyDungeon('flat');
+    doc = paintCell(doc, 'region-1', f(1, 1));
+    doc = paintCell(doc, 'region-1', f(2, 1));
+    doc = toggleWall(doc, [f(1, 1), f(2, 1)]);
+    const { container } = mount(doc);
+    expect(container.querySelectorAll('[data-run]')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-edge^="w:"]')).toHaveLength(1);
   });
 });
 

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -44,6 +44,7 @@ import {
 } from '../markerStyle';
 import { thumbForRef } from '../paletteData';
 import type { BoardTool, Selection } from '../types';
+import { boardWallScene } from './boardWallRuns';
 import {
   cellCenter,
   cellsInBounds,
@@ -178,6 +179,18 @@ export function CreationBoard({
     [doc.regions]
   );
   const doorOwners = useMemo(() => doorEdgeOwners(doc), [doc]);
+  // The straightened picture (#800): existing walls and doors drawn as
+  // the SAME runs the 3D preview and game will render, via the shared
+  // geometry module — null on a flat-top document, where the board
+  // keeps its literal edge drawing (3D refuses flat-top by name, #763,
+  // so the literal edges ARE the honest picture there). Derived from
+  // the document directly, not the debounced server compile, so the
+  // wall the author just clicked straightens immediately.
+  const wallScene = useMemo(() => boardWallScene(doc, size), [doc, size]);
+  const doorById = useMemo(
+    () => new Map(doc.doors.map((d) => [d.id, d] as const)),
+    [doc.doors]
+  );
 
   const errorCells = useMemo(() => {
     const s = new Set<string>();
@@ -279,7 +292,12 @@ export function CreationBoard({
   const selectedPlacement =
     selection?.kind === 'placement' ? selection.index : null;
 
-  // Edges to draw: walls, door edges, the hover edge.
+  // Literal hex-edge lines. With the straightened picture on (pointy),
+  // walls and doors render as runs instead, and only ERROR edges stay
+  // literal, drawn on top of the runs — an error is edge-scoped truth
+  // about what the author clicked, not about the fitted line (#800).
+  // On a flat-top document everything stays literal, as before.
+  const straightened = wallScene !== null;
   const edgeLines: {
     key: string;
     edge: Edge;
@@ -288,20 +306,24 @@ export function CreationBoard({
     dash?: string;
   }[] = [];
   for (const w of doc.walls) {
+    const isError = errorEdges.has(edgeKey(w));
+    if (straightened && !isError) continue;
     edgeLines.push({
       key: `w:${edgeKey(w)}`,
       edge: w,
-      stroke: errorEdges.has(edgeKey(w)) ? ERROR_STROKE : WALL_STROKE,
+      stroke: isError ? ERROR_STROKE : WALL_STROKE,
       width: 4,
     });
   }
   for (const d of doc.doors) {
     for (const e of d.edges) {
       const k = edgeKey(e);
+      const isError = errorEdges.has(k);
+      if (straightened && !isError) continue;
       edgeLines.push({
         key: `d:${k}`,
         edge: e,
-        stroke: errorEdges.has(k)
+        stroke: isError
           ? ERROR_STROKE
           : d.locked
             ? DOOR_LOCKED_STROKE
@@ -481,6 +503,42 @@ export function CreationBoard({
             })}
           </g>
           <g data-layer="edges" pointerEvents="none" strokeLinecap="round">
+            {/* Straight runs first, then the gap-aligned doors, then any
+                literal (error) edges on top, then the hover edge. The
+                door keeps its stroke identity (locked/closed/selected)
+                but sits IN the run's gap, exactly where 3D will put it;
+                hit-testing stays edge-based (this layer takes no
+                pointer events). */}
+            {wallScene?.runs.map((r) => (
+              <line
+                key={`run:${r.key}`}
+                data-run={r.key}
+                x1={r.a.x}
+                y1={r.a.y}
+                x2={r.b.x}
+                y2={r.b.y}
+                stroke={WALL_STROKE}
+                strokeWidth={4}
+              />
+            ))}
+            {wallScene?.doors.map((d) => {
+              const doorDoc = doorById.get(d.doorId);
+              return (
+                <line
+                  key={`dr:${edgeKey(d.edge)}`}
+                  data-door-run={edgeKey(d.edge)}
+                  x1={d.a.x}
+                  y1={d.a.y}
+                  x2={d.b.x}
+                  y2={d.b.y}
+                  stroke={doorDoc?.locked ? DOOR_LOCKED_STROKE : DOOR_STROKE}
+                  strokeWidth={d.doorId === selectedDoor ? 6 : 4}
+                  strokeDasharray={
+                    doorDoc?.closed || doorDoc?.locked ? undefined : '4 3'
+                  }
+                />
+              );
+            })}
             {edgeLines.map((l) => {
               const seg = edgeSegment(l.edge, size, o);
               if (!seg) return null;

--- a/src/author/creation/boardWallRuns.test.ts
+++ b/src/author/creation/boardWallRuns.test.ts
@@ -1,0 +1,142 @@
+/**
+ * boardWallRuns — the board's straightened wall picture (#800) is the
+ * SAME geometry 3D renders, projected. The projection is pinned by a
+ * PIXEL formula (exact numbers for known inputs), never a round-trip:
+ * a conversion swapped identically both ways passes every consistency
+ * test (rpg-toolkit#1150, rpg-dnd5e-web#1141 — twice real), and only
+ * asserting the actual picture catches it. The reference-tomb golden
+ * pins the input mapping + projection against `buildScene3D`'s own
+ * output for the same document — same run module on both sides, so any
+ * disagreement is a mapping or projection defect by construction.
+ */
+import { DOOR_FRAME_CALIBRATED_WIDTH } from '@/components/hex-grid/syntyHexWallHelpers';
+import { buildScene3D } from '@/components/session/atlasToScene3D';
+import { describe, expect, it } from 'vitest';
+import { hexCenter } from '../../concepts/session-tomb/atlas';
+import { emptyDungeon, paintCell, toggleWall } from '../dungeonYaml';
+import { fixtureAtlasOf } from '../fixtures/fixtureAtlas';
+import { referenceTombDoc } from '../fixtures/referenceTomb';
+import { fromOffset, type Axial } from '../hexOffset';
+import { BOARD_HEX_SIZE } from './CreationBoard';
+import {
+  boardWallScene,
+  cubeToWorld,
+  HEX_SIZE,
+  worldToBoard,
+} from './boardWallRuns';
+
+const asPosition = (a: Axial) => ({ x: a.q, y: a.r }) as never;
+
+describe('worldToBoard (the ONE world → SVG projection)', () => {
+  it('is the pixel formula: scale by boardSize/worldSize, world z becomes SVG y', () => {
+    // Exact numbers, not a round-trip. scale = 24 / 1.
+    expect(worldToBoard({ x: 1, z: 2 }, 1, 24)).toEqual({ x: 24, y: 48 });
+    expect(worldToBoard({ x: -0.5, z: 0 }, 1, 24)).toEqual({ x: -12, y: 0 });
+    // A real hex center: cube (2, 3) at world size 1 sits at
+    // (√3·(2+1.5), 1.5·3) = (6.06217782649107, 4.5); at board size 24
+    // that must land at exactly 24× those numbers.
+    const p = worldToBoard({ x: 6.06217782649107, z: 4.5 }, 1, 24);
+    expect(p.x).toBeCloseTo(145.4922678357857, 10);
+    expect(p.y).toBe(108);
+    // The scale is a ratio, not a bake-in of 24: doubling the world
+    // unit halves the SVG magnitude for the same world point.
+    expect(worldToBoard({ x: 6, z: 3 }, 2, 24)).toEqual({ x: 72, y: 36 });
+  });
+
+  it('sends 3D cell centers exactly onto the board’s own hex centers (the pure-scale proof)', () => {
+    // The board places cells via hexCenter (SVG, y-down, BOARD_HEX_SIZE);
+    // 3D places them via cubeToWorld (world, HEX_SIZE). The projection
+    // claims those are the same formulas at different sizes — prove it
+    // on cells in all four quadrants rather than assume it.
+    const cells: Axial[] = [
+      { q: 0, r: 0 },
+      { q: 2, r: 3 },
+      { q: -4, r: 5 },
+      { q: 7, r: -2 },
+      { q: -3, r: -3 },
+    ];
+    for (const cell of cells) {
+      const world = cubeToWorld(
+        { x: cell.q, y: -cell.q - cell.r, z: cell.r },
+        HEX_SIZE
+      );
+      const projected = worldToBoard(world, HEX_SIZE, BOARD_HEX_SIZE);
+      const board = hexCenter(asPosition(cell), BOARD_HEX_SIZE, 'pointy');
+      expect(projected.x).toBeCloseTo(board.x, 10);
+      expect(projected.y).toBeCloseTo(board.y, 10);
+    }
+  });
+});
+
+describe('boardWallScene', () => {
+  it('returns null for a flat-top document — the board keeps literal edges, mirroring 3D’s pointy-only gate (#763)', () => {
+    let doc = emptyDungeon('flat');
+    doc = paintCell(doc, 'region-1', fromOffset('flat', [1, 1]));
+    doc = paintCell(doc, 'region-1', fromOffset('flat', [2, 1]));
+    doc = toggleWall(doc, [
+      fromOffset('flat', [1, 1]),
+      fromOffset('flat', [2, 1]),
+    ]);
+    expect(boardWallScene(doc, BOARD_HEX_SIZE)).toBeNull();
+  });
+
+  it('reference tomb golden: 2D run endpoints are exactly the projection of the 3D preview’s runs', () => {
+    const doc = referenceTombDoc();
+    const scene2d = boardWallScene(doc, BOARD_HEX_SIZE);
+    expect(scene2d).not.toBeNull();
+    // The 3D preview path for the same document (fixtureAtlasOf is what
+    // the sandbox preview compiles with; the same module the game uses).
+    const scene3d = buildScene3D(fixtureAtlasOf(doc), HEX_SIZE, 'pointy');
+    expect(scene2d!.runs.length).toBeGreaterThan(0);
+    expect(scene2d!.runs.length).toBe(scene3d.wallRuns.length);
+    const byKey = new Map(scene3d.wallRuns.map((r) => [r.key, r] as const));
+    for (const run of scene2d!.runs) {
+      const three = byKey.get(run.key);
+      expect(three, `2D run ${run.key} exists in 3D`).toBeDefined();
+      // Exact equality, not closeTo: same module, same input mapping,
+      // same floats — anything less means the 2D input mapping diverged
+      // from what 3D consumes.
+      expect(run.a).toEqual(
+        worldToBoard(three!.start, HEX_SIZE, BOARD_HEX_SIZE)
+      );
+      expect(run.b).toEqual(worldToBoard(three!.end, HEX_SIZE, BOARD_HEX_SIZE));
+    }
+  });
+
+  it('the tomb’s axis-true runs stay axis-true in SVG space', () => {
+    // The tomb's walls are its two authored column seams; #799 renders
+    // them exactly vertical in world space (|dirX| < 1e-6). A projection
+    // that rotated, sheared, or mixed axes would break that here.
+    const scene2d = boardWallScene(referenceTombDoc(), BOARD_HEX_SIZE)!;
+    for (const run of scene2d.runs) {
+      expect(Math.abs(run.a.x - run.b.x)).toBeLessThan(1e-6 * BOARD_HEX_SIZE);
+    }
+  });
+
+  it('doors sit exactly in the run gaps, one per door edge, keyed to their document door', () => {
+    const doc = referenceTombDoc();
+    const scene2d = boardWallScene(doc, BOARD_HEX_SIZE)!;
+    const scene3d = buildScene3D(fixtureAtlasOf(doc), HEX_SIZE, 'pointy');
+    expect(scene2d.doors.map((d) => d.doorId)).toEqual([
+      'entrance-hall',
+      'hall-tomb',
+    ]);
+    scene2d.doors.forEach((door, i) => {
+      const gap = scene3d.doorGaps[i];
+      // One end IS the gap's leaf end; the midpoint IS the gap's center
+      // — the door is drawn in the gap, not on the raw hex edge.
+      expect(door.a).toEqual(
+        worldToBoard(gap.leafPosition, HEX_SIZE, BOARD_HEX_SIZE)
+      );
+      const center = worldToBoard(gap.position, HEX_SIZE, BOARD_HEX_SIZE);
+      expect((door.a.x + door.b.x) / 2).toBeCloseTo(center.x, 9);
+      expect((door.a.y + door.b.y) / 2).toBeCloseTo(center.y, 9);
+      // And it spans the full calibrated gap the flanking runs stop at.
+      const len = Math.hypot(door.b.x - door.a.x, door.b.y - door.a.y);
+      expect(len).toBeCloseTo(
+        DOOR_FRAME_CALIBRATED_WIDTH * (BOARD_HEX_SIZE / HEX_SIZE),
+        9
+      );
+    });
+  });
+});

--- a/src/author/creation/boardWallRuns.ts
+++ b/src/author/creation/boardWallRuns.ts
@@ -1,0 +1,199 @@
+/**
+ * boardWallRuns — the 2D canvas's picture of EXISTING walls and doors as
+ * the SAME straight runs the 3D preview and game route render
+ * (rpg-dnd5e-web#800). Kirk's walk: "in the previous dungeon builder we
+ * drew the straight walls and it was clear how they would show in 3D;
+ * with the follow-the-hexes it seems we need to do some guessing." The
+ * 2D board drew each authored wall as its literal hex-edge zigzag while
+ * 3D straightened the same file into runs — so the author authored
+ * blind. This module makes the board draw what 3D will draw.
+ *
+ * # One geometry source, two projections — NEVER re-derived
+ *
+ * The run geometry comes from `atlasWallRuns.boundariesToWallRuns`, the
+ * exact module `buildScene3D` composes for the 3D preview and the game
+ * route (axis-true by authored-pair declaration, corner closure, door
+ * gaps — see its own module doc for every ruling it encodes). This file
+ * contains ZERO run math: it maps the authored document into the
+ * atlas-shaped input that module already takes, calls it at the game's
+ * own `HEX_SIZE`, and projects the world-space result into SVG user
+ * space. The symmetric-bug rule (rpg-toolkit#1150, rpg-dnd5e-web#1141):
+ * mirrored math drifts and round-trips can't see it; a shared module
+ * cannot disagree with itself.
+ *
+ * # Why the input is built locally, not read off the server compile
+ *
+ * `usePutDungeonPreview` debounces 400ms and then round-trips
+ * `PutDungeon{validate_only}` — fine for the 3D tab, too slow for a
+ * board that must repaint the wall the author JUST clicked.
+ * `docAtlasFacts` is a pure MAPPING (cells = the regions' union,
+ * boundaries = `doc.walls`, doorways = the doors' edges — the same
+ * plain facts `fixtureAtlasOf` mirrors and the server's compile
+ * projects), so the board's runs are current on every click and
+ * bit-identical to what the 3D preview derives for the same document
+ * (pinned by `boardWallRuns.test.ts`'s reference-tomb golden).
+ *
+ * # The projection is a pure scale, proven not assumed
+ *
+ * `canvasGeometry.ts` places the board's pointy-top cells with
+ * `hexCenter` — the SAME standard axial formulas `cubeToWorld` uses
+ * (x = size·√3·(q + r/2); y/z = size·3/2·r), just in SVG user space
+ * (y-down) at `BOARD_HEX_SIZE` instead of world space at `HEX_SIZE`.
+ * So world → SVG is exactly: scale both components by
+ * `boardHexSize / worldHexSize`, world z becomes SVG y. That identity
+ * is pinned by a pixel-formula test (exact numbers for known inputs,
+ * not a round-trip — the repo's symmetric-bug lesson, twice learned),
+ * not trusted from this comment.
+ *
+ * # Pointy-top only, mirroring 3D by name
+ *
+ * `hexMath.ts` places pointy-top only (rpg-dnd5e-web#763) and
+ * `buildScene3D` throws on flat-top rather than draw the rotated
+ * picture. A flat-top document therefore keeps the board's literal
+ * hex-edge drawing — that IS the honest picture while 3D cannot render
+ * it at all; straightening it here would invent geometry no other view
+ * has. `boardWallScene` returns null and the board falls back.
+ */
+import {
+  cubeToWorld,
+  HEX_SIZE,
+  type WorldPos,
+} from '@/components/hex-grid/hexMath';
+import { boundariesToWallRuns } from '@/components/session/atlasWallRuns';
+import { create } from '@bufbuild/protobuf';
+import {
+  GetAtlasResponseSchema,
+  type GetAtlasResponse,
+} from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/service_pb';
+import type { Point } from '../../concepts/session-tomb/atlas';
+import type { DungeonDoc } from '../dungeonYaml';
+import { compareAxial, type Axial, type Edge } from '../hexOffset';
+
+// cubeToWorld is re-exported so the test can pin the projection identity
+// against the exact function the shared module places with.
+export { cubeToWorld, HEX_SIZE };
+
+/**
+ * World (x, z) → SVG user space (x, y): ONE exported projection, used
+ * for every run endpoint and door gap the board draws, so the board and
+ * the 3D scene can never disagree about where a shared point lands.
+ * For pointy-top the board's `hexCenter` and 3D's `cubeToWorld` are the
+ * same axial formulas at different sizes, so this is a pure scale with
+ * world z mapped to SVG y (both "down"): no rotation, no offset — see
+ * this module's header doc, and the pixel-formula test that pins it.
+ */
+export function worldToBoard(
+  world: WorldPos,
+  worldHexSize: number,
+  boardHexSize: number
+): Point {
+  const scale = boardHexSize / worldHexSize;
+  return { x: world.x * scale, y: world.z * scale };
+}
+
+/** One straight wall run in SVG user space, keyed by the shared
+ * module's own stable run key. */
+export interface BoardWallRun {
+  key: string;
+  a: Point;
+  b: Point;
+}
+
+/** One door, drawn IN its run's gap (aligned to the straightened run,
+ * not the raw hex edge), still carrying its document identity so the
+ * board can style it (locked/closed/selected) and overlay errors on
+ * the authored edge it toggles. */
+export interface BoardDoorRun {
+  doorId: string;
+  edge: Edge;
+  a: Point;
+  b: Point;
+}
+
+export interface BoardWallScene {
+  runs: BoardWallRun[];
+  doors: BoardDoorRun[];
+}
+
+const pos = (a: Axial) => ({ x: a.q, y: a.r });
+
+/**
+ * The atlas-shaped plain facts `boundariesToWallRuns` consumes, mapped
+ * straight from the document — mapping ONLY, zero geometry: cells are
+ * the regions' union (the compiled atlas's own definition), boundaries
+ * are the declared walls, doorways are the doors' edges. The same
+ * shapes `fixtureAtlasOf` mirrors for the sandbox and the server's
+ * compile projects for real, positions as wire axial (x = q, y = r).
+ * Also returns the doorways' document identities, index-aligned with
+ * the doorways array (and therefore with `boundariesToWallRuns`'s
+ * `doorGaps`, which processes every doorway once, in order).
+ */
+export function docAtlasFacts(doc: DungeonDoc): {
+  facts: Pick<GetAtlasResponse, 'cells' | 'boundaries' | 'doorways'>;
+  doorSources: { doorId: string; edge: Edge }[];
+} {
+  const doorSources = doc.doors.flatMap((d) =>
+    d.edges.map((edge) => ({ doorId: d.id, edge }))
+  );
+  const facts = create(GetAtlasResponseSchema, {
+    cells: doc.regions
+      .flatMap((r) => r.cells)
+      .sort(compareAxial)
+      .map(pos),
+    boundaries: doc.walls.map(([a, b]) => ({
+      from: pos(a),
+      to: pos(b),
+      blocksMovement: true,
+      blocksLineOfSight: true,
+    })),
+    doorways: doorSources.map(({ doorId, edge: [a, b] }) => ({
+      connection: `${doc.key}/${doorId}`,
+      from: pos(a),
+      to: pos(b),
+    })),
+  });
+  return { facts, doorSources };
+}
+
+/**
+ * The straightened wall/door picture for the board, or null for a
+ * flat-top document (the board keeps its literal edge drawing — see
+ * this module's header doc). Runs are computed at the game's own
+ * `HEX_SIZE` — the calibrated door-frame width and corner-overlap
+ * margin inside the shared module are world-unit constants sized for
+ * it — then projected, so gaps and overlaps land at exactly the
+ * proportions 3D will show.
+ */
+export function boardWallScene(
+  doc: DungeonDoc,
+  boardHexSize: number
+): BoardWallScene | null {
+  if (doc.orientation !== 'pointy') return null;
+  const { facts, doorSources } = docAtlasFacts(doc);
+  const { wallRuns, doorGaps } = boundariesToWallRuns(facts, HEX_SIZE);
+  const project = (w: WorldPos) => worldToBoard(w, HEX_SIZE, boardHexSize);
+  const runs: BoardWallRun[] = wallRuns.map((r) => ({
+    key: r.key,
+    a: project(r.start),
+    b: project(r.end),
+  }));
+  const doors: BoardDoorRun[] = [];
+  doorGaps.forEach((gap, i) => {
+    const source = doorSources[i];
+    if (!source) return; // never expected: doorGaps is one per doorway, in order
+    // The gap runs leafPosition → its mirror across the gap's center
+    // (DoorGapPiece carries the center and ONE end; the other end is
+    // the reflection, by the gap's own construction).
+    const far: WorldPos = {
+      x: 2 * gap.position.x - gap.leafPosition.x,
+      z: 2 * gap.position.z - gap.leafPosition.z,
+    };
+    doors.push({
+      doorId: source.doorId,
+      edge: source.edge,
+      a: project(gap.leafPosition),
+      b: project(far),
+    });
+  });
+  return { runs, doors };
+}


### PR DESCRIPTION
## What

The builder's 2D canvas now draws EXISTING walls as the same straight runs the 3D preview and game route render, with door gaps shown as gaps and each door drawn in its gap, aligned to the straightened run. Authoring interaction is untouched: clicks still toggle a hex edge, the hover highlight stays a hex edge, hit-testing stays edge-based. For KirkDiggler/rpg-dnd5e-web#800 — "the 2D canvas draws walls the way they will RENDER."

## How — one geometry source, two projections

- **No run math in 2D.** New `src/author/creation/boardWallRuns.ts` calls the shared `atlasWallRuns.boundariesToWallRuns` — the exact module `buildScene3D` composes — at the game's own `HEX_SIZE`, then projects the world-space output into SVG user space. The symmetric-bug rule (rpg-toolkit#1150, #1141): mirrored math drifts; a shared module cannot disagree with itself.
- **Input path: (b), built locally from the document.** `docAtlasFacts(doc)` is a pure mapping (cells = the regions' union, boundaries = `doc.walls`, doorways = the doors' edges — the same plain facts `fixtureAtlasOf` mirrors and the server compile projects). Why not the server-compiled `preview.atlas` (a): `usePutDungeonPreview` debounces 400ms and round-trips `PutDungeon{validate_only}` — fine for the 3D tab, too slow for a board that must repaint the wall the author JUST clicked. The reference-tomb golden test pins that this mapping feeds the run module bit-identically to what the 3D preview consumes (exact float equality, not closeTo).
- **The projection is ONE exported function with a pixel-formula test.** For pointy-top the board's `hexCenter` and 3D's `cubeToWorld` are the same standard axial formulas at different sizes, so `worldToBoard` is a pure scale (`boardHexSize / worldHexSize`) with world z → SVG y. Proven by exact numbers for known inputs, never a round-trip, plus a test that 3D cell centers project exactly onto the board's own hex centers.
- **Doors drawn in the gap**, keyed back to their document door (the doorways array is index-aligned with `doorGaps`), keeping their stroke identity — locked/closed dash, selected width — so selection visuals are unchanged.
- **Error edges stay literal**: an edge named by a compiler error still draws as its red hex-edge segment ON TOP of the runs — an error is edge-scoped truth about what the author clicked.
- **Flat-top keeps the literal edge drawing** (`boardWallScene` returns null): 3D refuses flat-top by name (#763), so the literal picture IS the honest one there; straightening it would invent geometry no other view has.

## Tests

- `boardWallRuns.test.ts`: pixel-formula projection pin (exact numbers); pure-scale proof (3D cell centers land exactly on board hex centers, four quadrants); flat-top → null; reference-tomb golden (2D run endpoints exactly equal the projection of `buildScene3D`'s runs); the tomb's axis-true runs stay axis-true in SVG (constant x within 1e-6 × scale); doors sit exactly in the run gaps at the full calibrated width, keyed to their document doors.
- `CreationBoard.test.tsx`: pointy doc renders runs + gap doors and zero literal wall/door edges; an edge ERROR stays a literal red segment over the run; a flat-top doc keeps literal edges.

`npm run ci-check` green (format, lint, typecheck, build, full test suite).

## Visual evidence

Verified live on the Concepts Lab sandbox (reference tomb, fixtures mode): the hall–tomb seam draws as one dead-straight run with the locked door red in its gap, where the same seam was a hex-edge zigzag before. Before/after screenshots captured; the session that dispatched this lane has the files and will attach them for the walk.

Part of KirkDiggler/rpg-project#169.

— world-builder lane, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MbNn6jFLjJwzTw6ZbY5M1