### PR TITLE
feat: sighted players render as their characters — roster loaded once, referenced at render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
         "@discord/embedded-app-sdk": "^2.1.0",
-        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.138",
+        "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.139",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -1393,7 +1393,7 @@
     },
     "node_modules/@kirkdiggler/rpg-api-protos": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#930fa762e34785cbe2e1f124f9f643b0a0b01e04",
+      "resolved": "git+ssh://git@github.com/KirkDiggler/rpg-api-protos.git#430477a0529a0f5edc2541a24abddfa682952543",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@connectrpc/connect": "^2.0.2",
     "@connectrpc/connect-web": "^2.0.2",
     "@discord/embedded-app-sdk": "^2.1.0",
-    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.138",
+    "@kirkdiggler/rpg-api-protos": "github:KirkDiggler/rpg-api-protos#v0.1.139",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/src/api/useSessionRoster.test.ts
+++ b/src/api/useSessionRoster.test.ts
@@ -1,0 +1,93 @@
+import type { GetRosterResponse } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/service_pb';
+import { MemberKind } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getRosterFn: vi.fn<() => Promise<GetRosterResponse>>(),
+}));
+
+vi.mock('./client', () => ({
+  sessionClient: {
+    getRoster: hoisted.getRosterFn,
+  },
+}));
+
+// Import AFTER vi.mock so the mock is applied
+import { useSessionRoster } from './useSessionRoster';
+
+function rosterResponse(): GetRosterResponse {
+  return {
+    members: [
+      {
+        id: 'char-alice',
+        kind: MemberKind.PLAYER,
+        name: 'Alice',
+        classRef: 'fighter',
+        raceRef: 'human',
+        monsterRef: '',
+      },
+      {
+        id: 'skeleton-1',
+        kind: MemberKind.MONSTER,
+        name: 'Skeleton',
+        classRef: '',
+        raceRef: '',
+        monsterRef: 'dnd5e:monsters:skeleton',
+      },
+    ],
+  } as GetRosterResponse;
+}
+
+beforeEach(() => {
+  hoisted.getRosterFn.mockReset();
+});
+
+describe('useSessionRoster', () => {
+  it('fetches ONCE on mount and keys the roster by member id — identity is load-once (rpg-project#264)', async () => {
+    hoisted.getRosterFn.mockResolvedValue(rosterResponse());
+    const { result } = renderHook(() => useSessionRoster('enc-1'));
+
+    await waitFor(() => expect(result.current.roster.size).toBe(2));
+    expect(hoisted.getRosterFn).toHaveBeenCalledTimes(1);
+    expect(result.current.roster.get('char-alice')?.classRef).toBe('fighter');
+    expect(result.current.roster.get('skeleton-1')?.monsterRef).toBe(
+      'dnd5e:monsters:skeleton'
+    );
+  });
+
+  it('does not fetch while session is empty, and refetch stays a no-op', async () => {
+    const { result } = renderHook(() => useSessionRoster(''));
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(hoisted.getRosterFn).not.toHaveBeenCalled();
+    expect(result.current.roster.size).toBe(0);
+  });
+
+  it('a failed refetch keeps the last known roster — rendering degrades, never blanks mid-session', async () => {
+    hoisted.getRosterFn.mockResolvedValueOnce(rosterResponse());
+    const { result } = renderHook(() => useSessionRoster('enc-1'));
+    await waitFor(() => expect(result.current.roster.size).toBe(2));
+
+    hoisted.getRosterFn.mockRejectedValueOnce(new Error('boom'));
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.roster.size).toBe(2);
+  });
+
+  it('the session going away clears roster and error — nothing outlives its session', async () => {
+    hoisted.getRosterFn.mockResolvedValue(rosterResponse());
+    const { result, rerender } = renderHook(
+      ({ session }: { session: string }) => useSessionRoster(session),
+      { initialProps: { session: 'enc-1' } }
+    );
+    await waitFor(() => expect(result.current.roster.size).toBe(2));
+
+    rerender({ session: '' });
+    expect(result.current.roster.size).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/api/useSessionRoster.ts
+++ b/src/api/useSessionRoster.ts
@@ -1,0 +1,75 @@
+import type { PublicMemberInfo } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
+import { useCallback, useEffect, useState } from 'react';
+import { sessionClient } from './client';
+
+export interface UseSessionRosterResult {
+  /** The roster keyed by member id (`PublicMemberInfo.id` — the same id
+   * `Sighting.subject` speaks), for O(1) lookup at render. */
+  roster: ReadonlyMap<string, PublicMemberInfo>;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+const EMPTY_ROSTER: ReadonlyMap<string, PublicMemberInfo> = new Map();
+
+/**
+ * Fetches the session's roster (`SessionService.GetRoster`) — the PUBLIC
+ * half of every member (rpg-project#264, ideas/characters/presentation):
+ * name, kind, and the body's refs. Never positions and never the sheet —
+ * `PublicMemberInfo`'s own wire doc carries the law.
+ *
+ * LOAD ONCE, REFERENCE AT RENDER: identity is stable per session (it
+ * changes at join time and in an editor, not per turn), so unlike
+ * `useSessionView` this hook DOES fetch on mount, and the only other
+ * fetch a caller should ever fire is `refetch` on a `joined` event —
+ * pull-on-join is the ruled shape (design.md "Decisions"). Nothing here
+ * refetches per perception refresh, which is the whole point of the
+ * roster/sighting split.
+ *
+ * `session` empty/falsy is the "not ready yet" state; `loading`/`error`
+ * clear rather than leaving a stale error visible from a previous session
+ * (the same clearing rule as `useSessionView`/`useSessionWhere`).
+ */
+export function useSessionRoster(session: string): UseSessionRosterResult {
+  const [roster, setRoster] =
+    useState<ReadonlyMap<string, PublicMemberInfo>>(EMPTY_ROSTER);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchRoster = useCallback(async () => {
+    if (!session) {
+      setRoster(EMPTY_ROSTER);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await sessionClient.getRoster({ session });
+      setRoster(new Map(response.members.map((m) => [m.id, m])));
+    } catch (err) {
+      // A failed roster read degrades rendering to the pre-roster
+      // placeholders, never blocks it — keep whatever was last known
+      // rather than blanking members mid-session.
+      setError(err instanceof Error ? err : new Error('GetRoster RPC failed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [session]);
+
+  // Load once per session — identity is stable, so mount (or the session id
+  // arriving) is the one automatic fetch.
+  useEffect(() => {
+    if (!session) {
+      setRoster(EMPTY_ROSTER);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    void fetchRoster();
+  }, [session, fetchRoster]);
+
+  return { roster, loading, error, refetch: fetchRoster };
+}

--- a/src/components/session/SessionCanvas.test.tsx
+++ b/src/components/session/SessionCanvas.test.tsx
@@ -6,6 +6,7 @@
  * rather than nesting a second `<Canvas>` inside it.
  */
 import type { AuthoredWallRun } from '@/hooks/authoredWallRuns';
+import type { PublicMemberInfo } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import {
   MemberKind,
   Standing,
@@ -14,6 +15,7 @@ import ReactThreeTestRenderer from '@react-three/test-renderer';
 import * as THREE from 'three';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AbsoluteFloorTile } from '../../hooks/dungeonMapGeometry';
+import { resolveClassCharacterModelUrl } from '../hex-grid/classCharacterModels';
 import { facingToYaw } from '../hex-grid/facingYaw';
 import { cubeToWorld } from '../hex-grid/hexMath';
 import { buildAtlasPathIndex } from './atlasPath';
@@ -428,6 +430,131 @@ describe('SessionScene', () => {
       });
 
       expect(onHexClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('roster identity (rpg-project#264, rpg-dnd5e-web#806)', () => {
+    const sightedPlayer = {
+      subject: 'char-bob',
+      name: 'Bob',
+      monsterRefId: undefined,
+      kind: MemberKind.PLAYER,
+      position: { x: 1, y: -1, z: 0 },
+      remembered: false,
+      standing: Standing.UP,
+    };
+
+    it('a PLAYER-kind member with a roster entry mounts their CLASS GLB, not the neutral placeholder', async () => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <SessionScene
+          scene={scene()}
+          hexSize={1}
+          characterId="char-1"
+          characterName="Toolkit Sandbox Fighter"
+          character={undefined}
+          classRefId={undefined}
+          myPosition={{ x: 0, y: 0, z: 0 }}
+          otherMembers={[sightedPlayer]}
+          roster={
+            new Map([
+              [
+                'char-bob',
+                {
+                  id: 'char-bob',
+                  kind: MemberKind.PLAYER,
+                  name: 'Bob',
+                  classRef: 'fighter',
+                  raceRef: 'human',
+                  monsterRef: '',
+                } as PublicMemberInfo,
+              ],
+            ])
+          }
+        />
+      );
+      // Mocked useGLTF names its mesh after the resolved URL — the fighter
+      // class GLB path appears only when the class model actually mounted.
+      const expectedUrl = resolveClassCharacterModelUrl('fighter', false);
+      expect(expectedUrl).toBeTruthy();
+      const classMeshes = renderer.scene.findAll(
+        (node) =>
+          node.type === 'Mesh' &&
+          (node.instance as THREE.Mesh).name.includes(expectedUrl as string)
+      );
+      expect(classMeshes.length).toBeGreaterThan(0);
+    });
+
+    it('a PLAYER-kind member with NO roster entry keeps the neutral placeholder — a missing row degrades, never blocks', async () => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <SessionScene
+          scene={scene()}
+          hexSize={1}
+          characterId="char-1"
+          characterName="Toolkit Sandbox Fighter"
+          character={undefined}
+          classRefId={undefined}
+          myPosition={{ x: 0, y: 0, z: 0 }}
+          otherMembers={[sightedPlayer]}
+          roster={new Map()}
+        />
+      );
+      const expectedUrl = resolveClassCharacterModelUrl('fighter', false);
+      const classMeshes = renderer.scene.findAll(
+        (node) =>
+          node.type === 'Mesh' &&
+          (node.instance as THREE.Mesh).name.includes(expectedUrl as string)
+      );
+      expect(classMeshes).toHaveLength(0);
+      expect(renderer.scene.children.length).toBeGreaterThan(0);
+    });
+
+    it("a MONSTER-kind member's model resolves from the roster's authored ref — no subject-derived monsterRefId needed", async () => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <SessionScene
+          scene={scene()}
+          hexSize={1}
+          characterId="char-1"
+          characterName="Toolkit Sandbox Fighter"
+          character={undefined}
+          classRefId={undefined}
+          myPosition={{ x: 0, y: 0, z: 0 }}
+          otherMembers={[
+            {
+              subject: 'bag-of-bones-7',
+              name: 'Skeleton',
+              // Deliberately NO derived ref: the roster's authored ref is
+              // the primary source now (rpg-project#264); derivation
+              // survives only as the missing-entry fallback.
+              monsterRefId: undefined,
+              kind: MemberKind.MONSTER,
+              position: { x: 1, y: -1, z: 0 },
+              remembered: false,
+              standing: Standing.UP,
+            },
+          ]}
+          roster={
+            new Map([
+              [
+                'bag-of-bones-7',
+                {
+                  id: 'bag-of-bones-7',
+                  kind: MemberKind.MONSTER,
+                  name: 'Skeleton',
+                  classRef: '',
+                  raceRef: '',
+                  monsterRef: 'dnd5e:monsters:skeleton',
+                } as PublicMemberInfo,
+              ],
+            ])
+          }
+        />
+      );
+      const skeletonMeshes = renderer.scene.findAll(
+        (node) =>
+          node.type === 'Mesh' &&
+          (node.instance as THREE.Mesh).name.includes('skeleton')
+      );
+      expect(skeletonMeshes.length).toBeGreaterThan(0);
     });
   });
 

--- a/src/components/session/SessionCanvas.tsx
+++ b/src/components/session/SessionCanvas.tsx
@@ -58,6 +58,7 @@
  */
 
 import { CAMERA_OFFSET } from '@/rendering/calibrationConstants';
+import type { PublicMemberInfo } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import { MemberKind } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/session/v1alpha1/types_pb';
 import type { Character } from '@kirkdiggler/rpg-api-protos/gen/ts/dnd5e/api/v1alpha1/character_pb';
 import { Canvas } from '@react-three/fiber';
@@ -146,6 +147,20 @@ function AtlasPropModel({
   );
 }
 
+/**
+ * The model-resolving id inside an authored monster ref —
+ * "dnd5e:monsters:skeleton" -> "skeleton", the vocabulary
+ * `resolveMonsterModelUrl` already speaks (rpg-project#264: the roster's
+ * authored ref replaces deriving this by stripping the subject's ordinal;
+ * the derivation survives only as the missing-entry fallback above).
+ * `undefined` in, or a ref with no segments, is `undefined` out.
+ */
+function monsterRefIdFrom(monsterRef: string | undefined): string | undefined {
+  if (!monsterRef) return undefined;
+  const segment = monsterRef.split(':').pop();
+  return segment || undefined;
+}
+
 export interface SessionCanvasProps {
   scene: Scene3D;
   hexSize: number;
@@ -191,6 +206,13 @@ export interface SessionCanvasProps {
    * relocates it on the next render. Undefined/empty draws nothing
    * extra. */
   otherMembers?: SightedMember[];
+  /** The session roster keyed by member id (`useSessionRoster` —
+   * rpg-project#264): the PUBLIC identity each sighted member renders
+   * with. A missing map (fetch failed, not landed yet) or a missing
+   * entry degrades every lookup below to the pre-roster behavior —
+   * neutral placeholder for players, subject-derived ref for monsters —
+   * never a blocked render. */
+  roster?: ReadonlyMap<string, PublicMemberInfo>;
   /** Subject ids the caller currently offers as in-reach, AFFORDABLE
    * Attack candidates (rpg-project#249) — see this component's own doc
    * comment on why this is narrower than every in-reach candidate.
@@ -236,6 +258,7 @@ export function SessionScene({
   onHoverEntity,
   onMovementPresentationComplete,
   otherMembers,
+  roster,
   attackableTargets,
   pathIndex = null,
   turnLocked = false,
@@ -496,7 +519,15 @@ export function SessionScene({
           position={member.position}
           type={member.kind === MemberKind.PLAYER ? 'player' : 'monster'}
           hexSize={hexSize}
-          monsterRefId={member.monsterRefId}
+          classRefId={
+            member.kind === MemberKind.PLAYER
+              ? roster?.get(member.subject)?.classRef
+              : undefined
+          }
+          monsterRefId={
+            monsterRefIdFrom(roster?.get(member.subject)?.monsterRef) ??
+            member.monsterRefId
+          }
           knowledgeState={member.remembered ? 'remembered' : undefined}
           isDead={isSightedDowned(member.standing)}
           onClick={handleTargetClick}

--- a/src/components/session/SessionEncounterView.tsx
+++ b/src/components/session/SessionEncounterView.tsx
@@ -118,6 +118,7 @@ import { useEquipItem } from '../../api/useEquipItem';
 import { useGetCharacterData } from '../../api/useGetCharacterData';
 import { useSessionAfford } from '../../api/useSessionAfford';
 import { useSessionAtlas } from '../../api/useSessionAtlas';
+import { useSessionRoster } from '../../api/useSessionRoster';
 import { useSessionTurn } from '../../api/useSessionTurn';
 import { useSessionView } from '../../api/useSessionView';
 import { useSessionWhere } from '../../api/useSessionWhere';
@@ -203,6 +204,13 @@ export function SessionEncounterView({
     sessionId,
     characterId ?? ''
   );
+
+  // The session roster — PUBLIC identity, loaded once and referenced at
+  // render (rpg-project#264, ideas/characters/presentation). The only
+  // refetch trigger is a `joined` event (pull-on-join, the ruled shape) in
+  // `handleSessionEvent` below; nothing perception-driven ever refetches
+  // identity.
+  const { roster, refetch: refetchRoster } = useSessionRoster(sessionId);
   // Afford — "what can I still declare this turn" (slice 5a). Same
   // additive-not-blocking treatment as GetView above: a turn-economy
   // readout degrades to "no panel data yet" (free-roam, per
@@ -538,6 +546,11 @@ export function SessionEncounterView({
       if (event.body?.case === 'moved' && event.body.value.member === member) {
         void refetchWhere();
       }
+      if (event.body?.case === 'joined') {
+        // A new member is new IDENTITY, the roster's one change signal
+        // (rpg-project#264's pull-on-join ruling).
+        void refetchRoster();
+      }
       // Beat-line formatting, another member's turn pacing, and every
       // Afford/Turn/View refetch trigger besides the self-MOVED GetWhere
       // refresh above now live in `useCombatPanel`'s own `handleEvent` —
@@ -548,7 +561,7 @@ export function SessionEncounterView({
         return [...next, event];
       });
     },
-    [member, refetchWhere, handleCombatEvent]
+    [member, refetchWhere, refetchRoster, handleCombatEvent]
   );
 
   // Names for the debug log — the SAME `participantNameMap` +
@@ -713,6 +726,7 @@ export function SessionEncounterView({
           characterName={character?.name ?? 'You'}
           character={character ?? undefined}
           classRefId={classRefId}
+          roster={roster}
           // Falls back to the last known-good GetWhere position — see
           // `lastGoodPositionRef`'s own comment above for why this reads
           // from that ref rather than a live `wherePosition`.


### PR DESCRIPTION
Closes #806. Unit 3 of rpg-project#264 (design+plan on rpg-project PR #264, journey rpg-project#253). Protos v0.1.139; server side rpg-api#838.

- **`useSessionRoster`**: fetches the `PublicMemberInfo` roster once at session mount, keyed by member id; the ONLY refetch trigger is a `joined` event (pull-on-join, the ruled shape). Identity never rides a perception refresh — that split is the point of the design.
- **`SessionCanvas`** looks the roster up at render: a sighted PLAYER's `classRef` flows down the exact prop the local player's path already maps to a class GLB; a monster's model resolves from the roster's authored ref (`dnd5e:monsters:skeleton` → `skeleton`), with the subject-ordinal derivation surviving only as the missing-entry fallback. A missing map or row degrades to today's placeholders, never blocks rendering.
- Follow-on from #792: kind picked the *category*; this delivers the *identity*.

**Live evidence (pre-merge, two browsers on the local stack, api built from rpg-api#838's branch)**: fighter (alice) and barbarian (bob) each render as the other's real class model in both directions; `GetRoster` answered 200 on both clients; zero page errors. Unit evidence: 4 hook tests (load-once, no-session no-op, failed-refetch-keeps-last-roster, session-clear), 3 canvas tests (class GLB mounts from roster entry, missing entry degrades to placeholder, monster resolves from authored ref), full ci-check green.

Known and accepted for v1: the stream's story catch-up replays `joined` beats through the same handler, so a session start fires several idempotent GetRoster refetches (~5-7 observed). Harmless (tiny idempotent read); a debounce is a trivial follow-up if it ever matters.

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu
