### PR TITLE
feat(author): drag-to-draw walls — corner-lattice gesture, preview = commit (#804)

### DIFF
--- a/src/author/DungeonBuilder.tsx
+++ b/src/author/DungeonBuilder.tsx
@@ -57,7 +57,7 @@ import {
   updateRegion,
   type DungeonDoc,
 } from './dungeonYaml';
-import { type Axial, type Edge, type Orientation } from './hexOffset';
+import { edgeKey, type Axial, type Edge, type Orientation } from './hexOffset';
 import { Inspector } from './Inspector';
 import { Palette } from './Palette';
 import { PALETTE_PROPS } from './paletteData';
@@ -311,8 +311,26 @@ export function DungeonBuilder({
   const handleWallErase = (chain: Edge[]) => {
     setDoc((d) => applyWallErase(d, chain));
   };
+  // Manipulation rides selection (Kirk's walk ruling): keep the wall
+  // selected through a reshape by re-selecting the edges the re-derived
+  // chains produced, so its handles stay up for the next grab.
   const handleWallReshape = (oldChains: Edge[][], newChains: Edge[][]) => {
-    setDoc((d) => applyReshape(d, oldChains, newChains));
+    setDoc((d) => {
+      const next = applyReshape(d, oldChains, newChains);
+      if (next !== d) {
+        const untouched = new Set(
+          removeWalls(
+            d,
+            oldChains.flatMap((c) => c)
+          ).walls.map(edgeKey)
+        );
+        setSelection({
+          kind: 'wall',
+          edges: next.walls.filter((w) => !untouched.has(edgeKey(w))),
+        });
+      }
+      return next;
+    });
   };
   // One drag, ONE door — and select it, same as the click path does.
   const handleDoorDraw = (chain: Edge[]) => {

--- a/src/author/DungeonBuilder.tsx
+++ b/src/author/DungeonBuilder.tsx
@@ -27,6 +27,7 @@ import {
 } from './authoringRpc';
 import { CreationBoard } from './creation/CreationBoard';
 import {
+  applyDoorDraw,
   applyReshape,
   applyWallDraw,
   applyWallErase,
@@ -313,6 +314,19 @@ export function DungeonBuilder({
   const handleWallReshape = (oldChains: Edge[][], newChains: Edge[][]) => {
     setDoc((d) => applyReshape(d, oldChains, newChains));
   };
+  // One drag, ONE door — and select it, same as the click path does.
+  const handleDoorDraw = (chain: Edge[]) => {
+    setDoc((d) => {
+      const next = applyDoorDraw(d, chain);
+      if (next !== d && next.doors.length > 0) {
+        setSelection({
+          kind: 'door',
+          id: next.doors[next.doors.length - 1].id,
+        });
+      }
+      return next;
+    });
+  };
   const handleEdgeClick = (edge: Edge) => {
     if (tool === 'wall') setDoc((d) => toggleWall(d, edge));
     if (tool === 'door') {
@@ -506,6 +520,7 @@ export function DungeonBuilder({
               onWallDraw={handleWallDraw}
               onWallErase={handleWallErase}
               onWallReshape={handleWallReshape}
+              onDoorDraw={handleDoorDraw}
               onCellClick={handleCellClick}
               onSelect={setSelection}
             />

--- a/src/author/DungeonBuilder.tsx
+++ b/src/author/DungeonBuilder.tsx
@@ -26,6 +26,7 @@ import {
   type AuthoringClient,
 } from './authoringRpc';
 import { CreationBoard } from './creation/CreationBoard';
+import { applyWallDraw, applyWallErase } from './creation/wallGesture';
 import { discardDraft, loadDraft, saveDraft } from './draftStorage';
 import './DungeonBuilder.css';
 import {
@@ -295,6 +296,15 @@ export function DungeonBuilder({
     if (activeRegionId) setDoc((d) => paintCell(d, activeRegionId, cell));
   };
   const handleErase = (cell: Axial) => setDoc((d) => eraseCell(d, cell));
+  // The wall drag commits its RAW taut chain; applying the same
+  // mutator composition the board's live preview used (wallGesture's
+  // apply*) is what makes the preview the commit (#804).
+  const handleWallDraw = (chain: Edge[]) => {
+    setDoc((d) => applyWallDraw(d, chain));
+  };
+  const handleWallErase = (chain: Edge[]) => {
+    setDoc((d) => applyWallErase(d, chain));
+  };
   const handleEdgeClick = (edge: Edge) => {
     if (tool === 'wall') setDoc((d) => toggleWall(d, edge));
     if (tool === 'door') {
@@ -485,6 +495,8 @@ export function DungeonBuilder({
               onPaint={handlePaint}
               onErase={handleErase}
               onEdgeClick={handleEdgeClick}
+              onWallDraw={handleWallDraw}
+              onWallErase={handleWallErase}
               onCellClick={handleCellClick}
               onSelect={setSelection}
             />

--- a/src/author/DungeonBuilder.tsx
+++ b/src/author/DungeonBuilder.tsx
@@ -26,7 +26,11 @@ import {
   type AuthoringClient,
 } from './authoringRpc';
 import { CreationBoard } from './creation/CreationBoard';
-import { applyWallDraw, applyWallErase } from './creation/wallGesture';
+import {
+  applyReshape,
+  applyWallDraw,
+  applyWallErase,
+} from './creation/wallGesture';
 import { discardDraft, loadDraft, saveDraft } from './draftStorage';
 import './DungeonBuilder.css';
 import {
@@ -41,6 +45,7 @@ import {
   placeAt,
   removePlacement,
   removeRegion,
+  removeWalls,
   resolveErrorTargets,
   setStart,
   toggleDoorEdge,
@@ -305,6 +310,9 @@ export function DungeonBuilder({
   const handleWallErase = (chain: Edge[]) => {
     setDoc((d) => applyWallErase(d, chain));
   };
+  const handleWallReshape = (oldChains: Edge[][], newChains: Edge[][]) => {
+    setDoc((d) => applyReshape(d, oldChains, newChains));
+  };
   const handleEdgeClick = (edge: Edge) => {
     if (tool === 'wall') setDoc((d) => toggleWall(d, edge));
     if (tool === 'door') {
@@ -497,6 +505,7 @@ export function DungeonBuilder({
               onEdgeClick={handleEdgeClick}
               onWallDraw={handleWallDraw}
               onWallErase={handleWallErase}
+              onWallReshape={handleWallReshape}
               onCellClick={handleCellClick}
               onSelect={setSelection}
             />
@@ -531,6 +540,10 @@ export function DungeonBuilder({
               setDoc((d) => updateDoor(d, id, patch));
               if (patch.id !== undefined)
                 setSelection({ kind: 'door', id: patch.id });
+            }}
+            onRemoveWall={(edges) => {
+              setDoc((d) => removeWalls(d, edges));
+              setSelection({ kind: 'dungeon' });
             }}
             onRemoveDoor={(id) => {
               setDoc((d) => ({

--- a/src/author/Inspector.test.tsx
+++ b/src/author/Inspector.test.tsx
@@ -34,6 +34,7 @@ function mountPlacement(
       onRemoveDoor={noop}
       onPlacement={overrides.onPlacement ?? noop}
       onRemovePlacement={noop}
+      onRemoveWall={noop}
     />
   );
 }
@@ -116,5 +117,58 @@ describe('PlacementPanel facing/offset (rpg-project#261)', () => {
     mountPlacement(doc);
     expect(screen.queryByTestId('facing-compass')).toBeNull();
     expect(screen.queryByLabelText('x')).toBeNull();
+  });
+});
+
+describe('wall selection (#804)', () => {
+  it('shows "Wall — N edges" for the selected run and deletes all of them', () => {
+    let doc = emptyDungeon('pointy');
+    doc = {
+      ...doc,
+      regions: [{ ...doc.regions[0], cells: [p(0, 0), p(1, 0), p(0, 1)] }],
+      walls: [
+        [p(0, 0), p(1, 0)],
+        [p(0, 0), p(0, 1)],
+      ],
+    };
+    const onRemoveWall = vi.fn();
+    render(
+      <Inspector
+        doc={doc}
+        selection={{ kind: 'wall', edges: doc.walls }}
+        onDungeon={noop}
+        onRegion={noop}
+        onRemoveRegion={noop}
+        onDoor={noop}
+        onRemoveDoor={noop}
+        onPlacement={noop}
+        onRemovePlacement={noop}
+        onRemoveWall={onRemoveWall}
+      />
+    );
+    expect(screen.getByTestId('wall-panel').textContent).toContain(
+      'Wall — 2 edges'
+    );
+    fireEvent.click(screen.getByRole('button', { name: /delete wall/i }));
+    expect(onRemoveWall).toHaveBeenCalledWith(doc.walls);
+  });
+
+  it('a wall selection whose edges are all gone falls back to the dungeon panel', () => {
+    const doc = emptyDungeon('pointy');
+    render(
+      <Inspector
+        doc={doc}
+        selection={{ kind: 'wall', edges: [[p(0, 0), p(1, 0)]] }}
+        onDungeon={noop}
+        onRegion={noop}
+        onRemoveRegion={noop}
+        onDoor={noop}
+        onRemoveDoor={noop}
+        onPlacement={noop}
+        onRemovePlacement={noop}
+        onRemoveWall={noop}
+      />
+    );
+    expect(screen.getByTestId('dungeon-panel')).toBeTruthy();
   });
 });

--- a/src/author/Inspector.tsx
+++ b/src/author/Inspector.tsx
@@ -7,11 +7,12 @@
 import { FACING_NAMES, facingAngleDeg } from '@/components/hex-grid/facingYaw';
 import {
   isMonsterRef,
+  wallKeys,
   type DoorDoc,
   type DungeonDoc,
   type PlacementDoc,
 } from './dungeonYaml';
-import type { Orientation } from './hexOffset';
+import { edgeKey, type Edge, type Orientation } from './hexOffset';
 import { RegionPanel } from './RegionPanel';
 import { ABILITIES, TARGETINGS, type Selection } from './types';
 
@@ -41,6 +42,8 @@ export interface InspectorProps {
     patch: Partial<Omit<PlacementDoc, 'ref' | 'at'>>
   ) => void;
   onRemovePlacement: (index: number) => void;
+  /** Delete every edge of the selected wall run (#804). */
+  onRemoveWall: (edges: Edge[]) => void;
 }
 
 export function Inspector(props: InspectorProps) {
@@ -70,6 +73,17 @@ export function Inspector(props: InspectorProps) {
         onChange={(p) => props.onDoor(door.id, p)}
         onRemove={() => props.onRemoveDoor(door.id)}
       />
+    );
+  }
+  if (selection.kind === 'wall') {
+    // The selection is the doc edges resolved at click time; edges the
+    // document no longer holds (erased, re-derived) drop out here, and
+    // an emptied selection falls back to the dungeon panel.
+    const present = wallKeys(doc);
+    const edges = selection.edges.filter((e) => present.has(edgeKey(e)));
+    if (edges.length === 0) return <DungeonPanel {...props} />;
+    return (
+      <WallPanel edges={edges} onRemove={() => props.onRemoveWall(edges)} />
     );
   }
   if (selection.kind === 'placement') {
@@ -135,6 +149,29 @@ function DungeonPanel({ doc, onDungeon }: InspectorProps) {
         {doc.walls.length} walls · {doc.doors.length} doors · {doc.place.length}{' '}
         placed
       </div>
+    </div>
+  );
+}
+
+function WallPanel({
+  edges,
+  onRemove,
+}: {
+  edges: Edge[];
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3" data-testid="wall-panel">
+      <h3 className="dg-h">
+        Wall — {edges.length} edge{edges.length === 1 ? '' : 's'}
+      </h3>
+      <div className="text-xs opacity-70">
+        One straight run: the doc edges behind the line you clicked. There is no
+        wall id in the file — this selection IS the edges.
+      </div>
+      <button type="button" className="dg-mini dg-danger" onClick={onRemove}>
+        delete wall
+      </button>
     </div>
   );
 }

--- a/src/author/creation/CreationBoard.test.tsx
+++ b/src/author/creation/CreationBoard.test.tsx
@@ -322,13 +322,27 @@ describe('wall gesture affordances (#804)', () => {
     return addWalls(doc, [[p(1, 1), p(2, 1)]]);
   }
 
-  it('the wall tool shows a handle at each chain endpoint', () => {
-    const { container } = mount(walledDoc(), { tool: 'wall' });
+  it('selecting a wall shows a handle at each chain endpoint — manipulation rides selection', () => {
+    const doc = walledDoc();
+    const { container } = mount(doc, {
+      tool: 'select',
+      selection: { kind: 'wall', edges: doc.walls },
+    });
     // One single-edge run: two endpoint vertices, each with exactly one
-    // incident run.
+    // incident run, visible the moment the wall is selected.
     const handles = container.querySelectorAll('[data-run-vertex]');
     expect(handles).toHaveLength(2);
     handles.forEach((h) => expect(h.getAttribute('data-run-vertex')).toBe('1'));
+  });
+
+  it('the wall tool draws — it shows no handles (continuing a wall presses at its end)', () => {
+    const { container } = mount(walledDoc(), { tool: 'wall' });
+    expect(container.querySelectorAll('[data-run-vertex]')).toHaveLength(0);
+  });
+
+  it('an unselected board shows no handles under the select tool', () => {
+    const { container } = mount(walledDoc(), { tool: 'select' });
+    expect(container.querySelectorAll('[data-run-vertex]')).toHaveLength(0);
   });
 
   it('a wall selection highlights the run whose edges it holds', () => {

--- a/src/author/creation/CreationBoard.test.tsx
+++ b/src/author/creation/CreationBoard.test.tsx
@@ -39,6 +39,8 @@ function mount(doc: DungeonDoc, overrides: Partial<CreationBoardProps> = {}) {
       onPaint={(c) => calls.paint.push(axialKey(c))}
       onErase={(c) => calls.erase.push(axialKey(c))}
       onEdgeClick={(e) => calls.edges.push(e)}
+      onWallDraw={() => {}}
+      onWallErase={() => {}}
       onCellClick={() => {}}
       onSelect={() => {}}
       {...overrides}
@@ -80,6 +82,7 @@ describe('CreationBoard', () => {
   it('the wall tool on a void cell never reports an edge', () => {
     const { container, calls } = mount(emptyDungeon(), { tool: 'wall' });
     fireEvent.pointerDown(cellEl(container, 1, 1), { button: 0 });
+    fireEvent.pointerUp(container.querySelector('svg')!);
     expect(calls.edges).toHaveLength(0);
   });
 
@@ -88,7 +91,10 @@ describe('CreationBoard', () => {
     doc = paintCell(doc, 'region-1', p(1, 1));
     doc = paintCell(doc, 'region-1', p(2, 1));
     const { container, calls } = mount(doc, { tool: 'wall' });
+    // Press + release without moving: the drag-capable wall tool still
+    // commits today's single-edge toggle, on release (#804).
     fireEvent.pointerDown(cellEl(container, 1, 1), { button: 0 });
+    fireEvent.pointerUp(container.querySelector('svg')!);
     expect(calls.edges).toHaveLength(1);
     const [a, b] = calls.edges[0];
     expect(axialKey(a)).toBe(axialKey(p(1, 1)));
@@ -183,6 +189,8 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
         onPaint={() => {}}
         onErase={() => {}}
         onEdgeClick={() => {}}
+        onWallDraw={() => {}}
+        onWallErase={() => {}}
         onCellClick={() => {}}
         onSelect={() => {}}
       />
@@ -224,6 +232,8 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
         onPaint={() => {}}
         onErase={() => {}}
         onEdgeClick={() => {}}
+        onWallDraw={() => {}}
+        onWallErase={() => {}}
         onCellClick={() => {}}
         onSelect={() => {}}
       />

--- a/src/author/creation/CreationBoard.test.tsx
+++ b/src/author/creation/CreationBoard.test.tsx
@@ -3,7 +3,7 @@
  * pointer events and assert on the document the callbacks produce.
  */
 import { fireEvent, render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   addWalls,
   emptyDungeon,
@@ -13,7 +13,8 @@ import {
   toggleWall,
   type DungeonDoc,
 } from '../dungeonYaml';
-import { axialKey, fromOffset, type Edge } from '../hexOffset';
+import { axialKey, edgeKey, fromOffset, type Edge } from '../hexOffset';
+import { boardWallScene } from './boardWallRuns';
 import { cellCenter, growBounds, neededBounds } from './canvasGeometry';
 import {
   BOARD_HEX_SIZE,
@@ -21,6 +22,8 @@ import {
   CreationBoard,
   type CreationBoardProps,
 } from './CreationBoard';
+import { cornerPoint, type CornerRef } from './hexCorner';
+import { runVertices, tautPath } from './wallGesture';
 
 const p = (c: number, r: number) => fromOffset('pointy', [c, r]);
 
@@ -353,5 +356,155 @@ describe('wall gesture affordances (#804)', () => {
     });
     const selected = container.querySelectorAll('[data-run][data-selected]');
     expect(selected).toHaveLength(1);
+  });
+});
+
+/**
+ * Press–move–release integration (#804, Copilot review on PR #808):
+ * the pure module pins the derivation; these pin the PLUMBING — that a
+ * DOM drag reaches onWallDraw/onWallErase/onDoorDraw/onWallReshape
+ * with the exact taut chain. jsdom has no SVG layout, so `svgPoint`'s
+ * CTM path is enabled with a scoped identity polyfill: `getScreenCTM`
+ * returns an identity whose inverse maps client coords straight to SVG
+ * user space, and events carry SVG coordinates in clientX/clientY.
+ */
+describe('gesture plumbing — press, drag, release (#804)', () => {
+  const S = BOARD_HEX_SIZE;
+  const ref = (c: number, r: number, corner: number): CornerRef => ({
+    cell: p(c, r),
+    corner,
+  });
+  const pt = (r: CornerRef) => cornerPoint(r, S, 'pointy');
+  const keys = (edges: readonly Edge[]) => edges.map(edgeKey);
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'DOMPoint',
+      class {
+        x: number;
+        y: number;
+        constructor(x = 0, y = 0) {
+          this.x = x;
+          this.y = y;
+        }
+        matrixTransform() {
+          return { x: this.x, y: this.y };
+        }
+      }
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function floorDoc() {
+    let doc = emptyDungeon();
+    for (const [c, r] of [
+      [1, 1],
+      [2, 1],
+      [1, 2],
+      [2, 2],
+    ] as const) {
+      doc = paintCell(doc, 'region-1', p(c, r));
+    }
+    return doc;
+  }
+
+  function enableSvgCtm(container: HTMLElement) {
+    const svg = container.querySelector('svg')!;
+    (svg as unknown as { getScreenCTM: () => unknown }).getScreenCTM = () => ({
+      inverse: () => ({}),
+    });
+    return svg;
+  }
+
+  const at = (point: { x: number; y: number }) => ({
+    button: 0,
+    clientX: point.x,
+    clientY: point.y,
+  });
+
+  // A = top of the col1|2 seam's row-1 edge, B = bottom of its row-2
+  // edge — the expected chain is the module's own tautPath, pinned
+  // exactly in wallGesture.test.ts.
+  const A = ref(1, 1, 0); // (√3·2, 1)·size
+  const B = ref(2, 2, 3); // (√3·1.5, 3.5)·size
+  const expectedChain = () => tautPath(A, B, S, 'pointy');
+
+  it('a wall drag commits the derived chain through onWallDraw', () => {
+    const onWallDraw = vi.fn();
+    const { container } = mount(floorDoc(), { tool: 'wall', onWallDraw });
+    const svg = enableSvgCtm(container);
+    fireEvent.pointerDown(cellEl(container, 1, 1), at(pt(A)));
+    fireEvent.pointerMove(cellEl(container, 2, 2), at(pt(B)));
+    fireEvent.pointerUp(svg);
+    expect(onWallDraw).toHaveBeenCalledTimes(1);
+    expect(keys(onWallDraw.mock.calls[0][0])).toEqual(keys(expectedChain()));
+    expect(expectedChain().length).toBeGreaterThan(0);
+  });
+
+  it('a shift-drag erases along the same derived path through onWallErase', () => {
+    const onWallErase = vi.fn();
+    const doc = addWalls(floorDoc(), expectedChain());
+    const { container } = mount(doc, { tool: 'wall', onWallErase });
+    const svg = enableSvgCtm(container);
+    fireEvent.pointerDown(cellEl(container, 1, 1), {
+      ...at(pt(A)),
+      shiftKey: true,
+    });
+    fireEvent.pointerMove(cellEl(container, 2, 2), at(pt(B)));
+    fireEvent.pointerUp(svg);
+    expect(onWallErase).toHaveBeenCalledTimes(1);
+    expect(keys(onWallErase.mock.calls[0][0])).toEqual(keys(expectedChain()));
+  });
+
+  it('a door drag commits ONE chain through onDoorDraw', () => {
+    const onDoorDraw = vi.fn();
+    const { container } = mount(floorDoc(), { tool: 'door', onDoorDraw });
+    const svg = enableSvgCtm(container);
+    fireEvent.pointerDown(cellEl(container, 1, 1), at(pt(A)));
+    fireEvent.pointerMove(cellEl(container, 2, 2), at(pt(B)));
+    fireEvent.pointerUp(svg);
+    expect(onDoorDraw).toHaveBeenCalledTimes(1);
+    expect(keys(onDoorDraw.mock.calls[0][0])).toEqual(keys(expectedChain()));
+  });
+
+  it('grabbing a selected wall’s handle re-derives the chain through onWallReshape', () => {
+    const onWallReshape = vi.fn();
+    const wall: Edge[] = [[p(1, 1), p(2, 1)]];
+    const doc = addWalls(floorDoc(), wall);
+    const { container } = mount(doc, {
+      tool: 'select',
+      selection: { kind: 'wall', edges: doc.walls },
+      onWallReshape,
+    });
+    const svg = enableSvgCtm(container);
+    // The handle sits at the RENDERED endpoint; grab the bottom one.
+    const vertices = runVertices(boardWallScene(doc, S)!.runs, S, 'pointy');
+    const bottom = vertices.reduce((acc, v) =>
+      v.point.y > acc.point.y ? v : acc
+    );
+    const target = ref(1, 1, 2); // (√3·1.5, 2.5)·size
+    fireEvent.pointerDown(cellEl(container, 1, 1), at(bottom.point));
+    fireEvent.pointerMove(cellEl(container, 1, 1), at(pt(target)));
+    fireEvent.pointerUp(svg);
+    expect(onWallReshape).toHaveBeenCalledTimes(1);
+    const [oldChains, newChains] = onWallReshape.mock.calls[0];
+    expect(oldChains.map(keys)).toEqual([keys(wall)]);
+    const far = vertices.find((v) => v !== bottom)!;
+    expect(newChains.map(keys)).toEqual([
+      keys(tautPath(far.ref, target, S, 'pointy')),
+    ]);
+  });
+
+  it('a canceled pointer drops the gesture without committing', () => {
+    const onWallDraw = vi.fn();
+    const { container } = mount(floorDoc(), { tool: 'wall', onWallDraw });
+    const svg = enableSvgCtm(container);
+    fireEvent.pointerDown(cellEl(container, 1, 1), at(pt(A)));
+    fireEvent.pointerMove(cellEl(container, 2, 2), at(pt(B)));
+    fireEvent.pointerCancel(svg);
+    fireEvent.pointerUp(svg); // a later unrelated release commits nothing
+    expect(onWallDraw).not.toHaveBeenCalled();
   });
 });

--- a/src/author/creation/CreationBoard.test.tsx
+++ b/src/author/creation/CreationBoard.test.tsx
@@ -43,6 +43,7 @@ function mount(doc: DungeonDoc, overrides: Partial<CreationBoardProps> = {}) {
       onWallDraw={() => {}}
       onWallErase={() => {}}
       onWallReshape={() => {}}
+      onDoorDraw={() => {}}
       onCellClick={() => {}}
       onSelect={() => {}}
       {...overrides}
@@ -194,6 +195,7 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
         onWallDraw={() => {}}
         onWallErase={() => {}}
         onWallReshape={() => {}}
+        onDoorDraw={() => {}}
         onCellClick={() => {}}
         onSelect={() => {}}
       />
@@ -238,6 +240,7 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
         onWallDraw={() => {}}
         onWallErase={() => {}}
         onWallReshape={() => {}}
+        onDoorDraw={() => {}}
         onCellClick={() => {}}
         onSelect={() => {}}
       />

--- a/src/author/creation/CreationBoard.test.tsx
+++ b/src/author/creation/CreationBoard.test.tsx
@@ -5,6 +5,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
+  addWalls,
   emptyDungeon,
   eraseCell,
   paintCell,
@@ -41,6 +42,7 @@ function mount(doc: DungeonDoc, overrides: Partial<CreationBoardProps> = {}) {
       onEdgeClick={(e) => calls.edges.push(e)}
       onWallDraw={() => {}}
       onWallErase={() => {}}
+      onWallReshape={() => {}}
       onCellClick={() => {}}
       onSelect={() => {}}
       {...overrides}
@@ -191,6 +193,7 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
         onEdgeClick={() => {}}
         onWallDraw={() => {}}
         onWallErase={() => {}}
+        onWallReshape={() => {}}
         onCellClick={() => {}}
         onSelect={() => {}}
       />
@@ -234,6 +237,7 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
         onEdgeClick={() => {}}
         onWallDraw={() => {}}
         onWallErase={() => {}}
+        onWallReshape={() => {}}
         onCellClick={() => {}}
         onSelect={() => {}}
       />
@@ -298,5 +302,39 @@ describe('CreationBoard viewport (Kirk walk 2026-08-23: no jumping at the edges)
       6
     );
     expect(container.querySelector('[data-facing-tick="1"]')).toBeNull();
+  });
+});
+
+describe('wall gesture affordances (#804)', () => {
+  function walledDoc() {
+    let doc = emptyDungeon();
+    for (const [c, r] of [
+      [1, 1],
+      [2, 1],
+      [1, 2],
+      [2, 2],
+    ] as const) {
+      doc = paintCell(doc, 'region-1', p(c, r));
+    }
+    return addWalls(doc, [[p(1, 1), p(2, 1)]]);
+  }
+
+  it('the wall tool shows a handle at each chain endpoint', () => {
+    const { container } = mount(walledDoc(), { tool: 'wall' });
+    // One single-edge run: two endpoint vertices, each with exactly one
+    // incident run.
+    const handles = container.querySelectorAll('[data-run-vertex]');
+    expect(handles).toHaveLength(2);
+    handles.forEach((h) => expect(h.getAttribute('data-run-vertex')).toBe('1'));
+  });
+
+  it('a wall selection highlights the run whose edges it holds', () => {
+    const doc = walledDoc();
+    const { container } = mount(doc, {
+      tool: 'select',
+      selection: { kind: 'wall', edges: doc.walls },
+    });
+    const selected = container.querySelectorAll('[data-run][data-selected]');
+    expect(selected).toHaveLength(1);
   });
 });

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -261,14 +261,7 @@ export function CreationBoard({
   // never the mid-gesture candidate's, or the endpoint would chase its
   // own preview.
   const vertices = useMemo(
-    () =>
-      wallScene
-        ? runVertices(
-            wallScene.runs.map((r) => r.edges),
-            size,
-            o
-          )
-        : [],
+    () => (wallScene ? runVertices(wallScene.runs, size, o) : []),
     [wallScene, size, o]
   );
   // THE PREVIEW IS THE COMMIT: the candidate document is the same
@@ -330,13 +323,33 @@ export function CreationBoard({
   }, [gesture, doc, chains]);
   const displayDoc = previewDoc ?? doc;
   const scene = previewDoc ? previewScene : wallScene;
-  // The handle under the pointer (wall tool, not mid-drag): grabbing it
-  // starts a reshape instead of a new wall.
+  // Manipulation rides SELECTION (Kirk's walk ruling, 2026-08-25 —
+  // Strava-route-builder grammar): selecting a wall shows its handles
+  // immediately and they drag right there with the Select tool; the
+  // wall tool stays pure draw/erase, so pressing near a chain end
+  // CONTINUES the wall instead of grabbing it (the old hover-grab made
+  // continuation impossible within the pickup radius).
+  const selectedRunIndices = useMemo(() => {
+    if (!wallScene || selection?.kind !== 'wall') return new Set<number>();
+    const keys = new Set(selection.edges.map(edgeKey));
+    const indices = new Set<number>();
+    wallScene.runs.forEach((r, i) => {
+      if (r.edges.some((edge) => keys.has(edgeKey(edge)))) indices.add(i);
+    });
+    return indices;
+  }, [wallScene, selection]);
+  const handleVertices = useMemo(
+    () =>
+      selectedRunIndices.size === 0
+        ? []
+        : vertices.filter((v) => v.runs.some((i) => selectedRunIndices.has(i))),
+    [vertices, selectedRunIndices]
+  );
   const hoverVertex = useMemo(() => {
-    if (tool !== 'wall' || gesture || !hoverPoint) return null;
+    if (tool !== 'select' || gesture || !hoverPoint) return null;
     let best: RunVertex | null = null;
     let bestDist = GESTURE_TUNING.cornerSnapRadius * size;
-    for (const v of vertices) {
+    for (const v of handleVertices) {
       const d = Math.hypot(v.point.x - hoverPoint.x, v.point.y - hoverPoint.y);
       if (d <= bestDist) {
         best = v;
@@ -344,7 +357,7 @@ export function CreationBoard({
       }
     }
     return best;
-  }, [tool, gesture, hoverPoint, vertices, size]);
+  }, [tool, gesture, hoverPoint, handleVertices, size]);
   useEffect(() => {
     if (!gesture) return;
     const onKey = (e: KeyboardEvent) => {
@@ -409,35 +422,11 @@ export function CreationBoard({
       const pressEdge = nearestEdge(cell, p, size, o);
       if (tool === 'wall') {
         const erase = e.shiftKey || e.button === 2;
-        // A handle under the pointer grabs the incident chains instead
-        // of starting a new wall (rulings 2 + 4): each re-derives from
-        // its own far endpoint — the far endpoint is the chain's OTHER
-        // odd-degree lattice vertex.
-        if (!erase && hoverVertex && wallScene) {
-          const grabbed = hoverVertex;
-          const chainsToDrag = grabbed.runs.flatMap((runIndex) => {
-            const edges = wallScene.runs[runIndex]?.edges ?? [];
-            const far = chainEndpoints(edges, size, o).find(
-              (r) => !sameCorner(r, grabbed.ref, size, o)
-            );
-            return far ? [{ far, old: edges }] : [];
-          });
-          if (chainsToDrag.length > 0) {
-            setGesture({
-              kind: 'reshape',
-              chains: chainsToDrag,
-              origin: grabbed.ref,
-              b: grabbed.ref,
-              moved: false,
-              draggedRuns: grabbed.runs,
-            });
-            setHoverEdge(null);
-            return;
-          }
-        }
         // Press anchors A (wall-vertex magnetism first, then the
         // corner lattice); release decides click vs drag. Shift or
         // right button erases along the derived path (ruling 3).
+        // Pressing at an existing chain's rendered end magnetizes A
+        // onto its vertex — that is how a wall is CONTINUED.
         const a = snapGesturePoint(p, size, o, { wallVertices: vertices });
         setGesture({
           kind: erase ? 'erase' : 'draw',
@@ -467,6 +456,31 @@ export function CreationBoard({
       return;
     }
     if (tool === 'select') {
+      // A handle on the selected wall grabs its incident chains
+      // (rulings 2 + 4, riding selection): each re-derives from its own
+      // far endpoint — the chain's OTHER odd-degree lattice vertex.
+      if (hoverVertex && wallScene) {
+        const grabbed = hoverVertex;
+        const chainsToDrag = grabbed.runs.flatMap((runIndex) => {
+          const edges = wallScene.runs[runIndex]?.edges ?? [];
+          const far = chainEndpoints(edges, size, o).find(
+            (r) => !sameCorner(r, grabbed.ref, size, o)
+          );
+          return far ? [{ far, old: [...edges] }] : [];
+        });
+        if (chainsToDrag.length > 0) {
+          setGesture({
+            kind: 'reshape',
+            chains: chainsToDrag,
+            origin: grabbed.ref,
+            b: grabbed.ref,
+            moved: false,
+            draggedRuns: grabbed.runs,
+          });
+          setHoverEdge(null);
+          return;
+        }
+      }
       const key = axialKey(cell);
       const placementIndex = doc.place.findIndex((p) => axialKey(p.at) === key);
       if (placementIndex !== -1) {
@@ -534,7 +548,7 @@ export function CreationBoard({
       }
       return;
     }
-    if (tool === 'wall' && svgRef.current) {
+    if (tool === 'select' && svgRef.current) {
       setHoverPoint(svgPoint(svgRef.current, e));
     }
     if ((edgeTool || tool === 'select') && svgRef.current) {
@@ -897,12 +911,14 @@ export function CreationBoard({
                 );
               })()}
           </g>
-          {tool === 'wall' && !gesture && (
+          {tool === 'select' && !gesture && (
             <g data-layer="handles" pointerEvents="none">
-              {/* Every chain endpoint / shared corner is a handle
-                  (rulings 2 + 4); the one under the pointer lights up
-                  to say a press grabs it instead of drawing. */}
-              {vertices.map((v) => {
+              {/* The selected wall's endpoints and shared corners are
+                  drag handles, visible the moment it is selected
+                  (Kirk's walk ruling: manipulation rides selection,
+                  the Strava-route-builder grammar). Drawn at the
+                  RENDERED endpoints — the points the author sees. */}
+              {handleVertices.map((v) => {
                 const hot =
                   hoverVertex !== null &&
                   sameCorner(v.ref, hoverVertex.ref, size, o);

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -311,7 +311,17 @@ export function CreationBoard({
         doc,
         gesture.chains.flatMap((c) => c.old)
       );
-      return chains.flatMap((c) => deriveWallAdd(base, c));
+      // Two re-derived chains can share an edge near the dragged
+      // vertex; dedup so the trace draws (and keys) each edge once.
+      const seen = new Set<string>();
+      return chains
+        .flatMap((c) => deriveWallAdd(base, c))
+        .filter((edge) => {
+          const key = edgeKey(edge);
+          if (seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
     }
     if (gesture.kind === 'erase') return deriveWallErase(doc, chains[0]);
     return gesture.tool === 'door'

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -345,19 +345,30 @@ export function CreationBoard({
         : vertices.filter((v) => v.runs.some((i) => selectedRunIndices.has(i))),
     [vertices, selectedRunIndices]
   );
-  const hoverVertex = useMemo(() => {
-    if (tool !== 'select' || gesture || !hoverPoint) return null;
-    let best: RunVertex | null = null;
-    let bestDist = GESTURE_TUNING.cornerSnapRadius * size;
-    for (const v of handleVertices) {
-      const d = Math.hypot(v.point.x - hoverPoint.x, v.point.y - hoverPoint.y);
-      if (d <= bestDist) {
-        best = v;
-        bestDist = d;
+  // The selected wall's handle nearest `p`, within the pickup radius —
+  // used for the hover affordance AND hit-tested directly on pointer
+  // down (Copilot review, PR #808: gating the press on hover state
+  // misses direct-touch input, which presses without a hover pass).
+  const handleAt = useCallback(
+    (p: Point): RunVertex | null => {
+      let best: RunVertex | null = null;
+      let bestDist = GESTURE_TUNING.cornerSnapRadius * size;
+      for (const v of handleVertices) {
+        const d = Math.hypot(v.point.x - p.x, v.point.y - p.y);
+        if (d <= bestDist) {
+          best = v;
+          bestDist = d;
+        }
       }
-    }
-    return best;
-  }, [tool, gesture, hoverPoint, handleVertices, size]);
+      return best;
+    },
+    [handleVertices, size]
+  );
+  const hoverVertex = useMemo(
+    () =>
+      tool !== 'select' || gesture || !hoverPoint ? null : handleAt(hoverPoint),
+    [tool, gesture, hoverPoint, handleAt]
+  );
   useEffect(() => {
     if (!gesture) return;
     const onKey = (e: KeyboardEvent) => {
@@ -459,8 +470,12 @@ export function CreationBoard({
       // A handle on the selected wall grabs its incident chains
       // (rulings 2 + 4, riding selection): each re-derives from its own
       // far endpoint — the chain's OTHER odd-degree lattice vertex.
-      if (hoverVertex && wallScene) {
-        const grabbed = hoverVertex;
+      // Hit-tested against the press point itself, not hover state.
+      const grabbed =
+        wallScene && svgRef.current
+          ? handleAt(svgPoint(svgRef.current, e))
+          : null;
+      if (grabbed && wallScene) {
         const chainsToDrag = grabbed.runs.flatMap((runIndex) => {
           const edges = wallScene.runs[runIndex]?.edges ?? [];
           const far = chainEndpoints(edges, size, o).find(
@@ -683,6 +698,17 @@ export function CreationBoard({
           onPointerUp={() => {
             endPaint();
             finishGesture();
+          }}
+          onPointerCancel={() => {
+            // A browser-canceled pointer (touch interruption, capture
+            // loss) must drop the in-flight gesture WITHOUT committing
+            // it — otherwise a later unrelated pointer-up would commit
+            // the stale chain (Copilot review, PR #808).
+            endPaint();
+            setGesture(null);
+            setHoverEdge(null);
+            setHoverCell(null);
+            setHoverPoint(null);
           }}
           onPointerLeave={() => {
             endPaint();

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -60,10 +60,12 @@ import {
 } from './canvasGeometry';
 import { cornerPoint, sameCorner, type CornerRef } from './hexCorner';
 import {
+  applyDoorDraw,
   applyReshape,
   applyWallDraw,
   applyWallErase,
   chainEndpoints,
+  deriveDoorAdd,
   deriveWallAdd,
   deriveWallErase,
   GESTURE_TUNING,
@@ -103,6 +105,9 @@ export interface CreationBoardProps {
    * own fixed far endpoint. Raw chains; the owner applies the same
    * `applyReshape` the preview used. */
   onWallReshape: (oldChains: Edge[][], newChains: Edge[][]) => void;
+  /** A door drag's chain becomes ONE door's edges[] (design §Doors
+   * compose); a door click stays today's per-edge toggle. */
+  onDoorDraw: (chain: Edge[]) => void;
   onCellClick: (cell: Axial) => void;
   onSelect: (selection: Selection) => void;
 }
@@ -123,6 +128,9 @@ function svgPoint(svg: SVGSVGElement, e: PointerEvent): Point {
  * today's single-edge toggle, released on pointer up. */
 interface DrawGesture {
   kind: 'draw' | 'erase';
+  /** The door tool inherits the same drag (design §Doors compose): one
+   * drag's chain becomes ONE door's edges[]. Erase stays wall-only. */
+  tool: 'wall' | 'door';
   a: CornerRef;
   b: CornerRef;
   moved: boolean;
@@ -157,6 +165,7 @@ export function CreationBoard({
   onWallDraw,
   onWallErase,
   onWallReshape,
+  onDoorDraw,
   onCellClick,
   onSelect,
 }: CreationBoardProps) {
@@ -284,9 +293,10 @@ export function CreationBoard({
         chains
       );
     }
-    return gesture.kind === 'draw'
-      ? applyWallDraw(doc, chains[0])
-      : applyWallErase(doc, chains[0]);
+    if (gesture.kind === 'erase') return applyWallErase(doc, chains[0]);
+    return gesture.tool === 'door'
+      ? applyDoorDraw(doc, chains[0])
+      : applyWallDraw(doc, chains[0]);
   }, [gesture, doc, chains]);
   const previewScene = useMemo(
     () => (previewDoc ? boardWallScene(previewDoc, size) : null),
@@ -303,9 +313,10 @@ export function CreationBoard({
       );
       return chains.flatMap((c) => deriveWallAdd(base, c));
     }
-    return gesture.kind === 'draw'
-      ? deriveWallAdd(doc, chains[0])
-      : deriveWallErase(doc, chains[0]);
+    if (gesture.kind === 'erase') return deriveWallErase(doc, chains[0]);
+    return gesture.tool === 'door'
+      ? deriveDoorAdd(doc, chains[0])
+      : deriveWallAdd(doc, chains[0]);
   }, [gesture, doc, chains]);
   const displayDoc = previewDoc ?? doc;
   const scene = previewDoc ? previewScene : wallScene;
@@ -420,6 +431,7 @@ export function CreationBoard({
         const a = snapGesturePoint(p, size, o, { wallVertices: vertices });
         setGesture({
           kind: erase ? 'erase' : 'draw',
+          tool: 'wall',
           a,
           b: a,
           moved: false,
@@ -428,7 +440,20 @@ export function CreationBoard({
         setHoverEdge(null);
         return;
       }
-      onEdgeClick(pressEdge);
+      if (e.shiftKey || e.button === 2) {
+        onEdgeClick(pressEdge);
+        return;
+      }
+      const a = snapGesturePoint(p, size, o, { wallVertices: vertices });
+      setGesture({
+        kind: 'draw',
+        tool: 'door',
+        a,
+        b: a,
+        moved: false,
+        pressEdge,
+      });
+      setHoverEdge(null);
       return;
     }
     if (tool === 'select') {
@@ -546,8 +571,9 @@ export function CreationBoard({
       return;
     }
     if (sameCorner(gesture.a, gesture.b, size, o)) return;
-    if (gesture.kind === 'draw') onWallDraw(chains[0]);
-    else onWallErase(chains[0]);
+    if (gesture.kind === 'erase') onWallErase(chains[0]);
+    else if (gesture.tool === 'door') onDoorDraw(chains[0]);
+    else onWallDraw(chains[0]);
   };
 
   const selectedRegion = selection?.kind === 'region' ? selection.id : null;

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -12,6 +12,7 @@
 import { facingAngleDeg } from '@/components/hex-grid/facingYaw';
 import {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -56,6 +57,16 @@ import {
   viewRectFor,
   type GridBounds,
 } from './canvasGeometry';
+import { cornerPoint, sameCorner, type CornerRef } from './hexCorner';
+import {
+  applyWallDraw,
+  applyWallErase,
+  deriveWallAdd,
+  deriveWallErase,
+  runVertices,
+  snapGesturePoint,
+  tautPath,
+} from './wallGesture';
 
 export const BOARD_HEX_SIZE = 24;
 
@@ -75,6 +86,12 @@ export interface CreationBoardProps {
   onPaint: (cell: Axial) => void;
   onErase: (cell: Axial) => void;
   onEdgeClick: (edge: Edge) => void;
+  /** The wall drag's commit (#804): the RAW taut chain of the released
+   * drag — the owner applies the same `applyWallDraw` the preview used,
+   * so the preview IS the commit. */
+  onWallDraw: (chain: Edge[]) => void;
+  /** Shift/right-drag erase along the same derived path (ruling 3). */
+  onWallErase: (chain: Edge[]) => void;
   onCellClick: (cell: Axial) => void;
   onSelect: (selection: Selection) => void;
 }
@@ -90,6 +107,17 @@ function svgPoint(svg: SVGSVGElement, e: PointerEvent): Point {
   return { x: p.x, y: p.y };
 }
 
+/** One in-flight wall drag (#804). `pressEdge` carries the click
+ * fallback: a press that never moves off its snapped corner stays
+ * today's single-edge toggle, released on pointer up. */
+interface DragGesture {
+  kind: 'draw' | 'erase';
+  a: CornerRef;
+  b: CornerRef;
+  moved: boolean;
+  pressEdge: Edge;
+}
+
 export function CreationBoard({
   doc,
   tool,
@@ -99,6 +127,8 @@ export function CreationBoard({
   onPaint,
   onErase,
   onEdgeClick,
+  onWallDraw,
+  onWallErase,
   onCellClick,
   onSelect,
 }: CreationBoardProps) {
@@ -187,6 +217,60 @@ export function CreationBoard({
   // the document directly, not the debounced server compile, so the
   // wall the author just clicked straightens immediately.
   const wallScene = useMemo(() => boardWallScene(doc, size), [doc, size]);
+  const [gesture, setGesture] = useState<DragGesture | null>(null);
+  // The magnetism targets and (later) drag handles: the lattice
+  // vertices at the ends of the COMMITTED doc's rendered chains —
+  // never the mid-gesture candidate's, or the endpoint would chase its
+  // own preview.
+  const vertices = useMemo(
+    () =>
+      wallScene
+        ? runVertices(
+            wallScene.runs.map((r) => r.edges),
+            size,
+            o
+          )
+        : [],
+    [wallScene, size, o]
+  );
+  // THE PREVIEW IS THE COMMIT: the candidate document is the same
+  // mutator composition the release applies (wallGesture's apply*),
+  // and its runs come from the same shared geometry module. On
+  // flat-top docs boardWallScene stays null and the literal edge
+  // drawing below previews the candidate doc instead — the honest
+  // picture there (#763).
+  const chain = useMemo(
+    () => (gesture ? tautPath(gesture.a, gesture.b, size, o) : []),
+    [gesture, size, o]
+  );
+  const previewDoc = useMemo(() => {
+    if (!gesture || !gesture.moved) return null;
+    return gesture.kind === 'draw'
+      ? applyWallDraw(doc, chain)
+      : applyWallErase(doc, chain);
+  }, [gesture, doc, chain]);
+  const previewScene = useMemo(
+    () => (previewDoc ? boardWallScene(previewDoc, size) : null),
+    [previewDoc, size]
+  );
+  // The faint literal trace of the candidate edges (draw), or of the
+  // edges about to be removed (erase).
+  const traceEdges = useMemo(() => {
+    if (!gesture || !gesture.moved) return [];
+    return gesture.kind === 'draw'
+      ? deriveWallAdd(doc, chain)
+      : deriveWallErase(doc, chain);
+  }, [gesture, doc, chain]);
+  const displayDoc = previewDoc ?? doc;
+  const scene = previewDoc ? previewScene : wallScene;
+  useEffect(() => {
+    if (!gesture) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setGesture(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [gesture]);
   const doorById = useMemo(
     () => new Map(doc.doors.map((d) => [d.id, d] as const)),
     [doc.doors]
@@ -239,7 +323,24 @@ export function CreationBoard({
     }
     if (edgeTool) {
       if (!svgRef.current || !owners.has(axialKey(cell))) return;
-      onEdgeClick(nearestEdge(cell, svgPoint(svgRef.current, e), size, o));
+      const p = svgPoint(svgRef.current, e);
+      const pressEdge = nearestEdge(cell, p, size, o);
+      if (tool === 'wall') {
+        // Press anchors A (wall-vertex magnetism first, then the
+        // corner lattice); release decides click vs drag. Shift or
+        // right button erases along the derived path (ruling 3).
+        const a = snapGesturePoint(p, size, o, { wallVertices: vertices });
+        setGesture({
+          kind: e.shiftKey || e.button === 2 ? 'erase' : 'draw',
+          a,
+          b: a,
+          moved: false,
+          pressEdge,
+        });
+        setHoverEdge(null);
+        return;
+      }
+      onEdgeClick(pressEdge);
       return;
     }
     if (tool === 'select') {
@@ -266,6 +367,22 @@ export function CreationBoard({
     if (painting.current && (tool === 'region' || tool === 'erase')) {
       applyBrush(cell, painting.current);
     }
+    if (gesture && svgRef.current) {
+      // Every move re-snaps B: wall vertices first, then the corner
+      // lattice, with angle magnetism toward the seam families unless
+      // Alt is held (ruling 1). The preview re-derives from the doc on
+      // every change of B — O(chain) + the shared module's O(walls).
+      const b = snapGesturePoint(svgPoint(svgRef.current, e), size, o, {
+        origin: cornerPoint(gesture.a, size, o),
+        alt: e.altKey,
+        wallVertices: vertices,
+      });
+      const moved = gesture.moved || !sameCorner(b, gesture.a, size, o);
+      if (moved !== gesture.moved || !sameCorner(b, gesture.b, size, o)) {
+        setGesture({ ...gesture, b, moved });
+      }
+      return;
+    }
     if ((edgeTool || tool === 'select') && svgRef.current) {
       if (!owners.has(axialKey(cell))) {
         setHoverEdge(null);
@@ -287,6 +404,21 @@ export function CreationBoard({
     painting.current = null;
   };
 
+  // Release commits (or falls back to the single-edge click); releasing
+  // with B back on A after moving, or Escape, or leaving the canvas,
+  // cancels.
+  const finishGesture = () => {
+    if (!gesture) return;
+    setGesture(null);
+    if (!gesture.moved) {
+      onEdgeClick(gesture.pressEdge);
+      return;
+    }
+    if (sameCorner(gesture.a, gesture.b, size, o)) return;
+    if (gesture.kind === 'draw') onWallDraw(chain);
+    else onWallErase(chain);
+  };
+
   const selectedRegion = selection?.kind === 'region' ? selection.id : null;
   const selectedDoor = selection?.kind === 'door' ? selection.id : null;
   const selectedPlacement =
@@ -297,7 +429,7 @@ export function CreationBoard({
   // literal, drawn on top of the runs — an error is edge-scoped truth
   // about what the author clicked, not about the fitted line (#800).
   // On a flat-top document everything stays literal, as before.
-  const straightened = wallScene !== null;
+  const straightened = scene !== null;
   const edgeLines: {
     key: string;
     edge: Edge;
@@ -305,7 +437,7 @@ export function CreationBoard({
     width: number;
     dash?: string;
   }[] = [];
-  for (const w of doc.walls) {
+  for (const w of displayDoc.walls) {
     const isError = errorEdges.has(edgeKey(w));
     if (straightened && !isError) continue;
     edgeLines.push({
@@ -315,7 +447,7 @@ export function CreationBoard({
       width: 4,
     });
   }
-  for (const d of doc.doors) {
+  for (const d of displayDoc.doors) {
     for (const e of d.edges) {
       const k = edgeKey(e);
       const isError = errorEdges.has(k);
@@ -354,9 +486,13 @@ export function CreationBoard({
             touchAction: 'none',
             cursor: cursorFor(tool),
           }}
-          onPointerUp={endPaint}
+          onPointerUp={() => {
+            endPaint();
+            finishGesture();
+          }}
           onPointerLeave={() => {
             endPaint();
+            setGesture(null);
             setHoverEdge(null);
             setHoverCell(null);
           }}
@@ -509,7 +645,7 @@ export function CreationBoard({
                 but sits IN the run's gap, exactly where 3D will put it;
                 hit-testing stays edge-based (this layer takes no
                 pointer events). */}
-            {wallScene?.runs.map((r) => (
+            {scene?.runs.map((r) => (
               <line
                 key={`run:${r.key}`}
                 data-run={r.key}
@@ -521,7 +657,7 @@ export function CreationBoard({
                 strokeWidth={4}
               />
             ))}
-            {wallScene?.doors.map((d) => {
+            {scene?.doors.map((d) => {
               const doorDoc = doorById.get(d.doorId);
               return (
                 <line
@@ -574,6 +710,49 @@ export function CreationBoard({
                 );
               })()}
           </g>
+          {gesture && gesture.moved && (
+            <g data-layer="gesture" pointerEvents="none">
+              {/* The faint literal trace of the candidate edges — the
+                  chain the drag derived (skipped pairs shown absent),
+                  or the walls the erase will remove. The straightened
+                  result is already live above via the candidate doc. */}
+              {traceEdges.map((edge) => {
+                const seg = edgeSegment(edge, size, o);
+                if (!seg) return null;
+                return (
+                  <line
+                    key={`trace:${edgeKey(edge)}`}
+                    data-gesture-trace={edgeKey(edge)}
+                    x1={seg.a.x}
+                    y1={seg.a.y}
+                    x2={seg.b.x}
+                    y2={seg.b.y}
+                    stroke={
+                      gesture.kind === 'erase' ? ERROR_STROKE : HOVER_STROKE
+                    }
+                    strokeWidth={3}
+                    strokeOpacity={0.4}
+                    strokeDasharray="3 3"
+                  />
+                );
+              })}
+              {(['a', 'b'] as const).map((end) => {
+                const p = cornerPoint(gesture[end], size, o);
+                return (
+                  <circle
+                    key={end}
+                    data-gesture-end={end}
+                    cx={p.x}
+                    cy={p.y}
+                    r={size * 0.18}
+                    fill="none"
+                    stroke={HOVER_STROKE}
+                    strokeWidth={2}
+                  />
+                );
+              })}
+            </g>
+          )}
         </svg>
       </div>
     </div>

--- a/src/author/creation/CreationBoard.tsx
+++ b/src/author/creation/CreationBoard.tsx
@@ -24,6 +24,7 @@ import {
   doorEdgeOwners,
   floorOwners,
   isMonsterRef,
+  removeWalls,
   type DungeonDoc,
   type ErrorTarget,
 } from '../dungeonYaml';
@@ -34,14 +35,14 @@ import {
   DOOR_STROKE,
   ERROR_STROKE,
   HOVER_STROKE,
+  litColor,
   MONSTER_COLOR,
   PROP_COLOR,
+  regionColor,
   START_COLOR,
   VOID_FILL,
   VOID_STROKE,
   WALL_STROKE,
-  litColor,
-  regionColor,
 } from '../markerStyle';
 import { thumbForRef } from '../paletteData';
 import type { BoardTool, Selection } from '../types';
@@ -59,13 +60,18 @@ import {
 } from './canvasGeometry';
 import { cornerPoint, sameCorner, type CornerRef } from './hexCorner';
 import {
+  applyReshape,
   applyWallDraw,
   applyWallErase,
+  chainEndpoints,
   deriveWallAdd,
   deriveWallErase,
+  GESTURE_TUNING,
+  nearestRunIndex,
   runVertices,
   snapGesturePoint,
   tautPath,
+  type RunVertex,
 } from './wallGesture';
 
 export const BOARD_HEX_SIZE = 24;
@@ -92,6 +98,11 @@ export interface CreationBoardProps {
   onWallDraw: (chain: Edge[]) => void;
   /** Shift/right-drag erase along the same derived path (ruling 3). */
   onWallErase: (chain: Edge[]) => void;
+  /** Rulings 2 + 4: an endpoint or shared-corner drag replaces each
+   * incident run's old edges with its chain re-derived from that run's
+   * own fixed far endpoint. Raw chains; the owner applies the same
+   * `applyReshape` the preview used. */
+  onWallReshape: (oldChains: Edge[][], newChains: Edge[][]) => void;
   onCellClick: (cell: Axial) => void;
   onSelect: (selection: Selection) => void;
 }
@@ -110,13 +121,29 @@ function svgPoint(svg: SVGSVGElement, e: PointerEvent): Point {
 /** One in-flight wall drag (#804). `pressEdge` carries the click
  * fallback: a press that never moves off its snapped corner stays
  * today's single-edge toggle, released on pointer up. */
-interface DragGesture {
+interface DrawGesture {
   kind: 'draw' | 'erase';
   a: CornerRef;
   b: CornerRef;
   moved: boolean;
   pressEdge: Edge;
 }
+
+/** An endpoint or shared-corner grab (rulings 2 + 4): every incident
+ * chain re-derives from its own fixed far endpoint to wherever B goes.
+ * The endpoint grab is the one-incident-chain case. */
+interface ReshapeGesture {
+  kind: 'reshape';
+  chains: { far: CornerRef; old: Edge[] }[];
+  origin: CornerRef;
+  b: CornerRef;
+  moved: boolean;
+  /** Indices of the grabbed runs — their own vertices are excluded
+   * from the magnetism targets so the drag doesn't stick to itself. */
+  draggedRuns: number[];
+}
+
+type DragOrReshape = DrawGesture | ReshapeGesture;
 
 export function CreationBoard({
   doc,
@@ -129,6 +156,7 @@ export function CreationBoard({
   onEdgeClick,
   onWallDraw,
   onWallErase,
+  onWallReshape,
   onCellClick,
   onSelect,
 }: CreationBoardProps) {
@@ -217,7 +245,8 @@ export function CreationBoard({
   // the document directly, not the debounced server compile, so the
   // wall the author just clicked straightens immediately.
   const wallScene = useMemo(() => boardWallScene(doc, size), [doc, size]);
-  const [gesture, setGesture] = useState<DragGesture | null>(null);
+  const [gesture, setGesture] = useState<DragOrReshape | null>(null);
+  const [hoverPoint, setHoverPoint] = useState<Point | null>(null);
   // The magnetism targets and (later) drag handles: the lattice
   // vertices at the ends of the COMMITTED doc's rendered chains —
   // never the mid-gesture candidate's, or the endpoint would chase its
@@ -239,16 +268,26 @@ export function CreationBoard({
   // flat-top docs boardWallScene stays null and the literal edge
   // drawing below previews the candidate doc instead — the honest
   // picture there (#763).
-  const chain = useMemo(
-    () => (gesture ? tautPath(gesture.a, gesture.b, size, o) : []),
-    [gesture, size, o]
-  );
+  const chains = useMemo(() => {
+    if (!gesture) return [];
+    if (gesture.kind === 'reshape') {
+      return gesture.chains.map((c) => tautPath(c.far, gesture.b, size, o));
+    }
+    return [tautPath(gesture.a, gesture.b, size, o)];
+  }, [gesture, size, o]);
   const previewDoc = useMemo(() => {
     if (!gesture || !gesture.moved) return null;
+    if (gesture.kind === 'reshape') {
+      return applyReshape(
+        doc,
+        gesture.chains.map((c) => c.old),
+        chains
+      );
+    }
     return gesture.kind === 'draw'
-      ? applyWallDraw(doc, chain)
-      : applyWallErase(doc, chain);
-  }, [gesture, doc, chain]);
+      ? applyWallDraw(doc, chains[0])
+      : applyWallErase(doc, chains[0]);
+  }, [gesture, doc, chains]);
   const previewScene = useMemo(
     () => (previewDoc ? boardWallScene(previewDoc, size) : null),
     [previewDoc, size]
@@ -257,12 +296,34 @@ export function CreationBoard({
   // edges about to be removed (erase).
   const traceEdges = useMemo(() => {
     if (!gesture || !gesture.moved) return [];
+    if (gesture.kind === 'reshape') {
+      const base = removeWalls(
+        doc,
+        gesture.chains.flatMap((c) => c.old)
+      );
+      return chains.flatMap((c) => deriveWallAdd(base, c));
+    }
     return gesture.kind === 'draw'
-      ? deriveWallAdd(doc, chain)
-      : deriveWallErase(doc, chain);
-  }, [gesture, doc, chain]);
+      ? deriveWallAdd(doc, chains[0])
+      : deriveWallErase(doc, chains[0]);
+  }, [gesture, doc, chains]);
   const displayDoc = previewDoc ?? doc;
   const scene = previewDoc ? previewScene : wallScene;
+  // The handle under the pointer (wall tool, not mid-drag): grabbing it
+  // starts a reshape instead of a new wall.
+  const hoverVertex = useMemo(() => {
+    if (tool !== 'wall' || gesture || !hoverPoint) return null;
+    let best: RunVertex | null = null;
+    let bestDist = GESTURE_TUNING.cornerSnapRadius * size;
+    for (const v of vertices) {
+      const d = Math.hypot(v.point.x - hoverPoint.x, v.point.y - hoverPoint.y);
+      if (d <= bestDist) {
+        best = v;
+        bestDist = d;
+      }
+    }
+    return best;
+  }, [tool, gesture, hoverPoint, vertices, size]);
   useEffect(() => {
     if (!gesture) return;
     const onKey = (e: KeyboardEvent) => {
@@ -326,12 +387,39 @@ export function CreationBoard({
       const p = svgPoint(svgRef.current, e);
       const pressEdge = nearestEdge(cell, p, size, o);
       if (tool === 'wall') {
+        const erase = e.shiftKey || e.button === 2;
+        // A handle under the pointer grabs the incident chains instead
+        // of starting a new wall (rulings 2 + 4): each re-derives from
+        // its own far endpoint — the far endpoint is the chain's OTHER
+        // odd-degree lattice vertex.
+        if (!erase && hoverVertex && wallScene) {
+          const grabbed = hoverVertex;
+          const chainsToDrag = grabbed.runs.flatMap((runIndex) => {
+            const edges = wallScene.runs[runIndex]?.edges ?? [];
+            const far = chainEndpoints(edges, size, o).find(
+              (r) => !sameCorner(r, grabbed.ref, size, o)
+            );
+            return far ? [{ far, old: edges }] : [];
+          });
+          if (chainsToDrag.length > 0) {
+            setGesture({
+              kind: 'reshape',
+              chains: chainsToDrag,
+              origin: grabbed.ref,
+              b: grabbed.ref,
+              moved: false,
+              draggedRuns: grabbed.runs,
+            });
+            setHoverEdge(null);
+            return;
+          }
+        }
         // Press anchors A (wall-vertex magnetism first, then the
         // corner lattice); release decides click vs drag. Shift or
         // right button erases along the derived path (ruling 3).
         const a = snapGesturePoint(p, size, o, { wallVertices: vertices });
         setGesture({
-          kind: e.shiftKey || e.button === 2 ? 'erase' : 'draw',
+          kind: erase ? 'erase' : 'draw',
           a,
           b: a,
           moved: false,
@@ -354,6 +442,21 @@ export function CreationBoard({
         onSelect({ kind: 'door', id: doorOwners.get(edgeKey(hoverEdge))! });
         return;
       }
+      // A rendered run selects the doc edges behind it, resolved at
+      // click time from the derived scene — no wall id exists and none
+      // is added (#804). Flat-top docs draw literal edges, not runs, so
+      // there is nothing to hit here by construction.
+      if (wallScene && svgRef.current) {
+        const hit = nearestRunIndex(
+          wallScene.runs,
+          svgPoint(svgRef.current, e),
+          size
+        );
+        if (hit !== null) {
+          onSelect({ kind: 'wall', edges: wallScene.runs[hit].edges });
+          return;
+        }
+      }
       const owner = owners.get(key);
       if (owner) onSelect({ kind: 'region', id: owner });
       else onSelect({ kind: 'dungeon' });
@@ -372,16 +475,32 @@ export function CreationBoard({
       // lattice, with angle magnetism toward the seam families unless
       // Alt is held (ruling 1). The preview re-derives from the doc on
       // every change of B — O(chain) + the shared module's O(walls).
-      const b = snapGesturePoint(svgPoint(svgRef.current, e), size, o, {
-        origin: cornerPoint(gesture.a, size, o),
+      // A reshape drag skips angle magnetism (several chains would each
+      // want their own origin) and never magnetizes to the vertices of
+      // the runs being dragged — B would stick to its own old position.
+      const p = svgPoint(svgRef.current, e);
+      const anchor = gesture.kind === 'reshape' ? gesture.origin : gesture.a;
+      const b = snapGesturePoint(p, size, o, {
+        origin:
+          gesture.kind === 'reshape'
+            ? undefined
+            : cornerPoint(gesture.a, size, o),
         alt: e.altKey,
-        wallVertices: vertices,
+        wallVertices:
+          gesture.kind === 'reshape'
+            ? vertices.filter(
+                (v) => !v.runs.some((i) => gesture.draggedRuns.includes(i))
+              )
+            : vertices,
       });
-      const moved = gesture.moved || !sameCorner(b, gesture.a, size, o);
+      const moved = gesture.moved || !sameCorner(b, anchor, size, o);
       if (moved !== gesture.moved || !sameCorner(b, gesture.b, size, o)) {
         setGesture({ ...gesture, b, moved });
       }
       return;
+    }
+    if (tool === 'wall' && svgRef.current) {
+      setHoverPoint(svgPoint(svgRef.current, e));
     }
     if ((edgeTool || tool === 'select') && svgRef.current) {
       if (!owners.has(axialKey(cell))) {
@@ -410,17 +529,37 @@ export function CreationBoard({
   const finishGesture = () => {
     if (!gesture) return;
     setGesture(null);
+    if (gesture.kind === 'reshape') {
+      // Released in place = no-op; released elsewhere replaces every
+      // grabbed chain with its re-derived one.
+      if (!gesture.moved || sameCorner(gesture.origin, gesture.b, size, o)) {
+        return;
+      }
+      onWallReshape(
+        gesture.chains.map((c) => c.old),
+        chains
+      );
+      return;
+    }
     if (!gesture.moved) {
       onEdgeClick(gesture.pressEdge);
       return;
     }
     if (sameCorner(gesture.a, gesture.b, size, o)) return;
-    if (gesture.kind === 'draw') onWallDraw(chain);
-    else onWallErase(chain);
+    if (gesture.kind === 'draw') onWallDraw(chains[0]);
+    else onWallErase(chains[0]);
   };
 
   const selectedRegion = selection?.kind === 'region' ? selection.id : null;
   const selectedDoor = selection?.kind === 'door' ? selection.id : null;
+  // A selected wall is a set of doc edges; a run reads as selected when
+  // any of its source edges is in the set (the runs re-derive on every
+  // doc change, so membership is resolved at render time).
+  const selectedWallKeys = useMemo(
+    () =>
+      selection?.kind === 'wall' ? new Set(selection.edges.map(edgeKey)) : null,
+    [selection]
+  );
   const selectedPlacement =
     selection?.kind === 'placement' ? selection.index : null;
 
@@ -484,7 +623,12 @@ export function CreationBoard({
           style={{
             background: VOID_FILL,
             touchAction: 'none',
-            cursor: cursorFor(tool),
+            cursor:
+              gesture?.kind === 'reshape'
+                ? 'grabbing'
+                : hoverVertex
+                  ? 'grab'
+                  : cursorFor(tool),
           }}
           onPointerUp={() => {
             endPaint();
@@ -495,6 +639,7 @@ export function CreationBoard({
             setGesture(null);
             setHoverEdge(null);
             setHoverCell(null);
+            setHoverPoint(null);
           }}
           onContextMenu={(e) => e.preventDefault()}
         >
@@ -645,18 +790,24 @@ export function CreationBoard({
                 but sits IN the run's gap, exactly where 3D will put it;
                 hit-testing stays edge-based (this layer takes no
                 pointer events). */}
-            {scene?.runs.map((r) => (
-              <line
-                key={`run:${r.key}`}
-                data-run={r.key}
-                x1={r.a.x}
-                y1={r.a.y}
-                x2={r.b.x}
-                y2={r.b.y}
-                stroke={WALL_STROKE}
-                strokeWidth={4}
-              />
-            ))}
+            {scene?.runs.map((r) => {
+              const isSelected =
+                !!selectedWallKeys &&
+                r.edges.some((edge) => selectedWallKeys.has(edgeKey(edge)));
+              return (
+                <line
+                  key={`run:${r.key}`}
+                  data-run={r.key}
+                  data-selected={isSelected || undefined}
+                  stroke={isSelected ? HOVER_STROKE : WALL_STROKE}
+                  strokeWidth={isSelected ? 6 : 4}
+                  x1={r.a.x}
+                  y1={r.a.y}
+                  x2={r.b.x}
+                  y2={r.b.y}
+                />
+              );
+            })}
             {scene?.doors.map((d) => {
               const doorDoc = doorById.get(d.doorId);
               return (
@@ -710,6 +861,30 @@ export function CreationBoard({
                 );
               })()}
           </g>
+          {tool === 'wall' && !gesture && (
+            <g data-layer="handles" pointerEvents="none">
+              {/* Every chain endpoint / shared corner is a handle
+                  (rulings 2 + 4); the one under the pointer lights up
+                  to say a press grabs it instead of drawing. */}
+              {vertices.map((v) => {
+                const hot =
+                  hoverVertex !== null &&
+                  sameCorner(v.ref, hoverVertex.ref, size, o);
+                return (
+                  <circle
+                    key={`vx:${v.point.x.toFixed(2)},${v.point.y.toFixed(2)}`}
+                    data-run-vertex={v.runs.length}
+                    cx={v.point.x}
+                    cy={v.point.y}
+                    r={size * (hot ? 0.22 : 0.12)}
+                    fill={hot ? HOVER_STROKE : WALL_STROKE}
+                    fillOpacity={hot ? 0.9 : 0.5}
+                    stroke={hot ? HOVER_STROKE : 'none'}
+                  />
+                );
+              })}
+            </g>
+          )}
           {gesture && gesture.moved && (
             <g data-layer="gesture" pointerEvents="none">
               {/* The faint literal trace of the candidate edges — the
@@ -736,12 +911,15 @@ export function CreationBoard({
                   />
                 );
               })}
-              {(['a', 'b'] as const).map((end) => {
-                const p = cornerPoint(gesture[end], size, o);
+              {(gesture.kind === 'reshape'
+                ? [gesture.b, ...gesture.chains.map((c) => c.far)]
+                : [gesture.a, gesture.b]
+              ).map((end, i) => {
+                const p = cornerPoint(end, size, o);
                 return (
                   <circle
-                    key={end}
-                    data-gesture-end={end}
+                    key={`end:${i}`}
+                    data-gesture-end={i}
                     cx={p.x}
                     cy={p.y}
                     r={size * 0.18}

--- a/src/author/creation/boardWallRuns.test.ts
+++ b/src/author/creation/boardWallRuns.test.ts
@@ -16,7 +16,7 @@ import { hexCenter } from '../../concepts/session-tomb/atlas';
 import { emptyDungeon, paintCell, toggleWall } from '../dungeonYaml';
 import { fixtureAtlasOf } from '../fixtures/fixtureAtlas';
 import { referenceTombDoc } from '../fixtures/referenceTomb';
-import { fromOffset, type Axial } from '../hexOffset';
+import { edgeKey, fromOffset, type Axial } from '../hexOffset';
 import { BOARD_HEX_SIZE } from './CreationBoard';
 import {
   boardWallScene,
@@ -110,6 +110,18 @@ describe('boardWallScene', () => {
     const scene2d = boardWallScene(referenceTombDoc(), BOARD_HEX_SIZE)!;
     for (const run of scene2d.runs) {
       expect(Math.abs(run.a.x - run.b.x)).toBeLessThan(1e-6 * BOARD_HEX_SIZE);
+    }
+  });
+
+  it('threads each run’s source doc edges through (#804) — the union is exactly walls[]', () => {
+    const doc = referenceTombDoc();
+    const scene2d = boardWallScene(doc, BOARD_HEX_SIZE)!;
+    const threaded = scene2d.runs.flatMap((r) => r.edges).map(edgeKey);
+    // Every doc wall appears in exactly one run's source list, and no
+    // run carries an edge the doc doesn't have.
+    expect(threaded.sort()).toEqual(doc.walls.map(edgeKey).sort());
+    for (const run of scene2d.runs) {
+      expect(run.edges.length).toBeGreaterThan(0);
     }
   });
 

--- a/src/author/creation/boardWallRuns.ts
+++ b/src/author/creation/boardWallRuns.ts
@@ -57,9 +57,12 @@
 import {
   cubeToWorld,
   HEX_SIZE,
+  hexEdgeBetween,
   type WorldPos,
 } from '@/components/hex-grid/hexMath';
 import { boundariesToWallRuns } from '@/components/session/atlasWallRuns';
+import { positionToCube } from '@/components/session/positionBridge';
+import { vertexKey } from '@/hooks/authoredWallRuns';
 import { create } from '@bufbuild/protobuf';
 import {
   GetAtlasResponseSchema,
@@ -92,11 +95,21 @@ export function worldToBoard(
 }
 
 /** One straight wall run in SVG user space, keyed by the shared
- * module's own stable run key. */
+ * module's own stable run key — and carrying the document edges it was
+ * derived from (rpg-dnd5e-web#804), so a rendered run can answer "which
+ * doc edges am I" for hit-testing, selection, and the gesture's
+ * endpoint handles. Presentation metadata threaded ADDITIVELY on the
+ * board side only: the shared 3D module's geometry is untouched; the
+ * mapping rides the run's own `key`, which is the ';'-join of one token
+ * per constituent edge (`vertexKey(a)|vertexKey(b)` from
+ * `hexEdgeBetween` — see `edgeFitDataByToken`'s doc comment in
+ * atlasWallRuns.ts for why that token is bit-identical when recomputed
+ * here from the same cell pair). */
 export interface BoardWallRun {
   key: string;
   a: Point;
   b: Point;
+  edges: Edge[];
 }
 
 /** One door, drawn IN its run's gap (aligned to the straightened run,
@@ -131,10 +144,24 @@ const pos = (a: Axial) => ({ x: a.q, y: a.r });
 export function docAtlasFacts(doc: DungeonDoc): {
   facts: Pick<GetAtlasResponse, 'cells' | 'boundaries' | 'doorways'>;
   doorSources: { doorId: string; edge: Edge }[];
+  /** Run-key token (one per non-door edge, exactly as the chaining
+   * engine builds them into each run's `key`) → the document edge it
+   * came from — how `boardWallScene` threads each run's source edges
+   * through (#804). */
+  wallSourcesByToken: Map<string, Edge>;
 } {
   const doorSources = doc.doors.flatMap((d) =>
     d.edges.map((edge) => ({ doorId: d.id, edge }))
   );
+  const wallSourcesByToken = new Map<string, Edge>();
+  for (const edge of doc.walls) {
+    const { a, b } = hexEdgeBetween(
+      positionToCube({ x: edge[0].q, y: edge[0].r } as never),
+      positionToCube({ x: edge[1].q, y: edge[1].r } as never),
+      HEX_SIZE
+    );
+    wallSourcesByToken.set(`${vertexKey(a)}|${vertexKey(b)}`, edge);
+  }
   const facts = create(GetAtlasResponseSchema, {
     cells: doc.regions
       .flatMap((r) => r.cells)
@@ -152,7 +179,7 @@ export function docAtlasFacts(doc: DungeonDoc): {
       to: pos(b),
     })),
   });
-  return { facts, doorSources };
+  return { facts, doorSources, wallSourcesByToken };
 }
 
 /**
@@ -169,13 +196,21 @@ export function boardWallScene(
   boardHexSize: number
 ): BoardWallScene | null {
   if (doc.orientation !== 'pointy') return null;
-  const { facts, doorSources } = docAtlasFacts(doc);
+  const { facts, doorSources, wallSourcesByToken } = docAtlasFacts(doc);
   const { wallRuns, doorGaps } = boundariesToWallRuns(facts, HEX_SIZE);
   const project = (w: WorldPos) => worldToBoard(w, HEX_SIZE, boardHexSize);
   const runs: BoardWallRun[] = wallRuns.map((r) => ({
     key: r.key,
     a: project(r.start),
     b: project(r.end),
+    // Every token in a run's key is one constituent non-door edge; a
+    // missing lookup is never expected (every boundary fed to the
+    // engine came from doc.walls above) and is dropped rather than
+    // invented.
+    edges: r.key
+      .split(';')
+      .map((token) => wallSourcesByToken.get(token))
+      .filter((e): e is Edge => e !== undefined),
   }));
   const doors: BoardDoorRun[] = [];
   doorGaps.forEach((gap, i) => {

--- a/src/author/creation/hexCorner.test.ts
+++ b/src/author/creation/hexCorner.test.ts
@@ -1,0 +1,227 @@
+/**
+ * hexCorner — corner-lattice addressing pins (#804). Adapted from the
+ * pre-restart module's own test (`git show
+ * 6503936^:src/author/creation/hexCorner.test.ts`): the owner counts and
+ * canonicalization invariants are re-verified in the new axial +
+ * orientation-aware frame, not carried over on trust. Expected owner
+ * triples are hand-derived from `hexCorners`' own angle convention
+ * (pointy: corner i at −30° + 60°·i, SVG y-down) — exact addresses, not
+ * just counts, so a broken owner search cannot pass by finding the
+ * wrong three cells.
+ */
+import { describe, expect, it } from 'vitest';
+import { sameCell, type Axial } from '../hexOffset';
+import { cellCenter, edgeSegment } from './canvasGeometry';
+import {
+  canonicalCorner,
+  cellAtPoint,
+  cornerKey,
+  cornerNeighbors,
+  cornerOwners,
+  cornerPoint,
+  latticeEdgeCells,
+  nearestCorner,
+  sameCorner,
+  type CornerRef,
+} from './hexCorner';
+
+const SIZE = 24;
+const a = (q: number, r: number): Axial => ({ q, r });
+
+describe('cornerOwners — every interior corner is shared by exactly 3 cells', () => {
+  it('finds all 3 owners of (0,0)#0 (pointy), all at the same point', () => {
+    // Corner 0 of (0,0) sits at (√3/2, −1/2)·size. Its co-owners, by
+    // the corner-angle convention: (1,0)#4 (210°) and (1,−1)#2 (90°).
+    const owners = cornerOwners({ cell: a(0, 0), corner: 0 }, SIZE, 'pointy');
+    expect(owners).toHaveLength(3);
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        { cell: a(0, 0), corner: 0 },
+        { cell: a(1, 0), corner: 4 },
+        { cell: a(1, -1), corner: 2 },
+      ])
+    );
+    const points = owners.map((o) => cornerPoint(o, SIZE, 'pointy'));
+    for (const p of points) {
+      expect(p.x).toBeCloseTo(points[0].x, 8);
+      expect(p.y).toBeCloseTo(points[0].y, 8);
+    }
+  });
+
+  it('finds all 3 owners of (0,0)#1 (pointy)', () => {
+    const owners = cornerOwners({ cell: a(0, 0), corner: 1 }, SIZE, 'pointy');
+    expect(owners).toHaveLength(3);
+    expect(owners).toEqual(
+      expect.arrayContaining([
+        { cell: a(0, 0), corner: 1 },
+        { cell: a(1, 0), corner: 3 },
+        { cell: a(0, 1), corner: 5 },
+      ])
+    );
+  });
+
+  it('holds under flat-top too — 3 owners, one physical point', () => {
+    const owners = cornerOwners({ cell: a(2, 3), corner: 4 }, SIZE, 'flat');
+    expect(owners).toHaveLength(3);
+    const points = owners.map((o) => cornerPoint(o, SIZE, 'flat'));
+    for (const p of points) {
+      expect(p.x).toBeCloseTo(points[0].x, 8);
+      expect(p.y).toBeCloseTo(points[0].y, 8);
+    }
+  });
+});
+
+describe('canonicalCorner — deterministic single owner, smallest (r, q) wins', () => {
+  it('picks the smallest-r owner when rows differ', () => {
+    // (0,0)#0's owners are (0,0), (1,0), (1,−1) — r = −1 wins.
+    expect(
+      canonicalCorner({ cell: a(0, 0), corner: 0 }, SIZE, 'pointy')
+    ).toEqual({ cell: a(1, -1), corner: 2 });
+  });
+
+  it('picks the smallest-q owner when rows tie', () => {
+    // (0,0)#1's owners: (0,0) and (1,0) tie on r=0; q=0 beats q=1.
+    expect(
+      canonicalCorner({ cell: a(0, 0), corner: 1 }, SIZE, 'pointy')
+    ).toEqual({ cell: a(0, 0), corner: 1 });
+  });
+
+  it('every owner of the same vertex canonicalizes to the identical answer', () => {
+    for (const orientation of ['pointy', 'flat'] as const) {
+      const owners = cornerOwners(
+        { cell: a(3, 2), corner: 5 },
+        SIZE,
+        orientation
+      );
+      const canonical = owners.map((o) =>
+        canonicalCorner(o, SIZE, orientation)
+      );
+      for (const c of canonical) expect(c).toEqual(canonical[0]);
+    }
+  });
+
+  it('a negative-coordinate owner is a legal canonical address (the canvas grows in every direction)', () => {
+    const c = canonicalCorner({ cell: a(0, 0), corner: 0 }, SIZE, 'pointy');
+    expect(c.cell.r).toBe(-1);
+  });
+});
+
+describe('sameCorner / cornerKey — identity across differently-chosen owners', () => {
+  it('recognizes two different (cell,corner) pairs as the same physical vertex', () => {
+    expect(
+      sameCorner(
+        { cell: a(0, 0), corner: 1 },
+        { cell: a(0, 1), corner: 5 },
+        SIZE,
+        'pointy'
+      )
+    ).toBe(true);
+    expect(cornerKey({ cell: a(0, 0), corner: 1 }, SIZE, 'pointy')).toBe(
+      cornerKey({ cell: a(1, 0), corner: 3 }, SIZE, 'pointy')
+    );
+  });
+
+  it('rejects two genuinely different vertices', () => {
+    expect(
+      sameCorner(
+        { cell: a(0, 0), corner: 0 },
+        { cell: a(0, 0), corner: 1 },
+        SIZE,
+        'pointy'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('nearestCorner', () => {
+  it('snaps to the anchor cell’s own corner when the point sits near it', () => {
+    const target: CornerRef = { cell: a(2, 2), corner: 1 };
+    const p = cornerPoint(target, SIZE, 'pointy');
+    const snapped = nearestCorner({ x: p.x + 2, y: p.y - 3 }, SIZE, 'pointy');
+    expect(sameCorner(snapped, target, SIZE, 'pointy')).toBe(true);
+  });
+
+  it('can resolve to a neighbor cell’s corner when that one is truly nearest', () => {
+    // A point just OUTSIDE the anchor cell, past its corner 0, is
+    // nearest to a vertex the anchor also owns — but the check must
+    // consider neighbors' corners by real distance either way. Verify
+    // with a point near the MIDDLE of a neighboring cell's far edge.
+    const neighborCorner: CornerRef = { cell: a(3, 2), corner: 1 };
+    const p = cornerPoint(neighborCorner, SIZE, 'pointy');
+    const snapped = nearestCorner({ x: p.x - 1, y: p.y + 1 }, SIZE, 'pointy');
+    expect(sameCorner(snapped, neighborCorner, SIZE, 'pointy')).toBe(true);
+  });
+});
+
+describe('cellAtPoint — the exact inverse of cellCenter', () => {
+  it('round-trips cell centers and resolves off-center points, both orientations', () => {
+    for (const orientation of ['pointy', 'flat'] as const) {
+      for (const cell of [a(0, 0), a(3, 2), a(-2, 4), a(5, -3)]) {
+        const c = cellCenter(cell, SIZE, orientation);
+        expect(cellAtPoint(c, SIZE, orientation)).toEqual(cell);
+        // A point nudged toward a corner still resolves to the same cell
+        // (inside the hex), pinning the rounding correction too.
+        expect(
+          cellAtPoint(
+            { x: c.x + SIZE * 0.4, y: c.y + SIZE * 0.2 },
+            SIZE,
+            orientation
+          )
+        ).toEqual(cell);
+      }
+    }
+  });
+});
+
+describe('cornerNeighbors — the honeycomb’s 3 incident lattice edges', () => {
+  it('an interior corner has exactly 3 neighbors, each one hex side away', () => {
+    for (const orientation of ['pointy', 'flat'] as const) {
+      const ref: CornerRef = { cell: a(1, 1), corner: 2 };
+      const neighbors = cornerNeighbors(ref, SIZE, orientation);
+      expect(neighbors).toHaveLength(3);
+      const p0 = cornerPoint(ref, SIZE, orientation);
+      for (const n of neighbors) {
+        const p = cornerPoint(n, SIZE, orientation);
+        expect(Math.hypot(p.x - p0.x, p.y - p0.y)).toBeCloseTo(SIZE, 8);
+      }
+      // All three are distinct vertices.
+      const keys = new Set(
+        neighbors.map((n) => cornerKey(n, SIZE, orientation))
+      );
+      expect(keys.size).toBe(3);
+    }
+  });
+});
+
+describe('latticeEdgeCells — a lattice edge separates exactly one adjacent cell pair', () => {
+  it('recovers the cell pair whose shared side the two corners span', () => {
+    // The shared side of (0,0)/(1,0) runs corner-to-corner; walking its
+    // two endpoints back through the lattice must name exactly that
+    // pair (cross-checked against edgeSegment, the board's own edge
+    // geometry — one construction verifying the other).
+    for (const orientation of ['pointy', 'flat'] as const) {
+      const seg = edgeSegment([a(0, 0), a(1, 0)], SIZE, orientation)!;
+      const v = nearestCorner(seg.a, SIZE, orientation);
+      const w = nearestCorner(seg.b, SIZE, orientation);
+      const pair = latticeEdgeCells(v, w, SIZE, orientation);
+      expect(pair).not.toBeNull();
+      const cells = pair!;
+      expect(
+        (sameCell(cells[0], a(0, 0)) && sameCell(cells[1], a(1, 0))) ||
+          (sameCell(cells[0], a(1, 0)) && sameCell(cells[1], a(0, 0)))
+      ).toBe(true);
+    }
+  });
+
+  it('returns null for two corners that are not lattice-adjacent', () => {
+    // Opposite corners of one cell span the whole hex, not one side.
+    expect(
+      latticeEdgeCells(
+        { cell: a(0, 0), corner: 0 },
+        { cell: a(0, 0), corner: 3 },
+        SIZE,
+        'pointy'
+      )
+    ).toBeNull();
+  });
+});

--- a/src/author/creation/hexCorner.ts
+++ b/src/author/creation/hexCorner.ts
@@ -1,0 +1,276 @@
+/**
+ * hexCorner — corner-lattice addressing for the wall gesture's endpoints
+ * (rpg-dnd5e-web#804, design: rpg-project#267 `wall-authoring-gesture.md`).
+ *
+ * Resurrected from this repo's own history (the pre-restart builder's
+ * `hexCorner.ts`, `git show 6503936^:src/author/creation/hexCorner.ts`)
+ * rather than re-derived — the corner-anchoring lesson it encodes is
+ * Kirk's own, live: "it always hangs over a little." Cell-CENTER
+ * anchoring overshoots by up to half a hex at each end by construction,
+ * no matter how carefully a wall is drawn; corners are the finest honest
+ * lattice a hex grid has, and a corner is where a real wall's own
+ * boundary already lives (`edgeSegment`'s edge geometry is
+ * corner-to-corner). The adaptation: the old copy addressed corners as
+ * `{cell: [col,row], corner}` over the pointy-only `hexLayout` module;
+ * this one is AXIAL over `canvasGeometry.ts`'s orientation-aware SVG
+ * space, like everything else in `src/author/` (`hexOffset.ts`: nothing
+ * outside parse/emit holds a `[col,row]`).
+ *
+ * **Dedup convention.** Every interior corner is shared by exactly 3 hex
+ * cells (verified by `hexCorner.test.ts`'s `cornerOwners` cases, not
+ * assumed), so the same physical point has up to 3 equally valid
+ * `{cell, corner}` representations, and two chains (or one drag's own
+ * A/B addressed from either side) must serialize the SAME physical
+ * corner IDENTICALLY for equality and Map keys to work without an
+ * epsilon comparison at every call site. The rule: **canonical = the
+ * owner with the smallest `(r, q)`** (`compareAxial`'s own order), ties
+ * broken by the smaller corner index. The old copy ordered by
+ * `[col, row]` and excluded negative cells (its grid started at 0);
+ * this canvas's bounds GROW in every direction (`growBounds`), so the
+ * rule is axial and unbounded — any deterministic total order works,
+ * this one is the module's own `compareAxial`, reused not invented.
+ *
+ * The lattice-topology helpers (`cornerNeighbors`, `latticeEdgeCells`)
+ * are new with #804: the taut-path walk steps corner-to-corner and
+ * needs, at each corner, its 3 incident lattice edges and the one
+ * adjacent cell pair each edge separates. They live here, not in
+ * `wallGesture.ts`, because they are corner-lattice facts, not gesture
+ * policy.
+ */
+import type { Point } from '../../concepts/session-tomb/atlas';
+import {
+  axialNeighbors,
+  compareAxial,
+  normalizeEdge,
+  type Axial,
+  type Edge,
+  type Orientation,
+} from '../hexOffset';
+import { cellCorners } from './canvasGeometry';
+
+/** One (cell, corner-index) address of a hex-lattice vertex. `corner`
+ * is 0-5 in `hexCorners`' own convention (`atlas.ts`: angle
+ * `offset + 60°·i`, offset −30° pointy / 0° flat) — the SAME indexing
+ * every corner consumer of `canvasGeometry` already uses. */
+export interface CornerRef {
+  cell: Axial;
+  corner: number;
+}
+
+/** Two floating-point evaluations of the same real corner (via
+ * `hexCenter`'s trig from different owner cells) agree to ~1e-12 at
+ * this board's scale; different corners sit a full hex side apart.
+ * Scaled by `size` so the tolerance means the same thing at any board
+ * scale. */
+const CORNER_MATCH_EPSILON = 1e-6;
+
+function normalizeCornerIndex(i: number): number {
+  return ((i % 6) + 6) % 6;
+}
+
+/** The SVG user-space point `ref` addresses. */
+export function cornerPoint(
+  ref: CornerRef,
+  size: number,
+  o: Orientation
+): Point {
+  return cellCorners(ref.cell, size, o)[normalizeCornerIndex(ref.corner)];
+}
+
+/**
+ * Every `{cell, corner}` pair whose corner point coincides with `ref`'s
+ * own — geometric neighbors only (`ref.cell` plus its 6 hex neighbors,
+ * the only cells that CAN share a vertex with it). Unbounded: the
+ * canvas grows in every direction, so unlike the old copy there is no
+ * in-grid filter — every geometric owner is a legal address.
+ */
+export function cornerOwners(
+  ref: CornerRef,
+  size: number,
+  o: Orientation
+): CornerRef[] {
+  const target = cornerPoint(ref, size, o);
+  const eps = CORNER_MATCH_EPSILON * size;
+  const owners: CornerRef[] = [];
+  for (const cell of [ref.cell, ...axialNeighbors(ref.cell)]) {
+    cellCorners(cell, size, o).forEach((p, ci) => {
+      if (Math.hypot(p.x - target.x, p.y - target.y) < eps) {
+        owners.push({ cell, corner: ci });
+      }
+    });
+  }
+  return owners;
+}
+
+/** The one canonical `{cell, corner}` representation of the point `ref`
+ * addresses — smallest `(r, q)` owner cell (`compareAxial`), then the
+ * smaller corner index. Always returns at least `ref` itself
+ * (canonicalized): `ref.cell` is one of its own owners. */
+export function canonicalCorner(
+  ref: CornerRef,
+  size: number,
+  o: Orientation
+): CornerRef {
+  const normalized: CornerRef = {
+    cell: ref.cell,
+    corner: normalizeCornerIndex(ref.corner),
+  };
+  const owners = cornerOwners(normalized, size, o);
+  let best = owners[0] ?? normalized;
+  for (const owner of owners) {
+    if (
+      compareAxial(owner.cell, best.cell) < 0 ||
+      (compareAxial(owner.cell, best.cell) === 0 && owner.corner < best.corner)
+    ) {
+      best = owner;
+    }
+  }
+  return best;
+}
+
+/** The canonical corner as a Map/Set key — exact string equality for
+ * the same physical vertex, whichever owner cell addressed it. */
+export function cornerKey(
+  ref: CornerRef,
+  size: number,
+  o: Orientation
+): string {
+  const c = canonicalCorner(ref, size, o);
+  return `${c.cell.q},${c.cell.r}#${c.corner}`;
+}
+
+/** Two `CornerRef`s addressing the identical physical vertex, regardless
+ * of which of their (up to 3) equally valid owner cells each uses —
+ * exact integer comparison of canonical forms, not an epsilon-tolerant
+ * float comparison at every call site. */
+export function sameCorner(
+  a: CornerRef,
+  b: CornerRef,
+  size: number,
+  o: Orientation
+): boolean {
+  const ca = canonicalCorner(a, size, o);
+  const cb = canonicalCorner(b, size, o);
+  return compareAxial(ca.cell, cb.cell) === 0 && ca.corner === cb.corner;
+}
+
+/**
+ * The axial cell containing an SVG point — the exact inverse of
+ * `cellCenter`'s two layout formulas plus standard cube rounding
+ * (round q/r/s, then recompute the component with the largest rounding
+ * error from the other two, so the result is always a real cell). The
+ * gesture needs a true inverse because angle magnetism PROJECTS the
+ * pointer onto a seam line: over a long drag the projected point can
+ * land hexes away from the cell the pointer event fired on, so an
+ * anchor-cell-plus-neighbors search is not enough.
+ */
+export function cellAtPoint(point: Point, size: number, o: Orientation): Axial {
+  const qf =
+    o === 'pointy'
+      ? point.x / (size * Math.sqrt(3)) - point.y / (3 * size)
+      : point.x / (1.5 * size);
+  const rf =
+    o === 'pointy'
+      ? point.y / (1.5 * size)
+      : point.y / (size * Math.sqrt(3)) - point.x / (3 * size);
+  const sf = -qf - rf;
+  let q = Math.round(qf);
+  let r = Math.round(rf);
+  const sr = Math.round(sf);
+  const dq = Math.abs(q - qf);
+  const dr = Math.abs(r - rf);
+  const ds = Math.abs(sr - sf);
+  if (dq > dr && dq > ds) q = -r - sr;
+  else if (dr > ds) r = -q - sr;
+  // Math.round(-0.2) is -0; +0 normalizes it so axialKey/toEqual never
+  // see two spellings of the same cell.
+  return { q: q + 0, r: r + 0 };
+}
+
+/**
+ * Nearest corner-lattice point to an SVG point, canonicalized — what a
+ * gesture endpoint snaps to. Anchored by `cellAtPoint`: the true
+ * nearest corner to a point inside a cell is always a corner of that
+ * cell or of one of its 6 neighbors, and all of those are checked by
+ * real distance — a point near a cell boundary can have its nearest
+ * corner belong to the neighbor first.
+ */
+export function nearestCorner(
+  point: Point,
+  size: number,
+  o: Orientation
+): CornerRef {
+  const anchorCell = cellAtPoint(point, size, o);
+  let best: CornerRef = { cell: anchorCell, corner: 0 };
+  let bestDistSq = Infinity;
+  for (const cell of [anchorCell, ...axialNeighbors(anchorCell)]) {
+    cellCorners(cell, size, o).forEach((p, ci) => {
+      const d = (p.x - point.x) ** 2 + (p.y - point.y) ** 2;
+      if (d < bestDistSq) {
+        bestDistSq = d;
+        best = { cell, corner: ci };
+      }
+    });
+  }
+  return canonicalCorner(best, size, o);
+}
+
+/**
+ * The 3 lattice corners adjacent to `ref` — the far ends of its
+ * incident lattice edges (every interior honeycomb vertex has exactly
+ * 3). Computed from the owners: within each owner cell, the two
+ * corners flanking `ref`'s own index are lattice-adjacent to it;
+ * deduped across owners by canonical key.
+ */
+export function cornerNeighbors(
+  ref: CornerRef,
+  size: number,
+  o: Orientation
+): CornerRef[] {
+  const neighbors: CornerRef[] = [];
+  const seen = new Set<string>();
+  for (const owner of cornerOwners(ref, size, o)) {
+    for (const delta of [-1, 1]) {
+      const candidate: CornerRef = {
+        cell: owner.cell,
+        corner: normalizeCornerIndex(owner.corner + delta),
+      };
+      const key = cornerKey(candidate, size, o);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      neighbors.push(canonicalCorner(candidate, size, o));
+    }
+  }
+  return neighbors;
+}
+
+/**
+ * The one adjacent cell pair the lattice edge `v`–`w` separates — the
+ * `walls[]` edge that lattice edge authors (design: "each lattice edge
+ * walked separates exactly one adjacent cell pair"). The pair is the
+ * intersection of the two corners' owner cells: a lattice edge is a
+ * shared hex side, and exactly its two flanking cells own both of its
+ * endpoints. Returns null when `v` and `w` are not lattice-adjacent
+ * (no cell pair shares both corners — a caller's mistake surfaced as
+ * absence, mirroring `edgeBetween`'s own adjacency-is-checked rule).
+ */
+export function latticeEdgeCells(
+  v: CornerRef,
+  w: CornerRef,
+  size: number,
+  o: Orientation
+): Edge | null {
+  const wOwnerKeys = new Set(
+    cornerOwners(w, size, o).map((owner) => `${owner.cell.q},${owner.cell.r}`)
+  );
+  const shared: Axial[] = [];
+  for (const owner of cornerOwners(v, size, o)) {
+    const key = `${owner.cell.q},${owner.cell.r}`;
+    if (wOwnerKeys.has(key)) {
+      wOwnerKeys.delete(key); // each cell counted once
+      shared.push(owner.cell);
+    }
+  }
+  if (shared.length !== 2) return null;
+  return normalizeEdge([shared[0], shared[1]]);
+}

--- a/src/author/creation/wallGesture.test.ts
+++ b/src/author/creation/wallGesture.test.ts
@@ -1,0 +1,380 @@
+/**
+ * wallGesture — the drag table (#804, design: rpg-project#267
+ * `wall-authoring-gesture.md` §Tests). Pixel-formula discipline, no
+ * round-trips (rpg-toolkit#1150 / rpg-dnd5e-web#1141: a symmetric bug
+ * passes every round-trip): every named drag asserts the EXACT derived
+ * edge list, hand-derived from the corner lattice's own geometry
+ * (pointy corners at −30°+60°·i, columns of vertical seam edges at
+ * x = √3·(c+1)·size joined by parity-alternating diagonals), not
+ * captured from the implementation's own output.
+ *
+ * The one deliberate deterministic choice pinned here: a drag lying
+ * EXACTLY on a corner column (the vertical-seam case) reaches corners
+ * where both zigzag sides advance with identical deviation; ties break
+ * toward the candidate with the greater x (then greater y), so the
+ * derived seam is the one just right of the dragged line, the same
+ * chain regardless of which end the author dragged from.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  addWalls,
+  emitDungeon,
+  emptyDungeon,
+  paintCell,
+  toggleDoorEdge,
+  type DungeonDoc,
+} from '../dungeonYaml';
+import { edgeKey, fromOffset, normalizeEdge, type Edge } from '../hexOffset';
+import { boardWallScene } from './boardWallRuns';
+import { BOARD_HEX_SIZE } from './CreationBoard';
+import { cornerPoint, sameCorner, type CornerRef } from './hexCorner';
+import {
+  applyDoorDraw,
+  applyReshape,
+  applyWallDraw,
+  applyWallErase,
+  deriveWallAdd,
+  deriveWallErase,
+  GESTURE_TUNING,
+  nearestRunIndex,
+  runVertices,
+  seamAngles,
+  snapGesturePoint,
+  tautPath,
+} from './wallGesture';
+
+const SIZE = BOARD_HEX_SIZE;
+const o = 'pointy' as const;
+
+const off = (c: number, r: number) => fromOffset(o, [c, r]);
+/** An expected edge, written in the file's own offset pairs. */
+const E = (a: [number, number], b: [number, number]): Edge =>
+  normalizeEdge([off(a[0], a[1]), off(b[0], b[1])]);
+const keys = (edges: readonly Edge[]) => edges.map(edgeKey);
+const ref = (c: number, r: number, corner: number): CornerRef => ({
+  cell: off(c, r),
+  corner,
+});
+const pt = (r: CornerRef) => cornerPoint(r, SIZE, o);
+
+/** A 7×6 block of floor (offset cols 0..6, rows 0..5), one region. */
+function fixtureDoc(): DungeonDoc {
+  let doc = emptyDungeon(o, 'gesture-fixture');
+  for (let row = 0; row <= 5; row += 1) {
+    for (let col = 0; col <= 6; col += 1) {
+      doc = paintCell(doc, 'region-1', off(col, row));
+    }
+  }
+  return doc;
+}
+
+// The named drags. Corners are addressed by (offset cell, corner index)
+// in hexCorners' own convention; the comments give the SVG points in
+// units of `size` so the geometry stays checkable by hand.
+const VERT = {
+  // A = (√3·2.5, −0.5) — top corner of the col2|3 seam's row-0 edge.
+  a: ref(2, 0, 0),
+  // B = (√3·2.5, 3.5) — bottom corner of the same seam's row-2 edge.
+  b: ref(2, 2, 1),
+  chain: [
+    E([2, 0], [3, 0]),
+    E([2, 1], [3, 0]),
+    E([2, 1], [3, 1]),
+    E([2, 1], [3, 2]),
+    E([2, 2], [3, 2]),
+  ],
+};
+const HORIZ = {
+  // A = (0, 2) — left corner of the row1|2 seam.
+  a: ref(0, 1, 3),
+  // B = (√3·2, 2) — four seam edges to the right.
+  b: ref(1, 1, 1),
+  chain: [
+    E([0, 1], [0, 2]),
+    E([0, 1], [1, 2]),
+    E([1, 1], [1, 2]),
+    E([1, 1], [2, 2]),
+  ],
+};
+const FREE = {
+  // A = (√3/2, 2.5) → B = (√3·2, 5): a ~44° drag, no seam family near.
+  a: ref(1, 2, 4),
+  b: ref(1, 3, 1),
+  chain: [
+    E([0, 2], [1, 2]),
+    E([0, 3], [1, 2]),
+    E([1, 2], [1, 3]),
+    E([1, 3], [2, 2]),
+    E([1, 3], [2, 3]),
+  ],
+};
+
+describe('GESTURE_TUNING — one exported place, pinned', () => {
+  it('holds the designed starting points (Kirk’s walk recalibrates, tests re-pin)', () => {
+    expect(GESTURE_TUNING).toEqual({
+      cornerSnapRadius: 0.4,
+      wallVertexSnapRadius: 0.6,
+      angleToleranceDeg: 6,
+      runHitRadius: 0.25,
+    });
+  });
+});
+
+describe('seamAngles — ruling 1’s four families per orientation', () => {
+  it('pointy: horizontal row seam, both diagonals, vertical column seam', () => {
+    expect(seamAngles('pointy')).toEqual([0, 60, 90, 120]);
+  });
+  it('flat: the same four families rotated 30°', () => {
+    expect(seamAngles('flat')).toEqual([30, 90, 120, 150]);
+  });
+});
+
+describe('tautPath — the drag table', () => {
+  it('vertical seam drag derives exactly the col2|3 seam chain', () => {
+    expect(keys(tautPath(VERT.a, VERT.b, SIZE, o))).toEqual(keys(VERT.chain));
+  });
+
+  it('the same vertical line dragged BOTTOM-UP derives the same chain', () => {
+    // Direction independence: the tie-break is geometric (greater x),
+    // not drag-order-dependent, so erase re-derives what draw derived.
+    expect(keys(tautPath(VERT.b, VERT.a, SIZE, o))).toEqual(
+      [...keys(VERT.chain)].reverse()
+    );
+  });
+
+  it('horizontal seam drag derives exactly the row1|2 seam chain', () => {
+    expect(keys(tautPath(HORIZ.a, HORIZ.b, SIZE, o))).toEqual(
+      keys(HORIZ.chain)
+    );
+  });
+
+  it('a ~44° free drag derives its own zigzag chain, exactly', () => {
+    expect(keys(tautPath(FREE.a, FREE.b, SIZE, o))).toEqual(keys(FREE.chain));
+  });
+
+  it('A = B derives nothing', () => {
+    expect(tautPath(VERT.a, VERT.a, SIZE, o)).toEqual([]);
+  });
+});
+
+describe('the derived runs are axis-true (the #802 pins guard the geometry; these pin the derivation)', () => {
+  it('the vertical drag’s committed run renders exactly vertical', () => {
+    const doc = applyWallDraw(fixtureDoc(), VERT.chain);
+    const scene = boardWallScene(doc, SIZE)!;
+    expect(scene.runs.length).toBeGreaterThan(0);
+    for (const run of scene.runs) {
+      expect(Math.abs(run.a.x - run.b.x)).toBeLessThan(1e-6 * SIZE);
+    }
+  });
+
+  it('the horizontal drag’s committed run renders exactly horizontal', () => {
+    const doc = applyWallDraw(fixtureDoc(), HORIZ.chain);
+    const scene = boardWallScene(doc, SIZE)!;
+    expect(scene.runs.length).toBeGreaterThan(0);
+    for (const run of scene.runs) {
+      expect(Math.abs(run.a.y - run.b.y)).toBeLessThan(1e-6 * SIZE);
+    }
+  });
+});
+
+describe('derivation rules — floor filter, door break, dedup', () => {
+  it('a drag across a door skips the door edge and the chain breaks there', () => {
+    const doorEdge = E([2, 1], [3, 1]);
+    const doc = toggleDoorEdge(fixtureDoc(), doorEdge);
+    const derived = deriveWallAdd(doc, tautPath(VERT.a, VERT.b, SIZE, o));
+    expect(keys(derived)).toEqual(
+      keys(VERT.chain.filter((e) => edgeKey(e) !== edgeKey(doorEdge)))
+    );
+  });
+
+  it('an off-floor pair is skipped — the envelope is implied, never authored', () => {
+    // Same drag on a doc whose floor stops at offset row 1: the chain's
+    // row-2-touching edges vanish rather than author the void.
+    let doc = emptyDungeon(o, 'gesture-fixture');
+    for (let row = 0; row <= 1; row += 1) {
+      for (let col = 0; col <= 6; col += 1) {
+        doc = paintCell(doc, 'region-1', off(col, row));
+      }
+    }
+    const derived = deriveWallAdd(doc, tautPath(VERT.a, VERT.b, SIZE, o));
+    expect(keys(derived)).toEqual(keys(VERT.chain.slice(0, 3)));
+  });
+
+  it('drawing over an existing wall is idempotent — the overlap edge is deduplicated', () => {
+    const doc = addWalls(fixtureDoc(), [VERT.chain[0]]);
+    const derived = deriveWallAdd(doc, tautPath(VERT.a, VERT.b, SIZE, o));
+    expect(keys(derived)).toEqual(keys(VERT.chain.slice(1)));
+    // …and committing still yields the full seam exactly once.
+    const committed = applyWallDraw(doc, tautPath(VERT.a, VERT.b, SIZE, o));
+    expect(keys(committed.walls).sort()).toEqual(keys(VERT.chain).sort());
+  });
+});
+
+describe('snapGesturePoint — corners snap by construction', () => {
+  it('an existing wall vertex within its (stronger) radius beats a nearer plain corner', () => {
+    // P sits 0.55·size from the chain endpoint at (√3, 2)·size but only
+    // 0.45·size from the plain corner at (√3·1.5, 2.5)·size — the wall
+    // vertex still wins: sharing a vertex IS the closed corner.
+    const vertices = runVertices(
+      [[E([0, 1], [0, 2]), E([0, 1], [1, 2])]],
+      SIZE,
+      o
+    );
+    const endpoint = ref(0, 1, 1); // (√3, 2)·size
+    const p = pt(endpoint);
+    const raw = { x: p.x + 0.478 * SIZE, y: p.y + 0.275 * SIZE };
+    const withMagnet = snapGesturePoint(raw, SIZE, o, {
+      wallVertices: vertices,
+    });
+    expect(sameCorner(withMagnet, endpoint, SIZE, o)).toBe(true);
+    const without = snapGesturePoint(raw, SIZE, o, {});
+    expect(sameCorner(without, ref(1, 1, 2), SIZE, o)).toBe(true); // (√3·1.5, 2.5)
+  });
+
+  it('angle magnetism: within ~6° of vertical the endpoint lands on the dragged column', () => {
+    const origin = pt(VERT.a);
+    const rad = (deg: number) => (deg * Math.PI) / 180;
+    const at = (deg: number, len: number) => ({
+      x: origin.x + len * SIZE * Math.sin(rad(deg)),
+      y: origin.y + len * SIZE * Math.cos(rad(deg)),
+    });
+    // 4° off vertical over a 12-hex drag: raw nearest corner is OFF the
+    // column; the snapped one is ON it.
+    const onColumn = ref(2, 8, 0); // (√3·2.5, 11.5)·size
+    const snapped = snapGesturePoint(at(4, 12), SIZE, o, { origin });
+    expect(sameCorner(snapped, onColumn, SIZE, o)).toBe(true);
+    // Alt bypasses: the same pointer keeps its own nearest corner.
+    const free = snapGesturePoint(at(4, 12), SIZE, o, { origin, alt: true });
+    expect(sameCorner(free, onColumn, SIZE, o)).toBe(false);
+    expect(sameCorner(free, ref(3, 8, 5), SIZE, o)).toBe(true); // (√3·3, 11)·size
+    // 20° is outside every family: no snap even without Alt.
+    const wide = snapGesturePoint(at(20, 6), SIZE, o, { origin });
+    expect(sameCorner(wide, onColumn, SIZE, o)).toBe(false);
+  });
+});
+
+describe('a drag ending on an existing wall vertex shares it — the corner closes by construction', () => {
+  it('snaps B to the chain endpoint and derives the connecting edge', () => {
+    const existing = [E([0, 1], [0, 2]), E([0, 1], [1, 2])];
+    const doc = addWalls(fixtureDoc(), existing);
+    const vertices = runVertices([existing], SIZE, o);
+    const sharedVertex = ref(0, 1, 1); // (√3, 2)·size
+    const vp = pt(sharedVertex);
+    const b = snapGesturePoint({ x: vp.x + 10, y: vp.y - 6 }, SIZE, o, {
+      wallVertices: vertices,
+    });
+    expect(sameCorner(b, sharedVertex, SIZE, o)).toBe(true);
+    const chain = tautPath(ref(1, 0, 2), b, SIZE, o); // from (√3, 1)·size
+    expect(keys(deriveWallAdd(doc, chain))).toEqual(keys([E([0, 1], [1, 1])]));
+  });
+});
+
+describe('shared-corner drag (ruling 4) — every incident chain re-derives to the new vertex', () => {
+  const chainA = [E([0, 1], [0, 2]), E([0, 1], [1, 2])];
+  const chainB = [E([0, 1], [1, 1]), E([1, 0], [1, 1])];
+
+  it('runVertices finds the shared corner (2 incident runs) and the far endpoints (1 each)', () => {
+    const vertices = runVertices([chainA, chainB], SIZE, o);
+    const shared = vertices.find((v) =>
+      sameCorner(v.ref, ref(0, 1, 1), SIZE, o)
+    );
+    expect(shared?.runs.sort()).toEqual([0, 1]);
+    const farA = vertices.find((v) => sameCorner(v.ref, ref(0, 1, 3), SIZE, o));
+    expect(farA?.runs).toEqual([0]);
+    const farB = vertices.find((v) => sameCorner(v.ref, ref(1, 0, 1), SIZE, o));
+    expect(farB?.runs).toEqual([1]);
+  });
+
+  it('dragging the shared vertex re-derives BOTH chains, still sharing the new vertex', () => {
+    const doc = addWalls(fixtureDoc(), [...chainA, ...chainB]);
+    const newVertex = ref(1, 1, 2); // (√3·1.5, 2.5)·size
+    const newA = tautPath(ref(0, 1, 3), newVertex, SIZE, o);
+    const newB = tautPath(ref(1, 0, 1), newVertex, SIZE, o);
+    expect(keys(newA)).toEqual(
+      keys([E([0, 1], [0, 2]), E([0, 1], [1, 2]), E([1, 1], [1, 2])])
+    );
+    expect(keys(newB)).toEqual(
+      keys([E([1, 1], [2, 0]), E([1, 1], [2, 1]), E([1, 1], [2, 2])])
+    );
+    const committed = applyReshape(doc, [chainA, chainB], [newA, newB]);
+    expect(keys(committed.walls).sort()).toEqual(
+      keys([...newA, ...newB]).sort()
+    );
+  });
+});
+
+describe('preview identity — the preview IS the commit (one formula, float-exact)', () => {
+  it.each([
+    ['vertical seam', VERT],
+    ['horizontal seam', HORIZ],
+    ['free angle', FREE],
+  ])('%s: mid-gesture candidate scene === post-commit scene', (_name, row) => {
+    const doc = fixtureDoc();
+    const chain = tautPath(row.a, row.b, SIZE, o);
+    // The board's preview: the shared module on the candidate document.
+    const previewScene = boardWallScene(applyWallDraw(doc, chain), SIZE);
+    // The commit: the same mutator application on release.
+    const committed = applyWallDraw(doc, chain);
+    const commitScene = boardWallScene(committed, SIZE);
+    expect(previewScene).toEqual(commitScene);
+    expect(previewScene).not.toBeNull();
+  });
+});
+
+describe('erase — shift/right-drag along the same line (ruling 3)', () => {
+  it('draw then erase along the same drag returns byte-identical YAML', () => {
+    const doc = fixtureDoc();
+    const before = emitDungeon(doc);
+    const chain = tautPath(VERT.a, VERT.b, SIZE, o);
+    const drawn = applyWallDraw(doc, chain);
+    expect(emitDungeon(drawn)).not.toBe(before);
+    expect(emitDungeon(applyWallErase(drawn, chain))).toBe(before);
+  });
+
+  it('never touches door edges', () => {
+    const doorEdge = E([2, 1], [3, 1]);
+    const doc = toggleDoorEdge(fixtureDoc(), doorEdge);
+    const before = emitDungeon(doc);
+    const chain = tautPath(VERT.a, VERT.b, SIZE, o);
+    const drawn = applyWallDraw(doc, chain);
+    const erased = applyWallErase(drawn, chain);
+    expect(emitDungeon(erased)).toBe(before);
+    expect(erased.doors).toHaveLength(1);
+    expect(keys(erased.doors[0].edges)).toEqual(keys([doorEdge]));
+    // And the erase derivation itself never lists a door edge.
+    expect(keys(deriveWallErase(drawn, chain))).not.toContain(
+      edgeKey(doorEdge)
+    );
+  });
+});
+
+describe('door tool inherits the drag — one chain, ONE door', () => {
+  it('a door drag’s chain becomes a single door’s edges[]', () => {
+    const doc = applyDoorDraw(fixtureDoc(), HORIZ.chain);
+    expect(doc.doors).toHaveLength(1);
+    expect(keys(doc.doors[0].edges)).toEqual(keys(HORIZ.chain));
+    expect(doc.walls).toHaveLength(0);
+  });
+
+  it('a door drag over existing walls replaces them — an edge is a wall OR a door', () => {
+    const doc = applyDoorDraw(addWalls(fixtureDoc(), HORIZ.chain), HORIZ.chain);
+    expect(doc.walls).toHaveLength(0);
+    expect(doc.doors).toHaveLength(1);
+    expect(keys(doc.doors[0].edges)).toEqual(keys(HORIZ.chain));
+  });
+});
+
+describe('nearestRunIndex — select the thing you see', () => {
+  it('hits the run whose segment the point sits on, within the tuned radius', () => {
+    const runs = [
+      { a: { x: 0, y: 0 }, b: { x: 10 * SIZE, y: 0 } },
+      { a: { x: 0, y: 3 * SIZE }, b: { x: 10 * SIZE, y: 3 * SIZE } },
+    ];
+    const hit = nearestRunIndex(runs, { x: 5 * SIZE, y: 0.2 * SIZE }, SIZE);
+    expect(hit).toBe(0);
+    expect(
+      nearestRunIndex(runs, { x: 5 * SIZE, y: 1.5 * SIZE }, SIZE)
+    ).toBeNull();
+    expect(nearestRunIndex(runs, { x: 5 * SIZE, y: 2.9 * SIZE }, SIZE)).toBe(1);
+  });
+});

--- a/src/author/creation/wallGesture.test.ts
+++ b/src/author/creation/wallGesture.test.ts
@@ -68,6 +68,12 @@ function fixtureDoc(): DungeonDoc {
   return doc;
 }
 
+/** The magnetism/handle targets as the board builds them: from the
+ * rendered scene's runs, so `point` is the drawn endpoint (see-vs-snap:
+ * Kirk's walk found lattice-centered magnetism missing where he aimed). */
+const sceneVertices = (doc: DungeonDoc) =>
+  runVertices(boardWallScene(doc, SIZE)!.runs, SIZE, o);
+
 // The named drags. Corners are addressed by (offset cell, corner index)
 // in hexCorners' own convention; the comments give the SVG points in
 // units of `size` so the geometry stays checkable by hand.
@@ -215,11 +221,8 @@ describe('snapGesturePoint — corners snap by construction', () => {
     // P sits 0.55·size from the chain endpoint at (√3, 2)·size but only
     // 0.45·size from the plain corner at (√3·1.5, 2.5)·size — the wall
     // vertex still wins: sharing a vertex IS the closed corner.
-    const vertices = runVertices(
-      [[E([0, 1], [0, 2]), E([0, 1], [1, 2])]],
-      SIZE,
-      o
-    );
+    const existing = [E([0, 1], [0, 2]), E([0, 1], [1, 2])];
+    const vertices = sceneVertices(addWalls(fixtureDoc(), existing));
     const endpoint = ref(0, 1, 1); // (√3, 2)·size
     const p = pt(endpoint);
     const raw = { x: p.x + 0.478 * SIZE, y: p.y + 0.275 * SIZE };
@@ -251,13 +254,66 @@ describe('snapGesturePoint — corners snap by construction', () => {
     const wide = snapGesturePoint(at(20, 6), SIZE, o, { origin });
     expect(sameCorner(wide, onColumn, SIZE, o)).toBe(false);
   });
+
+  it('magnetizes to the RENDERED run endpoint, not the lattice vertex behind it (Kirk’s walk)', () => {
+    // A ~44° chain's fitted+projected endpoint sits ~0.52·size from its
+    // chain-end lattice vertex (measured; the fit, corner closure and
+    // margins all move the drawn end off the raw lattice). Aim just
+    // past the DRAWN end: the pointer is outside the 0.6·size gate
+    // measured from the lattice vertex — the old, lattice-centered
+    // magnetism missed exactly this aim — but well inside it measured
+    // from the rendered endpoint, and the snap still resolves to the
+    // chain's LATTICE vertex for derivation.
+    const doc = applyWallDraw(fixtureDoc(), FREE.chain);
+    const vertices = sceneVertices(doc);
+    const scene = boardWallScene(doc, SIZE)!;
+    expect(scene.runs).toHaveLength(1);
+    const run = scene.runs[0];
+    const latticeEnd = ref(1, 3, 1); // (√3·2, 5)·size
+    const lp = pt(latticeEnd);
+    const drawnEnd =
+      Math.hypot(run.a.x - lp.x, run.a.y - lp.y) <
+      Math.hypot(run.b.x - lp.x, run.b.y - lp.y)
+        ? run.a
+        : run.b;
+    const other = drawnEnd === run.a ? run.b : run.a;
+    const len = Math.hypot(drawnEnd.x - other.x, drawnEnd.y - other.y);
+    const out = {
+      x: drawnEnd.x + ((drawnEnd.x - other.x) / len) * 0.15 * SIZE,
+      y: drawnEnd.y + ((drawnEnd.y - other.y) / len) * 0.15 * SIZE,
+    };
+    // The receipt: this aim is OUTSIDE the lattice-centered gate…
+    expect(Math.hypot(out.x - lp.x, out.y - lp.y)).toBeGreaterThan(
+      GESTURE_TUNING.wallVertexSnapRadius * SIZE
+    );
+    // …and still snaps, resolving to the lattice vertex.
+    const snapped = snapGesturePoint(out, SIZE, o, { wallVertices: vertices });
+    expect(sameCorner(snapped, latticeEnd, SIZE, o)).toBe(true);
+  });
+
+  it('an off-axis wall vertex in range beats angle magnetism — vertex intent wins', () => {
+    // Drag ~5° off vertical from (√3, 1)·size toward the horizontal
+    // chain's rendered endpoint near (√3, 2.25)·size: the axis snap
+    // would project the endpoint onto the vertical line, but the
+    // vertex magnetism is tested on the raw pointer FIRST, so the
+    // corner closes instead of the axis winning.
+    const existing = [E([0, 1], [0, 2]), E([0, 1], [1, 2])];
+    const vertices = sceneVertices(addWalls(fixtureDoc(), existing));
+    const origin = pt(ref(1, 0, 2)); // (√3, 1)·size
+    const raw = { x: origin.x + 0.1 * SIZE, y: origin.y + 1.2 * SIZE };
+    const snapped = snapGesturePoint(raw, SIZE, o, {
+      origin,
+      wallVertices: vertices,
+    });
+    expect(sameCorner(snapped, ref(0, 1, 1), SIZE, o)).toBe(true);
+  });
 });
 
 describe('a drag ending on an existing wall vertex shares it — the corner closes by construction', () => {
   it('snaps B to the chain endpoint and derives the connecting edge', () => {
     const existing = [E([0, 1], [0, 2]), E([0, 1], [1, 2])];
     const doc = addWalls(fixtureDoc(), existing);
-    const vertices = runVertices([existing], SIZE, o);
+    const vertices = sceneVertices(doc);
     const sharedVertex = ref(0, 1, 1); // (√3, 2)·size
     const vp = pt(sharedVertex);
     const b = snapGesturePoint({ x: vp.x + 10, y: vp.y - 6 }, SIZE, o, {
@@ -274,15 +330,27 @@ describe('shared-corner drag (ruling 4) — every incident chain re-derives to t
   const chainB = [E([0, 1], [1, 1]), E([1, 0], [1, 1])];
 
   it('runVertices finds the shared corner (2 incident runs) and the far endpoints (1 each)', () => {
-    const vertices = runVertices([chainA, chainB], SIZE, o);
+    // Two REAL seam chains meeting at (√3·2.5, 3.5)·size — long enough
+    // that the engine's chain tolerance keeps them two runs (a
+    // two-edge elbow reads as one shallow zigzag and merges; a genuine
+    // corner between two seams does not).
+    const vert = VERT.chain;
+    const horiz = [E([2, 3], [3, 2]), E([3, 2], [3, 3]), E([3, 3], [4, 2])];
+    const vertices = sceneVertices(addWalls(fixtureDoc(), [...vert, ...horiz]));
+    // The shared corner is the SCENE's own break vertex — where the
+    // chaining engine judged straightness to end, one edge past the
+    // drag boundary here (the elbow's first horizontal edge still fit
+    // the vertical run's tolerance). Handles live on what is rendered,
+    // so that is the corner the author grabs.
     const shared = vertices.find((v) =>
-      sameCorner(v.ref, ref(0, 1, 1), SIZE, o)
+      sameCorner(v.ref, ref(3, 2, 2), SIZE, o)
     );
     expect(shared?.runs.sort()).toEqual([0, 1]);
-    const farA = vertices.find((v) => sameCorner(v.ref, ref(0, 1, 3), SIZE, o));
-    expect(farA?.runs).toEqual([0]);
-    const farB = vertices.find((v) => sameCorner(v.ref, ref(1, 0, 1), SIZE, o));
-    expect(farB?.runs).toEqual([1]);
+    const farV = vertices.find((v) => sameCorner(v.ref, VERT.a, SIZE, o));
+    expect(farV?.runs).toHaveLength(1);
+    const farH = vertices.find((v) => sameCorner(v.ref, ref(4, 3, 4), SIZE, o));
+    expect(farH?.runs).toHaveLength(1);
+    expect(farV?.runs[0]).not.toBe(farH?.runs[0]);
   });
 
   it('dragging the shared vertex re-derives BOTH chains, still sharing the new vertex', () => {

--- a/src/author/creation/wallGesture.ts
+++ b/src/author/creation/wallGesture.ts
@@ -86,12 +86,15 @@ import {
  * inferred; recalibration lands here and re-pins.
  */
 export const GESTURE_TUNING = {
-  /** Endpoint/shared-vertex handle pickup radius around a rendered
-   * run's endpoint (wall tool, pre-press hover → grab). */
+  /** Handle pickup radius around a selected run's RENDERED endpoint
+   * or shared corner (Select tool — manipulation rides selection,
+   * Kirk's walk ruling). */
   cornerSnapRadius: 0.4,
-  /** Existing-wall-vertex magnetism on the drag endpoints — STRONGER
-   * than the plain lattice snap: landing on a chain's vertex is what
-   * closes a corner by construction. */
+  /** Existing-wall-vertex magnetism on the drag endpoints, measured at
+   * the RENDERED endpoint the author aims at (never the lattice vertex
+   * behind it — see RunVertex) and STRONGER than the plain lattice
+   * snap: landing on a chain's vertex is what closes a corner by
+   * construction. */
   wallVertexSnapRadius: 0.6,
   /** Ruling 1: drag direction within this many degrees of a seam
    * family snaps the endpoint onto the dragged line; Alt bypasses. */
@@ -290,10 +293,19 @@ export function applyReshape(
 // Vertices and snapping
 // ---------------------------------------------------------------------------
 
-/** A lattice vertex where rendered runs end: the drag handles and the
- * wall-vertex magnetism targets. `runs` holds the indices (into the
- * caller's run list) of every incident run — 1 = an endpoint handle,
- * 2+ = a shared corner (ruling 4). */
+/** A vertex where rendered runs end: the drag handles and the
+ * wall-vertex magnetism targets. `ref` is the chain-end LATTICE vertex
+ * (what derivation anchors to); `point` is the RENDERED endpoint the
+ * author actually sees. The two differ by up to ~half a hex — the
+ * least-squares/axis fit, corner closure, and overlap margin all move
+ * a run's drawn end off the raw lattice (measured live on Kirk's walk:
+ * 0.15–0.52·size depending on chain angle, vs a 0.6·size magnet
+ * radius). Magnetism centered on the lattice vertex therefore missed
+ * exactly where he aimed — "I cannot get that upper right corner to
+ * snap in." Select the thing you see applies to magnetism too: snap
+ * and display live on `point`, derivation on `ref`. `runs` holds the
+ * indices of every incident run — 1 = an endpoint handle, 2+ = a
+ * shared corner (ruling 4). */
 export interface RunVertex {
   ref: CornerRef;
   point: Point;
@@ -326,33 +338,81 @@ export function chainEndpoints(
     .map((v) => v.ref);
 }
 
+/** A scene-shaped run: its rendered segment plus the doc edges behind
+ * it (`BoardWallRun`'s own shape, structurally). */
+export interface SceneRunLike {
+  a: Point;
+  b: Point;
+  edges: readonly Edge[];
+}
+
 /**
- * Every run-endpoint vertex over the rendered runs' source edge lists
- * (threaded through `boardWallRuns`), grouped by physical vertex —
- * the magnetism targets and the handles. The design's own definition:
- * "the lattice vertices at the ends of existing authored chains."
+ * Every run-endpoint vertex over the rendered runs, grouped by
+ * physical lattice vertex — the magnetism targets and the handles.
+ * Each vertex's `point` is the mean of the incident runs' own rendered
+ * endpoints on that side (each run's endpoint is matched to whichever
+ * of its two chain-end lattice vertices sits nearer): at a closed
+ * corner the incident runs' drawn ends all sit within the overlap
+ * margin of the shared joint, so the mean is the visible corner point.
  */
 export function runVertices(
-  runEdgeLists: readonly (readonly Edge[])[],
+  runs: readonly SceneRunLike[],
   size: number,
   o: Orientation
 ): RunVertex[] {
-  const byKey = new Map<string, RunVertex>();
-  runEdgeLists.forEach((edges, runIndex) => {
-    for (const ref of chainEndpoints(edges, size, o)) {
+  const byKey = new Map<
+    string,
+    {
+      ref: CornerRef;
+      sumX: number;
+      sumY: number;
+      count: number;
+      runs: number[];
+    }
+  >();
+  runs.forEach((run, runIndex) => {
+    const ends = chainEndpoints(run.edges, size, o);
+    if (ends.length !== 2) return; // degenerate (loop / empty) — no handles
+    // Match each lattice endpoint to the nearer rendered endpoint; the
+    // fit preserves the chain's extremes, so the pairing is unambiguous.
+    const [e0, e1] = ends;
+    const p0 = cornerPoint(e0, size, o);
+    const assignAtoE0 =
+      Math.hypot(run.a.x - p0.x, run.a.y - p0.y) <=
+      Math.hypot(run.b.x - p0.x, run.b.y - p0.y);
+    const pairs: [CornerRef, Point][] = assignAtoE0
+      ? [
+          [e0, run.a],
+          [e1, run.b],
+        ]
+      : [
+          [e0, run.b],
+          [e1, run.a],
+        ];
+    for (const [ref, rendered] of pairs) {
       const key = cornerKey(ref, size, o);
-      const existing = byKey.get(key);
-      if (existing) existing.runs.push(runIndex);
-      else {
+      const entry = byKey.get(key);
+      if (entry) {
+        entry.sumX += rendered.x;
+        entry.sumY += rendered.y;
+        entry.count += 1;
+        entry.runs.push(runIndex);
+      } else {
         byKey.set(key, {
           ref,
-          point: cornerPoint(ref, size, o),
+          sumX: rendered.x,
+          sumY: rendered.y,
+          count: 1,
           runs: [runIndex],
         });
       }
     }
   });
-  return [...byKey.values()];
+  return [...byKey.values()].map((v) => ({
+    ref: v.ref,
+    point: { x: v.sumX / v.count, y: v.sumY / v.count },
+    runs: v.runs,
+  }));
 }
 
 export interface SnapOptions {

--- a/src/author/creation/wallGesture.ts
+++ b/src/author/creation/wallGesture.ts
@@ -1,0 +1,463 @@
+/**
+ * wallGesture — the PURE derivation behind the wall tool's
+ * press–drag–release (rpg-dnd5e-web#804; design + rulings:
+ * rpg-project#267 `ideas/dungeon-builder/wall-authoring-gesture.md`).
+ * Zero React: geometry in, edge lists out; `CreationBoard.tsx` only
+ * holds pointer state and calls down here.
+ *
+ * The governing principle (recorded on #800): the old builder felt
+ * right because the gesture itself was straight — the author drew the
+ * line, the tool derived the cells. So the drag's endpoints snap to the
+ * hex CORNER lattice (`hexCorner.ts`, the finest honest lattice this
+ * grid has), the dragged segment derives its chain as the TAUT PATH
+ * along the lattice, and each lattice edge walked separates exactly one
+ * adjacent cell pair — that pair is one `walls[]` edge. Mechanics stay
+ * the edge chain; the straight run is how it reads.
+ *
+ * # The preview IS the commit
+ *
+ * `applyWallDraw` / `applyWallErase` / `applyDoorDraw` / `applyReshape`
+ * are used by BOTH the board's mid-drag candidate document (whose runs
+ * `boardWallScene` renders live) and the release commit — one mutator
+ * composition, so what the author sees mid-drag is float-identical to
+ * what release produces. Never write a second geometry formula here:
+ * the door-frame lesson (#787's "the walls do not touch") is exactly
+ * two independent computations that only approximately agree.
+ *
+ * # The taut path
+ *
+ * Walk corner-to-corner from A, at each corner stepping to the incident
+ * lattice edge that ADVANCES toward B (strictly decreases the distance;
+ * on the honeycomb such a step always exists while v ≠ B) with LEAST
+ * deviation from the infinite line AB. A drag along one of the grid's
+ * own seam directions derives exactly the chain whose rendered run IS
+ * that line — the column/row cases axis-true by the authored-pair
+ * declaration (#802), pinned by `wallGesture.test.ts`; any other angle
+ * derives the zigzag chain whose fitted run best expresses AB, visible
+ * live: angle as intent, never an emergent surprise.
+ *
+ * One deliberate deterministic choice, pinned by the drag table: at a
+ * corner where BOTH zigzag sides advance with identical deviation (a
+ * drag lying exactly on a corner column), the tie breaks toward the
+ * candidate with the greater x (then greater y). Geometric, so the
+ * same line derives the same chain dragged from either end — an erase
+ * drag re-derives what the draw derived.
+ *
+ * # Rulings encoded here (Kirk, 2026-08-25, PR #267)
+ *
+ * 1. Angle magnetism ON by default: a drag within ~6° of a seam family
+ *    snaps the endpoint onto the dragged line; Alt = free angle
+ *    (`snapGesturePoint`).
+ * 2. Endpoint drag re-derives the WHOLE chain from the fixed far
+ *    endpoint (`applyReshape` with one chain).
+ * 3. Erase = shift/right-drag along a line, the region brush's own
+ *    grammar (`deriveWallErase` — door edges never touched).
+ * 4. A shared corner vertex is a drag handle: every incident chain
+ *    re-derives from its own far endpoint to the new vertex
+ *    (`runVertices` finds them; `applyReshape` with many chains).
+ */
+import type { Point } from '../../concepts/session-tomb/atlas';
+import {
+  addDoor,
+  addWalls,
+  doorEdgeOwners,
+  floorOwners,
+  removeWalls,
+  wallKeys,
+  type DungeonDoc,
+} from '../dungeonYaml';
+import { axialKey, edgeKey, type Edge, type Orientation } from '../hexOffset';
+import { edgeSegment } from './canvasGeometry';
+import {
+  cornerKey,
+  cornerNeighbors,
+  cornerPoint,
+  latticeEdgeCells,
+  nearestCorner,
+  sameCorner,
+  type CornerRef,
+} from './hexCorner';
+
+/**
+ * Every tuning constant of the gesture, in ONE exported place, pinned
+ * by tests (the design's own rule). Radii are fractions of the board's
+ * hex size. These are STARTING points — Kirk's walk on :3001 is the
+ * calibration instrument, the same way facing yaw was measured, not
+ * inferred; recalibration lands here and re-pins.
+ */
+export const GESTURE_TUNING = {
+  /** Endpoint/shared-vertex handle pickup radius around a rendered
+   * run's endpoint (wall tool, pre-press hover → grab). */
+  cornerSnapRadius: 0.4,
+  /** Existing-wall-vertex magnetism on the drag endpoints — STRONGER
+   * than the plain lattice snap: landing on a chain's vertex is what
+   * closes a corner by construction. */
+  wallVertexSnapRadius: 0.6,
+  /** Ruling 1: drag direction within this many degrees of a seam
+   * family snaps the endpoint onto the dragged line; Alt bypasses. */
+  angleToleranceDeg: 6,
+  /** Select-tool hit radius around a rendered run's segment. */
+  runHitRadius: 0.25,
+} as const;
+
+/**
+ * The four seam-direction families of ruling 1, as SVG-space angles
+ * mod 180° (y-down, `atan2(dy, dx)`): the horizontal row seam, the two
+ * diagonal families (the axial r and q−r cell-chain directions), and
+ * the vertical column seam. Flat-top is the same lattice rotated 30°.
+ */
+export function seamAngles(o: Orientation): readonly number[] {
+  return o === 'pointy' ? [0, 60, 90, 120] : [30, 90, 120, 150];
+}
+
+const distance = (a: Point, b: Point) => Math.hypot(b.x - a.x, b.y - a.y);
+
+/**
+ * The taut path from corner A to corner B: the chain of `walls[]`-shaped
+ * cell-pair edges whose lattice edges the walk crosses, in walk order.
+ * A = B derives nothing (the release-cancel case). The walk terminates
+ * by construction — every step strictly decreases the distance to B,
+ * and on the honeycomb a strictly-decreasing neighbor always exists
+ * while v ≠ B (the three incident edge directions are 120° apart, so
+ * one is always within 60° of "toward B"; the step-count guard is a
+ * defensive floor, not a reachable exit).
+ */
+export function tautPath(
+  a: CornerRef,
+  b: CornerRef,
+  size: number,
+  o: Orientation
+): Edge[] {
+  if (sameCorner(a, b, size, o)) return [];
+  const pa = cornerPoint(a, size, o);
+  const pb = cornerPoint(b, size, o);
+  const len = distance(pa, pb);
+  const ux = (pb.x - pa.x) / len;
+  const uy = (pb.y - pa.y) / len;
+  const stepEps = 1e-6 * size;
+  const tieEps = 1e-9 * size;
+  const maxSteps = Math.ceil(len / size) * 4 + 12;
+
+  const edges: Edge[] = [];
+  let v = a;
+  let vp = pa;
+  for (let step = 0; step < maxSteps; step += 1) {
+    if (sameCorner(v, b, size, o)) break;
+    let next: CornerRef | null = null;
+    let nextPoint: Point = vp;
+    let bestDeviation = Infinity;
+    const dHere = distance(vp, pb);
+    for (const w of cornerNeighbors(v, size, o)) {
+      const wp = cornerPoint(w, size, o);
+      if (distance(wp, pb) >= dHere - stepEps) continue; // must advance
+      // Deviation from the infinite line AB (perpendicular distance).
+      const deviation = Math.abs(ux * (wp.y - pa.y) - uy * (wp.x - pa.x));
+      const better =
+        deviation < bestDeviation - tieEps ||
+        (Math.abs(deviation - bestDeviation) <= tieEps &&
+          (wp.x > nextPoint.x + tieEps ||
+            (Math.abs(wp.x - nextPoint.x) <= tieEps &&
+              wp.y > nextPoint.y + tieEps)));
+      if (next === null || better) {
+        next = w;
+        nextPoint = wp;
+        bestDeviation = deviation;
+      }
+    }
+    if (next === null) break; // unreachable on a real lattice; see doc
+    const edge = latticeEdgeCells(v, next, size, o);
+    if (edge) edges.push(edge);
+    v = next;
+    vp = nextPoint;
+  }
+  return edges;
+}
+
+/**
+ * The derivation rules on a raw chain, for DRAWING walls: a pair that
+ * is not two floor cells is skipped (the envelope is implied, never
+ * authored — design §2); an edge already in `walls[]` is deduplicated
+ * silently (drawing over a wall is idempotent); an edge belonging to a
+ * door is skipped and the chain breaks there (runs already break at
+ * doorways; an edge in both lists is a validation failure the gesture
+ * never authors).
+ */
+export function deriveWallAdd(doc: DungeonDoc, chain: Edge[]): Edge[] {
+  const floor = floorOwners(doc);
+  const doors = doorEdgeOwners(doc);
+  const walls = wallKeys(doc);
+  const seen = new Set<string>();
+  const out: Edge[] = [];
+  for (const e of chain) {
+    const key = edgeKey(e);
+    if (
+      !floor.has(axialKey(e[0])) ||
+      !floor.has(axialKey(e[1])) ||
+      doors.has(key) ||
+      walls.has(key) ||
+      seen.has(key)
+    ) {
+      continue;
+    }
+    seen.add(key);
+    out.push(e);
+  }
+  return out;
+}
+
+/** The erase drag's edges: whatever of the chain is PRESENT in
+ * `walls[]`. Door edges are never listed — they are never in `walls[]`
+ * (ruling 3: the wall eraser never touches doors). */
+export function deriveWallErase(doc: DungeonDoc, chain: Edge[]): Edge[] {
+  const walls = wallKeys(doc);
+  const seen = new Set<string>();
+  const out: Edge[] = [];
+  for (const e of chain) {
+    const key = edgeKey(e);
+    if (!walls.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(e);
+  }
+  return out;
+}
+
+/** The door drag's edges: floor pairs not already claimed by a door.
+ * Walls on the chain are NOT filtered here — `addDoor` replaces them
+ * (an edge is a wall OR a door, `toggleDoorEdge`'s own rule). */
+export function deriveDoorAdd(doc: DungeonDoc, chain: Edge[]): Edge[] {
+  const floor = floorOwners(doc);
+  const doors = doorEdgeOwners(doc);
+  const seen = new Set<string>();
+  const out: Edge[] = [];
+  for (const e of chain) {
+    const key = edgeKey(e);
+    if (
+      !floor.has(axialKey(e[0])) ||
+      !floor.has(axialKey(e[1])) ||
+      doors.has(key) ||
+      seen.has(key)
+    ) {
+      continue;
+    }
+    seen.add(key);
+    out.push(e);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The one formula, applied — used by BOTH the board's mid-drag candidate
+// document (the live preview) and the release commit, so preview ≡ commit
+// by construction (the design's one-formula law; wallGesture.test.ts
+// asserts it float-exactly anyway).
+// ---------------------------------------------------------------------------
+
+export function applyWallDraw(doc: DungeonDoc, chain: Edge[]): DungeonDoc {
+  return addWalls(doc, deriveWallAdd(doc, chain));
+}
+
+export function applyWallErase(doc: DungeonDoc, chain: Edge[]): DungeonDoc {
+  return removeWalls(doc, deriveWallErase(doc, chain));
+}
+
+export function applyDoorDraw(doc: DungeonDoc, chain: Edge[]): DungeonDoc {
+  return addDoor(doc, deriveDoorAdd(doc, chain));
+}
+
+/**
+ * Rulings 2 and 4 in one operation: remove every dragged chain's old
+ * edges, then re-derive each incident chain from its own fixed far
+ * endpoint (the caller walks `tautPath` per chain and passes the raw
+ * chains in). The endpoint grab is the one-incident-chain case of the
+ * shared-corner grab.
+ */
+export function applyReshape(
+  doc: DungeonDoc,
+  oldChains: readonly Edge[][],
+  newChains: readonly Edge[][]
+): DungeonDoc {
+  let next = removeWalls(
+    doc,
+    oldChains.flatMap((chain) => chain)
+  );
+  for (const chain of newChains) {
+    next = applyWallDraw(next, chain);
+  }
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Vertices and snapping
+// ---------------------------------------------------------------------------
+
+/** A lattice vertex where rendered runs end: the drag handles and the
+ * wall-vertex magnetism targets. `runs` holds the indices (into the
+ * caller's run list) of every incident run — 1 = an endpoint handle,
+ * 2+ = a shared corner (ruling 4). */
+export interface RunVertex {
+  ref: CornerRef;
+  point: Point;
+  runs: number[];
+}
+
+/** A run's chain endpoints: the odd-degree vertices of its own lattice
+ * segments (a run's chain is a path, so exactly two). The lattice
+ * segment of each doc edge comes from `edgeSegment` — the SAME
+ * corner-to-corner geometry the board draws literal edges with. */
+export function chainEndpoints(
+  edges: readonly Edge[],
+  size: number,
+  o: Orientation
+): CornerRef[] {
+  const degree = new Map<string, { ref: CornerRef; count: number }>();
+  for (const e of edges) {
+    const seg = edgeSegment(e, size, o);
+    if (!seg) continue;
+    for (const p of [seg.a, seg.b]) {
+      const ref = nearestCorner(p, size, o);
+      const key = cornerKey(ref, size, o);
+      const entry = degree.get(key);
+      if (entry) entry.count += 1;
+      else degree.set(key, { ref, count: 1 });
+    }
+  }
+  return [...degree.values()]
+    .filter((v) => v.count % 2 === 1)
+    .map((v) => v.ref);
+}
+
+/**
+ * Every run-endpoint vertex over the rendered runs' source edge lists
+ * (threaded through `boardWallRuns`), grouped by physical vertex —
+ * the magnetism targets and the handles. The design's own definition:
+ * "the lattice vertices at the ends of existing authored chains."
+ */
+export function runVertices(
+  runEdgeLists: readonly (readonly Edge[])[],
+  size: number,
+  o: Orientation
+): RunVertex[] {
+  const byKey = new Map<string, RunVertex>();
+  runEdgeLists.forEach((edges, runIndex) => {
+    for (const ref of chainEndpoints(edges, size, o)) {
+      const key = cornerKey(ref, size, o);
+      const existing = byKey.get(key);
+      if (existing) existing.runs.push(runIndex);
+      else {
+        byKey.set(key, {
+          ref,
+          point: cornerPoint(ref, size, o),
+          runs: [runIndex],
+        });
+      }
+    }
+  });
+  return [...byKey.values()];
+}
+
+export interface SnapOptions {
+  /** The press anchor A's own point — enables angle magnetism. */
+  origin?: Point;
+  /** Ruling 1: Alt = free angle (no seam snapping). */
+  alt?: boolean;
+  /** Existing wall vertices — the STRONGEST magnetism; landing on one
+   * shares it, and a shared vertex IS a closed corner. */
+  wallVertices?: readonly RunVertex[];
+}
+
+/**
+ * Where a gesture endpoint lands for a raw pointer position — the two
+ * magnetisms of the design, strongest first: (1) an existing wall
+ * vertex within `wallVertexSnapRadius`, else (2) the corner lattice,
+ * with the drag direction angle-snapped onto the nearest seam family
+ * within `angleToleranceDeg` first (unless Alt): the pointer projects
+ * onto the seam line through the press anchor, and the projection's
+ * nearest corner is the endpoint.
+ */
+export function snapGesturePoint(
+  point: Point,
+  size: number,
+  o: Orientation,
+  opts: SnapOptions = {}
+): CornerRef {
+  const magnetRadius = GESTURE_TUNING.wallVertexSnapRadius * size;
+  let magnet: RunVertex | null = null;
+  let magnetDist = Infinity;
+  for (const v of opts.wallVertices ?? []) {
+    const d = distance(point, v.point);
+    if (d <= magnetRadius && d < magnetDist) {
+      magnet = v;
+      magnetDist = d;
+    }
+  }
+  if (magnet) return magnet.ref;
+
+  let target = point;
+  if (opts.origin && !opts.alt) {
+    const dx = point.x - opts.origin.x;
+    const dy = point.y - opts.origin.y;
+    if (dx !== 0 || dy !== 0) {
+      const angle = ((Math.atan2(dy, dx) * 180) / Math.PI + 180) % 180;
+      let best: number | null = null;
+      let bestDelta = Infinity;
+      for (const seam of seamAngles(o)) {
+        const raw = Math.abs(angle - seam);
+        const delta = Math.min(raw, 180 - raw);
+        if (delta < bestDelta) {
+          bestDelta = delta;
+          best = seam;
+        }
+      }
+      if (best !== null && bestDelta <= GESTURE_TUNING.angleToleranceDeg) {
+        const rad = (best * Math.PI) / 180;
+        const ux = Math.cos(rad);
+        const uy = Math.sin(rad);
+        const t = dx * ux + dy * uy;
+        target = {
+          x: opts.origin.x + ux * t,
+          y: opts.origin.y + uy * t,
+        };
+      }
+    }
+  }
+  return nearestCorner(target, size, o);
+}
+
+/**
+ * Select the thing you see: the index of the run whose rendered segment
+ * `point` sits within `runHitRadius` of (nearest wins), or null. Runs
+ * are the board's own projected segments (`BoardWallRun.a`/`b`).
+ */
+export function nearestRunIndex(
+  runs: readonly { a: Point; b: Point }[],
+  point: Point,
+  size: number
+): number | null {
+  const radius = GESTURE_TUNING.runHitRadius * size;
+  let best: number | null = null;
+  let bestDist = Infinity;
+  runs.forEach((run, i) => {
+    const vx = run.b.x - run.a.x;
+    const vy = run.b.y - run.a.y;
+    const lenSq = vx * vx + vy * vy;
+    const t =
+      lenSq === 0
+        ? 0
+        : Math.max(
+            0,
+            Math.min(
+              1,
+              ((point.x - run.a.x) * vx + (point.y - run.a.y) * vy) / lenSq
+            )
+          );
+    const d = Math.hypot(
+      run.a.x + vx * t - point.x,
+      run.a.y + vy * t - point.y
+    );
+    if (d <= radius && d < bestDist) {
+      best = i;
+      bestDist = d;
+    }
+  });
+  return best;
+}

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -655,8 +655,16 @@ export function toggleWall(doc: DungeonDoc, e: Edge): DungeonDoc {
 }
 
 /** An edge the wall/door tools may act on: two adjacent floor cells. */
-export function edgeIsOfferable(doc: DungeonDoc, [a, b]: Edge): boolean {
-  const owners = floorOwners(doc);
+export function edgeIsOfferable(doc: DungeonDoc, edge: Edge): boolean {
+  return edgeOfferableWith(floorOwners(doc), edge);
+}
+
+/** `edgeIsOfferable` against a PRECOMPUTED owner map — the batch
+ * mutators below run per pointer move on the live preview, so they
+ * build `floorOwners` once per call instead of once per edge (Copilot
+ * review, PR #808: the per-edge rebuild made a long drag scan the
+ * whole floor per candidate, O(chain × floor) instead of O(chain)). */
+function edgeOfferableWith(owners: Map<string, string>, [a, b]: Edge): boolean {
   return (
     owners.has(axialKey(a)) &&
     owners.has(axialKey(b)) &&
@@ -675,12 +683,17 @@ export function edgeIsOfferable(doc: DungeonDoc, [a, b]: Edge): boolean {
  * gesture never authors) and the chain simply breaks there. Returns the
  * same doc when nothing survives the filter. */
 export function addWalls(doc: DungeonDoc, edges: Edge[]): DungeonDoc {
+  const owners = floorOwners(doc);
   const doorKeys = doorEdgeOwners(doc);
   const present = wallKeys(doc);
   const toAdd: Edge[] = [];
   for (const e of edges) {
     const key = edgeKey(e);
-    if (!edgeIsOfferable(doc, e) || doorKeys.has(key) || present.has(key)) {
+    if (
+      !edgeOfferableWith(owners, e) ||
+      doorKeys.has(key) ||
+      present.has(key)
+    ) {
       continue;
     }
     present.add(key);
@@ -705,12 +718,13 @@ export function removeWalls(doc: DungeonDoc, edges: Edge[]): DungeonDoc {
  * walls on the surviving edges are replaced, same as `toggleDoorEdge`'s
  * wall-or-door rule. Returns the same doc when no edge survives. */
 export function addDoor(doc: DungeonDoc, edges: Edge[]): DungeonDoc {
+  const owners = floorOwners(doc);
   const doorKeys = doorEdgeOwners(doc);
   const seen = new Set<string>();
   const clean: Edge[] = [];
   for (const e of edges) {
     const key = edgeKey(e);
-    if (!edgeIsOfferable(doc, e) || doorKeys.has(key) || seen.has(key)) {
+    if (!edgeOfferableWith(owners, e) || doorKeys.has(key) || seen.has(key)) {
       continue;
     }
     seen.add(key);

--- a/src/author/dungeonYaml.ts
+++ b/src/author/dungeonYaml.ts
@@ -667,6 +667,63 @@ export function edgeIsOfferable(doc: DungeonDoc, [a, b]: Edge): boolean {
   );
 }
 
+/** Add every offerable, non-door, not-already-present edge of `edges`
+ * to `walls[]` — the wall gesture's commit (rpg-dnd5e-web#804). Unlike
+ * `toggleWall`, drawing over an existing wall is IDEMPOTENT (the design's
+ * dedup rule): an edge already present is skipped, never removed. Door
+ * edges are skipped (an edge in both lists is a validation failure the
+ * gesture never authors) and the chain simply breaks there. Returns the
+ * same doc when nothing survives the filter. */
+export function addWalls(doc: DungeonDoc, edges: Edge[]): DungeonDoc {
+  const doorKeys = doorEdgeOwners(doc);
+  const present = wallKeys(doc);
+  const toAdd: Edge[] = [];
+  for (const e of edges) {
+    const key = edgeKey(e);
+    if (!edgeIsOfferable(doc, e) || doorKeys.has(key) || present.has(key)) {
+      continue;
+    }
+    present.add(key);
+    toAdd.push(normalizeEdge(e));
+  }
+  return toAdd.length === 0 ? doc : { ...doc, walls: [...doc.walls, ...toAdd] };
+}
+
+/** Remove every edge of `edges` from `walls[]` — the erase drag's commit
+ * and the wall selection's Delete (rpg-dnd5e-web#804). Door edges are
+ * untouchable by construction: they are never IN `walls[]` (an edge is a
+ * wall OR a door), so filtering `walls` alone is the whole rule. */
+export function removeWalls(doc: DungeonDoc, edges: Edge[]): DungeonDoc {
+  const keys = new Set(edges.map(edgeKey));
+  const walls = doc.walls.filter((w) => !keys.has(edgeKey(w)));
+  return walls.length === doc.walls.length ? doc : { ...doc, walls };
+}
+
+/** One door from one drag's chain (rpg-dnd5e-web#804, design: "a door
+ * drag's chain becomes ONE door's `edges[]`"). Offerable edges only;
+ * edges already belonging to any door are skipped rather than stolen;
+ * walls on the surviving edges are replaced, same as `toggleDoorEdge`'s
+ * wall-or-door rule. Returns the same doc when no edge survives. */
+export function addDoor(doc: DungeonDoc, edges: Edge[]): DungeonDoc {
+  const doorKeys = doorEdgeOwners(doc);
+  const seen = new Set<string>();
+  const clean: Edge[] = [];
+  for (const e of edges) {
+    const key = edgeKey(e);
+    if (!edgeIsOfferable(doc, e) || doorKeys.has(key) || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    clean.push(normalizeEdge(e));
+  }
+  if (clean.length === 0) return doc;
+  return {
+    ...doc,
+    walls: doc.walls.filter((w) => !seen.has(edgeKey(w))),
+    doors: [...doc.doors, { id: nextDoorId(doc), edges: clean }],
+  };
+}
+
 function nextDoorId(doc: DungeonDoc): string {
   const taken = new Set(doc.doors.map((d) => d.id));
   let n = doc.doors.length + 1;

--- a/src/author/types.ts
+++ b/src/author/types.ts
@@ -1,3 +1,5 @@
+import type { Edge } from './hexOffset';
+
 /** The palette's tools (design §1, left column) plus `select`, which
  * the inspector needs: clicking a placement, a door edge or a region
  * cell with it selects that thing. */
@@ -10,11 +12,15 @@ export type BoardTool =
   | 'start'
   | 'place';
 
-/** What the inspector is looking at. */
+/** What the inspector is looking at. A wall selection is the set of
+ * doc edges behind a rendered run, resolved at click time from the
+ * derived scene — there is no wall id in the file and none is added
+ * (rpg-dnd5e-web#804). */
 export type Selection =
   | { kind: 'dungeon' }
   | { kind: 'region'; id: string }
   | { kind: 'door'; id: string }
+  | { kind: 'wall'; edges: Edge[] }
   | { kind: 'placement'; index: number };
 
 /** The catalog item armed on the `place` tool. */


### PR DESCRIPTION
Implements KirkDiggler/rpg-dnd5e-web#804 (design: KirkDiggler/rpg-project#267, `ideas/dungeon-builder/wall-authoring-gesture.md` — all four rulings recorded there are honored below).

The author draws the line; the tool derives the cells. Wall (and door) authoring gains press–drag–release: endpoints snap to the hex **corner lattice**, the dragged segment derives its edge chain as the **taut path** on that lattice, and the live preview is computed by the **same shared geometry module on the same mutator-built candidate document the release commits** — the preview IS the commit, never a second formula.

## What landed, per plan unit

1. **`hexCorner.ts` resurrected** from history (`6503936^`), adapted from pointy-only offset `[col,row]` space to the builder's axial + orientation-aware `canvasGeometry` SVG space, plus the lattice-topology helpers the walk needs (`cornerNeighbors`, `latticeEdgeCells`, and a true `cellAtPoint` inverse). 15 tests.
2. **`wallGesture.ts`** — the pure derivation module (zero React): `tautPath` (advance toward B, least deviation from the dragged line), derivation rules (floor filter, door break, silent dedup), `snapGesturePoint` (wall-vertex magnetism at 0.6·size beats the lattice; angle magnetism within 6° of the four seam families, **Alt = free angle** — ruling 1), and `GESTURE_TUNING` pinning every constant in one exported place. New `dungeonYaml.ts` mutators `addWalls` (idempotent over existing walls, per the design's dedup rule), `removeWalls`, `addDoor`. 26 tests — the design's drag table, written first, expected edge lists hand-derived from the lattice geometry (not captured from output): vertical seam (run axis-true to 1e-6 via `boardWallScene`), horizontal seam, ~44° free drag, across-a-door, ending-on-a-wall-vertex, shared-corner re-derivation; preview-identity float-exact; draw+erase → byte-identical YAML with doors untouched.
3. **Board wiring**: draw + shift/right-drag erase (ruling 3) with the live candidate-doc preview plus a faint literal trace of the derived edges; single click stays the single-edge toggle (now committed on release); Escape / leave / release-on-A cancels. `boardWallRuns` threads each run's **source doc edges** through additively (run-key token → doc edge; the shared 3D module's geometry untouched), pinned by a reference-tomb test.
4. **Snapping + `GESTURE_TUNING`** — landed inside unit 2 (the pure module is where the constants live), exercised by the board wiring.
5. **Selection + handles**: Select on a run → `{ kind: 'wall', edges }` (resolved at click time; no wall id exists or is added); Inspector shows "Wall — N edges" with delete; chain endpoints and shared corners render as handles on the wall tool; grabbing one re-derives **every incident chain from its own far endpoint** (rulings 2 + 4) — the corner stays closed by construction at every pointer position.
6. **Door drag**: one drag's chain becomes ONE door's `edges[]` (walls on the chain are replaced; the new door is selected on commit). Door click unchanged.

## Rulings honored

1. Angle magnetism ON by default, ~6° tolerance, Alt bypass — `snapGesturePoint`, pinned.
2. Endpoint drag re-derives the whole chain from the fixed far endpoint — `applyReshape` (one-chain case).
3. Erase = shift/right-drag along the derived path; door edges never touched — pinned by the erase-inverse-with-door test.
4. Shared-corner grab re-derives every incident chain to the new vertex — `runVertices` + `applyReshape`, exact both-chains re-derivation pinned.

## Deliberate calls where the design left room (flagged for the addendum ledger)

- **Exactly-on-line tie-break**: a drag lying exactly on a corner column reaches corners where both zigzag sides advance with identical deviation; ties break toward the greater x (then y) — geometric, so the same line derives the same chain from either end. Pinned by the drag table.
- **Snap radii reading**: endpoints ALWAYS land on the corner lattice (the design's "A and B snap to the corner lattice"), so `cornerSnapRadius` (0.4·size) is used as the **handle pickup** radius and `wallVertexSnapRadius` (0.6·size) as the gate for the stronger wall-vertex magnetism. `runHitRadius` (0.25·size) was added for select-tool run hit-testing — all in `GESTURE_TUNING`, all pinned, all recalibratable from Kirk's walk.
- **Reshape drags skip angle magnetism**: several chains re-derive at once, so there is no single origin to measure the angle from; wall-vertex + lattice magnetism still apply (the grabbed runs' own vertices excluded so B doesn't stick to itself).
- **No door-tool erase drag**: the wall eraser never touches door edges (ruling 3), so a door-tool erase gesture has nothing to mean; shift/right on the door tool keeps today's immediate toggle.

## Evidence

- `npm run ci-check` green (format, lint, typecheck, build, full suite: 202 files, 3352+ tests).
- New tests: `hexCorner.test.ts` (15), `wallGesture.test.ts` (26), threading pin in `boardWallRuns.test.ts`, WallPanel tests in `Inspector.test.tsx`, handle/selection render tests in `CreationBoard.test.tsx`.
- Existing goldens unchanged — the gesture writes through the doc mutators only; reference-tomb fixtures never moved.
- Feel verdict is Kirk's: the :3001 walk (draw a wall in one drag, snap a second to its corner, grab the shared corner, shift-drag erase) is the calibration instrument; `GESTURE_TUNING` re-pins from it before merge.

— world-builder lane, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MbNn6jFLjJwzTw6ZbY5M1
